### PR TITLE
Add smoke test for breakpoint persistence

### DIFF
--- a/smoke-tester/src/tests.rs
+++ b/smoke-tester/src/tests.rs
@@ -8,7 +8,7 @@ use probe_rs::{
     Architecture, Core, MemoryInterface, Session,
 };
 
-pub mod stepping;
+pub mod test_arm;
 
 use miette::{IntoDiagnostic, Result, WrapErr};
 


### PR DESCRIPTION
When a target resets, it should persist its breakpoints. At least that's how system resets on the MIMXRT 10xx series seem to work. On the other hand, that's not how system resets on the MIMXRT 11xx series would work, unless there's custom support in the debug sequence (#2387). I used this smoke test to help me test that custom support.

I'm re-using the ARM target binary, used for step testing, to realize the new test case.