### PR TITLE
Add jtag support for daplink

### DIFF
--- a/changelog/added-dap-jtag-support.md
+++ b/changelog/added-dap-jtag-support.md
@@ -1,0 +1,1 @@
+Add jtag support for daplink, then you can debug riscv mcu with it.

--- a/changelog/added-dap-jtag-support.md
+++ b/changelog/added-dap-jtag-support.md
@@ -1,1 +1,1 @@
-Add jtag support for daplink, then you can debug riscv mcu with it.
+Add JTAG support for CMSIS-DAP probes.

--- a/probe-rs/src/probe/cmsisdap/commands/jtag/sequence.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/jtag/sequence.rs
@@ -100,7 +100,8 @@ impl Sequence {
             data,
         })
     }
-
+    /// Append one bit sequence a JTAG sequence.
+    /// It will return ok nnly if tms and capture are the same and current tck_cycles less than 64.
     pub(crate) fn append(&mut self, tms: bool, tdi: bool, capture: bool) -> Result<(), ()> {
         if self.tck_cycles < 64 && self.tms == tms && self.tdo_capture == capture {
             self.data[((self.tck_cycles) / 8) as usize] |= u8::from(tdi) << ((self.tck_cycles) % 8);
@@ -108,6 +109,14 @@ impl Sequence {
             Ok(())
         } else {
             Err(())
+        }
+    }
+    // Get how many tdo-bits need to be capture in this sequence.
+    pub(crate) fn capture_count(&self) -> usize {
+        if self.tdo_capture {
+            self.tck_cycles as usize
+        } else {
+            0
         }
     }
 }

--- a/probe-rs/src/probe/cmsisdap/commands/jtag/sequence.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/jtag/sequence.rs
@@ -100,8 +100,11 @@ impl Sequence {
             data,
         })
     }
-    /// Append one bit sequence a JTAG sequence.
-    /// It will return ok only if tms and capture are the same and current tck_cycles less than 64.
+    /// Appends one bit to a JTAG sequence.
+    ///
+    /// This function returns an error if the sequence can't be extended with the given parameters. These cases are:
+    /// - A sequence already contains 64 bits and is considered "full".
+    /// - The sequence was created with a different `tms` or `capture` value. Changing these requires creating a new sequence.
     pub(crate) fn append(&mut self, tms: bool, tdi: bool, capture: bool) -> Result<(), ()> {
         if self.tck_cycles < 64 && self.tms == tms && self.tdo_capture == capture {
             self.data[((self.tck_cycles) / 8) as usize] |= u8::from(tdi) << ((self.tck_cycles) % 8);

--- a/probe-rs/src/probe/cmsisdap/commands/jtag/sequence.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/jtag/sequence.rs
@@ -101,7 +101,7 @@ impl Sequence {
         })
     }
     /// Append one bit sequence a JTAG sequence.
-    /// It will return ok nnly if tms and capture are the same and current tck_cycles less than 64.
+    /// It will return ok only if tms and capture are the same and current tck_cycles less than 64.
     pub(crate) fn append(&mut self, tms: bool, tdi: bool, capture: bool) -> Result<(), ()> {
         if self.tck_cycles < 64 && self.tms == tms && self.tdo_capture == capture {
             self.data[((self.tck_cycles) / 8) as usize] |= u8::from(tdi) << ((self.tck_cycles) % 8);

--- a/probe-rs/src/probe/cmsisdap/commands/jtag/sequence.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/jtag/sequence.rs
@@ -100,6 +100,16 @@ impl Sequence {
             data,
         })
     }
+
+    pub(crate) fn append(&mut self, tms: bool, tdi: bool, capture: bool) -> Result<(), ()> {
+        if self.tck_cycles < 64 && self.tms == tms && self.tdo_capture == capture {
+            self.data[((self.tck_cycles) / 8) as usize] |= u8::from(tdi) << ((self.tck_cycles) % 8);
+            self.tck_cycles += 1;
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -1292,7 +1292,7 @@ impl RawJtagIo for CmsisDap {
     fn read_captured_bits(&mut self) -> Result<BitVec<u8, Lsb0>, DebugProbeError> {
         let mut capture = BitVec::<u8, Lsb0>::new();
         // We can transfer up to 255 sequences in one dap jtag-sequence command. But in some riscv chip there is some bug, thus I set up to 3 sequence in once jtag-sequence command transfer.
-        for sequence_slice in self.jtag_sequences.clone().chunks(3 as usize) {
+        for sequence_slice in self.jtag_sequences.clone().chunks(3) {
             let mut batch_sequence = Vec::new();
             batch_sequence.extend_from_slice(sequence_slice);
             let capture_count = batch_sequence.iter().map(|x| x.capture_count()).sum();

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -948,7 +948,7 @@ impl DebugProbe for CmsisDap {
             Ok(XtensaCommunicationInterface::new(self, state))
         } else {
             Err(DebugProbeError::InterfaceNotAvailable {
-                interface_name: "RISC-V",
+                interface_name: "Xtensa",
             })
         }
     }


### PR DESCRIPTION
# Description
The official full-featured DAPlink supports JTAG protocol, and the standard RISC-V MCU now only supports jtag debugging protocol. You can now use the DAPlink thith JTAG to debug RISC-V MCUs.
# Related issue:
close #2565 
# Test with:
- Probe: DAPlink(hpm5301evklite with CherryDAP firmware)
- Target: hpm5301evklite

![image](https://github.com/probe-rs/probe-rs/assets/172099550/fb7f365f-e626-46a8-bf44-cb3624b8492a)
