### PR TITLE
Validate that flash algos can be constructed

### DIFF
--- a/probe-rs-target/src/memory.rs
+++ b/probe-rs-target/src/memory.rs
@@ -22,6 +22,11 @@ pub struct NvmRegion {
 }
 
 impl NvmRegion {
+    /// Returns whether the region is accessible by the given core.
+    pub fn accessible_by(&self, core_name: &str) -> bool {
+        self.cores.iter().any(|c| c == core_name)
+    }
+
     /// Returns the access permissions for the region.
     pub fn access(&self) -> MemoryAccess {
         self.access.unwrap_or_default()
@@ -106,6 +111,11 @@ pub struct RamRegion {
 }
 
 impl RamRegion {
+    /// Returns whether the region is accessible by the given core.
+    pub fn accessible_by(&self, core_name: &str) -> bool {
+        self.cores.iter().any(|c| c == core_name)
+    }
+
     /// Returns the access permissions for the region.
     pub fn access(&self) -> MemoryAccess {
         self.access.unwrap_or_default()
@@ -149,6 +159,11 @@ pub struct GenericRegion {
 }
 
 impl GenericRegion {
+    /// Returns whether the region is accessible by the given core.
+    pub fn accessible_by(&self, core_name: &str) -> bool {
+        self.cores.iter().any(|c| c == core_name)
+    }
+
     /// Returns the access permissions for the region.
     pub fn access(&self) -> MemoryAccess {
         self.access.unwrap_or_default()

--- a/probe-rs/src/config/mod.rs
+++ b/probe-rs/src/config/mod.rs
@@ -36,7 +36,7 @@ pub use registry::{
     add_target_from_yaml, families, get_target_and_family_by_name, get_target_by_name,
     get_targets_by_family_name, search_chips, RegistryError,
 };
-pub use target::{DebugSequence, Target, TargetParseError, TargetSelector};
+pub use target::{DebugSequence, Target, TargetSelector};
 
 // Crate-internal API
 pub(crate) use chip_info::ChipInfo;

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -306,8 +306,8 @@ impl Registry {
     }
 
     fn get_target(&self, family: &ChipFamily, chip: &Chip) -> Result<Target, RegistryError> {
-        // The validity of the given `ChipFamily` is checked in the constructor.
-        Target::new(family, &chip.name)
+        // The validity of the given `ChipFamily` is checked in test time and in `add_target_from_yaml`.
+        Target::new(family, chip)
     }
 
     fn add_target_from_yaml<R>(&mut self, yaml_reader: R) -> Result<String, RegistryError>

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -431,6 +431,8 @@ fn match_name_prefix(pattern: &str, name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use crate::flashing::FlashAlgorithm;
+
     use super::*;
     use std::fs::File;
     type TestResult = Result<(), RegistryError>;
@@ -508,8 +510,7 @@ mod tests {
                 // Walk through the flash algorithms and cores and try to create each one.
                 for raw_flash_algo in target.flash_algorithms.iter() {
                     for core in raw_flash_algo.cores.iter() {
-                        target
-                            .initialized_flash_algorithm_by_name(&raw_flash_algo.name, core)
+                        FlashAlgorithm::assemble_from_raw_with_core(raw_flash_algo, core, &target)
                             .unwrap_or_else(|error| {
                                 panic!(
                                     "Failed to initialize flash algorithm ({}, {}, {core}): {}",

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -509,7 +509,7 @@ mod tests {
                 for raw_flash_algo in target.flash_algorithms.iter() {
                     for core in raw_flash_algo.cores.iter() {
                         target
-                            .initialized_flash_algorithm_by_name(&raw_flash_algo.name, &core)
+                            .initialized_flash_algorithm_by_name(&raw_flash_algo.name, core)
                             .unwrap_or_else(|error| {
                                 panic!(
                                     "Failed to initialize flash algorithm ({}, {}, {core}): {}",

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -500,7 +500,10 @@ mod tests {
             .families
             .iter()
             .flat_map(|family| {
-                // Validate all chip descriptors by constructing a Target.
+                // Validate all chip descriptors.
+                family.validate().unwrap();
+
+                // Make additional checks by creating a target for each chip.
                 family
                     .variants()
                     .iter()

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -497,7 +497,13 @@ mod tests {
         registry
             .families
             .iter()
-            .map(|family| family.validate())
+            .flat_map(|family| {
+                // Validate all chip descriptors by constructing a Target.
+                family
+                    .variants()
+                    .iter()
+                    .map(|chip| registry.get_target(family, chip))
+            })
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
     }

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -56,9 +56,6 @@ impl std::fmt::Debug for Target {
     }
 }
 
-/// An error occurred while parsing the target description.
-pub type TargetParseError = serde_yaml::Error;
-
 impl Target {
     /// Create a new target for the given details.
     ///

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -75,11 +75,6 @@ impl Target {
         family: &ChipFamily,
         chip_name: impl AsRef<str>,
     ) -> Result<Target, RegistryError> {
-        // Make sure we are given a valid family:
-        family
-            .validate()
-            .map_err(|e| RegistryError::InvalidChipFamilyDefinition(Box::new(family.clone()), e))?;
-
         let chip = family
             .variants
             .iter()

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -9,7 +9,7 @@ use crate::architecture::{
     xtensa::sequences::{DefaultXtensaSequence, XtensaDebugSequence},
 };
 use crate::flashing::FlashLoader;
-use probe_rs_target::{Architecture, BinaryFormat, ChipFamily, Jtag, MemoryRange};
+use probe_rs_target::{Architecture, BinaryFormat, Chip, ChipFamily, Jtag, MemoryRange};
 use std::sync::Arc;
 
 /// This describes a complete target with a fixed chip model and variant.
@@ -59,25 +59,8 @@ impl std::fmt::Debug for Target {
 impl Target {
     /// Create a new target for the given details.
     ///
-    /// We suggest never using this function directly.
-    /// Use [`crate::config::registry::get_target_by_name`] instead.
-    /// This will ensure that the used target is valid.
-    ///
-    /// The user has to make sure that all the cores have the same [`Architecture`].
-    /// In any case, this function will always just use the architecture of the first core in any further functionality.
-    /// In practice we have never encountered a [`Chip`] with mixed architectures so this should not be of issue.
-    ///
-    /// Furthermore, the user has to ensure that any [`Core`] in `flash_algorithms[n].cores` is present in `cores` as well.
-    pub(crate) fn new(
-        family: &ChipFamily,
-        chip_name: impl AsRef<str>,
-    ) -> Result<Target, RegistryError> {
-        let chip = family
-            .variants
-            .iter()
-            .find(|chip| chip.name == chip_name.as_ref())
-            .ok_or_else(|| RegistryError::ChipNotFound(chip_name.as_ref().to_string()))?;
-
+    /// The given chip must be a member of the given family.
+    pub(super) fn new(family: &ChipFamily, chip: &Chip) -> Result<Target, RegistryError> {
         let mut flash_algorithms = Vec::new();
         for algo_name in chip.flash_algorithms.iter() {
             let algo = family.get_algorithm(algo_name).expect(

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     flashing::FlashError,
 };
-use probe_rs_target::{Architecture, BinaryFormat, ChipFamily, Jtag, MemoryRange};
+use probe_rs_target::{Architecture, BinaryFormat, ChipFamily, Jtag, MemoryRange, RamRegion};
 use std::sync::Arc;
 
 /// This describes a complete target with a fixed chip model and variant.
@@ -206,58 +206,7 @@ impl Target {
         core_name: &str,
     ) -> Result<FlashAlgorithm, FlashError> {
         self.flash_algorithm_by_name(algo_name)
-            .map(|algo| {
-                // Find a RAM region from which we can run the algo.
-                let mm = &self.memory_map;
-                let ram = mm
-                    .iter()
-                    .filter_map(MemoryRegion::as_ram_region)
-                    .find(|ram| {
-                        if !ram.is_executable() {
-                            return false;
-                        }
-
-                        // If the algorithm has a forced load address, we try to use it.
-                        // If not, then follow the CMSIS-Pack spec and use first available RAM region.
-                        // In theory, it should be the "first listed in the pack", but the process of
-                        // reading from the pack files obfuscates the list order, so we will use the first
-                        // one in the target spec, which is the qualifying region with the lowest start saddress.
-                        // - See https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/pdsc_family_pg.html#element_memory .
-                        if let Some(load_addr) = algo.load_address {
-                            // The RAM must contain the forced load address _and_
-                            // be accessible from the core we're going to run the
-                            // algorithm on.
-                            ram.range.contains(&load_addr) && ram.accessible_by(core_name)
-                        } else {
-                            // Any executable RAM is okay as long as it's accessible to the core;
-                            // the algorithm is presumably position-independent.
-                            ram.accessible_by(core_name)
-                        }
-                    })
-                    .ok_or(FlashError::NoRamDefined {
-                        name: self.name.clone(),
-                    })?;
-                tracing::info!("Chosen RAM to run the algo: {:x?}", ram);
-
-                let data_ram = if let Some(data_load_address) = algo.data_load_address {
-                    mm.iter()
-                        .filter_map(MemoryRegion::as_ram_region)
-                        .find(|ram| {
-                            // The RAM must contain the forced load address _and_
-                            // be accessible from the core we're going to run the
-                            // algorithm on.
-                            ram.range.contains(&data_load_address) && ram.accessible_by(core_name)
-                        })
-                        .ok_or(FlashError::NoRamDefined {
-                            name: self.name.clone(),
-                        })?
-                } else {
-                    ram
-                };
-                tracing::info!("Data will be loaded to: {:x?}", data_ram);
-
-                FlashAlgorithm::assemble_from_raw_with_data(algo, ram, data_ram, self)
-            })
+            .map(|algo| self.initialize_flash_algo(algo, core_name))
             .unwrap_or_else(|| {
                 Err(FlashError::AlgorithmNotFound {
                     name: self.name.clone(),
@@ -265,6 +214,70 @@ impl Target {
                 })
             })
     }
+
+    fn initialize_flash_algo(
+        &self,
+        algo: &RawFlashAlgorithm,
+        core_name: &str,
+    ) -> Result<FlashAlgorithm, FlashError> {
+        // Find a RAM region from which we can run the algo.
+        let mm = &self.memory_map;
+        let ram = mm
+            .iter()
+            .filter_map(MemoryRegion::as_ram_region)
+            .find(|ram| is_ram_suitable_for_algo(ram, core_name, algo.load_address))
+            .ok_or(FlashError::NoRamDefined {
+                name: self.name.clone(),
+            })?;
+        tracing::info!("Chosen RAM to run the algo: {:x?}", ram);
+
+        let data_ram = if let Some(data_load_address) = algo.data_load_address {
+            mm.iter()
+                .filter_map(MemoryRegion::as_ram_region)
+                .find(|ram| is_ram_suitable_for_data(ram, core_name, data_load_address))
+                .ok_or(FlashError::NoRamDefined {
+                    name: self.name.clone(),
+                })?
+        } else {
+            // If not specified, use the same region as the flash algo.
+            ram
+        };
+        tracing::info!("Data will be loaded to: {:x?}", data_ram);
+
+        FlashAlgorithm::assemble_from_raw_with_data(algo, ram, data_ram, self)
+    }
+}
+
+/// Returns whether the given RAM region is usable for downloading the flash algorithm.
+fn is_ram_suitable_for_algo(ram: &RamRegion, core_name: &str, load_address: Option<u64>) -> bool {
+    if !ram.is_executable() {
+        return false;
+    }
+
+    // If the algorithm has a forced load address, we try to use it.
+    // If not, then follow the CMSIS-Pack spec and use first available RAM region.
+    // In theory, it should be the "first listed in the pack", but the process of
+    // reading from the pack files obfuscates the list order, so we will use the first
+    // one in the target spec, which is the qualifying region with the lowest start saddress.
+    // - See https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/pdsc_family_pg.html#element_memory .
+    if let Some(load_addr) = load_address {
+        // The RAM must contain the forced load address _and_
+        // be accessible from the core we're going to run the
+        // algorithm on.
+        ram.range.contains(&load_addr) && ram.accessible_by(core_name)
+    } else {
+        // Any executable RAM is okay as long as it's accessible to the core;
+        // the algorithm is presumably position-independent.
+        ram.accessible_by(core_name)
+    }
+}
+
+/// Returns whether the given RAM region is usable for downloading the flash algorithm data.
+fn is_ram_suitable_for_data(ram: &RamRegion, core_name: &str, load_address: u64) -> bool {
+    // The RAM must contain the forced load address _and_
+    // be accessible from the core we're going to run the
+    // algorithm on.
+    ram.range.contains(&load_address) && ram.accessible_by(core_name)
 }
 
 /// Selector for the debug target.

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -95,8 +95,11 @@ pub enum FlashError {
         address: u64,
     },
     /// Failed to configure a valid stack size for the flash algorithm.
-    #[error("Failed to configure a stack for the flash algorithm.")]
-    InvalidFlashAlgorithmStackSize,
+    #[error("Failed to configure a stack of size {size} for the flash algorithm.")]
+    InvalidFlashAlgorithmStackSize {
+        /// The size of the stack that was tried to be configured.
+        size: u64,
+    },
     /// The given page size is not valid. Only page sizes multiples of 4 bytes are allowed.
     #[error("Invalid page size {size:#010x}. Must be a multiple of 4 bytes.")]
     InvalidPageSize {

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -5,6 +5,14 @@ use std::ops::Range;
 /// Describes any error that happened during the or in preparation for the flashing procedure.
 #[derive(thiserror::Error, Debug)]
 pub enum FlashError {
+    /// No flash algorithm was found by the given name.
+    #[error("The {name} target has no flash algorithm called {name}")]
+    AlgorithmNotFound {
+        /// The name of the target.
+        name: String,
+        /// The name of the algorithm that was not found.
+        algo_name: String,
+    },
     /// No flash memory contains the entire requested memory range.
     #[error("No flash memory contains the entire requested memory range {range:#010X?}.")]
     NoSuitableNvm {
@@ -80,7 +88,7 @@ pub enum FlashError {
     ///
     /// Check the algorithm code and settings before you try again.
     #[error(
-        "Failed to load flash algorithm into RAM at address {address:08X?}. Is there space for the algorithm header?"
+        "Failed to load flash algorithm into RAM at address {address:#010x}. Is there space for the algorithm header?"
     )]
     InvalidFlashAlgorithmLoadAddress {
         /// The address where the algorithm was supposed to be loaded to.
@@ -90,7 +98,7 @@ pub enum FlashError {
     #[error("Failed to configure a stack for the flash algorithm.")]
     InvalidFlashAlgorithmStackSize,
     /// The given page size is not valid. Only page sizes multiples of 4 bytes are allowed.
-    #[error("Invalid page size {size:08X?}. Must be a multiple of 4 bytes.")]
+    #[error("Invalid page size {size:#010x}. Must be a multiple of 4 bytes.")]
     InvalidPageSize {
         /// The size of the page in bytes.
         size: u32,
@@ -99,7 +107,7 @@ pub enum FlashError {
     // TODO: 1 Add information about flash (name, address)
     // TODO: 2 Add source of target definition (built-in, yaml)
     /// No flash algorithm was linked to this target.
-    #[error("Trying to write to flash region {range:#010X?}, but no suitable (default) flash loader algorithm is linked to the given target: {name}.")]
+    #[error("Trying to write to flash region {range:#010x?}, but no suitable (default) flash loader algorithm is linked to the given target: {name}.")]
     NoFlashLoaderAlgorithmAttached {
         /// The name of the chip.
         name: String,
@@ -156,7 +164,7 @@ pub enum FlashError {
     #[error("No core can access the ram region {0:?}.")]
     NoRamCoreAccess(RamRegion),
     /// The register value supplied for this flash algorithm is out of the supported range.
-    #[error("The register value {0:#010x?} is out of the supported range.")]
+    #[error("The register value {0:#010x} is out of the supported range.")]
     RegisterValueNotSupported(u64),
     /// Stack overflow while flashing.
     #[error("Stack overflow detected during {operation}.")]

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -327,7 +327,7 @@ impl FlashAlgorithm {
             // We can't place data and stack.
             // TODO: this should probably be done in the target validation.
             // TODO: make the errors a bit more meaningful.
-            return Err(FlashError::InvalidFlashAlgorithmStackSize);
+            return Err(FlashError::InvalidFlashAlgorithmStackSize { size: stack_size });
         };
 
         // We need to make sure the blocks don't overlap and we have enough memory.
@@ -350,7 +350,7 @@ impl FlashAlgorithm {
         tracing::info!("Stack top: {:#010x}", stack_top);
 
         if stack_top > ram_region.range.end {
-            return Err(FlashError::InvalidFlashAlgorithmStackSize);
+            return Err(FlashError::InvalidFlashAlgorithmStackSize { size: stack_size });
         }
 
         // Determine whether we can use double buffering or not by the remaining RAM region size.

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -1,7 +1,8 @@
 use super::FlashError;
 use crate::{architecture::riscv, core::Architecture, Target};
 use probe_rs_target::{
-    FlashProperties, PageInfo, RamRegion, RawFlashAlgorithm, SectorInfo, TransferEncoding,
+    FlashProperties, MemoryRegion, PageInfo, RamRegion, RawFlashAlgorithm, SectorInfo,
+    TransferEncoding,
 };
 use std::mem::size_of_val;
 
@@ -383,6 +384,113 @@ impl FlashAlgorithm {
             flash_properties: raw.flash_properties.clone(),
             transfer_encoding: raw.transfer_encoding.unwrap_or_default(),
             stack_overflow_check: raw.stack_overflow_check(),
+        })
+    }
+
+    /// Constructs a complete flash algorithm, choosing a suitable RAM region to run the algorithm.
+    pub(crate) fn assemble_from_raw_with_core(
+        algo: &RawFlashAlgorithm,
+        core_name: &str,
+        target: &Target,
+    ) -> Result<FlashAlgorithm, FlashError> {
+        // Find a RAM region from which we can run the algo.
+        let mm = &target.memory_map;
+        let ram = mm
+            .iter()
+            .filter_map(MemoryRegion::as_ram_region)
+            .merged()
+            .filter(|ram| is_ram_suitable_for_algo(ram, core_name, algo.load_address))
+            .max_by_key(|region| region.range.end - region.range.start)
+            .ok_or(FlashError::NoRamDefined {
+                name: target.name.clone(),
+            })?;
+        tracing::info!("Chosen RAM to run the algo: {:x?}", ram);
+
+        let data_ram;
+        let data_ram = if let Some(data_load_address) = algo.data_load_address {
+            data_ram = mm
+                .iter()
+                .filter_map(MemoryRegion::as_ram_region)
+                .merged()
+                .find(|ram| is_ram_suitable_for_data(ram, core_name, data_load_address))
+                .ok_or(FlashError::NoRamDefined {
+                    name: target.name.clone(),
+                })?;
+
+            &data_ram
+        } else {
+            // If not specified, use the same region as the flash algo.
+            &ram
+        };
+        tracing::info!("Data will be loaded to: {:x?}", data_ram);
+
+        Self::assemble_from_raw_with_data(algo, &ram, data_ram, target)
+    }
+}
+
+/// Returns whether the given RAM region is usable for downloading the flash algorithm.
+fn is_ram_suitable_for_algo(ram: &RamRegion, core_name: &str, load_address: Option<u64>) -> bool {
+    if !ram.is_executable() {
+        return false;
+    }
+
+    // If the algorithm has a forced load address, we try to use it.
+    // If not, then follow the CMSIS-Pack spec and use first available RAM region.
+    // In theory, it should be the "first listed in the pack", but the process of
+    // reading from the pack files obfuscates the list order, so we will use the first
+    // one in the target spec, which is the qualifying region with the lowest start saddress.
+    // - See https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/pdsc_family_pg.html#element_memory .
+    if let Some(load_addr) = load_address {
+        // The RAM must contain the forced load address _and_
+        // be accessible from the core we're going to run the
+        // algorithm on.
+        ram.range.contains(&load_addr) && ram.accessible_by(core_name)
+    } else {
+        // Any executable RAM is okay as long as it's accessible to the core;
+        // the algorithm is presumably position-independent.
+        ram.accessible_by(core_name)
+    }
+}
+
+/// Returns whether the given RAM region is usable for downloading the flash algorithm data.
+fn is_ram_suitable_for_data(ram: &RamRegion, core_name: &str, load_address: u64) -> bool {
+    // The RAM must contain the forced load address _and_
+    // be accessible from the core we're going to run the
+    // algorithm on.
+    ram.range.contains(&load_address) && ram.accessible_by(core_name)
+}
+
+trait IterExt {
+    /// Merge adjacent regions.
+    fn merged(self) -> impl Iterator<Item = RamRegion>;
+}
+
+impl<'a, I> IterExt for I
+where
+    I: Iterator<Item = &'a RamRegion>,
+{
+    fn merged(self) -> impl Iterator<Item = RamRegion> {
+        let mut iter = self.peekable();
+        std::iter::from_fn(move || {
+            let first = iter.next()?;
+            let mut range = first.range.clone();
+            while let Some(next) = iter.peek() {
+                if range.end != next.range.start
+                    || first.cores != next.cores
+                    || first.access != next.access
+                {
+                    break;
+                }
+                range.end = next.range.end;
+                iter.next();
+            }
+
+            Some(RamRegion {
+                name: first.name.clone(),
+                range,
+                cores: first.cores.clone(),
+                access: first.access,
+            })
         })
     }
 }

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -1,4 +1,4 @@
-use probe_rs_target::{MemoryRegion, RawFlashAlgorithm};
+use probe_rs_target::RawFlashAlgorithm;
 use tracing::Level;
 
 use super::{FlashAlgorithm, FlashBuilder, FlashError, FlashFill, FlashPage, FlashProgress};

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -70,9 +70,10 @@ impl<'session> Flasher<'session> {
     ) -> Result<Self, FlashError> {
         let target = session.target();
 
-        let flash_algorithm = target.initialized_flash_algorithm_by_name(
-            raw_flash_algorithm.name.as_str(),
+        let flash_algorithm = FlashAlgorithm::assemble_from_raw_with_core(
+            raw_flash_algorithm,
             &target.cores[core_index].name,
+            target,
         )?;
 
         let mut this = Self {

--- a/probe-rs/targets/LPC800_Series.yaml
+++ b/probe-rs/targets/LPC800_Series.yaml
@@ -756,6 +756,7 @@ flash_algorithms:
   pc_erase_sector: 0x6d
   pc_erase_all: 0x2d
   data_section_offset: 0x130
+  stack_size: 256
   flash_properties:
     address_range:
       start: 0x0

--- a/probe-rs/targets/STM32WL_Series.yaml
+++ b/probe-rs/targets/STM32WL_Series.yaml
@@ -101,7 +101,7 @@ variants:
   - stm32wlxx_cm4
 - name: STM32WL55JCIx
   cores:
-  - name: application
+  - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
@@ -117,14 +117,14 @@ variants:
       start: 0x20000000
       end: 0x20010000
     cores:
-    - application
+    - main
     - network
   - !Nvm
     range:
       start: 0x8000000
       end: 0x8040000
     cores:
-    - application
+    - main
     - network
     access:
       boot: true


### PR DESCRIPTION
Includes (or will include) fixes made to targets that fail the validation.

- Set stack size for a small target
- Implement memory region merging for targets where we can't place the algorithm in a single block of RAM.
- Rename application core of STM32WL55JCIx to main
- Remove runtime family validation from Target