### PR TITLE
Update STM32F0,F1,F2 from packs

### DIFF
--- a/changelog/added-STM32F205RGEx.md
+++ b/changelog/added-STM32F205RGEx.md
@@ -1,0 +1,1 @@
+Added STM32F205RGEx target information

--- a/probe-rs/targets/STM32F0_Series.yaml
+++ b/probe-rs/targets/STM32F0_Series.yaml
@@ -2,6 +2,8 @@ name: STM32F0 Series
 manufacturer:
   id: 0x20
   cc: 0x0
+generated_from_pack: true
+pack_file_release: 2.1.1
 variants:
 - name: STM32F030C6Tx
   cores:
@@ -12,12 +14,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -25,7 +29,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F030C8Tx
   cores:
@@ -36,12 +40,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -49,7 +55,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F030CCTx
   cores:
@@ -60,12 +66,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -73,7 +81,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F030F4Px
   cores:
@@ -84,12 +92,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -97,7 +107,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F030K6Tx
   cores:
@@ -108,12 +118,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -121,7 +133,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F030R8Tx
   cores:
@@ -132,12 +144,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -145,7 +159,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F030RCTx
   cores:
@@ -156,12 +170,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -169,7 +185,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F031C4Tx
   cores:
@@ -180,12 +196,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -193,7 +211,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F031C6Tx
   cores:
@@ -204,12 +222,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -217,7 +237,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F031E6Yx
   cores:
@@ -228,12 +248,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -241,7 +263,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F031F4Px
   cores:
@@ -252,12 +274,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -265,7 +289,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F031F6Px
   cores:
@@ -276,12 +300,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -289,7 +315,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F031G4Ux
   cores:
@@ -300,12 +326,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -313,7 +341,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F031G6Ux
   cores:
@@ -324,12 +352,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -337,7 +367,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F031K4Ux
   cores:
@@ -348,12 +378,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -361,7 +393,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F031K6Tx
   cores:
@@ -372,12 +404,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -385,7 +419,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F031K6Ux
   cores:
@@ -396,12 +430,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -409,7 +445,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F038C6Tx
   cores:
@@ -420,12 +456,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -433,7 +471,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F038E6Yx
   cores:
@@ -444,12 +482,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -457,7 +497,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F038F6Px
   cores:
@@ -468,12 +508,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -481,7 +523,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F038G6Ux
   cores:
@@ -492,12 +534,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -505,7 +549,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F038K6Ux
   cores:
@@ -516,12 +560,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -529,7 +575,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F042C4Tx
   cores:
@@ -540,12 +586,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -553,7 +601,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F042C4Ux
   cores:
@@ -564,12 +612,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -577,7 +627,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F042C6Tx
   cores:
@@ -588,12 +638,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -601,7 +653,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F042C6Ux
   cores:
@@ -612,12 +664,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -625,7 +679,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F042F4Px
   cores:
@@ -636,12 +690,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -649,7 +705,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F042F6Px
   cores:
@@ -660,12 +716,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -673,7 +731,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F042G4Ux
   cores:
@@ -684,12 +742,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -697,7 +757,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F042G6Ux
   cores:
@@ -708,12 +768,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -721,7 +783,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F042K4Tx
   cores:
@@ -732,12 +794,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -745,7 +809,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F042K4Ux
   cores:
@@ -756,12 +820,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -769,7 +835,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F042K6Tx
   cores:
@@ -780,12 +846,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -793,7 +861,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F042K6Ux
   cores:
@@ -804,12 +872,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -817,7 +887,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F042T6Yx
   cores:
@@ -828,12 +898,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -841,7 +913,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F048C6Ux
   cores:
@@ -852,12 +924,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -865,7 +939,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F048G6Ux
   cores:
@@ -876,12 +950,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -889,7 +965,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F048T6Yx
   cores:
@@ -900,12 +976,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -913,7 +991,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051C4Tx
   cores:
@@ -924,12 +1002,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -937,7 +1017,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051C4Ux
   cores:
@@ -948,12 +1028,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -961,7 +1043,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051C6Tx
   cores:
@@ -972,12 +1054,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -985,7 +1069,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051C6Ux
   cores:
@@ -996,12 +1080,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1009,7 +1095,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051C8Tx
   cores:
@@ -1020,12 +1106,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1033,7 +1121,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051C8Ux
   cores:
@@ -1044,12 +1132,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1057,7 +1147,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051K4Tx
   cores:
@@ -1068,12 +1158,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -1081,7 +1173,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051K4Ux
   cores:
@@ -1092,12 +1184,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -1105,7 +1199,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051K6Tx
   cores:
@@ -1116,12 +1210,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1129,7 +1225,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051K6Ux
   cores:
@@ -1140,12 +1236,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1153,7 +1251,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051K8Tx
   cores:
@@ -1164,12 +1262,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1177,7 +1277,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051K8Ux
   cores:
@@ -1188,12 +1288,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1201,7 +1303,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051R4Tx
   cores:
@@ -1212,12 +1314,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -1225,7 +1329,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051R6Tx
   cores:
@@ -1236,12 +1340,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1249,7 +1355,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051R8Hx
   cores:
@@ -1260,12 +1366,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1273,7 +1381,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051R8Tx
   cores:
@@ -1284,12 +1392,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1297,7 +1407,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F051T8Yx
   cores:
@@ -1308,12 +1418,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1321,7 +1433,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F058C8Ux
   cores:
@@ -1332,12 +1444,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1345,7 +1459,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F058R8Hx
   cores:
@@ -1356,12 +1470,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1369,7 +1485,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F058R8Tx
   cores:
@@ -1380,12 +1496,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1393,7 +1511,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F058T8Yx
   cores:
@@ -1404,12 +1522,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1417,7 +1537,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F070C6Tx
   cores:
@@ -1428,12 +1548,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1441,7 +1563,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F070CBTx
   cores:
@@ -1452,12 +1574,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1465,7 +1589,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F070F6Px
   cores:
@@ -1476,12 +1600,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1489,7 +1615,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_64
   - stm32f0xx_opt
 - name: STM32F070RBTx
   cores:
@@ -1500,12 +1626,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1513,7 +1641,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F071C8Tx
   cores:
@@ -1524,12 +1652,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1537,7 +1667,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F071C8Ux
   cores:
@@ -1548,12 +1678,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1561,7 +1693,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F071CBTx
   cores:
@@ -1572,12 +1704,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1585,7 +1719,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F071CBUx
   cores:
@@ -1596,12 +1730,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1609,7 +1745,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F071CBYx
   cores:
@@ -1620,12 +1756,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1633,7 +1771,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F071RBTx
   cores:
@@ -1644,12 +1782,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1657,7 +1797,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F071V8Hx
   cores:
@@ -1668,12 +1808,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1681,7 +1823,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F071V8Tx
   cores:
@@ -1692,12 +1834,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1705,7 +1849,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F071VBHx
   cores:
@@ -1716,12 +1860,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1729,7 +1875,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F071VBTx
   cores:
@@ -1740,12 +1886,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1753,7 +1901,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F072C8Tx
   cores:
@@ -1764,12 +1912,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1777,7 +1927,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F072C8Ux
   cores:
@@ -1788,12 +1938,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1801,7 +1953,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F072CBTx
   cores:
@@ -1812,12 +1964,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1825,7 +1979,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F072CBUx
   cores:
@@ -1836,12 +1990,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1849,7 +2005,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F072CBYx
   cores:
@@ -1860,12 +2016,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1873,7 +2031,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F072R8Tx
   cores:
@@ -1884,12 +2042,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1897,7 +2057,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F072RBHx
   cores:
@@ -1908,12 +2068,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1921,7 +2083,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F072RBIx
   cores:
@@ -1932,12 +2094,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1945,7 +2109,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F072RBTx
   cores:
@@ -1956,12 +2120,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1969,7 +2135,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F072V8Hx
   cores:
@@ -1980,12 +2146,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1993,7 +2161,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F072V8Tx
   cores:
@@ -2004,12 +2172,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2017,7 +2187,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F072VBHx
   cores:
@@ -2028,12 +2198,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2041,7 +2213,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F072VBTx
   cores:
@@ -2052,12 +2224,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2065,7 +2239,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F078CBTx
   cores:
@@ -2076,12 +2250,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2089,7 +2265,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F078CBUx
   cores:
@@ -2100,12 +2276,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2113,7 +2291,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F078CBYx
   cores:
@@ -2124,12 +2302,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2137,7 +2317,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F078RBHx
   cores:
@@ -2148,12 +2328,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2161,7 +2343,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F078RBTx
   cores:
@@ -2172,12 +2354,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2185,7 +2369,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F078VBHx
   cores:
@@ -2196,12 +2380,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2209,7 +2395,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F078VBTx
   cores:
@@ -2220,12 +2406,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2233,7 +2421,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F091CBTx
   cores:
@@ -2244,12 +2432,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2257,7 +2447,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F091CBUx
   cores:
@@ -2268,12 +2458,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2281,7 +2473,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F091CCTx
   cores:
@@ -2292,12 +2484,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2305,7 +2499,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F091CCUx
   cores:
@@ -2316,12 +2510,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2329,7 +2525,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F091RBTx
   cores:
@@ -2340,12 +2536,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2353,7 +2551,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F091RCHx
   cores:
@@ -2364,12 +2562,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2377,7 +2577,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F091RCTx
   cores:
@@ -2388,12 +2588,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2401,7 +2603,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F091RCYx
   cores:
@@ -2412,12 +2614,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2425,7 +2629,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F091VBTx
   cores:
@@ -2436,12 +2640,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2449,7 +2655,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_128
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F091VCHx
   cores:
@@ -2460,12 +2666,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2473,7 +2681,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F091VCTx
   cores:
@@ -2484,12 +2692,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2497,7 +2707,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F098CCTx
   cores:
@@ -2508,12 +2718,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2521,7 +2733,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F098CCUx
   cores:
@@ -2532,12 +2744,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2545,7 +2759,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F098RCHx
   cores:
@@ -2556,12 +2770,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2569,7 +2785,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F098RCTx
   cores:
@@ -2580,12 +2796,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2593,7 +2811,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F098RCYx
   cores:
@@ -2604,12 +2822,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2617,7 +2837,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F098VCHx
   cores:
@@ -2628,12 +2848,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2641,7 +2863,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 - name: STM32F098VCTx
   cores:
@@ -2652,12 +2874,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2665,13 +2889,13 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32f0xx_256
+  - stm32f0xx_256_2k
   - stm32f0xx_opt
 flash_algorithms:
-- name: stm32f0xx_256
-  description: STM32F0xx 256kB Flash
+- name: stm32f0xx_64
+  description: STM32F0xx 64kB Flash
   default: true
-  instructions: RkhFSUFgRklBYAAhAWDBaBQiEUPBYMBpQAcG1EJIQUkBYAYhQWBBSYFgACBwRztIAWmAIhFDAWEAIHBHMLU3SMFoFCQhQ8FgAWkEJSlDAWEBaUAiEUMBYTVJM0oA4BFgw2jbB/vRAWmpQwFhwWghQgTQwWghQ8FgASAwvQAgML0wtSZJymgUIxpDymAKaQIkIkMKYUhhCGlAIhBDCGEkSCFKAOAQYM1o7Qf70QhpoEMIYchoGEAD0MhoGEPIYAEgML3wtRVNSRxJCOtoSQAEJCND62AUJxZMGuAraQEmM0MrYROIA4AQSwDgHGDuaPYH+9EraVsIWwArYetoO0IE0OhoOEPoYAEg8L2AHIkekhwAKeLRACDwvSMBZ0UAIAJAq4nvzVVVAAAAMABA/w8AAKqqAAAAAAAA
+  instructions: RkhFSUFgRklBYAAhAWDBaBQiEUPBYMBpQAcG1EJIQUkBYAYhQWBBSYFgACBwRztIAWmAIhFDAWEAIHBHMLU3SMFoFCQhQ8FgAWkEJSlDAWEBaUAiEUMBYTVJM0oA4BFgw2jbB/vRAWmpQwFhwWghQgTQwWghQ8FgASAwvQAgML0wtSZJymgUIxpDymAKaQIkIkMKYUhhCGlAIhBDCGEkSCFKAOAQYM1o7Qf70QhpoEMIYchoGEAD0MhoGEPIYAEgML3wtRVNSRxJCOtoSQAEJCND62AUJxZMGuAraQEmM0MrYROIA4AQSwDgHGDuaPYH+9EraVsIWwArYetoO0IE0OhoOEPoYAEg8L2AHJIciR4AKeLRACDwvSMBZ0UAIAJAq4nvzVVVAAAAMABA/w8AAKqqAAAAAAAA
   pc_init: 0x1
   pc_uninit: 0x2f
   pc_program_page: 0xc3
@@ -2681,7 +2905,7 @@ flash_algorithms:
   flash_properties:
     address_range:
       start: 0x8000000
-      end: 0x8040000
+      end: 0x8010000
     page_size: 0x400
     erased_byte_value: 0xff
     program_page_timeout: 100
@@ -2689,8 +2913,6 @@ flash_algorithms:
     sectors:
     - size: 0x400
       address: 0x0
-  cores:
-  - main
 - name: stm32f0xx_opt
   description: STM32F0xx Flash Options
   instructions: U0hSSkJgU0lBYIJggWAAIQFgwWgUIhFDwWDAaUAHBtROSE1JAWAGIUFgTUmBYAAgcEdHSAFpgCIRQwFhAWmCFZFDAWEAIHBHcLVBSMFoFCMZQ8FgAWkgJCFDAWEBaUAiEUMBYT9JPUoA4BFgxWjtB/vRBWmlQwVhBWkQJCVDBWE1TTlOVTU1gADgEWDFaO0H+9EBaaFDAWHBaBlCBNDBaBlDwWABIHC9ACBwvTC1KEjBaBQkIUPBYAFpICUpQwFhAWlAIhFDAWEmSSRKAOARYMNo2wf70QFpqUMBYcFoIUIE0MFoIUPBYAEgML0AIDC9ASBwR/C1Fk1JHEkI62hJAAQkI0PrYBAmFksa4CxpNEMsYRSIBIARTADgI2DvaP8H+9EsabRDLGHsaBQnPEIF0OhoFCEIQ+hgASDwvYAckhyJHgAp4tEAIPC9AAAjAWdFACACQKuJ781VVQAAADAAQP8PAACqqgAAAPj/HwAAAAA=
@@ -2711,12 +2933,10 @@ flash_algorithms:
     sectors:
     - size: 0x10
       address: 0x0
-  cores:
-  - main
-- name: stm32f0xx_128
-  description: STM32F0xx 128kB Flash
+- name: stm32f0xx_256_2k
+  description: STM32F0xx 256kB Flash (2kB page)
   default: true
-  instructions: RkhFSUFgRklBYAAhAWDBaBQiEUPBYMBpQAcG1EJIQUkBYAYhQWBBSYFgACBwRztIAWmAIhFDAWEAIHBHMLU3SMFoFCQhQ8FgAWkEJSlDAWEBaUAiEUMBYTVJM0oA4BFgw2jbB/vRAWmpQwFhwWghQgTQwWghQ8FgASAwvQAgML0wtSZJymgUIxpDymAKaQIkIkMKYUhhCGlAIhBDCGEkSCFKAOAQYM1o7Qf70QhpoEMIYchoGEAD0MhoGEPIYAEgML3wtRVNSRxJCOtoSQAEJCND62AUJxZMGuAraQEmM0MrYROIA4AQSwDgHGDuaPYH+9EraVsIWwArYetoO0IE0OhoOEPoYAEg8L2AHJIciR4AKeLRACDwvSMBZ0UAIAJAq4nvzVVVAAAAMABA/w8AAKqqAAAAAAAA
+  instructions: RkhFSUFgRklBYAAhAWDBaBQiEUPBYMBpQAcG1EJIQUkBYAYhQWBBSYFgACBwRztIAWmAIhFDAWEAIHBHMLU3SMFoFCQhQ8FgAWkEJSlDAWEBaUAiEUMBYTVJM0oA4BFgw2jbB/vRAWmpQwFhwWghQgTQwWghQ8FgASAwvQAgML0wtSZJymgUIxpDymAKaQIkIkMKYUhhCGlAIhBDCGEkSCFKAOAQYM1o7Qf70QhpoEMIYchoGEAD0MhoGEPIYAEgML3wtRVNSRxJCOtoSQAEJCND62AUJxZMGuAraQEmM0MrYROIA4AQSwDgHGDuaPYH+9EraVsIWwArYetoO0IE0OhoOEPoYAEg8L2AHIkekhwAKeLRACDwvSMBZ0UAIAJAq4nvzVVVAAAAMABA/w8AAKqqAAAAAAAA
   pc_init: 0x1
   pc_uninit: 0x2f
   pc_program_page: 0xc3
@@ -2726,13 +2946,11 @@ flash_algorithms:
   flash_properties:
     address_range:
       start: 0x8000000
-      end: 0x8020000
+      end: 0x8040000
     page_size: 0x400
     erased_byte_value: 0xff
     program_page_timeout: 100
     erase_sector_timeout: 6000
     sectors:
-    - size: 0x400
+    - size: 0x800
       address: 0x0
-  cores:
-  - main

--- a/probe-rs/targets/STM32F1_Series.yaml
+++ b/probe-rs/targets/STM32F1_Series.yaml
@@ -2,6 +2,8 @@ name: STM32F1 Series
 manufacturer:
   id: 0x20
   cc: 0x0
+generated_from_pack: true
+pack_file_release: 2.4.1
 variants:
 - name: STM32F100C4
   cores:
@@ -12,12 +14,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -36,12 +40,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -60,12 +66,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -84,12 +92,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -108,12 +118,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -132,12 +144,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -156,12 +170,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -180,12 +196,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -204,12 +222,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20006000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -228,12 +248,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8060000
@@ -252,12 +274,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -276,12 +300,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -300,12 +326,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -324,12 +352,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20006000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -348,12 +378,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8060000
@@ -372,12 +404,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -396,12 +430,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20006000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -420,12 +456,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8060000
@@ -444,12 +482,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -468,12 +508,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -492,12 +534,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -516,12 +560,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -540,12 +586,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -564,12 +612,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -588,12 +638,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -612,12 +664,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -636,12 +690,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -660,12 +716,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -684,12 +742,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x2000c000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8060000
@@ -708,12 +768,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x2000c000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -732,12 +794,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20014000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x80c0000
@@ -756,12 +820,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20014000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -780,12 +846,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -804,12 +872,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -828,12 +898,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -852,12 +924,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -876,12 +950,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -900,12 +976,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -924,12 +1002,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -948,12 +1028,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x2000c000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8060000
@@ -972,12 +1054,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x2000c000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -996,12 +1080,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20014000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x80c0000
@@ -1020,12 +1106,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20014000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1044,12 +1132,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20008000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1068,12 +1158,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x2000c000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8060000
@@ -1092,12 +1184,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x2000c000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1116,12 +1210,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20014000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x80c0000
@@ -1140,12 +1236,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20014000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1164,12 +1262,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -1188,12 +1288,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1212,12 +1314,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1236,12 +1340,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1260,12 +1366,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -1284,12 +1392,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1308,12 +1418,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1332,12 +1444,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20004000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1356,12 +1470,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -1380,12 +1496,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1404,12 +1522,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20005000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1428,12 +1548,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20005000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1452,12 +1574,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -1476,12 +1600,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1500,12 +1626,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20005000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1524,12 +1652,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20005000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1548,12 +1678,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x2000c000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1572,12 +1704,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8060000
@@ -1596,12 +1730,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1620,12 +1756,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20018000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x80c0000
@@ -1644,12 +1782,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20018000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1668,12 +1808,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20001800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8004000
@@ -1692,12 +1834,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20002800
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8008000
@@ -1716,12 +1860,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20005000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1740,12 +1886,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20005000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1764,12 +1912,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20005000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -1788,12 +1938,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20005000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -1812,12 +1964,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x2000c000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1836,12 +1990,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8060000
@@ -1860,12 +2016,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1884,12 +2042,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20018000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x80c0000
@@ -1908,12 +2068,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20018000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1932,12 +2094,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x2000c000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -1956,12 +2120,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8060000
@@ -1980,12 +2146,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -2004,12 +2172,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20018000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x80c0000
@@ -2028,12 +2198,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20018000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -2052,12 +2224,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2076,12 +2250,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2100,12 +2276,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2124,12 +2302,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8010000
@@ -2148,12 +2328,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2172,12 +2354,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2196,12 +2380,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2220,12 +2406,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2244,12 +2432,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -2268,12 +2458,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -2284,29 +2476,6 @@ variants:
   - stm32f10x_512
   - stm32f10x_opt
 flash_algorithms:
-- name: stm32f10x_512
-  description: STM32F10x High-density Flash
-  default: true
-  instructions: ELUDRgAgREwgYERIYGBESGBgIEbAaRDwBA8I0UXyVVBATCBgBiBgYED2/3CgYAAgEL0BRjhIAGlA8IAANkoQYQAgcEc0SABpQPAEADJJCGEIRgBpQPBAAAhhA+BK9qogMEkIYCxIwGgQ8AEP9tEqSABpIPAEAChJCGEAIHBHAUYlSABpQPACACNKEGEQRkFhAGlA8EAAEGED4Er2qiAhShBgHUjAaBDwAQ/20RpIAGkg8AIAGEoQYQAgcEcQtQNGSBwg8AEBIuATSABpQPABABFMIGEQiBiAAL8PSMBoEPABD/rRDEgAaSDwAQAKTCBhIEbAaBDwFA8G0CBGwGhA8BQA4GABIBC9mxySHIkeACna0QAg9+cAAAAgAkAjAWdFq4nvzQAwAEAAAAAA
-  pc_init: 0x1
-  pc_uninit: 0x33
-  pc_program_page: 0xbd
-  pc_erase_sector: 0x7f
-  pc_erase_all: 0x45
-  data_section_offset: 0x128
-  flash_properties:
-    address_range:
-      start: 0x8000000
-      end: 0x8080000
-    page_size: 0x400
-    erased_byte_value: 0xff
-    program_page_timeout: 100
-    erase_sector_timeout: 500
-    sectors:
-    - size: 0x800
-      address: 0x0
-  cores:
-  - main
 - name: stm32f10x_128
   description: STM32F10x Med-density Flash
   default: true
@@ -2328,8 +2497,6 @@ flash_algorithms:
     sectors:
     - size: 0x400
       address: 0x0
-  cores:
-  - main
 - name: stm32f10x_opt
   description: STM32F10x Flash Options
   instructions: ELUDRgAgXkwgYF5IYGBeSGBgXEigYFxIoGAgRsBpEPAEDwjRRfJVUFhMIGAGIGBgQPb/cKBgACAQvQFGUEgAaSD0gHBOShBhEEYAaUDwgAAQYQAgcEdKSABpQPAgAEhJCGEIRgBpQPBAAAhhA+BK9qogRkkIYEJIwGgQ8AEP9tE/SABpIPAgAD1JCGEIRgBpQPAQAAhhRfalID1JCIAD4Er2qiA5SQhgNUjAaBDwAQ/20TNIAGkg8BAAMUkIYQhGwGgQ8BQPBtAIRsBoQPAUAMhgASBwRwAg/OcBRihIAGlA8CAAJkoQYRBGAGlA8EAAEGED4Er2qiAkShBgIEjAaBDwAQ/20R5IAGkg8CAAHEoQYQAgcEcDRgEgcEcQtQNGSBwg8AEBJuAVSABpQPAQABNMIGEQiBiAA+BK9qogE0wgYA9IwGgQ8AEP9tEMSABpIPAQAApMIGEgRsBoEPAUDwbQIEbAaEDwFADgYAEgEL2bHJIciR4AKdbRACD35wAAACACQCMBZ0Wrie/NADAAQAD4/x8AAAAA
@@ -2350,8 +2517,27 @@ flash_algorithms:
     sectors:
     - size: 0x10
       address: 0x0
-  cores:
-  - main
+- name: stm32f10x_512
+  description: STM32F10x High-density Flash
+  default: true
+  instructions: ELUDRgAgREwgYERIYGBESGBgIEbAaRDwBA8I0UXyVVBATCBgBiBgYED2/3CgYAAgEL0BRjhIAGlA8IAANkoQYQAgcEc0SABpQPAEADJJCGEIRgBpQPBAAAhhA+BK9qogMEkIYCxIwGgQ8AEP9tEqSABpIPAEAChJCGEAIHBHAUYlSABpQPACACNKEGEQRkFhAGlA8EAAEGED4Er2qiAhShBgHUjAaBDwAQ/20RpIAGkg8AIAGEoQYQAgcEcQtQNGSBwg8AEBIuATSABpQPABABFMIGEQiBiAAL8PSMBoEPABD/rRDEgAaSDwAQAKTCBhIEbAaBDwFA8G0CBGwGhA8BQA4GABIBC9mxySHIkeACna0QAg9+cAAAAgAkAjAWdFq4nvzQAwAEAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x33
+  pc_program_page: 0xbd
+  pc_erase_sector: 0x7f
+  pc_erase_all: 0x45
+  data_section_offset: 0x128
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8080000
+    page_size: 0x400
+    erased_byte_value: 0xff
+    program_page_timeout: 100
+    erase_sector_timeout: 500
+    sectors:
+    - size: 0x800
+      address: 0x0
 - name: stm32f10x_1024
   description: STM32F10x XL-density Flash
   default: true
@@ -2373,5 +2559,3 @@ flash_algorithms:
     sectors:
     - size: 0x800
       address: 0x0
-  cores:
-  - main

--- a/probe-rs/targets/STM32F2_Series.yaml
+++ b/probe-rs/targets/STM32F2_Series.yaml
@@ -2,6 +2,8 @@ name: STM32F2 Series
 manufacturer:
   id: 0x20
   cc: 0x0
+generated_from_pack: true
+pack_file_release: 2.11.0
 variants:
 - name: STM32F205RBTx
   cores:
@@ -12,12 +14,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -37,12 +41,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20018000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -62,12 +68,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -87,12 +95,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -112,15 +122,44 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x80c0000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32f2xx_1024
+  - stm32f2xx_opt
+  - stm32f2xx_otp
+- name: STM32F205RGEx
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0x0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
     is_boot_memory: true
     cores:
     - main
@@ -137,12 +176,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -162,12 +203,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -187,12 +230,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20010000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8020000
@@ -212,12 +257,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20018000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -237,12 +284,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -262,12 +311,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x80c0000
@@ -287,12 +338,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -312,12 +365,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20018000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -337,12 +392,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -362,12 +419,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x80c0000
@@ -387,12 +446,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -412,12 +473,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -437,12 +500,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -462,12 +527,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -487,12 +554,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -512,12 +581,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x80c0000
@@ -537,12 +608,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x80c0000
@@ -562,12 +635,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -587,12 +662,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -612,12 +689,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -637,12 +716,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -662,12 +743,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x80c0000
@@ -687,12 +770,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -712,12 +797,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8040000
@@ -737,12 +824,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -762,12 +851,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x80c0000
@@ -787,12 +878,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -812,12 +905,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -837,12 +932,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -862,12 +959,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -887,12 +986,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -912,12 +1013,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -937,12 +1040,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -962,12 +1067,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -987,12 +1094,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1012,12 +1121,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1037,12 +1148,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1062,12 +1175,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1087,12 +1202,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1112,12 +1229,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8080000
@@ -1137,12 +1256,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: IRAM1
     range:
       start: 0x20000000
       end: 0x20020000
     cores:
     - main
   - !Nvm
+    name: IROM1
     range:
       start: 0x8000000
       end: 0x8100000
@@ -1179,8 +1300,6 @@ flash_algorithms:
       address: 0x10000
     - size: 0x20000
       address: 0x20000
-  cores:
-  - main
 - name: stm32f2xx_opt
   description: STM32F2xx Flash Options
   instructions: AAMADiAoAtNACQAdcEcQKALTAAnAHHBHgAhwRylIKEmBYClJgWDBaPAiEUPBYEBpgAYG1CZIJUkBYAYhQWAlSYFgACBwRx9IQWkBIhFDQWEAIHBHG0jCaPAhCkPCYB5KQmFCaQIjGkNCYcJoEgYSDwTQwmgKQ8JgASBwRwAgcEcAIHBHEYkQiAkFCQmACIAAAUMMSMNo8CITQ8NgAiMZQ0FhwWjJA/zUwWgJBgkPBNDBaBFDwWABIHBHACBwRwAAOyoZCAA8AkB/bl1MVVUAAAAwAED/DwAA7Kr/DwAAAAA=
@@ -1201,8 +1320,6 @@ flash_algorithms:
     sectors:
     - size: 0x10
       address: 0x0
-  cores:
-  - main
 - name: stm32f2xx_otp
   description: STM32F2xx Flash OTP
   instructions: AAMADiAoAtNACQAdcEcQKALTAAnAHHBHgAhwRyVIJElBYCVJQWAAIQFgwWjwIhFDwWBAaYAGBtQhSCBJAWAGIUFgIEmBYAAgcEcaSAFpQgURQwFhACBwRwAgcEdwtRVNyRyJCOtoiQDwJjND62AAIythFUsX4CxpHEMsYRRoBGDsaOQD/NQsaWQIZAAsYexoJAYkDwTQ6GgwQ+hgASBwvQAdEh0JHwAp5dEAIHC9AAAjAWdFADwCQKuJ781VVQAAADAAQP8PAAABAgAAAAAAAA==
@@ -1222,5 +1339,3 @@ flash_algorithms:
     sectors:
     - size: 0x210
       address: 0x0
-  cores:
-  - main


### PR DESCRIPTION
This adds STM32F205RGEx, adds names to memory regions and includes some flash algo changes. While the names don't match #2556 I really did not want manually delete a million new strings especially that the names aren't the only change.