### PR TITLE
Update STM32 memory regions

### DIFF
--- a/changelog/changed-stm.md
+++ b/changelog/changed-stm.md
@@ -1,0 +1,1 @@
+Updated memory maps for most of STM32 chips.

--- a/probe-rs/targets/STM32C0_Series.yaml
+++ b/probe-rs/targets/STM32C0_Series.yaml
@@ -14,13 +14,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -40,13 +41,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -66,13 +68,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -92,13 +95,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -118,13 +122,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -144,13 +149,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -170,13 +176,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -196,13 +203,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -222,13 +230,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -248,13 +257,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -274,13 +284,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -300,13 +311,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -326,13 +338,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -352,13 +365,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -378,13 +392,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -404,13 +419,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -430,13 +446,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -456,13 +473,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -482,13 +500,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM

--- a/probe-rs/targets/STM32F0_Series.yaml
+++ b/probe-rs/targets/STM32F0_Series.yaml
@@ -14,16 +14,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -41,16 +42,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -68,16 +70,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -95,16 +98,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -122,16 +126,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -149,16 +154,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -176,16 +182,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -203,16 +210,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -230,16 +238,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -257,16 +266,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -284,16 +294,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -311,16 +322,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -338,16 +350,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -365,16 +378,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -392,16 +406,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -419,16 +434,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -446,16 +462,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -473,16 +490,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -500,16 +518,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -527,16 +546,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -554,16 +574,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -581,16 +602,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -608,16 +630,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -635,16 +658,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -662,16 +686,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -689,16 +714,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -716,16 +742,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -743,16 +770,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -770,16 +798,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -797,16 +826,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -824,16 +854,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -851,16 +882,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -878,16 +910,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -905,16 +938,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -932,16 +966,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -959,16 +994,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -986,16 +1022,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -1013,16 +1050,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -1040,16 +1078,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1067,16 +1106,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1094,16 +1134,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1121,16 +1162,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1148,16 +1190,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1175,16 +1218,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1202,16 +1246,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1229,16 +1274,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1256,16 +1302,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1283,16 +1330,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1310,16 +1358,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1337,16 +1386,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1364,16 +1414,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1391,16 +1442,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1418,16 +1470,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1445,16 +1498,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1472,16 +1526,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1499,16 +1554,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1526,16 +1582,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1553,16 +1610,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1580,16 +1638,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1607,16 +1666,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -1634,16 +1694,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1661,16 +1722,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -1688,16 +1750,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1715,16 +1778,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1742,16 +1806,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1769,16 +1834,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1796,16 +1862,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1823,16 +1890,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1850,16 +1918,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1877,16 +1946,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1904,16 +1974,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1931,16 +2002,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1958,16 +2030,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1985,16 +2058,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2012,16 +2086,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2039,16 +2114,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2066,16 +2142,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2093,16 +2170,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2120,16 +2198,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2147,16 +2226,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2174,16 +2254,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2201,16 +2282,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2228,16 +2310,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2255,16 +2338,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2282,16 +2366,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2309,16 +2394,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2336,16 +2422,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2363,16 +2450,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2390,16 +2478,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2417,16 +2506,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2444,16 +2534,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2471,16 +2562,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2498,16 +2590,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2525,16 +2618,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2552,16 +2646,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2579,16 +2674,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2606,16 +2702,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2633,16 +2730,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2660,16 +2758,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2687,16 +2786,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2714,16 +2814,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2741,16 +2842,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2768,16 +2870,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2795,16 +2898,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2822,16 +2926,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2849,16 +2954,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2876,16 +2982,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2903,16 +3010,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2930,16 +3038,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2957,16 +3066,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2984,16 +3094,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000

--- a/probe-rs/targets/STM32F1_Series.yaml
+++ b/probe-rs/targets/STM32F1_Series.yaml
@@ -14,16 +14,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -41,16 +42,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -68,16 +70,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -95,16 +98,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -122,16 +126,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -149,16 +154,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -176,16 +182,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -203,16 +210,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -230,16 +238,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20006000
@@ -257,16 +266,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -284,16 +294,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -311,16 +322,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -338,16 +350,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -365,16 +378,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20006000
@@ -392,16 +406,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -419,16 +434,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -446,16 +462,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20006000
@@ -473,16 +490,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -500,16 +518,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -527,16 +546,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -554,16 +574,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -581,16 +602,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -608,16 +630,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -635,16 +658,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -662,16 +686,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -689,16 +714,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -716,16 +742,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -743,16 +770,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -770,16 +798,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -797,16 +826,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -824,16 +854,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x80c0000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -851,16 +892,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -878,16 +930,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -905,16 +958,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -932,16 +986,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -959,16 +1014,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -986,16 +1042,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -1013,16 +1070,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1040,16 +1098,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1067,16 +1126,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -1094,16 +1154,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -1121,16 +1182,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x80c0000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -1148,16 +1220,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -1175,16 +1258,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1202,16 +1286,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -1229,16 +1314,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -1256,16 +1342,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x80c0000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -1283,16 +1380,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -1310,16 +1418,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -1337,16 +1446,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -1364,16 +1474,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -1391,16 +1502,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1418,16 +1530,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -1445,16 +1558,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -1472,16 +1586,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -1499,16 +1614,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1526,16 +1642,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -1553,16 +1670,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -1580,16 +1698,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -1607,16 +1726,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -1634,16 +1754,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -1661,16 +1782,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -1688,16 +1810,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -1715,16 +1838,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -1742,16 +1866,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -1769,16 +1894,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -1796,16 +1922,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -1823,16 +1950,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x80c0000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -1850,16 +1988,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -1877,16 +2026,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001800
@@ -1904,16 +2054,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -1931,16 +2082,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -1958,16 +2110,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -1985,16 +2138,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2012,16 +2166,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2039,16 +2194,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -2066,16 +2222,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -2093,16 +2250,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -2120,16 +2278,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x80c0000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -2147,16 +2316,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -2174,16 +2354,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -2201,16 +2382,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -2228,16 +2410,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -2255,16 +2438,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x80c0000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -2282,16 +2476,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -2309,16 +2514,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -2336,16 +2542,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -2363,16 +2570,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -2390,16 +2598,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -2417,16 +2626,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -2444,16 +2654,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -2471,16 +2682,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -2498,16 +2710,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -2525,16 +2738,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -2552,16 +2766,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000

--- a/probe-rs/targets/STM32F2_Series.yaml
+++ b/probe-rs/targets/STM32F2_Series.yaml
@@ -14,19 +14,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
+      end: 0x20020000
     cores:
     - main
   flash_algorithms:
@@ -42,19 +50,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20018000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
+      end: 0x20020000
     cores:
     - main
   flash_algorithms:
@@ -70,18 +86,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -98,18 +122,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -126,18 +158,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x80c0000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -154,18 +194,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -182,18 +230,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -210,18 +266,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -238,19 +302,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
+      end: 0x20020000
     cores:
     - main
   flash_algorithms:
@@ -266,19 +338,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20018000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
+      end: 0x20020000
     cores:
     - main
   flash_algorithms:
@@ -294,18 +374,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -322,18 +410,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x80c0000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -350,18 +446,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -378,19 +482,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20018000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
+      end: 0x20020000
     cores:
     - main
   flash_algorithms:
@@ -406,18 +518,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -434,18 +554,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x80c0000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -462,18 +590,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -490,18 +626,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -518,18 +662,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -546,18 +698,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -574,18 +734,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -602,18 +770,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x80c0000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -630,18 +806,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x80c0000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -658,18 +842,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -686,18 +878,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -714,18 +914,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -742,18 +950,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -770,18 +986,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x80c0000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -798,18 +1022,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -826,18 +1058,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -854,18 +1094,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -882,18 +1130,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x80c0000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -910,18 +1166,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -938,18 +1202,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -966,18 +1238,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -994,18 +1274,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1022,18 +1310,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1050,18 +1346,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1078,18 +1382,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1106,18 +1418,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1134,18 +1454,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1162,18 +1490,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1190,18 +1526,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1218,18 +1562,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1246,18 +1598,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1274,18 +1634,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1302,18 +1670,26 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main

--- a/probe-rs/targets/STM32F3_Series.yaml
+++ b/probe-rs/targets/STM32F3_Series.yaml
@@ -12,16 +12,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -39,16 +40,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -66,16 +68,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -93,16 +96,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -120,16 +124,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -147,16 +152,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -174,16 +180,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -201,16 +208,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -228,16 +236,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -255,16 +264,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -282,16 +292,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -309,16 +320,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -336,16 +348,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000a000
@@ -363,16 +376,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -390,16 +404,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -417,16 +432,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -444,16 +460,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -471,16 +488,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -498,16 +516,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000a000
@@ -525,16 +544,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -552,16 +572,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -579,16 +600,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -606,16 +628,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000a000
@@ -633,16 +656,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000a000
@@ -660,16 +684,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -687,16 +712,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -714,16 +740,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -741,16 +768,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -768,16 +796,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -795,16 +824,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -822,23 +852,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -856,23 +887,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -890,23 +922,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -924,23 +957,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000a000
@@ -958,23 +992,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -992,23 +1027,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -1026,23 +1062,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -1060,23 +1097,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -1094,23 +1132,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -1128,23 +1167,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -1162,23 +1202,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1196,23 +1237,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000a000
@@ -1230,23 +1272,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -1264,23 +1307,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -1298,23 +1342,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1332,23 +1377,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000a000
@@ -1366,23 +1412,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000a000
@@ -1400,23 +1447,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -1434,23 +1482,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -1468,23 +1517,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -1502,23 +1552,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -1536,23 +1587,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -1570,23 +1622,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -1604,23 +1657,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -1638,16 +1692,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1665,16 +1720,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1692,16 +1748,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1719,23 +1776,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -1753,23 +1811,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -1787,23 +1846,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -1821,23 +1881,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -1855,23 +1916,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -1889,23 +1951,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -1923,23 +1986,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -1957,23 +2021,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -1991,23 +2056,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -2025,23 +2091,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -2059,23 +2126,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -2093,23 +2161,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -2127,23 +2196,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10001000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
@@ -2161,23 +2231,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000a000
@@ -2195,23 +2266,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000a000
@@ -2229,23 +2301,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: CCM SRAM
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000a000
@@ -2263,16 +2336,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2290,16 +2364,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20006000
@@ -2317,16 +2392,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2344,16 +2420,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2371,16 +2448,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20006000
@@ -2398,16 +2476,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2425,16 +2504,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2452,16 +2532,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2479,16 +2560,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20006000
@@ -2506,16 +2588,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20006000
@@ -2533,16 +2616,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2560,16 +2644,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2587,16 +2672,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2614,16 +2700,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2641,16 +2728,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2668,16 +2756,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2695,16 +2784,24 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000

--- a/probe-rs/targets/STM32F4_Series.yaml
+++ b/probe-rs/targets/STM32F4_Series.yaml
@@ -14,7 +14,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -24,7 +24,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -43,7 +43,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -53,7 +53,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -72,7 +72,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -82,7 +82,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -101,7 +101,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -111,7 +111,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -130,7 +130,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -140,7 +140,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -159,7 +159,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
@@ -169,7 +169,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -188,7 +188,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
@@ -198,7 +198,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -217,7 +217,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -227,7 +227,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -246,7 +246,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -256,7 +256,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -275,7 +275,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -285,7 +285,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -304,7 +304,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -314,7 +314,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -333,7 +333,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
@@ -343,7 +343,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -362,7 +362,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -372,7 +372,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -391,7 +391,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -401,7 +401,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -420,7 +420,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -430,7 +430,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -449,7 +449,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -459,7 +459,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -478,7 +478,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -488,7 +488,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -507,7 +507,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
@@ -517,7 +517,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -536,7 +536,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8060000
@@ -546,7 +546,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -565,7 +565,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -575,7 +575,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -594,7 +594,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -604,7 +604,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -623,7 +623,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -632,8 +632,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -642,9 +642,16 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -661,7 +668,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -670,8 +677,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -680,9 +687,16 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -699,7 +713,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -708,8 +722,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -718,9 +732,16 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -737,7 +758,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -746,8 +767,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -756,9 +777,16 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -775,7 +803,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -784,8 +812,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -794,9 +822,16 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -813,7 +848,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -822,8 +857,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -832,9 +867,16 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -851,7 +893,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -860,8 +902,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -870,9 +912,16 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -889,7 +938,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -898,8 +947,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -908,9 +957,16 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -927,7 +983,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -936,8 +992,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -946,9 +1002,16 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -965,7 +1028,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -974,8 +1037,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -984,9 +1047,16 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1003,7 +1073,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1012,8 +1082,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -1022,9 +1092,16 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1041,7 +1118,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1050,8 +1127,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -1060,9 +1137,16 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1079,7 +1163,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1088,8 +1172,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -1098,9 +1182,16 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x2001c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2001c000
       end: 0x20020000
     cores:
     - main
@@ -1117,7 +1208,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1127,7 +1218,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1145,7 +1236,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1155,7 +1246,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1173,7 +1264,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1183,7 +1274,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1201,7 +1292,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1211,7 +1302,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1229,7 +1320,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1239,7 +1330,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1257,7 +1348,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1267,7 +1358,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1285,7 +1376,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1295,7 +1386,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1313,7 +1404,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1323,7 +1414,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1341,7 +1432,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1351,7 +1442,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1369,7 +1460,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1379,7 +1470,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1397,7 +1488,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1407,7 +1498,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1426,7 +1517,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1436,7 +1527,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1455,7 +1546,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1465,7 +1556,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1484,7 +1575,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1494,7 +1585,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1513,7 +1604,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1523,7 +1614,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1542,7 +1633,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1552,7 +1643,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1571,7 +1662,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1581,7 +1672,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1600,7 +1691,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1610,7 +1701,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1629,7 +1720,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1639,7 +1730,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1658,7 +1749,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1668,7 +1759,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1687,7 +1778,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1697,7 +1788,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -1716,7 +1807,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1726,7 +1817,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -1745,7 +1836,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1755,7 +1846,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -1774,7 +1865,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1784,7 +1875,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -1803,7 +1894,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1813,7 +1904,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -1832,7 +1923,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1842,7 +1933,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -1861,7 +1952,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1871,7 +1962,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -1890,7 +1981,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1900,7 +1991,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -1919,7 +2010,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1929,7 +2020,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -1948,7 +2039,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1958,7 +2049,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -1977,7 +2068,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1987,7 +2078,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -2006,7 +2097,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2016,7 +2107,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -2035,7 +2126,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2045,7 +2136,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -2064,7 +2155,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2074,7 +2165,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -2093,7 +2184,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2103,7 +2194,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -2122,7 +2213,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2132,7 +2223,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
@@ -2151,7 +2242,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2161,7 +2252,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -2179,7 +2270,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8180000
@@ -2189,7 +2280,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -2207,7 +2298,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2217,7 +2308,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -2235,7 +2326,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8180000
@@ -2245,7 +2336,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -2263,7 +2354,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2273,7 +2364,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -2291,7 +2382,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8180000
@@ -2301,7 +2392,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -2319,7 +2410,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2329,7 +2420,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -2347,7 +2438,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2357,7 +2448,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -2375,7 +2466,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8180000
@@ -2385,7 +2476,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -2403,7 +2494,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8180000
@@ -2413,7 +2504,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -2431,7 +2522,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2441,7 +2532,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -2459,7 +2550,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2469,7 +2560,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -2487,7 +2578,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8180000
@@ -2497,7 +2588,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -2515,7 +2606,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8180000
@@ -2525,7 +2616,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -2543,7 +2634,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2552,8 +2643,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -2562,7 +2653,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2581,7 +2672,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2590,8 +2681,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -2600,7 +2691,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2619,7 +2710,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2628,8 +2719,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -2638,7 +2729,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2657,7 +2748,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2666,8 +2757,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -2676,7 +2767,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2695,7 +2786,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2704,8 +2795,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -2714,7 +2805,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2733,7 +2824,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2742,8 +2833,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -2752,7 +2843,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2771,7 +2862,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2780,8 +2871,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -2790,7 +2881,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2809,7 +2900,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2818,8 +2909,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -2828,7 +2919,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2847,7 +2938,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2856,8 +2947,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -2866,7 +2957,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2885,7 +2976,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2894,8 +2985,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -2904,7 +2995,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2923,7 +3014,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2932,8 +3023,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -2942,7 +3033,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2961,7 +3052,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2970,8 +3061,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -2980,7 +3071,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2999,7 +3090,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8180000
@@ -3009,7 +3100,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -3027,7 +3118,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8180000
@@ -3037,7 +3128,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -3055,7 +3146,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8180000
@@ -3065,7 +3156,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -3083,7 +3174,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8180000
@@ -3093,7 +3184,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -3111,7 +3202,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8180000
@@ -3121,7 +3212,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -3139,7 +3230,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8180000
@@ -3149,7 +3240,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -3167,7 +3258,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8180000
@@ -3177,7 +3268,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -3195,7 +3286,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3204,8 +3295,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3214,7 +3305,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3234,17 +3325,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3253,7 +3354,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3272,7 +3373,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3281,8 +3382,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3291,7 +3392,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3311,7 +3412,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3320,8 +3421,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3330,7 +3431,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3350,17 +3451,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3369,7 +3480,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3388,17 +3499,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3407,7 +3528,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3426,7 +3547,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3435,8 +3556,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3445,7 +3566,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3465,17 +3586,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3484,7 +3615,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3503,7 +3634,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3512,8 +3643,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3522,7 +3653,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3542,17 +3673,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3561,7 +3702,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3580,7 +3721,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3589,8 +3730,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3599,7 +3740,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3619,17 +3760,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3638,7 +3789,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3657,7 +3808,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3666,8 +3817,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3676,7 +3827,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3695,7 +3846,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3704,8 +3855,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3714,7 +3865,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3734,17 +3885,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3753,7 +3914,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3772,7 +3933,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3781,8 +3942,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3791,7 +3952,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3810,7 +3971,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3819,8 +3980,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3829,7 +3990,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3848,7 +4009,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3857,8 +4018,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3867,7 +4028,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3887,7 +4048,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3896,8 +4057,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3906,7 +4067,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3926,17 +4087,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3945,7 +4116,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -3964,17 +4135,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -3983,7 +4164,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4002,7 +4183,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4011,8 +4192,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4021,7 +4202,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4040,7 +4221,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4049,8 +4230,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4059,7 +4240,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4079,17 +4260,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4098,7 +4289,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4117,7 +4308,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4126,8 +4317,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4136,7 +4327,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4155,7 +4346,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4164,8 +4355,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4174,7 +4365,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4194,17 +4385,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4213,7 +4414,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4232,7 +4433,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4241,8 +4442,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4251,7 +4452,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4270,7 +4471,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4279,8 +4480,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4289,7 +4490,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4309,7 +4510,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4318,8 +4519,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4328,7 +4529,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4348,17 +4549,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4367,7 +4578,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4386,17 +4597,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4405,7 +4626,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4424,17 +4645,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4443,7 +4674,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4462,7 +4693,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4471,8 +4702,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4481,7 +4712,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4501,7 +4732,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4510,8 +4741,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4520,7 +4751,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4540,17 +4771,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4559,7 +4800,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4578,17 +4819,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4597,7 +4848,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4616,7 +4867,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4625,8 +4876,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4635,7 +4886,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4655,17 +4906,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4674,7 +4935,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4693,7 +4954,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4702,8 +4963,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4712,7 +4973,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4732,17 +4993,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4751,7 +5022,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4770,17 +5041,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4789,7 +5070,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4808,7 +5089,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4817,8 +5098,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4827,7 +5108,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4847,17 +5128,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4866,7 +5157,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4885,7 +5176,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4894,8 +5185,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4904,7 +5195,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4924,7 +5215,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4933,8 +5224,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4943,7 +5234,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -4963,17 +5254,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -4982,7 +5283,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -5001,17 +5302,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -5020,7 +5331,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -5039,7 +5350,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -5048,8 +5359,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -5058,7 +5369,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -5078,17 +5389,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -5097,7 +5418,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -5116,7 +5437,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -5125,8 +5446,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -5135,7 +5456,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -5155,17 +5476,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -5174,7 +5505,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -5193,7 +5524,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -5202,8 +5533,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -5212,7 +5543,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -5232,7 +5563,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -5241,8 +5572,8 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -5251,7 +5582,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -5271,17 +5602,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -5290,7 +5631,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -5309,17 +5650,27 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: IRAM2
+  - !Ram
+    name: CCMRAM
     range:
       start: 0x10000000
       end: 0x10010000
@@ -5328,7 +5679,7 @@ variants:
     access:
       execute: false
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -5347,7 +5698,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -5357,7 +5708,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -5376,7 +5727,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -5386,7 +5737,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -5405,7 +5756,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -5415,7 +5766,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -5434,7 +5785,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -5444,7 +5795,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -5463,7 +5814,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -5473,7 +5824,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -5492,7 +5843,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -5502,7 +5853,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -5521,7 +5872,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -5531,7 +5882,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -5550,7 +5901,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -5560,7 +5911,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -5579,7 +5930,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -5589,7 +5940,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -5608,7 +5959,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -5618,7 +5969,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -5637,7 +5988,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -5647,7 +5998,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -5666,7 +6017,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -5676,7 +6027,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -5695,7 +6046,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -5705,7 +6056,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -5724,7 +6084,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -5734,7 +6094,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -5753,7 +6122,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -5763,7 +6132,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -5783,7 +6161,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -5793,7 +6171,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -5813,9 +6200,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -5823,7 +6220,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -5842,9 +6248,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -5852,7 +6268,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -5871,7 +6296,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -5881,7 +6306,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -5900,7 +6334,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -5910,7 +6344,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -5930,9 +6373,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -5940,7 +6393,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -5959,7 +6421,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -5969,7 +6431,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -5988,7 +6459,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -5998,7 +6469,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6017,7 +6497,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -6027,7 +6507,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6047,7 +6536,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -6057,7 +6546,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6077,9 +6575,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -6087,7 +6595,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6106,9 +6623,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -6116,7 +6643,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6135,7 +6671,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -6145,7 +6681,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6164,7 +6709,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -6174,7 +6719,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6194,9 +6748,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -6204,7 +6768,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6223,7 +6796,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -6233,7 +6806,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6252,7 +6834,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -6262,7 +6844,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6282,9 +6873,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -6292,7 +6893,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6311,7 +6921,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -6321,7 +6931,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6340,7 +6959,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -6350,7 +6969,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6370,9 +6998,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -6380,7 +7018,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6399,7 +7046,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -6409,7 +7056,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6429,7 +7085,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -6439,7 +7095,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6459,9 +7124,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -6469,7 +7144,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6488,9 +7172,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -6498,7 +7192,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6517,7 +7220,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -6527,7 +7230,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6547,9 +7259,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -6557,7 +7279,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6576,7 +7307,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -6586,7 +7317,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6606,7 +7346,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -6616,7 +7356,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6636,9 +7385,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -6646,7 +7405,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6665,9 +7433,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -6675,7 +7453,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6694,7 +7481,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -6704,7 +7491,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6724,9 +7520,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -6734,7 +7540,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6753,7 +7568,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -6763,7 +7578,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6783,9 +7607,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -6793,7 +7627,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6812,7 +7655,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -6822,7 +7665,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000
@@ -6842,9 +7694,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -6852,7 +7714,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20050000

--- a/probe-rs/targets/STM32F7_Series.yaml
+++ b/probe-rs/targets/STM32F7_Series.yaml
@@ -13,17 +13,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x240000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -33,14 +24,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -65,17 +56,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x240000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -85,14 +67,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -117,17 +99,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -137,14 +110,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -169,17 +142,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -189,14 +153,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -221,17 +185,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x240000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -241,14 +196,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -273,17 +228,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -293,14 +239,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -325,17 +271,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x240000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -345,14 +282,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -377,17 +314,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -397,14 +325,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -429,17 +357,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x240000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -449,14 +368,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -481,17 +400,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -501,14 +411,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -533,17 +443,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x240000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -553,14 +454,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -585,17 +486,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x240000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -605,14 +497,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -637,17 +529,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -657,14 +540,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -689,17 +572,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -709,14 +583,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -741,17 +615,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x240000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -761,14 +626,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -793,17 +658,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x240000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -813,14 +669,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -845,17 +701,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -865,14 +712,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -897,17 +744,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -917,14 +755,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -949,17 +787,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x240000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -969,14 +798,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1001,17 +830,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x240000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1021,14 +841,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1053,17 +873,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1073,14 +884,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1105,17 +916,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1125,14 +927,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1157,17 +959,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x210000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1177,14 +970,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1209,17 +1002,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x210000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1229,14 +1013,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1261,17 +1045,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x210000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1281,14 +1056,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1313,17 +1088,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x210000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1333,14 +1099,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1365,17 +1131,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1385,14 +1142,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1417,17 +1174,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1437,14 +1185,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1469,17 +1217,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1489,14 +1228,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1521,17 +1260,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1541,14 +1271,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1573,17 +1303,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1593,14 +1314,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1625,17 +1346,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1645,14 +1357,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1677,17 +1389,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1697,14 +1400,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1729,17 +1432,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1749,14 +1443,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1781,17 +1475,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1801,14 +1486,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1833,17 +1518,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1853,14 +1529,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1885,17 +1561,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1905,14 +1572,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20040000
@@ -1937,17 +1604,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1957,14 +1615,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -1989,17 +1647,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2009,14 +1658,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2041,17 +1690,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2061,14 +1701,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2093,17 +1733,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2113,14 +1744,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2145,17 +1776,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2165,14 +1787,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2197,17 +1819,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2217,14 +1830,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2249,17 +1862,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2269,14 +1873,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2301,17 +1905,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2321,14 +1916,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2353,17 +1948,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2373,14 +1959,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2405,17 +1991,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2425,14 +2002,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2457,17 +2034,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2477,14 +2045,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2509,17 +2077,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2529,14 +2088,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2561,17 +2120,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2581,14 +2131,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2613,17 +2163,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2633,14 +2174,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2665,17 +2206,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2685,14 +2217,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2717,17 +2249,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2737,14 +2260,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2769,17 +2292,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2789,14 +2303,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2821,17 +2335,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2841,14 +2346,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2873,17 +2378,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2893,14 +2389,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2925,17 +2421,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2945,14 +2432,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -2977,17 +2464,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2997,14 +2475,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3029,17 +2507,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3049,14 +2518,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3081,17 +2550,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3101,14 +2561,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3133,17 +2593,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x280000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3153,14 +2604,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3185,17 +2636,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3205,14 +2647,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3237,17 +2679,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3257,14 +2690,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3289,17 +2722,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x210000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -3309,14 +2733,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3341,17 +2765,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x210000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -3361,14 +2776,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3393,17 +2808,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x210000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -3413,14 +2819,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3445,17 +2851,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3465,14 +2862,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3497,17 +2894,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3517,14 +2905,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3549,17 +2937,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3569,14 +2948,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3601,17 +2980,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3621,14 +2991,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3653,17 +3023,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3673,14 +3034,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3705,17 +3066,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3725,14 +3077,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3757,17 +3109,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3777,14 +3120,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3809,17 +3152,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3829,14 +3163,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20010000
       end: 0x20050000
@@ -3861,17 +3195,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3881,14 +3206,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -3915,17 +3240,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -3935,14 +3251,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -3969,17 +3285,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3989,14 +3296,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4023,17 +3330,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4043,14 +3341,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4077,17 +3375,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -4097,14 +3386,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4131,17 +3420,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -4151,14 +3431,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4185,17 +3465,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4205,14 +3476,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4239,17 +3510,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -4259,14 +3521,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4293,17 +3555,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4313,14 +3566,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4347,17 +3600,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4367,14 +3611,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4401,17 +3645,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -4421,14 +3656,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4455,17 +3690,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -4475,14 +3701,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4509,17 +3735,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4529,14 +3746,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4563,17 +3780,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -4583,14 +3791,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4617,17 +3825,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4637,14 +3836,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4671,17 +3870,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -4691,14 +3881,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4725,17 +3915,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4745,14 +3926,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4779,17 +3960,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4799,14 +3971,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4833,17 +4005,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -4853,14 +4016,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4887,17 +4050,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -4907,14 +4061,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4941,17 +4095,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4961,14 +4106,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -4995,17 +4140,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -5015,14 +4151,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5049,17 +4185,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -5069,14 +4196,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5103,17 +4230,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -5123,14 +4241,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5157,17 +4275,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -5177,14 +4286,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5211,17 +4320,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -5231,14 +4331,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5265,17 +4365,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -5285,14 +4376,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5319,17 +4410,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -5339,14 +4421,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5373,17 +4455,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -5393,14 +4466,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5427,17 +4500,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -5447,14 +4511,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5481,17 +4545,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -5501,14 +4556,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5535,17 +4590,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -5555,14 +4601,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5589,17 +4635,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -5609,14 +4646,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5643,17 +4680,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -5663,14 +4691,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5697,17 +4725,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -5717,14 +4736,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5751,17 +4770,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x300000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -5771,14 +4781,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5805,17 +4815,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -5825,14 +4826,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5859,17 +4860,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -5879,14 +4871,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5913,17 +4905,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -5933,14 +4916,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -5967,17 +4950,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -5987,14 +4961,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -6021,17 +4995,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -6041,14 +5006,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -6075,17 +5040,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -6095,14 +5051,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -6129,17 +5085,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -6149,14 +5096,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -6183,17 +5130,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -6203,14 +5141,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -6237,17 +5175,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -6257,14 +5186,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -6291,17 +5220,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -6311,14 +5231,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -6345,17 +5265,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -6365,14 +5276,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -6399,17 +5310,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -6419,14 +5321,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000
@@ -6453,17 +5355,8 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
-  - !Generic
-    name: IROM2
-    range:
-      start: 0x200000
-      end: 0x400000
-    cores:
-    - main
-    access:
-      write: false
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -6473,14 +5366,14 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM2
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20020000
       end: 0x20080000

--- a/probe-rs/targets/STM32G0_Series.yaml
+++ b/probe-rs/targets/STM32G0_Series.yaml
@@ -14,7 +14,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -44,7 +44,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -74,7 +74,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -104,7 +104,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -134,7 +134,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -164,7 +164,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -194,7 +194,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -224,7 +224,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -254,7 +254,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -284,7 +284,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -314,7 +314,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -344,7 +344,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -374,7 +374,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -404,7 +404,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -434,7 +434,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -464,7 +464,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -494,7 +494,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -524,7 +524,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -554,7 +554,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -584,7 +584,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -614,7 +614,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -644,7 +644,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -674,7 +674,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -704,7 +704,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -734,7 +734,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -764,7 +764,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -794,7 +794,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -824,7 +824,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -854,7 +854,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -884,7 +884,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -914,7 +914,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -944,7 +944,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -974,7 +974,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1004,7 +1004,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1034,7 +1034,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1064,7 +1064,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1094,7 +1094,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1124,7 +1124,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1154,7 +1154,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1184,7 +1184,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1214,7 +1214,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1244,7 +1244,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1274,7 +1274,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1304,7 +1304,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1334,7 +1334,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1364,7 +1364,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1394,7 +1394,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1424,7 +1424,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1454,7 +1454,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1484,7 +1484,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1514,7 +1514,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1544,7 +1544,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1574,7 +1574,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1604,7 +1604,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1634,7 +1634,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1664,7 +1664,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1694,7 +1694,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1724,7 +1724,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1754,7 +1754,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1784,7 +1784,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1814,7 +1814,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1844,7 +1844,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1874,7 +1874,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1904,7 +1904,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1934,7 +1934,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1964,7 +1964,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1994,7 +1994,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -2024,7 +2024,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2054,7 +2054,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -2084,7 +2084,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -2114,7 +2114,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2144,7 +2144,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2174,7 +2174,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2204,7 +2204,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2234,7 +2234,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2264,7 +2264,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2294,7 +2294,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2324,7 +2324,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2354,7 +2354,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2384,7 +2384,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2414,7 +2414,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2444,7 +2444,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2474,7 +2474,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2504,7 +2504,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2534,7 +2534,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2564,7 +2564,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2594,7 +2594,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2624,7 +2624,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2654,7 +2654,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2684,7 +2684,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2714,7 +2714,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2744,7 +2744,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2774,7 +2774,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2804,7 +2804,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2834,7 +2834,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2864,7 +2864,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2894,7 +2894,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2924,7 +2924,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2954,7 +2954,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2984,7 +2984,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3014,7 +3014,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3044,7 +3044,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3074,7 +3074,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3104,7 +3104,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3134,7 +3134,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3164,7 +3164,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3194,9 +3194,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3224,9 +3234,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3254,9 +3274,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3284,9 +3314,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3297,7 +3337,7 @@ variants:
     name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
+      end: 0x20024000
     cores:
     - main
   flash_algorithms:
@@ -3314,7 +3354,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3344,7 +3384,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3374,7 +3414,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3404,7 +3444,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3434,7 +3474,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3464,7 +3504,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3494,7 +3534,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3524,7 +3564,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3554,9 +3594,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3584,9 +3634,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3614,9 +3674,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3644,9 +3714,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3674,7 +3754,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3704,7 +3784,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3734,7 +3814,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3764,7 +3844,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3794,7 +3874,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3824,7 +3904,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3854,7 +3934,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3884,7 +3964,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3914,9 +3994,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3944,9 +4034,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3974,9 +4074,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -4004,9 +4114,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -4034,7 +4154,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -4064,7 +4184,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4094,9 +4214,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -4124,9 +4254,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -4154,7 +4294,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -4184,7 +4324,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -4214,7 +4354,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -4244,7 +4384,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4274,7 +4414,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4304,7 +4444,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4334,9 +4474,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -4364,9 +4514,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -4394,9 +4554,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -4424,7 +4594,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -4454,7 +4624,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -4484,7 +4654,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4514,7 +4684,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4544,9 +4714,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -4574,9 +4754,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -4604,7 +4794,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4634,7 +4824,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4664,7 +4854,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4694,7 +4884,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4724,9 +4914,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -4754,9 +4954,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -4784,9 +4994,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -4814,9 +5034,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -4844,7 +5074,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4874,7 +5104,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4904,7 +5134,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4934,7 +5164,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4964,9 +5194,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -4994,9 +5234,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -5024,9 +5274,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -5054,9 +5314,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -5084,7 +5354,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -5114,9 +5384,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -5144,9 +5424,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -5174,7 +5464,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -5204,7 +5494,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -5234,7 +5524,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -5264,9 +5554,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -5294,9 +5594,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -5324,9 +5634,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -5354,7 +5674,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -5384,7 +5704,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -5414,9 +5734,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -5444,9 +5774,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main

--- a/probe-rs/targets/STM32G4_Series.yaml
+++ b/probe-rs/targets/STM32G4_Series.yaml
@@ -14,7 +14,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -24,9 +24,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -43,7 +64,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -53,9 +74,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -72,7 +114,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -82,9 +124,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -101,7 +164,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -111,9 +174,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -130,7 +214,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -140,9 +224,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -159,7 +264,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -169,9 +274,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -188,7 +314,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -198,9 +324,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -217,7 +364,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -227,9 +374,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -246,7 +414,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -256,9 +424,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -275,7 +464,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -285,9 +474,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -304,7 +514,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -314,9 +524,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -333,7 +564,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -343,9 +574,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -362,7 +614,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -372,9 +624,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -391,7 +664,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -401,9 +674,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -420,7 +714,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -430,9 +724,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -449,7 +764,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -459,9 +774,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -478,7 +814,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -488,9 +824,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -507,7 +864,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -517,9 +874,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -536,7 +914,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -546,9 +924,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -565,7 +964,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -575,9 +974,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -594,7 +1014,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -604,9 +1024,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -623,7 +1064,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -633,9 +1074,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -652,7 +1114,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -662,9 +1124,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -681,7 +1164,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -691,9 +1174,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -710,7 +1214,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -720,9 +1224,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -739,7 +1264,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -749,9 +1274,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -768,7 +1314,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -778,9 +1324,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -797,7 +1364,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -807,9 +1374,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -826,7 +1414,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -836,9 +1424,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -855,7 +1464,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -865,9 +1474,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -884,7 +1514,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -894,9 +1524,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -913,7 +1564,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -923,9 +1574,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -942,7 +1614,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -952,9 +1624,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -971,7 +1664,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -981,9 +1674,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10002800
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20004000
+      end: 0x20005800
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20005800
       end: 0x20008000
     cores:
     - main
@@ -1000,7 +1714,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1010,9 +1724,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1029,7 +1764,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1039,9 +1774,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1058,7 +1814,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1068,9 +1824,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1087,7 +1864,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1097,9 +1874,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1116,7 +1914,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1126,9 +1924,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1145,7 +1964,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1155,9 +1974,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1174,7 +2014,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1184,9 +2024,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1203,7 +2064,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1213,9 +2074,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1232,7 +2114,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1242,9 +2124,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1261,7 +2164,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1271,9 +2174,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1290,7 +2214,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1300,9 +2224,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1319,7 +2264,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1329,9 +2274,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1348,7 +2314,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1358,9 +2324,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1377,7 +2364,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1387,9 +2374,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1406,7 +2414,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1416,9 +2424,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1435,7 +2464,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1445,9 +2474,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1464,7 +2514,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1474,9 +2524,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1493,7 +2564,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1503,9 +2574,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1522,7 +2614,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1532,9 +2624,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1551,7 +2664,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1561,9 +2674,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1580,7 +2714,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1590,9 +2724,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1609,7 +2764,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1619,9 +2774,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1638,7 +2814,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1648,9 +2824,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1667,7 +2864,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1677,9 +2874,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1696,7 +2914,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1706,9 +2924,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1725,7 +2964,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1735,9 +2974,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1754,7 +3014,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1764,9 +3024,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1783,7 +3064,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1793,9 +3074,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1812,7 +3114,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1822,9 +3124,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1841,7 +3164,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1851,9 +3174,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1870,7 +3214,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1880,9 +3224,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1899,7 +3264,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1909,9 +3274,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1928,7 +3314,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1938,9 +3324,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1957,7 +3364,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1967,9 +3374,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -1986,7 +3414,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1996,9 +3424,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2015,7 +3464,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2025,9 +3474,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2044,7 +3514,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2054,9 +3524,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2073,7 +3564,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2083,9 +3574,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2102,7 +3614,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2112,9 +3624,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2131,7 +3664,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2141,9 +3674,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2160,7 +3714,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2170,9 +3724,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2189,7 +3764,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2199,9 +3774,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2218,7 +3814,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2228,9 +3824,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2247,7 +3864,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2257,9 +3874,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2276,7 +3914,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2286,9 +3924,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2305,7 +3964,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2315,9 +3974,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2334,7 +4014,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2344,9 +4024,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2363,7 +4064,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2373,9 +4074,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2392,7 +4114,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2402,9 +4124,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2421,7 +4164,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2431,9 +4174,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2450,7 +4214,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2460,9 +4224,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2479,7 +4264,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2489,9 +4274,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2508,7 +4314,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2518,9 +4324,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2537,7 +4364,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2547,9 +4374,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2566,7 +4414,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2576,9 +4424,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2595,7 +4464,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2605,9 +4474,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2624,7 +4514,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2634,9 +4524,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2653,7 +4564,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2663,9 +4574,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2682,7 +4614,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2692,9 +4624,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2711,7 +4664,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2721,9 +4674,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2740,7 +4714,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2750,9 +4724,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2769,7 +4764,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2779,9 +4774,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2798,7 +4814,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2808,9 +4824,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2827,7 +4864,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2837,9 +4874,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2856,7 +4914,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2866,9 +4924,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2885,7 +4964,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2895,9 +4974,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2914,7 +5014,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2924,9 +5024,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2943,7 +5064,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2953,9 +5074,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -2972,7 +5114,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2982,9 +5124,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3001,7 +5164,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3011,9 +5174,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3030,7 +5214,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3040,9 +5224,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3059,7 +5264,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3069,9 +5274,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3088,7 +5314,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3098,9 +5324,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3117,7 +5364,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3127,9 +5374,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3146,7 +5414,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3156,9 +5424,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3175,7 +5464,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3185,9 +5474,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3204,7 +5514,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3214,9 +5524,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3233,7 +5564,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3243,9 +5574,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3262,7 +5614,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3272,9 +5624,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3291,7 +5664,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3301,9 +5674,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3320,7 +5714,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3330,9 +5724,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3349,7 +5764,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3359,9 +5774,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3378,7 +5814,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3388,9 +5824,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3407,7 +5864,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3417,9 +5874,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3436,7 +5914,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3446,9 +5924,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3465,7 +5964,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3475,9 +5974,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3494,7 +6014,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3504,9 +6024,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3523,7 +6064,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3533,9 +6074,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3552,7 +6114,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3562,9 +6124,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3581,7 +6164,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3591,9 +6174,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3610,7 +6214,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3620,9 +6224,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3639,7 +6264,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3649,9 +6274,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3668,7 +6314,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3678,9 +6324,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x20020000
     cores:
     - main
@@ -3697,7 +6364,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3707,9 +6374,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -3726,7 +6414,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3736,9 +6424,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -3755,7 +6464,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3765,9 +6474,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -3784,7 +6514,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3794,9 +6524,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -3813,7 +6564,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3823,9 +6574,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -3842,7 +6614,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3852,9 +6624,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -3871,7 +6664,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3881,9 +6674,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -3900,7 +6714,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3910,9 +6724,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -3929,7 +6764,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3939,9 +6774,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -3958,7 +6814,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3968,9 +6824,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -3987,7 +6864,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3997,9 +6874,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4016,7 +6914,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4026,9 +6924,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4045,7 +6964,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4055,9 +6974,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4074,7 +7014,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4084,9 +7024,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4103,7 +7064,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4113,9 +7074,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4132,7 +7114,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -4142,9 +7124,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4161,7 +7164,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4171,9 +7174,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4190,7 +7214,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4200,9 +7224,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4219,7 +7264,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4229,9 +7274,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4248,7 +7314,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4258,9 +7324,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4277,7 +7364,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4287,9 +7374,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4306,7 +7414,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4316,9 +7424,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4335,7 +7464,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4345,9 +7474,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4364,7 +7514,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4374,9 +7524,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4393,7 +7564,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4403,9 +7574,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main
@@ -4422,7 +7614,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4432,9 +7624,30 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM
+    name: CCMRAM_ICODE
+    range:
+      start: 0x10000000
+      end: 0x10004000
+    cores:
+    - main
+  - !Ram
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20014000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20014000
+      end: 0x20018000
+    cores:
+    - main
+  - !Ram
+    name: CCMRAM_DCODE
+    range:
+      start: 0x20018000
       end: 0x2001c000
     cores:
     - main

--- a/probe-rs/targets/STM32H5_Series.yaml
+++ b/probe-rs/targets/STM32H5_Series.yaml
@@ -14,9 +14,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8010000
       end: 0x8020000
     cores:
     - main
@@ -48,9 +58,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8010000
       end: 0x8020000
     cores:
     - main
@@ -82,9 +102,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8010000
       end: 0x8020000
     cores:
     - main
@@ -116,9 +146,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8010000
       end: 0x8020000
     cores:
     - main
@@ -150,9 +190,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8010000
       end: 0x8020000
     cores:
     - main
@@ -184,9 +234,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -194,9 +254,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -219,9 +286,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -229,9 +306,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -254,9 +338,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -264,9 +358,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -289,9 +390,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -299,9 +410,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -359,9 +477,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -369,9 +497,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -394,9 +529,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -404,9 +549,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -429,9 +581,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -439,9 +601,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -464,9 +633,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -474,9 +653,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -499,9 +685,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -509,9 +705,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -534,9 +737,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -544,9 +757,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -569,9 +789,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -579,9 +809,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -604,9 +841,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -614,9 +861,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -639,9 +893,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -649,9 +913,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -674,9 +945,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -684,9 +965,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -709,9 +997,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -719,9 +1017,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -744,9 +1049,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -754,9 +1069,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -814,9 +1136,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -824,9 +1156,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -849,9 +1188,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -859,9 +1208,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -884,9 +1240,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -894,9 +1260,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -919,9 +1292,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -929,9 +1312,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -954,9 +1344,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -964,9 +1364,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
       end: 0x20034000
     cores:
     - main
@@ -989,9 +1396,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -999,9 +1416,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1024,9 +1448,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1034,9 +1468,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1059,9 +1500,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -1069,9 +1520,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1094,9 +1552,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -1104,9 +1572,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1129,9 +1604,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1139,9 +1624,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1164,9 +1656,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1174,9 +1676,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1199,9 +1708,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -1209,9 +1728,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1234,9 +1760,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -1244,9 +1780,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1269,9 +1812,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1279,9 +1832,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1304,9 +1864,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1314,9 +1884,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1339,9 +1916,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -1349,9 +1936,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1374,9 +1968,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1384,9 +1988,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1409,9 +2020,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -1419,9 +2040,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1444,9 +2072,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1454,9 +2092,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1479,9 +2124,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -1489,9 +2144,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1514,9 +2176,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1524,9 +2196,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1549,9 +2228,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1559,9 +2248,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1584,9 +2280,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -1594,9 +2300,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1619,9 +2332,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -1629,9 +2352,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1654,9 +2384,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1664,9 +2404,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1689,9 +2436,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1699,9 +2456,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1724,9 +2488,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1734,9 +2508,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1759,9 +2540,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1769,9 +2560,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1794,9 +2592,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1804,9 +2612,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1829,9 +2644,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -1839,9 +2664,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1864,9 +2696,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -1874,9 +2716,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1899,9 +2748,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1909,9 +2768,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1934,9 +2800,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1944,9 +2820,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -1969,9 +2852,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -1979,9 +2872,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2004,9 +2904,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2014,9 +2924,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2039,9 +2956,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2049,9 +2976,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2074,9 +3008,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -2084,9 +3028,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2109,9 +3060,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2119,9 +3080,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2144,9 +3112,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2154,9 +3132,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2179,9 +3164,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2189,9 +3184,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2214,9 +3216,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2224,9 +3236,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2249,9 +3268,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2259,9 +3288,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2284,9 +3320,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2294,9 +3340,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2319,9 +3372,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2329,9 +3392,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2354,9 +3424,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2364,9 +3444,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2389,9 +3476,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2399,9 +3496,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2424,9 +3528,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2434,9 +3548,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2459,9 +3580,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2469,9 +3600,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2494,9 +3632,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2504,9 +3652,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2529,9 +3684,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2539,9 +3704,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2564,9 +3736,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2574,9 +3756,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main
@@ -2599,9 +3788,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2609,9 +3808,16 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM1
     range:
       start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
       end: 0x20050000
     cores:
     - main

--- a/probe-rs/targets/STM32H7RS_Series.yaml
+++ b/probe-rs/targets/STM32H7RS_Series.yaml
@@ -13,15 +13,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -30,40 +30,55 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: DTCM_RAM
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
-    access:
-      execute: false
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
+      end: 0x30004000
+    cores:
+    - main
+  - !Ram
+    name: AHB_SRAM2
+    range:
+      start: 0x30004000
       end: 0x30008000
     cores:
     - main
-    access:
-      execute: false
-  - !Generic
-    name: BKP_SRAM
-    range:
-      start: 0x38800000
-      end: 0x38801000
-    cores:
-    - main
-    access:
-      execute: false
   flash_algorithms:
   - stm32h7rx_64k
   - mx66uw1g45g_stm32h7s78-dk
@@ -77,15 +92,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -94,40 +109,55 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: DTCM_RAM
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
-    access:
-      execute: false
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
+      end: 0x30004000
+    cores:
+    - main
+  - !Ram
+    name: AHB_SRAM2
+    range:
+      start: 0x30004000
       end: 0x30008000
     cores:
     - main
-    access:
-      execute: false
-  - !Generic
-    name: BKP_SRAM
-    range:
-      start: 0x38800000
-      end: 0x38801000
-    cores:
-    - main
-    access:
-      execute: false
   flash_algorithms:
   - stm32h7rx_64k
   - mx66uw1g45g_stm32h7s78-dk
@@ -141,15 +171,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -158,40 +188,55 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: DTCM_RAM
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
-    access:
-      execute: false
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
+      end: 0x30004000
+    cores:
+    - main
+  - !Ram
+    name: AHB_SRAM2
+    range:
+      start: 0x30004000
       end: 0x30008000
     cores:
     - main
-    access:
-      execute: false
-  - !Generic
-    name: BKP_SRAM
-    range:
-      start: 0x38800000
-      end: 0x38801000
-    cores:
-    - main
-    access:
-      execute: false
   flash_algorithms:
   - stm32h7rx_64k
   - mx66uw1g45g_stm32h7s78-dk
@@ -205,15 +250,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -222,40 +267,55 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: DTCM_RAM
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
-    access:
-      execute: false
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
+      end: 0x30004000
+    cores:
+    - main
+  - !Ram
+    name: AHB_SRAM2
+    range:
+      start: 0x30004000
       end: 0x30008000
     cores:
     - main
-    access:
-      execute: false
-  - !Generic
-    name: BKP_SRAM
-    range:
-      start: 0x38800000
-      end: 0x38801000
-    cores:
-    - main
-    access:
-      execute: false
   flash_algorithms:
   - stm32h7rx_64k
   - mx66uw1g45g_stm32h7s78-dk
@@ -269,15 +329,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -286,40 +346,55 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: DTCM_RAM
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
-    access:
-      execute: false
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
+      end: 0x30004000
+    cores:
+    - main
+  - !Ram
+    name: AHB_SRAM2
+    range:
+      start: 0x30004000
       end: 0x30008000
     cores:
     - main
-    access:
-      execute: false
-  - !Generic
-    name: BKP_SRAM
-    range:
-      start: 0x38800000
-      end: 0x38801000
-    cores:
-    - main
-    access:
-      execute: false
   flash_algorithms:
   - stm32h7rx_64k
   - mx66uw1g45g_stm32h7s78-dk
@@ -333,15 +408,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -350,40 +425,55 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: DTCM_RAM
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
-    access:
-      execute: false
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
+      end: 0x30004000
+    cores:
+    - main
+  - !Ram
+    name: AHB_SRAM2
+    range:
+      start: 0x30004000
       end: 0x30008000
     cores:
     - main
-    access:
-      execute: false
-  - !Generic
-    name: BKP_SRAM
-    range:
-      start: 0x38800000
-      end: 0x38801000
-    cores:
-    - main
-    access:
-      execute: false
   flash_algorithms:
   - stm32h7rx_64k
   - mx66uw1g45g_stm32h7s78-dk
@@ -397,15 +487,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -414,40 +504,55 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: DTCM_RAM
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
-    access:
-      execute: false
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
+      end: 0x30004000
+    cores:
+    - main
+  - !Ram
+    name: AHB_SRAM2
+    range:
+      start: 0x30004000
       end: 0x30008000
     cores:
     - main
-    access:
-      execute: false
-  - !Generic
-    name: BKP_SRAM
-    range:
-      start: 0x38800000
-      end: 0x38801000
-    cores:
-    - main
-    access:
-      execute: false
   flash_algorithms:
   - stm32h7rx_64k
   - mx66uw1g45g_stm32h7s78-dk
@@ -461,15 +566,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -478,40 +583,55 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: DTCM_RAM
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
-    access:
-      execute: false
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
+      end: 0x30004000
+    cores:
+    - main
+  - !Ram
+    name: AHB_SRAM2
+    range:
+      start: 0x30004000
       end: 0x30008000
     cores:
     - main
-    access:
-      execute: false
-  - !Generic
-    name: BKP_SRAM
-    range:
-      start: 0x38800000
-      end: 0x38801000
-    cores:
-    - main
-    access:
-      execute: false
   flash_algorithms:
   - stm32h7rx_64k
   - mx66uw1g45g_stm32h7s78-dk
@@ -525,15 +645,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -542,40 +662,55 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: DTCM_RAM
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
-    access:
-      execute: false
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
+      end: 0x30004000
+    cores:
+    - main
+  - !Ram
+    name: AHB_SRAM2
+    range:
+      start: 0x30004000
       end: 0x30008000
     cores:
     - main
-    access:
-      execute: false
-  - !Generic
-    name: BKP_SRAM
-    range:
-      start: 0x38800000
-      end: 0x38801000
-    cores:
-    - main
-    access:
-      execute: false
   flash_algorithms:
   - stm32h7rx_64k
   - mx66uw1g45g_stm32h7s78-dk
@@ -589,15 +724,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -606,40 +741,55 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: DTCM_RAM
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
-    access:
-      execute: false
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
+      end: 0x30004000
+    cores:
+    - main
+  - !Ram
+    name: AHB_SRAM2
+    range:
+      start: 0x30004000
       end: 0x30008000
     cores:
     - main
-    access:
-      execute: false
-  - !Generic
-    name: BKP_SRAM
-    range:
-      start: 0x38800000
-      end: 0x38801000
-    cores:
-    - main
-    access:
-      execute: false
   flash_algorithms:
   - stm32h7rx_64k
   - mx66uw1g45g_stm32h7s78-dk
@@ -653,15 +803,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -670,40 +820,55 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: DTCM_RAM
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
-    access:
-      execute: false
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
+      end: 0x30004000
+    cores:
+    - main
+  - !Ram
+    name: AHB_SRAM2
+    range:
+      start: 0x30004000
       end: 0x30008000
     cores:
     - main
-    access:
-      execute: false
-  - !Generic
-    name: BKP_SRAM
-    range:
-      start: 0x38800000
-      end: 0x38801000
-    cores:
-    - main
-    access:
-      execute: false
   flash_algorithms:
   - stm32h7rx_64k
   - mx66uw1g45g_stm32h7s78-dk
@@ -717,15 +882,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -735,31 +900,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -775,15 +961,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -793,31 +979,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -833,15 +1040,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -851,31 +1058,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -891,15 +1119,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -909,31 +1137,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -949,15 +1198,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -967,31 +1216,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1007,15 +1277,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1025,31 +1295,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1065,15 +1356,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1083,31 +1374,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1123,15 +1435,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1141,31 +1453,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1181,15 +1514,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1199,31 +1532,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1239,15 +1593,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1257,31 +1611,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1297,15 +1672,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1315,31 +1690,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1355,15 +1751,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1373,31 +1769,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1413,15 +1830,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1431,31 +1848,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1471,15 +1909,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1489,31 +1927,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1529,15 +1988,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1547,31 +2006,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1587,15 +2067,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1605,31 +2085,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1645,15 +2146,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1663,31 +2164,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1703,15 +2225,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1721,31 +2243,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1761,15 +2304,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1779,31 +2322,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1819,15 +2383,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1837,31 +2401,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1877,15 +2462,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1895,31 +2480,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1935,15 +2541,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1953,31 +2559,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:
@@ -1993,15 +2620,15 @@ variants:
       ap: 1
       psel: 0x0
   memory_map:
-  - !Generic
-    name: ITCM_RAM
+  - !Ram
+    name: ITCM
     range:
       start: 0x0
-      end: 0x10000
+      end: 0x30000
     cores:
     - main
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2011,31 +2638,52 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCM_RAM
+    name: DTCM
     range:
       start: 0x20000000
-      end: 0x20010000
+      end: 0x20030000
     cores:
     - main
   - !Ram
-    name: AXI_SRAM
+    name: SRAM1
     range:
       start: 0x24000000
+      end: 0x24020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x24020000
+      end: 0x24040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x24040000
+      end: 0x24060000
+    cores:
+    - main
+  - !Ram
+    name: SRAM4
+    range:
+      start: 0x24060000
       end: 0x24072000
     cores:
     - main
   - !Ram
-    name: AHB_SRAM
+    name: AHB_SRAM1
     range:
       start: 0x30000000
-      end: 0x30008000
+      end: 0x30004000
     cores:
     - main
-  - !Generic
-    name: BKP_SRAM
+  - !Ram
+    name: AHB_SRAM2
     range:
-      start: 0x38800000
-      end: 0x38801000
+      start: 0x30004000
+      end: 0x30008000
     cores:
     - main
   flash_algorithms:

--- a/probe-rs/targets/STM32H7_Series.yaml
+++ b/probe-rs/targets/STM32H7_Series.yaml
@@ -13,8 +13,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -24,7 +31,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -75,8 +82,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -86,7 +100,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -137,8 +151,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -148,7 +169,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -199,8 +220,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -210,7 +238,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -261,8 +289,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -272,7 +307,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -323,8 +358,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -334,7 +376,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -385,8 +427,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -396,7 +445,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -447,8 +496,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -458,7 +514,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -509,8 +565,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -520,7 +583,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -571,8 +634,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -582,7 +652,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -633,8 +703,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -644,7 +721,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -695,8 +772,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -706,7 +790,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -757,8 +841,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -768,7 +859,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -819,8 +910,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -830,7 +928,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -881,8 +979,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -892,7 +997,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -943,8 +1048,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -954,7 +1066,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1005,8 +1117,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1016,7 +1135,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1067,8 +1186,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1078,7 +1204,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1129,8 +1255,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1140,7 +1273,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1191,8 +1324,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1202,7 +1342,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1253,8 +1393,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1264,7 +1411,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1315,8 +1462,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1326,7 +1480,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1377,8 +1531,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1388,7 +1549,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1439,8 +1600,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1450,7 +1618,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1501,8 +1669,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1512,7 +1687,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1563,8 +1738,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1574,7 +1756,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1625,8 +1807,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1636,7 +1825,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1687,8 +1876,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1698,7 +1894,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1749,8 +1945,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1760,7 +1963,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1811,8 +2014,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1822,7 +2032,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1873,8 +2083,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1884,7 +2101,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1935,8 +2152,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1946,7 +2170,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -1997,8 +2221,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2008,7 +2239,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2059,8 +2290,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2070,7 +2308,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2121,8 +2359,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2132,7 +2377,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2183,8 +2428,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2194,7 +2446,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2245,8 +2497,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2256,7 +2515,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2307,8 +2566,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2318,7 +2584,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2369,8 +2635,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2380,7 +2653,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2431,8 +2704,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2442,7 +2722,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2493,8 +2773,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2504,7 +2791,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2555,8 +2842,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2566,7 +2860,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2617,8 +2911,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2628,7 +2929,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -2638,7 +2939,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2659,7 +2960,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -2696,8 +2997,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2707,7 +3015,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -2717,7 +3025,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2738,7 +3046,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -2775,8 +3083,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2786,7 +3101,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -2796,7 +3111,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2817,7 +3132,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -2854,8 +3169,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2865,7 +3187,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -2875,7 +3197,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2896,7 +3218,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -2933,8 +3255,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2944,7 +3273,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -2954,7 +3283,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -2975,7 +3304,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -3012,8 +3341,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3023,7 +3359,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -3033,7 +3369,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -3054,7 +3390,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -3091,8 +3427,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3102,7 +3445,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -3112,7 +3455,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -3133,7 +3476,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -3170,8 +3513,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3181,7 +3531,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -3191,7 +3541,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -3212,7 +3562,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -3249,8 +3599,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3260,7 +3617,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -3270,7 +3627,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -3291,7 +3648,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -3328,8 +3685,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3339,7 +3703,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -3349,7 +3713,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -3370,7 +3734,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -3407,8 +3771,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3418,7 +3789,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -3428,7 +3799,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -3449,7 +3820,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -3486,8 +3857,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3497,7 +3875,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -3507,7 +3885,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -3528,7 +3906,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -3565,8 +3943,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3576,7 +3961,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -3586,7 +3971,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -3607,7 +3992,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -3644,8 +4029,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3655,7 +4047,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -3665,7 +4057,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -3686,7 +4078,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -3723,8 +4115,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3734,7 +4133,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -3744,7 +4143,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -3765,7 +4164,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -3802,8 +4201,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3813,7 +4219,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -3823,7 +4229,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -3844,7 +4250,7 @@ variants:
     cores:
     - main
   - !Ram
-    name: RAM_D2S2
+    name: RAM2_D2
     range:
       start: 0x30020000
       end: 0x30024000
@@ -3881,8 +4287,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3892,7 +4305,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -3902,7 +4315,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -3953,8 +4366,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -3964,7 +4384,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -3974,7 +4394,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -4025,8 +4445,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4036,7 +4463,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -4046,7 +4473,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -4097,8 +4524,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4108,7 +4542,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -4118,7 +4552,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -4169,8 +4603,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4180,7 +4621,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -4190,7 +4631,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -4241,8 +4682,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4252,7 +4700,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -4262,7 +4710,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -4313,8 +4761,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4324,7 +4779,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -4334,7 +4789,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -4385,8 +4840,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4396,7 +4858,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -4406,7 +4868,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -4457,8 +4919,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4468,7 +4937,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -4478,7 +4947,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -4529,8 +4998,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4540,7 +5016,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -4550,7 +5026,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -4601,8 +5077,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4612,7 +5095,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -4622,7 +5105,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -4673,8 +5156,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4684,7 +5174,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -4694,7 +5184,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -4745,8 +5235,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4756,7 +5253,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -4766,7 +5263,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -4817,8 +5314,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4828,7 +5332,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -4838,7 +5342,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -4889,8 +5393,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4900,7 +5411,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -4910,7 +5421,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -4961,8 +5472,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -4972,7 +5490,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -4982,7 +5500,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -5038,22 +5556,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
-  - !Nvm
-    name: FLASH_Bank1
+  - !Ram
+    name: ITCM
     range:
-      start: 0x8000000
-      end: 0x8080000
+      start: 0x0
+      end: 0x10000
     cores:
     - cm7
+    - cm4
+  - !Nvm
+    name: BANK_1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
-      end: 0x8180000
+      end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -5064,18 +5592,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -5083,17 +5617,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -5123,22 +5647,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -5149,18 +5683,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -5168,17 +5708,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -5208,22 +5738,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
-  - !Nvm
-    name: FLASH_Bank1
+  - !Ram
+    name: ITCM
     range:
-      start: 0x8000000
-      end: 0x8080000
+      start: 0x0
+      end: 0x10000
     cores:
     - cm7
+    - cm4
+  - !Nvm
+    name: BANK_1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
-      end: 0x8180000
+      end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -5234,18 +5774,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -5253,17 +5799,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -5293,22 +5829,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
-  - !Nvm
-    name: FLASH_Bank1
+  - !Ram
+    name: ITCM
     range:
-      start: 0x8000000
-      end: 0x8080000
+      start: 0x0
+      end: 0x10000
     cores:
     - cm7
+    - cm4
+  - !Nvm
+    name: BANK_1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
-      end: 0x8180000
+      end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -5319,18 +5865,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -5338,17 +5890,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -5378,22 +5920,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -5404,18 +5956,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -5423,17 +5981,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -5463,22 +6011,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -5489,18 +6047,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -5508,17 +6072,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -5548,22 +6102,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
-  - !Nvm
-    name: FLASH_Bank1
+  - !Ram
+    name: ITCM
     range:
-      start: 0x8000000
-      end: 0x8080000
+      start: 0x0
+      end: 0x10000
     cores:
     - cm7
+    - cm4
+  - !Nvm
+    name: BANK_1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
-      end: 0x8180000
+      end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -5574,18 +6138,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -5593,17 +6163,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -5633,22 +6193,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -5659,18 +6229,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -5678,17 +6254,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -5718,22 +6284,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
-  - !Nvm
-    name: FLASH_Bank1
+  - !Ram
+    name: ITCM
     range:
-      start: 0x8000000
-      end: 0x8080000
+      start: 0x0
+      end: 0x10000
     cores:
     - cm7
+    - cm4
+  - !Nvm
+    name: BANK_1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
-      end: 0x8180000
+      end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -5744,18 +6320,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -5763,17 +6345,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -5803,22 +6375,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -5829,18 +6411,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -5848,17 +6436,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -5888,22 +6466,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
-  - !Nvm
-    name: FLASH_Bank1
+  - !Ram
+    name: ITCM
     range:
-      start: 0x8000000
-      end: 0x8080000
+      start: 0x0
+      end: 0x10000
     cores:
     - cm7
+    - cm4
+  - !Nvm
+    name: BANK_1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
-      end: 0x8180000
+      end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -5914,18 +6502,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -5933,17 +6527,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -5973,22 +6557,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -5999,18 +6593,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -6018,17 +6618,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -6058,22 +6648,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
-  - !Nvm
-    name: FLASH_Bank1
+  - !Ram
+    name: ITCM
     range:
-      start: 0x8000000
-      end: 0x8080000
+      start: 0x0
+      end: 0x10000
     cores:
     - cm7
+    - cm4
+  - !Nvm
+    name: BANK_1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
-      end: 0x8180000
+      end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -6084,18 +6684,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -6103,17 +6709,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -6143,22 +6739,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -6169,18 +6775,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -6188,17 +6800,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -6228,22 +6830,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
-  - !Nvm
-    name: FLASH_Bank1
+  - !Ram
+    name: ITCM
     range:
-      start: 0x8000000
-      end: 0x8080000
+      start: 0x0
+      end: 0x10000
     cores:
     - cm7
+    - cm4
+  - !Nvm
+    name: BANK_1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
-      end: 0x8180000
+      end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -6254,18 +6866,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -6273,17 +6891,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -6313,22 +6921,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -6339,18 +6957,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -6358,17 +6982,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -6398,22 +7012,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
-  - !Nvm
-    name: FLASH_Bank1
+  - !Ram
+    name: ITCM
     range:
-      start: 0x8000000
-      end: 0x8080000
+      start: 0x0
+      end: 0x10000
     cores:
     - cm7
+    - cm4
+  - !Nvm
+    name: BANK_1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
-      end: 0x8180000
+      end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -6424,18 +7048,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -6443,17 +7073,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -6483,22 +7103,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -6509,18 +7139,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -6528,17 +7164,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -6568,22 +7194,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -6594,18 +7230,24 @@ variants:
       start: 0x10000000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -6613,17 +7255,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -6648,8 +7280,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -6659,7 +7298,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -6710,8 +7349,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -6721,7 +7367,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -6772,8 +7418,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -6783,7 +7436,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -6834,8 +7487,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -6845,7 +7505,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -6896,8 +7556,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -6907,7 +7574,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -6958,8 +7625,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -6969,7 +7643,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -6979,7 +7653,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -7030,8 +7704,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7041,7 +7722,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -7051,7 +7732,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -7102,8 +7783,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7113,7 +7801,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -7123,7 +7811,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -7174,8 +7862,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7185,7 +7880,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -7195,7 +7890,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -7246,8 +7941,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7257,7 +7959,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -7267,7 +7969,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -7318,8 +8020,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7329,7 +8038,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -7339,7 +8048,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -7390,8 +8099,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7401,7 +8117,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -7411,7 +8127,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -7462,8 +8178,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7473,7 +8196,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -7483,7 +8206,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
@@ -7539,22 +8262,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -7563,29 +8296,26 @@ variants:
     name: RAM_D2
     range:
       start: 0x10000000
-      end: 0x10030000
-    cores:
-    - cm4
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D2S3
-    range:
-      start: 0x10040000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -7593,17 +8323,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -7633,22 +8353,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -7657,29 +8387,26 @@ variants:
     name: RAM_D2
     range:
       start: 0x10000000
-      end: 0x10030000
-    cores:
-    - cm4
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D2S3
-    range:
-      start: 0x10040000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -7687,17 +8414,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -7727,22 +8444,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -7751,29 +8478,26 @@ variants:
     name: RAM_D2
     range:
       start: 0x10000000
-      end: 0x10030000
-    cores:
-    - cm4
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D2S3
-    range:
-      start: 0x10040000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -7781,17 +8505,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -7821,22 +8535,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -7845,29 +8569,26 @@ variants:
     name: RAM_D2
     range:
       start: 0x10000000
-      end: 0x10030000
-    cores:
-    - cm4
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D2S3
-    range:
-      start: 0x10040000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -7875,17 +8596,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -7915,22 +8626,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -7939,29 +8660,26 @@ variants:
     name: RAM_D2
     range:
       start: 0x10000000
-      end: 0x10030000
-    cores:
-    - cm4
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D2S3
-    range:
-      start: 0x10040000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -7969,17 +8687,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -8009,22 +8717,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -8033,29 +8751,26 @@ variants:
     name: RAM_D2
     range:
       start: 0x10000000
-      end: 0x10030000
-    cores:
-    - cm4
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D2S3
-    range:
-      start: 0x10040000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -8063,17 +8778,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -8103,22 +8808,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -8127,29 +8842,26 @@ variants:
     name: RAM_D2
     range:
       start: 0x10000000
-      end: 0x10030000
-    cores:
-    - cm4
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D2S3
-    range:
-      start: 0x10040000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -8157,17 +8869,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -8197,22 +8899,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -8221,29 +8933,26 @@ variants:
     name: RAM_D2
     range:
       start: 0x10000000
-      end: 0x10030000
-    cores:
-    - cm4
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D2S3
-    range:
-      start: 0x10040000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -8251,17 +8960,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -8291,22 +8990,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -8315,29 +9024,26 @@ variants:
     name: RAM_D2
     range:
       start: 0x10000000
-      end: 0x10030000
-    cores:
-    - cm4
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D2S3
-    range:
-      start: 0x10040000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -8345,17 +9051,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -8385,22 +9081,32 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - cm7
+    - cm4
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - cm7
+    - cm4
     access:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
     cores:
+    - cm7
     - cm4
     access:
       write: false
@@ -8409,29 +9115,26 @@ variants:
     name: RAM_D2
     range:
       start: 0x10000000
-      end: 0x10030000
-    cores:
-    - cm4
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D2S3
-    range:
-      start: 0x10040000
       end: 0x10048000
     cores:
+    - cm7
     - cm4
-    access:
-      execute: false
   - !Ram
-    name: DTCMRAM
+    name: RAM_D3
+    range:
+      start: 0x18000000
+      end: 0x18010000
+    cores:
+    - cm7
+    - cm4
+  - !Ram
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - cm7
-    access:
-      execute: false
+    - cm4
   - !Ram
     name: RAM_D1
     range:
@@ -8439,17 +9142,7 @@ variants:
       end: 0x24080000
     cores:
     - cm7
-    access:
-      execute: false
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38010000
-    cores:
-    - cm7
-    access:
-      execute: false
+    - cm4
   flash_algorithms:
   - stm32h7x_2048
   - stm32h7b3i_eval_fmc-nor
@@ -8618,8 +9311,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -8629,7 +9329,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -8639,31 +9339,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -8762,8 +9448,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -8773,7 +9466,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -8783,31 +9476,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -8906,8 +9585,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8917,7 +9603,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -8927,31 +9613,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -9050,8 +9722,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9061,7 +9740,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -9071,31 +9750,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -9338,8 +10003,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -9349,7 +10021,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -9359,31 +10031,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -9410,8 +10068,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9421,7 +10086,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -9431,31 +10096,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -9554,8 +10205,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -9565,7 +10223,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -9575,31 +10233,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -9626,8 +10270,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9637,7 +10288,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -9647,31 +10298,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -9698,8 +10335,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -9709,7 +10353,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -9719,31 +10363,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -9842,8 +10472,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -9853,7 +10490,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -9863,31 +10500,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -9986,8 +10609,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9997,7 +10627,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -10007,31 +10637,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -10130,8 +10746,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -10141,7 +10764,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -10151,31 +10774,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -10274,8 +10883,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -10285,7 +10901,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8180000
@@ -10295,31 +10911,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -10418,8 +11020,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -10429,7 +11038,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -10439,31 +11048,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -10562,8 +11157,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -10573,31 +11175,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -10686,8 +11274,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -10697,31 +11292,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -10748,8 +11329,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -10759,31 +11347,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -10810,8 +11384,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -10821,31 +11402,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -10872,8 +11439,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -10883,31 +11457,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -11006,8 +11566,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -11017,7 +11584,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -11027,31 +11594,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -11150,8 +11703,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -11161,7 +11721,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -11171,31 +11731,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -11366,8 +11912,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -11377,7 +11930,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -11387,31 +11940,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -11510,8 +12049,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -11521,7 +12067,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -11531,31 +12077,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -11582,8 +12114,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -11593,7 +12132,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -11603,31 +12142,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -11726,8 +12251,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -11737,7 +12269,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -11747,31 +12279,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:
@@ -11870,8 +12388,15 @@ variants:
       ap: 0
       psel: 0x0
   memory_map:
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x10000
+    cores:
+    - main
   - !Nvm
-    name: FLASH_Bank1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -11881,7 +12406,7 @@ variants:
       write: false
       boot: true
   - !Nvm
-    name: FLASH_Bank2
+    name: BANK_2
     range:
       start: 0x8100000
       end: 0x8200000
@@ -11891,31 +12416,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: DTCMRAM
+    name: DTCM
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Ram
-    name: RAM_D1
+    name: SRAM
     range:
       start: 0x24000000
       end: 0x24100000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D2
-    range:
-      start: 0x30000000
-      end: 0x30020000
-    cores:
-    - main
-  - !Ram
-    name: RAM_D3
-    range:
-      start: 0x38000000
-      end: 0x38008000
     cores:
     - main
   flash_algorithms:

--- a/probe-rs/targets/STM32L0_Series.yaml
+++ b/probe-rs/targets/STM32L0_Series.yaml
@@ -14,7 +14,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -24,7 +24,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -43,7 +43,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -53,7 +53,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -72,7 +72,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -82,7 +82,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -101,7 +101,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -111,7 +111,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -130,7 +130,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -140,7 +140,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -159,7 +159,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -169,7 +169,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -188,7 +188,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8002000
@@ -198,7 +198,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -217,7 +217,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -227,7 +227,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -246,7 +246,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8002000
@@ -256,7 +256,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -275,7 +275,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -285,7 +285,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -304,7 +304,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8002000
@@ -314,7 +314,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -333,7 +333,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8002000
@@ -343,7 +343,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -362,7 +362,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -372,7 +372,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -391,7 +391,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -401,7 +401,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -420,7 +420,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8002000
@@ -430,7 +430,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -449,7 +449,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -459,7 +459,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -478,7 +478,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8002000
@@ -488,7 +488,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -507,7 +507,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8002000
@@ -517,7 +517,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -536,7 +536,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -546,7 +546,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -565,7 +565,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -575,7 +575,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -594,7 +594,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -604,7 +604,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -623,7 +623,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -633,7 +633,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -652,7 +652,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -662,7 +662,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -681,7 +681,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -691,7 +691,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20000800
@@ -710,7 +710,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -720,7 +720,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -739,7 +739,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -749,7 +749,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -768,7 +768,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -778,7 +778,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -797,7 +797,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -807,7 +807,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -826,7 +826,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -836,7 +836,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -855,7 +855,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -865,7 +865,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -884,7 +884,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -894,7 +894,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -913,7 +913,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -923,7 +923,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -942,7 +942,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -952,7 +952,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -971,7 +971,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -981,7 +981,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1000,7 +1000,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1010,7 +1010,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1029,7 +1029,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -1039,7 +1039,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1058,7 +1058,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1068,7 +1068,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1087,7 +1087,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1097,7 +1097,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1116,7 +1116,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1126,7 +1126,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1145,7 +1145,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1155,7 +1155,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1174,7 +1174,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1184,7 +1184,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1203,7 +1203,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1213,7 +1213,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1232,7 +1232,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1242,7 +1242,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1261,7 +1261,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1271,7 +1271,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1290,7 +1290,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1300,7 +1300,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1319,7 +1319,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1329,7 +1329,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1348,7 +1348,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1358,7 +1358,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1377,7 +1377,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1387,7 +1387,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1406,7 +1406,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1416,7 +1416,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1435,7 +1435,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1445,7 +1445,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1464,7 +1464,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1474,7 +1474,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1493,7 +1493,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1503,7 +1503,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1522,7 +1522,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1532,7 +1532,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1551,7 +1551,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1561,7 +1561,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1580,7 +1580,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1590,7 +1590,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1609,7 +1609,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1619,7 +1619,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1638,7 +1638,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1648,7 +1648,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1667,7 +1667,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1677,7 +1677,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1696,7 +1696,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1706,7 +1706,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1725,7 +1725,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1735,7 +1735,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1754,7 +1754,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1764,7 +1764,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1783,7 +1783,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1793,7 +1793,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1812,7 +1812,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1822,7 +1822,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1841,7 +1841,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1851,7 +1851,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1870,7 +1870,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1880,7 +1880,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1899,7 +1899,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1909,7 +1909,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1928,7 +1928,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1938,7 +1938,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1957,7 +1957,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1967,7 +1967,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -1986,7 +1986,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1996,7 +1996,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2015,7 +2015,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -2025,7 +2025,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2044,7 +2044,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2054,7 +2054,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2073,7 +2073,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2083,7 +2083,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2102,7 +2102,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -2112,7 +2112,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2131,7 +2131,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2141,7 +2141,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2160,7 +2160,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2170,7 +2170,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2189,7 +2189,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -2199,7 +2199,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2218,7 +2218,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -2228,7 +2228,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2247,7 +2247,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2257,7 +2257,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2276,7 +2276,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2286,7 +2286,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2305,7 +2305,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -2315,7 +2315,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2334,7 +2334,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -2344,7 +2344,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2363,7 +2363,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2373,7 +2373,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2392,7 +2392,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2402,7 +2402,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2421,7 +2421,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2431,7 +2431,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2450,7 +2450,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2460,7 +2460,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2479,7 +2479,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2489,7 +2489,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2508,7 +2508,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2518,7 +2518,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2537,7 +2537,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2547,7 +2547,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2566,7 +2566,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2576,7 +2576,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -2595,7 +2595,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2605,7 +2605,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2624,7 +2624,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2634,7 +2634,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2653,7 +2653,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2663,7 +2663,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2682,7 +2682,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2692,7 +2692,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2711,7 +2711,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2721,7 +2721,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2740,7 +2740,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -2750,7 +2750,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2769,7 +2769,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -2779,7 +2779,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2798,7 +2798,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -2808,7 +2808,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2827,7 +2827,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2837,7 +2837,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2856,7 +2856,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2866,7 +2866,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2885,7 +2885,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2895,7 +2895,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2914,7 +2914,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -2924,7 +2924,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2943,7 +2943,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -2953,7 +2953,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -2972,7 +2972,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2982,7 +2982,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3001,7 +3001,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3011,7 +3011,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3030,7 +3030,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3040,7 +3040,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3059,7 +3059,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3069,7 +3069,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3088,7 +3088,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -3098,7 +3098,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3117,7 +3117,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3127,7 +3127,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3146,7 +3146,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3156,7 +3156,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3175,7 +3175,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3185,7 +3185,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3204,7 +3204,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3214,7 +3214,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3233,7 +3233,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3243,7 +3243,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3262,7 +3262,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3272,7 +3272,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3291,7 +3291,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3301,7 +3301,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3320,7 +3320,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3330,7 +3330,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3349,7 +3349,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3359,7 +3359,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3378,7 +3378,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3388,7 +3388,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3407,7 +3407,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3417,7 +3417,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3436,7 +3436,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3446,7 +3446,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3465,7 +3465,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3475,7 +3475,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3494,7 +3494,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3504,7 +3504,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3523,7 +3523,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3533,7 +3533,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3552,7 +3552,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3562,7 +3562,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3581,7 +3581,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3591,7 +3591,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3610,7 +3610,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3620,7 +3620,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3639,7 +3639,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -3649,7 +3649,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3668,7 +3668,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -3678,7 +3678,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3697,7 +3697,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3707,7 +3707,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3726,7 +3726,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3736,7 +3736,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3755,7 +3755,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3765,7 +3765,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3784,7 +3784,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3794,7 +3794,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3813,7 +3813,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3823,7 +3823,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3842,7 +3842,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3852,7 +3852,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3871,7 +3871,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3881,7 +3881,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3900,7 +3900,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3910,7 +3910,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3929,7 +3929,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -3939,7 +3939,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3958,7 +3958,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3968,7 +3968,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -3987,7 +3987,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3997,7 +3997,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4016,7 +4016,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4026,7 +4026,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4045,7 +4045,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4055,7 +4055,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4074,7 +4074,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4084,7 +4084,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4103,7 +4103,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -4113,7 +4113,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4132,7 +4132,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -4142,7 +4142,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4161,7 +4161,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4171,7 +4171,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4190,7 +4190,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4200,7 +4200,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4219,7 +4219,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -4229,7 +4229,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4248,7 +4248,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4258,7 +4258,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4277,7 +4277,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4287,7 +4287,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4306,7 +4306,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4316,7 +4316,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4335,7 +4335,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4345,7 +4345,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4364,7 +4364,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4374,7 +4374,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4393,7 +4393,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4403,7 +4403,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4422,7 +4422,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -4432,7 +4432,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4451,7 +4451,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4461,7 +4461,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4480,7 +4480,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4490,7 +4490,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4509,7 +4509,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -4519,7 +4519,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4538,7 +4538,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4548,7 +4548,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4567,7 +4567,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4577,7 +4577,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4596,7 +4596,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -4606,7 +4606,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4625,7 +4625,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -4635,7 +4635,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4654,7 +4654,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4664,7 +4664,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4683,7 +4683,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4693,7 +4693,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4712,7 +4712,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -4722,10 +4722,10 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20050000
+      end: 0x20005000
     cores:
     - main
   flash_algorithms:
@@ -4741,7 +4741,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -4751,7 +4751,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4770,7 +4770,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4780,7 +4780,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000
@@ -4799,7 +4799,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8030000
@@ -4809,7 +4809,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20005000

--- a/probe-rs/targets/STM32L1_Series.yaml
+++ b/probe-rs/targets/STM32L1_Series.yaml
@@ -14,7 +14,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -24,7 +24,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20001000
@@ -72,7 +72,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -82,7 +82,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002000
@@ -130,7 +130,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -140,7 +140,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -188,7 +188,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -198,7 +198,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -217,7 +217,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -227,7 +227,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -275,7 +275,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -285,7 +285,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -333,7 +333,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -343,7 +343,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -391,7 +391,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -401,7 +401,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -449,7 +449,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -459,7 +459,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -507,7 +507,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -517,7 +517,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -565,7 +565,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -575,7 +575,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -594,7 +594,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -604,7 +604,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -623,7 +623,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -633,7 +633,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -652,9 +652,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -662,7 +672,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -681,9 +691,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -691,7 +711,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -710,7 +730,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -720,7 +740,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -768,7 +788,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -778,7 +798,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -826,7 +846,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -836,7 +856,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -884,7 +904,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -894,7 +914,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -942,7 +962,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -952,7 +972,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1000,7 +1020,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1010,7 +1030,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1058,7 +1078,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1068,7 +1088,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1116,7 +1136,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1126,7 +1146,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1145,9 +1165,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -1155,7 +1185,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -1174,9 +1204,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -1184,7 +1224,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -1203,9 +1243,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1213,7 +1263,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -1232,7 +1282,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1242,7 +1292,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1261,7 +1311,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1271,7 +1321,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -1319,7 +1369,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1329,7 +1379,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -1377,7 +1427,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1387,7 +1437,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1435,7 +1485,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1445,7 +1495,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -1493,7 +1543,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1503,7 +1553,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1522,7 +1572,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1532,7 +1582,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1580,9 +1630,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -1590,7 +1650,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -1667,9 +1727,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1677,7 +1747,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -1696,9 +1766,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1706,7 +1786,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -1725,7 +1805,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1735,7 +1815,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -1754,9 +1834,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -1764,7 +1854,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -1783,9 +1873,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1793,7 +1893,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -1812,7 +1912,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1822,7 +1922,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -1870,7 +1970,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1880,7 +1980,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -1928,7 +2028,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1938,7 +2038,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -1986,7 +2086,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1996,7 +2096,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -2044,7 +2144,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2054,7 +2154,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2102,7 +2202,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2112,7 +2212,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2160,7 +2260,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2170,7 +2270,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2189,7 +2289,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2199,7 +2299,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2218,7 +2318,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2228,7 +2328,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2247,9 +2347,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -2257,7 +2367,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -2276,9 +2386,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -2286,7 +2406,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -2305,7 +2425,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -2315,7 +2435,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -2363,7 +2483,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -2373,7 +2493,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -2421,7 +2541,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2431,7 +2551,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -2479,7 +2599,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2489,7 +2609,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -2537,7 +2657,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2547,7 +2667,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2595,7 +2715,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2605,7 +2725,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -2653,7 +2773,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2663,7 +2783,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2711,9 +2831,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -2721,7 +2851,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -2740,9 +2870,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -2750,7 +2890,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -2769,9 +2909,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -2779,7 +2929,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -2798,7 +2948,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2808,7 +2958,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -2827,7 +2977,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2837,7 +2987,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -2885,7 +3035,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2895,7 +3045,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20002800
@@ -2943,7 +3093,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2953,7 +3103,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -3001,7 +3151,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -3011,7 +3161,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20004000
@@ -3059,7 +3209,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3069,7 +3219,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -3088,7 +3238,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3098,7 +3248,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -3146,9 +3296,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -3156,7 +3316,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -3204,9 +3364,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3214,7 +3384,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -3233,9 +3403,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3243,7 +3423,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -3262,7 +3442,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3272,7 +3452,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -3291,9 +3471,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -3301,7 +3491,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -3320,9 +3510,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3330,7 +3530,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -3349,7 +3549,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3359,7 +3559,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -3378,9 +3578,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -3388,7 +3598,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -3407,7 +3617,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3417,7 +3627,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -3465,9 +3675,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -3475,7 +3695,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -3494,9 +3714,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -3504,7 +3734,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -3523,9 +3753,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3533,7 +3773,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -3552,7 +3792,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3562,7 +3802,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -3581,7 +3821,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3591,7 +3831,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -3639,9 +3879,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -3649,7 +3899,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -3697,9 +3947,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3707,7 +3967,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -3726,9 +3986,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3736,7 +4006,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000
@@ -3755,7 +4025,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3765,7 +4035,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -3784,9 +4054,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8030000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8030000
       end: 0x8060000
     cores:
     - main
@@ -3794,7 +4074,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
@@ -3813,9 +4093,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -3823,7 +4113,7 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20014000

--- a/probe-rs/targets/STM32L4_Series.yaml
+++ b/probe-rs/targets/STM32L4_Series.yaml
@@ -14,7 +14,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -23,18 +23,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -56,7 +63,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -65,18 +72,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -98,7 +112,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -107,18 +121,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -140,7 +161,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -149,18 +170,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -182,7 +210,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -191,18 +219,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -224,7 +259,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -233,18 +268,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -266,7 +308,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -275,18 +317,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -308,7 +357,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -317,18 +366,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -350,7 +406,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -359,18 +415,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -392,7 +455,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -401,18 +464,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -434,7 +504,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -443,18 +513,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -476,7 +553,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -485,18 +562,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -518,7 +602,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -527,18 +611,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -560,7 +651,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -569,18 +660,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -602,7 +700,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -611,18 +709,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -644,7 +749,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -653,18 +758,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -686,7 +798,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -695,18 +807,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -728,7 +847,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -737,18 +856,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -770,7 +896,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -779,18 +905,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -812,7 +945,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -821,18 +954,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -854,7 +994,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -863,18 +1003,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -896,7 +1043,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -905,18 +1052,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -938,7 +1092,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -947,18 +1101,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -980,7 +1141,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -989,18 +1150,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -1022,7 +1190,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1031,18 +1199,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -1064,7 +1239,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1073,18 +1248,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10002000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20008000
+      end: 0x2000a000
     cores:
     - main
   flash_algorithms:
@@ -1106,7 +1288,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1115,18 +1297,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1148,7 +1337,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1157,18 +1346,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1190,7 +1386,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1199,18 +1395,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1232,7 +1435,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1241,18 +1444,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1274,7 +1484,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1283,18 +1493,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1316,7 +1533,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1325,18 +1542,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1358,7 +1582,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1367,18 +1591,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1400,7 +1631,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1409,18 +1640,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1442,7 +1680,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1451,18 +1689,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1484,7 +1729,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1493,18 +1738,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1526,7 +1778,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1535,18 +1787,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1568,7 +1827,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1577,18 +1836,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1610,7 +1876,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1619,18 +1885,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1652,7 +1925,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1661,18 +1934,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1694,7 +1974,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1703,18 +1983,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1736,7 +2023,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1745,18 +2032,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1778,7 +2072,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1787,18 +2081,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1820,7 +2121,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1829,18 +2130,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1862,7 +2170,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1871,18 +2179,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1904,7 +2219,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1913,18 +2228,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1946,7 +2268,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1955,18 +2277,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -1988,7 +2317,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1997,18 +2326,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2030,7 +2366,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2039,18 +2375,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2072,7 +2415,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2081,18 +2424,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2114,7 +2464,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2123,18 +2473,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2156,7 +2513,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2165,18 +2522,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2198,7 +2562,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2207,18 +2571,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2240,7 +2611,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2249,18 +2620,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2282,7 +2660,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2291,18 +2669,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2324,7 +2709,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2333,18 +2718,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2366,7 +2758,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2375,18 +2767,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2408,7 +2807,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2417,18 +2816,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2450,7 +2856,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2459,18 +2865,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2492,7 +2905,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2501,18 +2914,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2534,7 +2954,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2543,18 +2963,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2576,7 +3003,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2585,18 +3012,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2618,7 +3052,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2627,18 +3061,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2660,7 +3101,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2669,18 +3110,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2702,7 +3150,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2711,18 +3159,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2744,7 +3199,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2753,18 +3208,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2786,7 +3248,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2795,18 +3257,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2828,7 +3297,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2837,18 +3306,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2870,7 +3346,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2879,18 +3355,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10004000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x2000c000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x2000c000
+      end: 0x20010000
     cores:
     - main
   flash_algorithms:
@@ -2912,7 +3395,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2921,18 +3404,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -2954,7 +3444,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2963,18 +3453,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -2996,7 +3493,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3005,18 +3502,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3038,7 +3542,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3047,18 +3551,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3080,7 +3591,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3089,18 +3600,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3122,7 +3640,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3131,18 +3649,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3164,7 +3689,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3173,18 +3698,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3206,7 +3738,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3215,18 +3747,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3248,7 +3787,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3257,18 +3796,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3290,7 +3836,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3299,18 +3845,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3332,7 +3885,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3341,18 +3894,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3374,7 +3934,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3383,18 +3943,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3416,7 +3983,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3425,18 +3992,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3458,7 +4032,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3467,18 +4041,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3500,7 +4081,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3509,18 +4090,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3542,7 +4130,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3551,18 +4139,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3584,7 +4179,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3593,18 +4188,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3626,7 +4228,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3635,18 +4237,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3668,7 +4277,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3677,18 +4286,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3710,7 +4326,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3719,18 +4335,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3752,7 +4375,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3761,18 +4384,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3794,7 +4424,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3803,18 +4433,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3836,7 +4473,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3845,18 +4482,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3878,7 +4522,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3887,18 +4531,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3920,7 +4571,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -3929,18 +4580,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -3962,7 +4620,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -3971,18 +4629,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -4004,7 +4669,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4013,18 +4678,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -4046,7 +4718,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4055,18 +4727,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -4088,7 +4767,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4097,18 +4776,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -4130,7 +4816,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4139,18 +4825,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -4172,7 +4865,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4181,18 +4874,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -4214,7 +4914,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4223,18 +4923,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -4256,7 +4963,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4265,18 +4972,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -4298,7 +5012,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4307,18 +5021,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20020000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20020000
+      end: 0x20028000
     cores:
     - main
   flash_algorithms:
@@ -4340,24 +5061,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4382,24 +5113,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4424,24 +5165,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4466,24 +5217,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4508,24 +5269,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4550,24 +5321,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4592,24 +5373,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4634,24 +5425,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4676,7 +5477,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -4685,15 +5486,25 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4718,24 +5529,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4760,24 +5581,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4802,24 +5633,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4844,24 +5685,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4886,24 +5737,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4928,24 +5789,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -4970,24 +5841,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5012,24 +5893,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5054,24 +5945,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5096,24 +5997,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5138,24 +6049,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5180,24 +6101,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5222,24 +6153,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5264,24 +6205,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5306,24 +6257,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5348,24 +6309,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5390,24 +6361,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5432,24 +6413,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5474,24 +6465,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5516,24 +6517,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5558,24 +6569,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5600,24 +6621,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5642,24 +6673,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5684,24 +6725,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5726,24 +6777,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
-      end: 0x8040000
+      end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5768,24 +6829,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5810,24 +6881,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5852,24 +6933,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5894,24 +6985,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5936,24 +7037,34 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10008000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20018000
@@ -5978,27 +7089,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
-      end: 0x8100000
+      end: 0x8040000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6020,27 +7148,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6062,27 +7207,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6104,27 +7266,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6146,27 +7325,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6188,27 +7384,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6230,27 +7443,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6272,27 +7502,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6314,27 +7561,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6356,27 +7620,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6398,27 +7679,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6440,27 +7738,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6482,27 +7797,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6524,27 +7856,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6566,27 +7915,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6608,27 +7974,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6650,27 +8033,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6692,27 +8092,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6734,27 +8151,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6776,27 +8210,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6818,27 +8269,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6860,27 +8328,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6902,27 +8387,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6944,27 +8446,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -6986,27 +8505,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -7028,27 +8564,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -7070,27 +8623,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -7112,27 +8682,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -7154,27 +8741,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -7196,27 +8800,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -7238,27 +8859,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
+  - !Ram
+    name: SRAM2_ICODE
     range:
       start: 0x10000000
       end: 0x10010000
     cores:
     - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20040000
+      end: 0x20050000
     cores:
     - main
   flash_algorithms:
@@ -7280,7 +8918,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -7289,24 +8927,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -7328,7 +8952,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7337,24 +8961,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -7376,7 +8986,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7385,24 +8995,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -7424,7 +9020,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -7433,24 +9029,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -7472,7 +9054,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -7481,24 +9063,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -7520,7 +9088,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7529,24 +9097,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -7568,7 +9122,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7577,24 +9131,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -7616,7 +9156,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7625,24 +9165,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -7664,7 +9190,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7673,24 +9199,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -7712,7 +9224,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -7721,24 +9233,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -7760,7 +9258,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7769,24 +9267,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -7808,7 +9292,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7817,24 +9301,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -7856,7 +9326,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7865,24 +9335,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -7904,7 +9360,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -7913,24 +9369,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -7952,7 +9394,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -7961,24 +9403,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8000,7 +9428,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8009,24 +9437,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8048,7 +9462,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -8057,24 +9471,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8096,7 +9496,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -8105,24 +9505,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8144,7 +9530,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8153,24 +9539,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8192,7 +9564,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8201,24 +9573,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8240,7 +9598,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8249,24 +9607,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8288,7 +9632,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8297,24 +9641,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8336,7 +9666,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -8345,24 +9675,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8384,7 +9700,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8393,24 +9709,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8432,7 +9734,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8441,24 +9743,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8480,7 +9768,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8489,24 +9777,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8528,7 +9802,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8537,24 +9811,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8576,7 +9836,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8585,24 +9845,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8624,7 +9870,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8633,24 +9879,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8672,7 +9904,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8681,24 +9913,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8720,7 +9938,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8729,24 +9947,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8768,7 +9972,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8777,24 +9981,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8816,7 +10006,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8825,24 +10015,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8864,7 +10040,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8873,24 +10049,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8912,7 +10074,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8921,24 +10083,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -8960,7 +10108,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -8969,24 +10117,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -9008,7 +10142,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9017,24 +10151,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -9056,7 +10176,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9065,24 +10185,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -9104,7 +10210,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9113,24 +10219,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -9152,7 +10244,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9161,24 +10253,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -9200,7 +10278,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9209,24 +10287,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20020000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20030000
       end: 0x20050000
     cores:
     - main
@@ -9248,7 +10312,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9257,24 +10321,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -9298,7 +10348,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -9307,24 +10357,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -9348,7 +10384,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -9357,24 +10393,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -9398,7 +10420,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9407,24 +10429,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -9448,7 +10456,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9457,24 +10465,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -9498,7 +10492,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -9507,24 +10501,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -9548,7 +10528,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -9557,24 +10537,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -9598,7 +10564,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9607,24 +10573,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -9648,7 +10600,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -9657,24 +10609,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -9698,7 +10636,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9707,24 +10645,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -9748,7 +10672,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -9757,24 +10681,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -9798,7 +10708,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -9807,24 +10717,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -9898,7 +10794,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -9907,24 +10803,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -9948,7 +10830,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -9957,24 +10839,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -9998,7 +10866,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -10007,24 +10875,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10048,7 +10902,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -10057,24 +10911,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10098,7 +10938,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -10107,24 +10947,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10148,7 +10974,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -10157,24 +10983,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10198,7 +11010,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -10207,24 +11019,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10248,7 +11046,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -10257,24 +11055,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10298,7 +11082,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -10307,24 +11091,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10348,7 +11118,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -10357,24 +11127,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10398,7 +11154,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -10407,24 +11163,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10448,7 +11190,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -10457,24 +11199,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10498,7 +11226,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -10507,24 +11235,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10548,7 +11262,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -10557,24 +11271,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10648,7 +11348,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -10657,24 +11357,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10698,7 +11384,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -10707,24 +11393,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10748,7 +11420,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -10757,24 +11429,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10798,7 +11456,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -10807,24 +11465,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10848,7 +11492,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -10857,24 +11501,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10898,7 +11528,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -10907,24 +11537,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10948,7 +11564,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -10957,24 +11573,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -10998,7 +11600,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -11007,24 +11609,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -11048,7 +11636,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -11057,24 +11645,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -11098,7 +11672,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -11107,24 +11681,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -11148,7 +11708,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -11157,24 +11717,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -11198,7 +11744,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -11207,24 +11753,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main
@@ -11248,7 +11780,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8200000
@@ -11257,24 +11789,10 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20030000
-    cores:
-    - main
-  - !Generic
-    name: SRAM3
-    range:
-      start: 0x20040000
       end: 0x200a0000
     cores:
     - main

--- a/probe-rs/targets/STM32L5_Series.yaml
+++ b/probe-rs/targets/STM32L5_Series.yaml
@@ -14,7 +14,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -23,28 +23,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc040000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -63,7 +46,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -72,28 +55,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc040000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -112,7 +78,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -121,28 +87,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -161,7 +110,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -170,28 +119,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -210,7 +142,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -219,28 +151,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -259,7 +174,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -268,28 +183,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -308,7 +206,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -317,28 +215,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -357,7 +238,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -366,28 +247,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -406,7 +270,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -415,28 +279,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc040000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -455,7 +302,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -464,28 +311,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -504,7 +334,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -513,28 +343,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -553,7 +366,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -562,28 +375,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -602,7 +398,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -611,28 +407,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc040000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -651,7 +430,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -660,28 +439,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -700,7 +462,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -709,28 +471,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -749,7 +494,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -758,28 +503,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -798,7 +526,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -807,28 +535,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc040000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -847,7 +558,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -856,28 +567,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -896,7 +590,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -905,28 +599,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -945,7 +622,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -954,28 +631,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc040000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -994,7 +654,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1003,28 +663,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1043,7 +686,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1052,28 +695,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1092,7 +718,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1101,28 +727,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1141,7 +750,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1150,28 +759,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1190,7 +782,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1199,28 +791,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1239,7 +814,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1248,28 +823,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1288,7 +846,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1297,28 +855,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1337,7 +878,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1346,28 +887,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1386,7 +910,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1395,28 +919,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1435,7 +942,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1444,28 +951,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1484,7 +974,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1493,28 +983,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1533,7 +1006,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1542,28 +1015,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1582,7 +1038,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1591,28 +1047,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1631,7 +1070,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1640,28 +1079,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1680,7 +1102,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1689,28 +1111,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1729,7 +1134,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1738,28 +1143,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1778,7 +1166,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1787,28 +1175,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:
@@ -1827,7 +1198,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: IROM1
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1836,28 +1207,11 @@ variants:
     access:
       write: false
       boot: true
-  - !Generic
-    name: IROM2
-    range:
-      start: 0xc000000
-      end: 0xc080000
-    cores:
-    - main
-    access:
-      write: false
-      boot: true
   - !Ram
-    name: IRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20040000
-    cores:
-    - main
-  - !Generic
-    name: IRAM2
-    range:
-      start: 0x30000000
-      end: 0x30040000
     cores:
     - main
   flash_algorithms:

--- a/probe-rs/targets/STM32U0_Series.yaml
+++ b/probe-rs/targets/STM32U0_Series.yaml
@@ -14,25 +14,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20002000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20002000
       end: 0x20003000
     cores:
     - main
@@ -47,25 +41,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20002000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20002000
       end: 0x20003000
     cores:
     - main
@@ -80,25 +68,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20002000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20002000
       end: 0x20003000
     cores:
     - main
@@ -113,25 +95,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20002000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20002000
       end: 0x20003000
     cores:
     - main
@@ -146,25 +122,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20002000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20002000
       end: 0x20003000
     cores:
     - main
@@ -179,25 +149,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20002000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20002000
       end: 0x20003000
     cores:
     - main
@@ -212,25 +176,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20002000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20002000
       end: 0x20003000
     cores:
     - main
@@ -311,25 +269,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8004000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20002000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20002000
       end: 0x20003000
     cores:
     - main
@@ -344,25 +296,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20002000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20002000
       end: 0x20003000
     cores:
     - main
@@ -377,25 +323,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20002000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20002000
       end: 0x20003000
     cores:
     - main
@@ -410,25 +350,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20002000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20002000
       end: 0x20003000
     cores:
     - main
@@ -443,25 +377,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8008000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20002000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20002000
       end: 0x20003000
     cores:
     - main
@@ -476,25 +404,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20002000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20002000
       end: 0x20003000
     cores:
     - main
@@ -509,25 +431,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20002000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20002000
       end: 0x20003000
     cores:
     - main
@@ -542,25 +458,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -575,25 +485,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -608,25 +512,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -641,25 +539,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -674,25 +566,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -707,25 +593,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -839,25 +719,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -872,25 +746,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -905,25 +773,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -938,25 +800,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -971,25 +827,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1004,25 +854,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1037,25 +881,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1070,25 +908,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1103,25 +935,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1136,25 +962,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1169,25 +989,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1202,25 +1016,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1235,25 +1043,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1268,25 +1070,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1301,25 +1097,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1334,25 +1124,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1367,25 +1151,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1433,25 +1211,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1466,25 +1238,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1499,25 +1265,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1532,25 +1292,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main
@@ -1565,25 +1319,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: SRAM2
-    range:
-      start: 0x20008000
       end: 0x2000a000
     cores:
     - main

--- a/probe-rs/targets/STM32U5_Series.yaml
+++ b/probe-rs/targets/STM32U5_Series.yaml
@@ -14,9 +14,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8010000
       end: 0x8020000
     cores:
     - main
@@ -24,17 +34,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -52,9 +62,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8010000
       end: 0x8020000
     cores:
     - main
@@ -62,17 +82,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -90,9 +110,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8010000
       end: 0x8020000
     cores:
     - main
@@ -100,17 +130,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -128,9 +158,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8010000
       end: 0x8020000
     cores:
     - main
@@ -138,17 +178,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -166,9 +206,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -176,17 +226,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -204,9 +254,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -214,17 +274,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -242,9 +302,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -252,17 +322,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -280,9 +350,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -290,17 +370,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -318,9 +398,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -328,17 +418,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -356,9 +446,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -366,17 +466,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -394,9 +494,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -404,17 +514,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -432,9 +542,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -442,17 +562,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -470,9 +590,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -480,17 +610,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -508,27 +638,37 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
-      end: 0x8080000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
+      end: 0x8040000
     cores:
     - main
     access:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -546,9 +686,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -556,17 +706,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -584,9 +734,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8010000
       end: 0x8020000
     cores:
     - main
@@ -594,17 +754,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -622,9 +782,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8010000
       end: 0x8020000
     cores:
     - main
@@ -632,17 +802,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -660,9 +830,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8010000
       end: 0x8020000
     cores:
     - main
@@ -670,17 +850,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -698,9 +878,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8010000
       end: 0x8020000
     cores:
     - main
@@ -708,17 +898,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -736,9 +926,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -746,17 +946,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -774,9 +974,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -784,17 +994,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -812,9 +1022,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -822,17 +1042,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -850,9 +1070,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -860,17 +1090,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -888,9 +1118,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -898,17 +1138,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -926,9 +1166,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -936,17 +1186,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -964,9 +1214,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -974,17 +1234,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1002,9 +1262,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1012,17 +1282,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1040,9 +1310,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -1050,17 +1330,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1078,9 +1358,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -1088,17 +1378,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1116,9 +1406,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -1126,17 +1426,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1154,9 +1454,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8020000
       end: 0x8040000
     cores:
     - main
@@ -1164,17 +1474,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1192,9 +1502,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1202,17 +1522,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1230,9 +1550,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1240,17 +1570,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1268,9 +1598,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1278,17 +1618,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1306,9 +1646,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1316,17 +1666,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1344,9 +1694,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1354,17 +1714,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1382,9 +1742,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1392,17 +1762,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1420,9 +1790,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1430,17 +1810,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1458,9 +1838,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1468,17 +1858,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1496,9 +1886,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1506,17 +1906,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1534,9 +1934,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1544,17 +1954,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1572,9 +1982,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1582,17 +2002,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1610,9 +2030,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1620,17 +2050,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1648,9 +2078,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1658,17 +2098,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1686,9 +2126,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1696,17 +2146,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1724,9 +2174,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1734,17 +2194,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1762,9 +2222,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1772,17 +2242,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1800,9 +2270,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1810,17 +2290,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1838,9 +2318,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8040000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8040000
       end: 0x8080000
     cores:
     - main
@@ -1848,17 +2338,17 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20040000
+      end: 0x20030000
     cores:
     - main
-  - !Generic
-    name: SRAM3
+  - !Ram
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20030000
+      end: 0x20040000
     cores:
     - main
   flash_algorithms:
@@ -1876,9 +2366,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -1886,13 +2386,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -1914,9 +2421,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -1924,13 +2441,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -1952,9 +2476,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -1962,13 +2496,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -1990,9 +2531,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2000,13 +2551,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2028,9 +2586,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -2038,13 +2606,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2066,9 +2641,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -2076,13 +2661,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2104,9 +2696,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -2114,13 +2716,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2142,9 +2751,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -2152,13 +2771,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2180,9 +2806,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2190,13 +2826,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2218,9 +2861,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2228,13 +2881,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2256,9 +2916,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2266,13 +2936,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2294,9 +2971,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2304,13 +2991,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2332,9 +3026,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -2342,13 +3046,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2370,9 +3081,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2380,13 +3101,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2408,9 +3136,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -2418,13 +3156,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2446,9 +3191,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -2456,13 +3211,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2484,9 +3246,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2494,13 +3266,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2522,9 +3301,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2532,13 +3321,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2560,9 +3356,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -2570,13 +3376,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2598,9 +3411,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -2608,13 +3431,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2636,9 +3466,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2646,13 +3486,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2674,9 +3521,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2684,13 +3541,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2712,9 +3576,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -2722,13 +3596,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2750,9 +3631,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -2760,13 +3651,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2788,9 +3686,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2798,13 +3706,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2826,9 +3741,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2836,13 +3761,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2864,9 +3796,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -2874,13 +3816,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2902,9 +3851,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8080000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8080000
       end: 0x8100000
     cores:
     - main
@@ -2912,13 +3871,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2940,9 +3906,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2950,13 +3926,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -2978,9 +3961,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -2988,13 +3981,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3016,9 +4016,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3026,13 +4036,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3054,9 +4071,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3064,13 +4091,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3092,9 +4126,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3102,13 +4146,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3130,9 +4181,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3140,13 +4201,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3168,9 +4236,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3178,13 +4256,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3206,9 +4291,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3216,13 +4311,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3244,9 +4346,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3254,13 +4366,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3282,9 +4401,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3292,13 +4421,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3320,9 +4456,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3330,13 +4476,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3358,9 +4511,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3368,13 +4531,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3396,9 +4566,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3406,13 +4586,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3434,9 +4621,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3444,13 +4641,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3472,9 +4676,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3482,13 +4696,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3510,9 +4731,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3520,13 +4751,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3548,9 +4786,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3558,13 +4806,20 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1_2
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x20030000
       end: 0x20040000
     cores:
     - main
-  - !Generic
+  - !Ram
     name: SRAM3
     range:
       start: 0x20040000
@@ -3586,9 +4841,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3596,24 +4861,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -3631,9 +4903,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3641,24 +4923,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -3676,9 +4965,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -3686,24 +4985,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -3721,9 +5027,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -3731,24 +5047,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -3766,9 +5089,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3776,24 +5109,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -3811,9 +5151,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3821,24 +5171,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -3856,9 +5213,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -3866,24 +5233,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -3901,9 +5275,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -3911,24 +5295,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -3946,9 +5337,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -3956,24 +5357,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -3991,9 +5399,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -4001,24 +5419,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4036,9 +5461,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -4046,24 +5481,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4081,9 +5523,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -4091,24 +5543,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4126,9 +5585,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -4136,24 +5605,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4171,9 +5647,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -4181,24 +5667,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4216,9 +5709,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -4226,24 +5729,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4261,9 +5771,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -4271,24 +5791,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4306,9 +5833,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -4316,24 +5853,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4351,9 +5895,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -4361,24 +5915,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4441,9 +6002,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -4451,24 +6022,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4486,9 +6064,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -4496,24 +6084,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4531,9 +6126,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -4541,24 +6146,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4576,9 +6188,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -4586,24 +6208,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4621,9 +6250,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -4631,24 +6270,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4666,9 +6312,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -4676,24 +6332,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4711,9 +6374,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -4721,24 +6394,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4756,9 +6436,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -4766,24 +6456,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4801,9 +6498,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -4811,24 +6518,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4846,9 +6560,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -4856,24 +6580,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4891,9 +6622,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -4901,24 +6642,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4936,9 +6684,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8100000
       end: 0x8200000
     cores:
     - main
@@ -4946,24 +6704,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -4981,9 +6746,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -4991,24 +6766,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5026,9 +6808,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5036,24 +6828,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5071,9 +6870,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5081,24 +6890,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5116,9 +6932,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5126,24 +6952,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5161,9 +6994,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5171,24 +7014,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5206,9 +7056,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5216,24 +7076,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5251,9 +7118,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5261,24 +7138,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5296,9 +7180,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5306,24 +7200,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5341,9 +7242,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5351,24 +7262,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5386,9 +7304,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5396,24 +7324,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5431,9 +7366,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5441,24 +7386,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5476,9 +7428,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5486,24 +7448,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5521,9 +7490,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5531,24 +7510,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5566,9 +7552,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5576,24 +7572,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5611,9 +7614,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5621,24 +7634,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5656,9 +7676,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5666,24 +7696,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5701,9 +7738,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5711,24 +7758,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5746,9 +7800,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5756,24 +7820,31 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM1235
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
-    cores:
-    - main
-  - !Ram
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
     cores:
     - main
   flash_algorithms:
@@ -5791,34 +7862,58 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
-      end: 0x8200000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
+      end: 0x8300000
     cores:
     - main
     access:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
     cores:
     - main
   - !Ram
-    name: SRAM_GFXMM
+    name: SRAM6
     range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -5836,34 +7931,58 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
-      end: 0x8200000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
+      end: 0x8300000
     cores:
     - main
     access:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
     cores:
     - main
   - !Ram
-    name: SRAM_GFXMM
+    name: SRAM6
     range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -5881,9 +8000,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5891,24 +8020,38 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
     cores:
     - main
   - !Ram
-    name: SRAM_GFXMM
+    name: SRAM6
     range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -5926,9 +8069,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5936,24 +8089,38 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
     cores:
     - main
   - !Ram
-    name: SRAM_GFXMM
+    name: SRAM6
     range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -5971,9 +8138,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -5981,24 +8158,38 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
     cores:
     - main
   - !Ram
-    name: SRAM_GFXMM
+    name: SRAM6
     range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -6016,9 +8207,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -6026,24 +8227,38 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
     cores:
     - main
   - !Ram
-    name: SRAM_GFXMM
+    name: SRAM6
     range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -6061,34 +8276,58 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
-      end: 0x8200000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
+      end: 0x8300000
     cores:
     - main
     access:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
     cores:
     - main
   - !Ram
-    name: SRAM_GFXMM
+    name: SRAM6
     range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -6106,9 +8345,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -6116,24 +8365,38 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
     cores:
     - main
   - !Ram
-    name: SRAM_GFXMM
+    name: SRAM6
     range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -6151,34 +8414,58 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
-      end: 0x8200000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
+      end: 0x8300000
     cores:
     - main
     access:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
     cores:
     - main
   - !Ram
-    name: SRAM_GFXMM
+    name: SRAM6
     range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -6196,34 +8483,58 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
-      end: 0x8200000
+      end: 0x8100000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
+      end: 0x8300000
     cores:
     - main
     access:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
     cores:
     - main
   - !Ram
-    name: SRAM_GFXMM
+    name: SRAM6
     range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -6241,9 +8552,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -6251,24 +8572,38 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
     cores:
     - main
   - !Ram
-    name: SRAM_GFXMM
+    name: SRAM6
     range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -6286,9 +8621,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -6296,24 +8641,38 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
     cores:
     - main
   - !Ram
-    name: SRAM_GFXMM
+    name: SRAM6
     range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -6331,9 +8690,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -6341,24 +8710,38 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
     cores:
     - main
   - !Ram
-    name: SRAM_GFXMM
+    name: SRAM6
     range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -6376,9 +8759,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -6386,24 +8779,38 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
       end: 0x20270000
     cores:
     - main
   - !Ram
-    name: SRAM_GFXMM
+    name: SRAM6
     range:
-      start: 0x24000000
-      end: 0x25000000
-    cores:
-    - main
-  - !Ram
-    name: SRAM4
-    range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -6421,9 +8828,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -6431,24 +8848,38 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20270000
-    cores:
-    - main
-  - !Generic
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
+      end: 0x200c0000
     cores:
     - main
   - !Ram
-    name: SRAM4
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
+      end: 0x20270000
+    cores:
+    - main
+  - !Ram
+    name: SRAM6
+    range:
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -6466,9 +8897,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -6476,24 +8917,38 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20270000
-    cores:
-    - main
-  - !Generic
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
+      end: 0x200c0000
     cores:
     - main
   - !Ram
-    name: SRAM4
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
+      end: 0x20270000
+    cores:
+    - main
+  - !Ram
+    name: SRAM6
+    range:
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -6511,9 +8966,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -6521,24 +8986,38 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20270000
-    cores:
-    - main
-  - !Generic
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
+      end: 0x200c0000
     cores:
     - main
   - !Ram
-    name: SRAM4
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
+      end: 0x20270000
+    cores:
+    - main
+  - !Ram
+    name: SRAM6
+    range:
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -6556,9 +9035,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -6566,24 +9055,38 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20270000
-    cores:
-    - main
-  - !Generic
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
+      end: 0x200c0000
     cores:
     - main
   - !Ram
-    name: SRAM4
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
+      end: 0x20270000
+    cores:
+    - main
+  - !Ram
+    name: SRAM6
+    range:
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:
@@ -6601,9 +9104,19 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Flash
+    name: BANK_1
     range:
       start: 0x8000000
+      end: 0x8200000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: BANK_2
+    range:
+      start: 0x8200000
       end: 0x8400000
     cores:
     - main
@@ -6611,24 +9124,38 @@ variants:
       write: false
       boot: true
   - !Ram
-    name: SRAM12356
+    name: SRAM
     range:
       start: 0x20000000
-      end: 0x20270000
-    cores:
-    - main
-  - !Generic
-    name: SRAM_GFXMM
-    range:
-      start: 0x24000000
-      end: 0x25000000
+      end: 0x200c0000
     cores:
     - main
   - !Ram
-    name: SRAM4
+    name: SRAM2
     range:
-      start: 0x28000000
-      end: 0x28004000
+      start: 0x200c0000
+      end: 0x200d0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM3
+    range:
+      start: 0x200d0000
+      end: 0x201a0000
+    cores:
+    - main
+  - !Ram
+    name: SRAM5
+    range:
+      start: 0x201a0000
+      end: 0x20270000
+    cores:
+    - main
+  - !Ram
+    name: SRAM6
+    range:
+      start: 0x20270000
+      end: 0x202f0000
     cores:
     - main
   flash_algorithms:

--- a/probe-rs/targets/STM32WB_Series.yaml
+++ b/probe-rs/targets/STM32WB_Series.yaml
@@ -14,26 +14,20 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8050000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
-    cores:
-    - main
-  - !Ram
-    name: SRAM2
-    range:
-      start: 0x20030000
-      end: 0x20039000
     cores:
     - main
   flash_algorithms:
@@ -47,26 +41,20 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8050000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
-    cores:
-    - main
-  - !Ram
-    name: SRAM2
-    range:
-      start: 0x20030000
-      end: 0x20039000
     cores:
     - main
   flash_algorithms:
@@ -80,26 +68,20 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8050000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
-    cores:
-    - main
-  - !Ram
-    name: SRAM2
-    range:
-      start: 0x20030000
-      end: 0x20039000
     cores:
     - main
   flash_algorithms:
@@ -113,26 +95,20 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8050000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20003000
-    cores:
-    - main
-  - !Ram
-    name: SRAM2
-    range:
-      start: 0x20030000
-      end: 0x20039000
     cores:
     - main
   flash_algorithms:
@@ -179,16 +155,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -205,16 +182,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -231,16 +209,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20008000
@@ -257,16 +236,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -283,16 +263,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -310,16 +291,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -337,16 +319,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -364,16 +347,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -391,16 +375,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -418,16 +403,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -445,16 +431,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -472,16 +459,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20010000
@@ -499,16 +487,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -526,16 +515,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8080000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -553,16 +543,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -580,16 +571,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8100000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000
@@ -607,16 +599,17 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: Main_Flash
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x80a0000
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
-    name: SRAM1
+    name: SRAM
     range:
       start: 0x20000000
       end: 0x20030000

--- a/probe-rs/targets/STM32WL_Series.yaml
+++ b/probe-rs/targets/STM32WL_Series.yaml
@@ -19,7 +19,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -62,7 +62,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -105,7 +105,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -148,7 +148,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -191,7 +191,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -229,7 +229,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -239,10 +239,17 @@ variants:
       write: false
       boot: true
   - !Ram
+    name: SRAM1
+    range:
+      start: 0x20000000
+      end: 0x20002800
+    cores:
+    - main
+  - !Ram
     name: SRAM2
     range:
-      start: 0x20008000
-      end: 0x2000d000
+      start: 0x20002800
+      end: 0x20005000
     cores:
     - main
   flash_algorithms:
@@ -256,7 +263,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -269,14 +276,14 @@ variants:
     name: SRAM1
     range:
       start: 0x20000000
-      end: 0x20004000
+      end: 0x20006000
     cores:
     - main
   - !Ram
     name: SRAM2
     range:
-      start: 0x20008000
-      end: 0x20010000
+      start: 0x20006000
+      end: 0x2000c000
     cores:
     - main
   flash_algorithms:
@@ -290,7 +297,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -324,7 +331,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -334,10 +341,17 @@ variants:
       write: false
       boot: true
   - !Ram
+    name: SRAM1
+    range:
+      start: 0x20000000
+      end: 0x20002800
+    cores:
+    - main
+  - !Ram
     name: SRAM2
     range:
-      start: 0x20008000
-      end: 0x2000d000
+      start: 0x20002800
+      end: 0x20005000
     cores:
     - main
   flash_algorithms:
@@ -351,7 +365,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -364,14 +378,14 @@ variants:
     name: SRAM1
     range:
       start: 0x20000000
-      end: 0x20004000
+      end: 0x20006000
     cores:
     - main
   - !Ram
     name: SRAM2
     range:
-      start: 0x20008000
-      end: 0x20010000
+      start: 0x20006000
+      end: 0x2000c000
     cores:
     - main
   flash_algorithms:
@@ -385,7 +399,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -419,7 +433,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -429,10 +443,17 @@ variants:
       write: false
       boot: true
   - !Ram
+    name: SRAM1
+    range:
+      start: 0x20000000
+      end: 0x20002800
+    cores:
+    - main
+  - !Ram
     name: SRAM2
     range:
-      start: 0x20008000
-      end: 0x2000d000
+      start: 0x20002800
+      end: 0x20005000
     cores:
     - main
   flash_algorithms:
@@ -446,7 +467,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -459,14 +480,14 @@ variants:
     name: SRAM1
     range:
       start: 0x20000000
-      end: 0x20004000
+      end: 0x20006000
     cores:
     - main
   - !Ram
     name: SRAM2
     range:
-      start: 0x20008000
-      end: 0x20010000
+      start: 0x20006000
+      end: 0x2000c000
     cores:
     - main
   flash_algorithms:
@@ -480,7 +501,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -514,7 +535,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -524,10 +545,17 @@ variants:
       write: false
       boot: true
   - !Ram
+    name: SRAM1
+    range:
+      start: 0x20000000
+      end: 0x20002800
+    cores:
+    - main
+  - !Ram
     name: SRAM2
     range:
-      start: 0x20008000
-      end: 0x2000d000
+      start: 0x20002800
+      end: 0x20005000
     cores:
     - main
   flash_algorithms:
@@ -541,7 +569,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -554,14 +582,14 @@ variants:
     name: SRAM1
     range:
       start: 0x20000000
-      end: 0x20004000
+      end: 0x20006000
     cores:
     - main
   - !Ram
     name: SRAM2
     range:
-      start: 0x20008000
-      end: 0x20010000
+      start: 0x20006000
+      end: 0x2000c000
     cores:
     - main
   flash_algorithms:
@@ -575,7 +603,7 @@ variants:
       psel: 0x0
   memory_map:
   - !Nvm
-    name: FLASH
+    name: BANK_1
     range:
       start: 0x8000000
       end: 0x8040000


### PR DESCRIPTION
Generated using https://github.com/bugadani/stm-probers - this uses embassy/stm32-data with minimal exceptions (affecting STM32WB) and one modification: I'm re-merging flash regions, because we don't need to know about the different erase granularities.

Updated everything except WBA ([waiting for author on pack update](https://github.com/probe-rs/probe-rs/pull/2612))

Rebased on top of #2632