### PR TITLE
Do not eagerly reject j-links with multiple USB interfaces

### DIFF
--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -98,11 +98,15 @@ impl ProbeFactory for JLinkFactory {
             .map_err(|e| open_error(e, "opening the USB device"))?;
 
         let mut configs = handle.configurations();
-        let conf = configs.next().unwrap();
+        let Some(conf) = configs.next() else {
+            // Since the device matches the J-Link VID/PID, it should have at
+            // least one configuration. Otherwise we can't do anything with it.
+            return Err(JlinkError::Other(String::from("Device has no configurations.")).into());
+        };
 
         let rest = configs.count();
         if rest != 0 {
-            warn!("device has {} configurations, expected 1", rest + 1);
+            debug!("device has {} configurations, expected 1", rest + 1);
         }
 
         debug!("scanning {} interfaces", conf.interfaces().count());

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -96,13 +96,14 @@ impl ProbeFactory for JLinkFactory {
             .open()
             .map_err(|e| open_error(e, "opening the USB device"))?;
 
-        let configs: Vec<_> = handle.configurations().collect();
+        let mut configs = handle.configurations();
+        let conf = configs.next().unwrap();
 
-        if configs.len() != 1 {
-            warn!("device has {} configurations, expected 1", configs.len());
+        let rest = configs.count();
+        if rest != 0 {
+            warn!("device has {} configurations, expected 1", rest + 1);
         }
 
-        let conf = &configs[0];
         debug!("scanning {} interfaces", conf.interfaces().count());
         trace!("active configuration descriptor: {:#x?}", conf);
 


### PR DESCRIPTION
Instead of bailing if we find a second semi-plausible interface, delay erroring if the second interface actually matches our filter criteria.

As a last-ditch effort, the code now tries to find a single `BULK interface` vendor-specific interface.