### PR TITLE
Add support for HPMicro's HPM5300 series of MCUs

### DIFF
--- a/changelog/added-hpm5300-series.md
+++ b/changelog/added-hpm5300-series.md
@@ -1,0 +1,1 @@
+Add support for HPMicro's HPM5300 series of MCUs

--- a/probe-rs/targets/HPM5300_Series.yaml
+++ b/probe-rs/targets/HPM5300_Series.yaml
@@ -1,0 +1,175 @@
+name: HPM5300 Series
+variants:
+- name: HPM5361
+  cores:
+  - name: core0
+    type: riscv
+    core_access_options: !Riscv {}
+  memory_map:
+  - !Ram
+    name: ILM0
+    range:
+      start: 0x0
+      end: 0x20000
+    cores:
+    - core0
+  - !Ram
+    name: DLM0
+    range:
+      start: 0x80000
+      end: 0xa0000
+    cores:
+    - core0
+  - !Ram
+    name: AHB_SRAM
+    range:
+      start: 0xf0400000
+      end: 0xf0408000
+    cores:
+    - core0
+  - !Nvm
+    name: XPI0
+    range:
+      start: 0x80000000
+      end: 0x80100000
+    is_boot_memory: true
+    cores:
+    - core0
+  flash_algorithms:
+  - flash-algo-hpm53x1
+- name: HPM5331
+  cores:
+  - name: core0
+    type: riscv
+    core_access_options: !Riscv {}
+  memory_map:
+  - !Ram
+    name: ILM0
+    range:
+      start: 0x0
+      end: 0x20000
+    cores:
+    - core0
+  - !Ram
+    name: DLM0
+    range:
+      start: 0x80000
+      end: 0xa0000
+    cores:
+    - core0
+  - !Ram
+    name: AHB_SRAM
+    range:
+      start: 0xf0400000
+      end: 0xf0408000
+    cores:
+    - core0
+  - !Nvm
+    name: XPI0
+    range:
+      start: 0x80000000
+      end: 0x80100000
+    is_boot_memory: true
+    cores:
+    - core0
+  flash_algorithms:
+  - flash-algo-hpm53x1
+- name: HPM5321
+  cores:
+  - name: core0
+    type: riscv
+    core_access_options: !Riscv {}
+  memory_map:
+  - !Ram
+    name: ILM0
+    range:
+      start: 0x0
+      end: 0x20000
+    cores:
+    - core0
+  - !Ram
+    name: DLM0
+    range:
+      start: 0x80000
+      end: 0xa0000
+    cores:
+    - core0
+  - !Ram
+    name: AHB_SRAM
+    range:
+      start: 0xf0400000
+      end: 0xf0408000
+    cores:
+    - core0
+  - !Nvm
+    name: XPI0
+    range:
+      start: 0x80000000
+      end: 0x80100000
+    is_boot_memory: true
+    cores:
+    - core0
+  flash_algorithms:
+  - flash-algo-hpm53x1
+- name: HPM5301
+  cores:
+  - name: core0
+    type: riscv
+    core_access_options: !Riscv {}
+  memory_map:
+  - !Ram
+    name: ILM0
+    range:
+      start: 0x0
+      end: 0x20000
+    cores:
+    - core0
+  - !Ram
+    name: DLM0
+    range:
+      start: 0x80000
+      end: 0xa0000
+    cores:
+    - core0
+  - !Ram
+    name: AHB_SRAM
+    range:
+      start: 0xf0400000
+      end: 0xf0408000
+    cores:
+    - core0
+  - !Nvm
+    name: XPI0
+    range:
+      start: 0x80000000
+      end: 0x80100000
+    is_boot_memory: true
+    cores:
+    - core0
+  flash_algorithms:
+  - flash-algo-hpm53x1
+flash_algorithms:
+- name: flash-algo-hpm53x1
+  description: flash algorithm for HPM53x1 series
+  default: true
+  instructions: EwEB3CMuESIjLIEiIyqRIiMoISO3BQAABUV9Fo1GI4SlSGN51gy3FQD0A6AFgH1WI6DFgAOgBYEjqMWAI6KlkGgAEwYAEIFFlwAAAOeAIBsjLgEQIywBEDcF+fwJBSMmoRAZRSMooRAFZSMqoRA3BQIgAyVF8XRF0cI3BQDzbABwAjcJAPOCliqEKemyRCMAAQQMCAgSEwbAD5cAAADngOApaAxsAlFGlwAAAOeAACk3BQAAIyiVNpMEBTcThUQADBITBgARlwAAAOeAICcjqiQRNwUAAIVFIwS1SCKFgyDBIwMkgSODJEEjAykBIxMBASSCgJcAAADngEANlwAAAOeAwA63BQAAA8aFSAVFAcYBRSOEBUiCgLcFAACDxYVIncG3BQIgg6VF8ZxRmc+3BQAAE4YFNwMnRhG3BgCAqY6RRTqFgocFRYKAlwAAAOeA4Am3BgAAA8eGSAXLLoi3BQIgg6VF8QOjhQJjAgMCsoa3BQAAE4YFN4MnRhE3BwCAKY+RRT6FwocCgwVFgoCXAAAA54CgBTcFAAADRYVIGc03BQIgAyVF8VxNmcs3BQAAEwYFNwMlRhGRRYKHBUWCgJcAAADngIACQREGxiLEAAiXAAAA54CAAkERBsYixAAIlwAAAOeAgP5BEQbGIsQACJcAAADngID+AaBBEQbGIsQACLJAIkRBARcDAABnAGMMQREGxiLEAAjBRmNr1gazBqBAE/g2ALMDBQFjDAgAqoeuhgPHBgAjgOcAhQeFBuPqd/6ziAUBMwgGQZNyyP+T9TgAs4ZTAKHBY1lQBJOVOAAT84UBk/fI/5BDswWwQBP+hQGRB5hDM1ZmALMVxwHRjSOgswCRA5EHOobj5dP+Maiqhg3iDahjWlAAxoWQQSOgwwCRA5EF4+vT/rOFWAATdjgAEco2lgPHBQAjgOYAhQaFBePqxv6yQCJEQQGCgEERBsYixAAIwUZjZNYEswagQI2KMwfVAJnGqocjgLcAhQfj7ef+FY6Td8b/swb3AGNe8AAT+PUPtwcBAZOHFxCzB/gCHMMRB+Nu1/4NigHmCaiqhhnGNpYjgLYAhQbj7cb+skAiREEBgoBBEQbGIsQACLJAIkRBARcDAABnAKPsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  load_address: 0x20
+  pc_init: 0x0
+  pc_uninit: 0x104
+  pc_program_page: 0x152
+  pc_erase_sector: 0x118
+  pc_erase_all: 0x196
+  data_section_offset: 0x468
+  flash_properties:
+    address_range:
+      start: 0x80000000
+      end: 0x80100000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 2000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+  cores:
+  - core0


### PR DESCRIPTION
This Pull Request adds flash algorithm of the HPM5300 series of MCUs. (HPM53x1, where the last "1" means flash size in MB)

HPM5300 series is a general-purpose microcontroller from HPMicro Semiconductor Co., Ltd.
It uses Andes' D25(F) RISC-V IP core(RV32-IMAFDCPB).

- Flyer(English): [HPM5300.pdf](http://hpmicro.com/Temp/HPM5300.pdf)
- Official Site(Simplified Chinese 中文): [HPM5300](http://hpmicro.com/product/series.html?id=b793ac43-1155-43f8-abf9-33626c063f0e)

The flash algorithm is maintained in <https://github.com/hpmicro-rs/flash-algo> (an unofficial team working on Rust support for HPM MCUs).
While implementing the flash algorithm, the following resources are referenced:

- OpenOCD fork: https://github.com/hpmicro/riscv-openocd
- OpenOCD conf in Official SDK: https://github.com/hpmicro/hpm_sdk/tree/main/boards/openocd
- Official JLink open flash loader: https://github.com/hpmicro/segger_open_flashloader
- Chip datasheet

Tested with:

- Probe: FT2232 probe
  - The MCU supports JLink and DAP as well(currently, probe-rs doesn't supports RISC-V JTag over DAP)
- Boards: Official hpm5301evklite(HPM5301),  hpm5300evk(HPM5361)
- RTT also works. Demo project setting is at https://github.com/hpmicro-rs/hpm5300-blinky and https://github.com/hpmicro-rs/hpm-hal

<img width="855" alt="image" src="https://github.com/probe-rs/probe-rs/assets/72891/75de9a3d-b802-4578-9565-ea9b437f6582">

Note that `probe-rs info` hangs with an infinite loop when communicating using DAP + FT2232 + HPM5300(while detecting ARM processors). Other subcommands work as expected.
