### PR TITLE
Remove duplicate nrf51 entry

### DIFF
--- a/probe-rs/targets/nRF51_Series.yaml
+++ b/probe-rs/targets/nRF51_Series.yaml
@@ -70,7 +70,7 @@ chip_detection:
       0x60: nRF51822_xxAB
       0x61: nRF51422_xxAB
       0x63: nRF51422_xxAA
-      0x63: nRF51822_xxAB
+      # 0x63: nRF51822_xxAB # duplicate hwid
       0x64: nRF51822_xxAB
       0x65: nRF51422_xxAB
       0x66: nRF51422_xxAB


### PR DESCRIPTION
I've chosen to drop the 822 over the 422, based on data in the nRF51 compatibility matrices.

Interesting how serde doesn't care about the duplicate.