### PR TITLE
Add memory access attributes

### DIFF
--- a/changelog/added-memory-access.md
+++ b/changelog/added-memory-access.md
@@ -1,0 +1,1 @@
+Added `MemoryAccess` attributes to `RamRegion`, `NvmRegion` and `GenericRegion`

--- a/changelog/changed-is-boot-memory.md
+++ b/changelog/changed-is-boot-memory.md
@@ -1,0 +1,1 @@
+Moved `RamRegion::is_boot_memory` to `MemoryAccess::boot`

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -28,6 +28,6 @@ pub use chip_family::{
 pub use flash_algorithm::{RawFlashAlgorithm, TransferEncoding};
 pub use flash_properties::FlashProperties;
 pub use memory::{
-    GenericRegion, MemoryRange, MemoryRegion, NvmRegion, PageInfo, RamRegion, SectorDescription,
-    SectorInfo,
+    GenericRegion, MemoryRange, MemoryRegion, NvmRegion, PageInfo, MemoryAccess, RamRegion,
+    SectorDescription, SectorInfo,
 };

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -28,6 +28,6 @@ pub use chip_family::{
 pub use flash_algorithm::{RawFlashAlgorithm, TransferEncoding};
 pub use flash_properties::FlashProperties;
 pub use memory::{
-    GenericRegion, MemoryRange, MemoryRegion, NvmRegion, PageInfo, MemoryAccess, RamRegion,
+    GenericRegion, MemoryAccess, MemoryRange, MemoryRegion, NvmRegion, PageInfo, RamRegion,
     SectorDescription, SectorInfo,
 };

--- a/probe-rs-target/src/memory.rs
+++ b/probe-rs-target/src/memory.rs
@@ -10,14 +10,41 @@ pub struct NvmRegion {
     /// Address range of the region
     #[serde(serialize_with = "hex_range")]
     pub range: Range<u64>,
-    /// True if the chip boots from this memory
-    #[serde(default)]
-    pub is_boot_memory: bool,
     /// List of cores that can access this region
     pub cores: Vec<String>,
     /// True if the memory region is an alias of a different memory region.
     #[serde(default)]
     pub is_alias: bool,
+    /// Access permissions for the region.
+    #[serde(default)]
+    pub access: Option<MemoryAccess>,
+}
+
+impl NvmRegion {
+    /// Returns the access permissions for the region.
+    pub fn access(&self) -> MemoryAccess {
+        self.access.unwrap_or_default()
+    }
+
+    /// Returns whether the region is readable.
+    pub fn is_readable(&self) -> bool {
+        self.access().read
+    }
+
+    /// Returns whether the region is writable.
+    pub fn is_writable(&self) -> bool {
+        self.access().write
+    }
+
+    /// Returns whether the region is executable.
+    pub fn is_executable(&self) -> bool {
+        self.access().execute
+    }
+
+    /// Returns whether the region is boot memory.
+    pub fn is_boot_memory(&self) -> bool {
+        self.access().boot
+    }
 }
 
 impl NvmRegion {
@@ -25,6 +52,38 @@ impl NvmRegion {
     pub fn nvm_info(&self) -> NvmInfo {
         NvmInfo {
             rom_start: self.range.start,
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Represents access permissions of a region in RAM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MemoryAccess {
+    /// True if the region is readable.
+    #[serde(default = "default_true")]
+    pub read: bool,
+    /// True if the region is writable.
+    #[serde(default = "default_true")]
+    pub write: bool,
+    /// True if the region is executable.
+    #[serde(default = "default_true")]
+    pub execute: bool,
+    /// True if the chip boots from this memory
+    #[serde(default)]
+    pub boot: bool,
+}
+
+impl Default for MemoryAccess {
+    fn default() -> Self {
+        MemoryAccess {
+            read: true,
+            write: true,
+            execute: true,
+            boot: false,
         }
     }
 }
@@ -37,11 +96,38 @@ pub struct RamRegion {
     /// Address range of the region
     #[serde(serialize_with = "hex_range")]
     pub range: Range<u64>,
-    /// True if the chip boots from this memory
-    #[serde(default)]
-    pub is_boot_memory: bool,
     /// List of cores that can access this region
     pub cores: Vec<String>,
+    /// Access permissions for the region.
+    #[serde(default)]
+    pub access: Option<MemoryAccess>,
+}
+
+impl RamRegion {
+    /// Returns the access permissions for the region.
+    pub fn access(&self) -> MemoryAccess {
+        self.access.unwrap_or_default()
+    }
+
+    /// Returns whether the region is readable.
+    pub fn is_readable(&self) -> bool {
+        self.access().read
+    }
+
+    /// Returns whether the region is writable.
+    pub fn is_writable(&self) -> bool {
+        self.access().write
+    }
+
+    /// Returns whether the region is executable.
+    pub fn is_executable(&self) -> bool {
+        self.access().execute
+    }
+
+    /// Returns whether the region is boot memory.
+    pub fn is_boot_memory(&self) -> bool {
+        self.access().boot
+    }
 }
 
 /// Represents a generic region.
@@ -54,6 +140,31 @@ pub struct GenericRegion {
     pub range: Range<u64>,
     /// List of cores that can access this region
     pub cores: Vec<String>,
+    /// Access permissions for the region.
+    #[serde(default)]
+    pub access: Option<MemoryAccess>,
+}
+
+impl GenericRegion {
+    /// Returns the access permissions for the region.
+    pub fn access(&self) -> MemoryAccess {
+        self.access.unwrap_or_default()
+    }
+
+    /// Returns whether the region is readable.
+    pub fn is_readable(&self) -> bool {
+        self.access().read
+    }
+
+    /// Returns whether the region is writable.
+    pub fn is_writable(&self) -> bool {
+        self.access().write
+    }
+
+    /// Returns whether the region is executable.
+    pub fn is_executable(&self) -> bool {
+        self.access().execute
+    }
 }
 
 /// Holds information about a specific, individual flash

--- a/probe-rs/src/flashing/builder.rs
+++ b/probe-rs/src/flashing/builder.rs
@@ -371,7 +371,7 @@ impl FlashBuilder {
 
 #[cfg(test)]
 mod tests {
-    use probe_rs_target::{FlashProperties, SectorDescription};
+    use probe_rs_target::{FlashProperties, MemoryAccess, SectorDescription};
 
     use super::*;
 
@@ -395,7 +395,10 @@ mod tests {
 
         let region = NvmRegion {
             name: Some("FLASH".into()),
-            is_boot_memory: true,
+            access: Some(MemoryAccess {
+                boot: true,
+                ..Default::default()
+            }),
             range: 0..1 << 16,
             cores: vec!["main".into()],
             is_alias: false,
@@ -424,7 +427,10 @@ mod tests {
 
         let region = NvmRegion {
             name: Some("FLASH".into()),
-            is_boot_memory: true,
+            access: Some(MemoryAccess {
+                boot: true,
+                ..Default::default()
+            }),
             range: 0..1 << 16,
             cores: vec!["main".into()],
             is_alias: false,

--- a/probe-rs/targets/STM32F4_Series.yaml
+++ b/probe-rs/targets/STM32F4_Series.yaml
@@ -3218,15 +3218,6 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
-    name: CCMRAM
-    range:
-      start: 0x10000000
-      end: 0x10010000
-    cores:
-    - main
-    access:
-      execute: false
-  - !Ram
     range:
       start: 0x20000000
       end: 0x20030000

--- a/probe-rs/targets/STM32F4_Series.yaml
+++ b/probe-rs/targets/STM32F4_Series.yaml
@@ -3218,6 +3218,15 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
+    name: CCMRAM
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
     range:
       start: 0x20000000
       end: 0x20030000

--- a/smoke-tester/src/tests/stepping.rs
+++ b/smoke-tester/src/tests/stepping.rs
@@ -15,11 +15,14 @@ const TEST_CODE: &[u8] = include_bytes!("test_arm.bin");
 fn test_stepping(tracker: &TestTracker, core: &mut Core) -> TestResult {
     println!("Testing stepping...");
 
-    if core.architecture() == Architecture::Riscv {
+    if core.architecture() != Architecture::Arm {
         // Not implemented for RISC-V yet
         return Err(TestFailure::UnimplementedForTarget(
             Box::new(tracker.current_target().clone()),
-            "Testing stepping is not implemented for RISC-V yet.".to_string(),
+            format!(
+                "Testing stepping is not implemented for {:?} yet.",
+                core.architecture()
+            ),
         ));
     }
 

--- a/smoke-tester/src/tests/stepping.rs
+++ b/smoke-tester/src/tests/stepping.rs
@@ -26,8 +26,7 @@ fn test_stepping(tracker: &TestTracker, core: &mut Core) -> TestResult {
     let ram_region = core
         .memory_regions()
         .filter_map(MemoryRegion::as_ram_region)
-        .filter(|r| r.is_executable())
-        .next();
+        .find(|r| r.is_executable());
 
     let Some(ram_region) = ram_region else {
         return Err(TestFailure::Skipped(

--- a/target-gen/src/commands/elf.rs
+++ b/target-gen/src/commands/elf.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use probe_rs_target::{
-    ArmCoreAccessOptions, Chip, ChipFamily, Core, CoreAccessOptions, CoreType, MemoryRegion,
-    NvmRegion, RamRegion, RawFlashAlgorithm, TargetDescriptionSource,
+    ArmCoreAccessOptions, Chip, ChipFamily, Core, CoreAccessOptions, CoreType, MemoryAccess,
+    MemoryRegion, NvmRegion, RamRegion, RawFlashAlgorithm, TargetDescriptionSource,
 };
 use std::{
     borrow::Cow,
@@ -95,17 +95,20 @@ pub fn cmd_elf(
                 name: "<chip name>".to_owned(),
                 memory_map: vec![
                     MemoryRegion::Nvm(NvmRegion {
-                        is_boot_memory: false,
+                        access: None,
                         range: 0..0x2000,
                         cores: vec!["main".to_owned()],
                         name: None,
                         is_alias: false,
                     }),
                     MemoryRegion::Ram(RamRegion {
-                        is_boot_memory: true,
                         range: 0x1_0000..0x2_0000,
                         cores: vec!["main".to_owned()],
                         name: None,
+                        access: Some(MemoryAccess {
+                            boot: true,
+                            ..Default::default()
+                        }),
                     }),
                 ],
                 flash_algorithms: vec![algorithm_name],

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -5,7 +5,7 @@ use futures::StreamExt;
 use probe_rs::flashing::FlashAlgorithm;
 use probe_rs_target::{
     Architecture, ArmCoreAccessOptions, Chip, ChipFamily, Core as ProbeCore, CoreAccessOptions,
-    CoreType, GenericRegion, MemoryRegion, NvmRegion, RamRegion, RawFlashAlgorithm,
+    CoreType, GenericRegion, MemoryAccess, MemoryRegion, NvmRegion, RamRegion, RawFlashAlgorithm,
     RiscvCoreAccessOptions, TargetDescriptionSource, XtensaCoreAccessOptions,
 };
 use std::collections::HashMap;
@@ -444,7 +444,7 @@ where
 }
 
 /// A flag to indicate what type of memory this is.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum MemoryType {
     /// A RAM memory.
     Ram,
@@ -457,14 +457,28 @@ enum MemoryType {
 /// A struct to combine essential information from [`cmsis_pack::pdsc::Device::memories`].
 /// This is used to apply the necessary sorting and filtering in creating [`MemoryRegion`]s.
 // The sequence of the fields is important for the sorting by derived natural order.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct DeviceMemory {
     memory_type: MemoryType,
     p_name: Option<String>,
-    is_boot_memory: bool,
     memory_start: u64,
     memory_end: u64,
     name: String,
+    access: MemoryAccess,
+}
+
+impl DeviceMemory {
+    fn access(&self) -> Option<MemoryAccess> {
+        fn is_default(access: &MemoryAccess) -> bool {
+            access == &MemoryAccess::default()
+        }
+
+        if is_default(&self.access) {
+            None
+        } else {
+            Some(self.access)
+        }
+    }
 }
 
 /// Extracts the memory regions in the package.
@@ -491,12 +505,24 @@ pub(crate) fn get_mem_map(device: &Device, cores: &[probe_rs_target::Core]) -> V
             },
             memory_start: memory.start,
             memory_end: memory.start + memory.size,
-            is_boot_memory: memory.startup,
+            access: MemoryAccess {
+                read: memory.access.read,
+                write: memory.access.write,
+                execute: memory.access.execute,
+                boot: memory.startup,
+            },
         })
         .collect();
 
     // Sort by memory type, then by processor name, then by boot memory, then by start address.
-    device_memories.sort();
+    device_memories.sort_by_key(|memory| {
+        (
+            memory.memory_type.clone(),
+            memory.p_name.clone(),
+            memory.access.boot,
+            memory.memory_start,
+        )
+    });
 
     let all_cores: Vec<_> = cores.iter().map(|core| core.name.clone()).collect();
 
@@ -518,30 +544,30 @@ pub(crate) fn get_mem_map(device: &Device, cores: &[probe_rs_target::Core]) -> V
         match region.memory_type {
             MemoryType::Ram => {
                 if let Some(MemoryRegion::Ram(existing_region)) = mem_map.iter_mut().find(|existing_region| {
-                        matches!(existing_region, MemoryRegion::Ram(ram_region) if ram_region.name.as_deref() == Some(&region.name))
+                        matches!(existing_region, MemoryRegion::Ram(ram_region) if ram_region.name.as_deref() == Some(&region.name) && ram_region.access == region.access())
                     })
                 {
                     existing_region.cores.extend_from_slice(&cores);
                 } else {
                     mem_map.push(MemoryRegion::Ram(RamRegion {
+                        access: region.access(),
                         name: Some(region.name),
                         range: region.memory_start..region.memory_end,
-                        is_boot_memory: region.is_boot_memory,
                         cores,
                     }));
                 }
             },
             MemoryType::Nvm => {
                 if let Some(MemoryRegion::Nvm(existing_region)) = mem_map.iter_mut().find(|existing_region| {
-                        matches!(existing_region, MemoryRegion::Nvm(nvm_region) if nvm_region.name.as_deref() == Some(&region.name))
+                        matches!(existing_region, MemoryRegion::Nvm(nvm_region) if nvm_region.name.as_deref() == Some(&region.name) && nvm_region.access == region.access())
                     })
                 {
                     existing_region.cores.extend_from_slice(&cores);
                 } else {
                     mem_map.push(MemoryRegion::Nvm(NvmRegion {
+                        access: region.access(),
                         name: Some(region.name),
                         range: region.memory_start..region.memory_end,
-                        is_boot_memory: region.is_boot_memory,
                         cores,
                         is_alias: false,
                     }));
@@ -549,12 +575,13 @@ pub(crate) fn get_mem_map(device: &Device, cores: &[probe_rs_target::Core]) -> V
             },
             MemoryType::Generic => {
                 if let Some(MemoryRegion::Generic(existing_region)) = mem_map.iter_mut().find(|existing_region| {
-                        matches!(existing_region, MemoryRegion::Generic(generic_region) if generic_region.name.as_deref() == Some(&region.name))
+                        matches!(existing_region, MemoryRegion::Generic(generic_region) if generic_region.name.as_deref() == Some(&region.name) && generic_region.access == region.access())
                     })
                 {
                     existing_region.cores.extend_from_slice(&cores);
                 } else {
                     mem_map.push(MemoryRegion::Generic(GenericRegion {
+                        access: region.access(),
                         name: Some(region.name),
                         range: region.memory_start..region.memory_end,
                         cores,

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -517,7 +517,7 @@ pub(crate) fn get_mem_map(device: &Device, cores: &[probe_rs_target::Core]) -> V
     // Sort by memory type, then by processor name, then by boot memory, then by start address.
     device_memories.sort_by_key(|memory| {
         (
-            memory.memory_type.clone(),
+            memory.memory_type,
             memory.p_name.clone(),
             memory.access.boot,
             memory.memory_start,


### PR DESCRIPTION
STM32F4 CCM RAM does not seem to be executable. This causes problems with the smoke tester, which downloads stepping code into the first RAM section it finds.