### PR TITLE
Some minor target-gen improvements

### DIFF
--- a/changelog/added-chip-to-target-gen-test.md
+++ b/changelog/added-chip-to-target-gen-test.md
@@ -1,0 +1,1 @@
+Added `--chip` to `target-gen test`

--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -170,10 +170,10 @@ impl LoadedProbeOptions {
                     source: error,
                     path: cdp.clone(),
                 }
-            })
-        } else {
-            Ok(())
+            })?;
         }
+
+        Ok(())
     }
 
     /// Resolves a resultant target selector from passed [ProbeOptions].

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -15,7 +15,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-probe-rs = { path = "../probe-rs", version = "0.24.0", default-features = false }
+probe-rs = { path = "../probe-rs", version = "0.24.0" }
 probe-rs-target = { path = "../probe-rs-target", version = "0.24.0", default-features = false }
 cmsis-pack = "0.7.0"
 goblin = { version = "0.8.2", default-features = false, features = [

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -12,7 +12,7 @@ use probe_rs::{
     },
     MemoryInterface, Permissions, Session,
 };
-use probe_rs_target::{ChipFamily, RawFlashAlgorithm};
+use probe_rs_target::RawFlashAlgorithm;
 use xshell::{cmd, Shell};
 
 use crate::commands::elf::cmd_elf;
@@ -24,6 +24,7 @@ pub fn cmd_test(
     template_path: &Path,
     definition_export_path: &Path,
     test_start_sector_address: Option<u64>,
+    chip: Option<String>,
 ) -> Result<()> {
     ensure_is_file(target_artifact)?;
     ensure_is_file(template_path)?;
@@ -59,161 +60,171 @@ pub fn cmd_test(
 
     // Add the target to the registry from the generated YAML file
     let file = File::open(Path::new(definition_export_path))?;
-    probe_rs::config::add_target_from_yaml(file)?;
+    let family_name = probe_rs::config::add_target_from_yaml(file)?;
 
-    // Likely there is only one chip family in the YAML file,
-    // but still iterate over all families and then all varaiants within the family
-    let families: Vec<ChipFamily> = probe_rs::config::families();
-    for family in families.iter() {
-        for chip in family.variants.iter() {
-            let target = chip.name.clone();
-            // We need to get the chip name so that special startup procedure can be used. (matched on name)
-            let mut session =
-                probe_rs::Session::auto_attach(target, Permissions::new().allow_erase_all())?;
+    let targets = probe_rs::config::get_targets_by_family_name(&family_name)
+        .with_context(|| format!("Failed to get targets of {family_name}"))?;
 
-            // Register callback to update the progress.
-            let t = Rc::new(RefCell::new(Instant::now()));
-            let progress = FlashProgress::new(move |event| match event {
-                ProgressEvent::StartedProgramming { .. } => {
-                    let mut t = t.borrow_mut();
-                    *t = Instant::now();
-                }
-                ProgressEvent::StartedErasing => {
-                    let mut t = t.borrow_mut();
-                    *t = Instant::now();
-                }
-                ProgressEvent::FailedErasing => {
-                    println!("Failed erasing in {:?}", t.borrow().elapsed());
-                }
-                ProgressEvent::FinishedErasing => {
-                    println!("Finished erasing in {:?}", t.borrow().elapsed());
-                }
-                ProgressEvent::FailedProgramming => {
-                    println!("Failed programming in {:?}", t.borrow().elapsed());
-                }
-                ProgressEvent::FinishedProgramming => {
-                    println!("Finished programming in {:?}", t.borrow().elapsed());
-                }
-                ProgressEvent::DiagnosticMessage { message } => {
-                    let prefix = "Message".yellow();
-                    if message.ends_with('\n') {
-                        print!("{prefix}: {message}");
-                    } else {
-                        println!("{prefix}: {message}");
-                    }
-                }
-                _ => (),
-            });
-
-            let flash_algorithm = if let Some(test_start_sector_address) = test_start_sector_address
-            {
-                let predicate = |x: &&RawFlashAlgorithm| {
-                    x.flash_properties.address_range.start <= test_start_sector_address
-                        && test_start_sector_address < x.flash_properties.address_range.end
-                };
-                let error_message =
-                    anyhow!("No flash algorithm matching specified address can be found");
-                session
-                    .target()
-                    .flash_algorithms
-                    .iter()
-                    .find(predicate)
-                    .ok_or(error_message)?
-            } else {
-                &session.target().flash_algorithms[0]
-            };
-            let flash_properties = flash_algorithm.flash_properties.clone();
-            let start_address = flash_properties.address_range.start;
-            let end_address = flash_properties.address_range.end;
-            let data_size = flash_properties.page_size;
-            let erased_state = flash_properties.erased_byte_value;
-            let sector_size = flash_properties.sectors[0].size;
-
-            let test_start_sector_address = test_start_sector_address.unwrap_or(start_address);
-            if test_start_sector_address < start_address
-                || test_start_sector_address > start_address + end_address - sector_size * 2
-                || test_start_sector_address % sector_size != 0
-            {
-                return Err(anyhow!(
-                    "test_start_sector_address must be sector aligned address pointing flash range"
-                ));
-            }
-            let test_start_sector_index =
-                ((test_start_sector_address - start_address) / sector_size) as usize;
-
-            let test = "Test".green();
-            println!("{test}: Erasing sectorwise and writing two pages ...");
-            run_flash_erase(
-                &mut session,
-                progress.clone(),
-                EraseSectors(test_start_sector_index, 2),
-            )?;
-            let mut readback = vec![0; (sector_size * 2) as usize];
-            session
-                .core(0)?
-                .read_8(test_start_sector_address, &mut readback)?;
-            assert!(
-                !readback.iter().any(|v| *v != erased_state),
-                "Not all sectors were erased"
-            );
-
-            let mut loader = session.target().flash_loader();
-            let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
-            loader.add_data(test_start_sector_address + 1, &data)?;
-            run_flash_download(&mut session, loader, progress.clone(), true)?;
-            let mut readback = vec![0; data_size as usize];
-            session
-                .core(0)?
-                .read_8(test_start_sector_address + 1, &mut readback)?;
-            assert_eq!(readback, data);
-
-            println!("{test}: Erasing the entire chip and writing two pages ...");
-            run_flash_erase(&mut session, progress.clone(), EraseAll)?;
-            let mut readback = vec![0; (sector_size * 2) as usize];
-            session
-                .core(0)?
-                .read_8(test_start_sector_address, &mut readback)?;
-            assert!(
-                !readback.iter().any(|v| *v != erased_state),
-                "Not all sectors were erased"
-            );
-
-            let mut loader = session.target().flash_loader();
-            let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
-            loader.add_data(test_start_sector_address + 1, &data)?;
-            run_flash_download(&mut session, loader, progress.clone(), true)?;
-            let mut readback = vec![0; data_size as usize];
-            session
-                .core(0)?
-                .read_8(test_start_sector_address + 1, &mut readback)?;
-            assert_eq!(readback, data);
-
-            println!("{test}: Erasing sectorwise and writing two pages double buffered ...");
-            run_flash_erase(
-                &mut session,
-                progress.clone(),
-                EraseSectors(test_start_sector_index, 2),
-            )?;
-            let mut readback = vec![0; (sector_size * 2) as usize];
-            session
-                .core(0)?
-                .read_8(test_start_sector_address, &mut readback)?;
-            assert!(
-                !readback.iter().any(|v| *v != erased_state),
-                "Not all sectors were erased"
-            );
-
-            let mut loader = session.target().flash_loader();
-            let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
-            loader.add_data(test_start_sector_address + 1, &data)?;
-            run_flash_download(&mut session, loader, progress, false)?;
-            let mut readback = vec![0; data_size as usize];
-            session
-                .core(0)?
-                .read_8(test_start_sector_address + 1, &mut readback)?;
-            assert_eq!(readback, data);
+    let target_name = match targets.len() {
+        0 => return Err(anyhow!("No targets found for family {family_name}")),
+        1 => &targets[0],
+        count if chip.is_none() => {
+            return Err(anyhow!(
+                "{count} targets found for family {family_name}: {targets:#?}. Specify the desired target with --chip."
+            ));
         }
+        _ => {
+            let chip = chip.as_ref().unwrap();
+            targets
+                .iter()
+                .find(|target| *target == chip)
+                .with_context(|| format!("No target found for chip {chip}"))?
+        }
+    };
+
+    // We need to get the chip name so that special startup procedure can be used. (matched on name)
+    let mut session =
+        probe_rs::Session::auto_attach(target_name, Permissions::new().allow_erase_all())?;
+
+    // Register callback to update the progress.
+    let t = Rc::new(RefCell::new(Instant::now()));
+    let progress = FlashProgress::new(move |event| match event {
+        ProgressEvent::StartedProgramming { .. } => {
+            let mut t = t.borrow_mut();
+            *t = Instant::now();
+        }
+        ProgressEvent::StartedErasing => {
+            let mut t = t.borrow_mut();
+            *t = Instant::now();
+        }
+        ProgressEvent::FailedErasing => {
+            println!("Failed erasing in {:?}", t.borrow().elapsed());
+        }
+        ProgressEvent::FinishedErasing => {
+            println!("Finished erasing in {:?}", t.borrow().elapsed());
+        }
+        ProgressEvent::FailedProgramming => {
+            println!("Failed programming in {:?}", t.borrow().elapsed());
+        }
+        ProgressEvent::FinishedProgramming => {
+            println!("Finished programming in {:?}", t.borrow().elapsed());
+        }
+        ProgressEvent::DiagnosticMessage { message } => {
+            let prefix = "Message".yellow();
+            if message.ends_with('\n') {
+                print!("{prefix}: {message}");
+            } else {
+                println!("{prefix}: {message}");
+            }
+        }
+        _ => (),
+    });
+
+    let flash_algorithm = if let Some(test_start_sector_address) = test_start_sector_address {
+        let predicate = |x: &&RawFlashAlgorithm| {
+            x.flash_properties.address_range.start <= test_start_sector_address
+                && test_start_sector_address < x.flash_properties.address_range.end
+        };
+        let error_message = anyhow!("No flash algorithm matching specified address can be found");
+        session
+            .target()
+            .flash_algorithms
+            .iter()
+            .find(predicate)
+            .ok_or(error_message)?
+    } else {
+        &session.target().flash_algorithms[0]
+    };
+    let flash_properties = &flash_algorithm.flash_properties;
+    let start_address = flash_properties.address_range.start;
+    let end_address = flash_properties.address_range.end;
+    let data_size = flash_properties.page_size;
+    let erased_state = flash_properties.erased_byte_value;
+    let sector_size = flash_properties.sectors[0].size;
+
+    let test_start_sector_address = test_start_sector_address.unwrap_or(start_address);
+    if test_start_sector_address < start_address
+        || test_start_sector_address > start_address + end_address - sector_size * 2
+        || test_start_sector_address % sector_size != 0
+    {
+        return Err(anyhow!(
+            "test_start_sector_address must be sector aligned address pointing flash range"
+        ));
     }
+    let test_start_sector_index =
+        ((test_start_sector_address - start_address) / sector_size) as usize;
+
+    let test = "Test".green();
+    println!("{test}: Erasing sectorwise and writing two pages ...");
+    run_flash_erase(
+        &mut session,
+        progress.clone(),
+        EraseSectors(test_start_sector_index, 2),
+    )?;
+    let mut readback = vec![0; (sector_size * 2) as usize];
+    session
+        .core(0)?
+        .read_8(test_start_sector_address, &mut readback)?;
+    assert!(
+        !readback.iter().any(|v| *v != erased_state),
+        "Not all sectors were erased"
+    );
+
+    let mut loader = session.target().flash_loader();
+    let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
+    loader.add_data(test_start_sector_address + 1, &data)?;
+    run_flash_download(&mut session, loader, progress.clone(), true)?;
+    let mut readback = vec![0; data_size as usize];
+    session
+        .core(0)?
+        .read_8(test_start_sector_address + 1, &mut readback)?;
+    assert_eq!(readback, data);
+
+    println!("{test}: Erasing the entire chip and writing two pages ...");
+    run_flash_erase(&mut session, progress.clone(), EraseAll)?;
+    let mut readback = vec![0; (sector_size * 2) as usize];
+    session
+        .core(0)?
+        .read_8(test_start_sector_address, &mut readback)?;
+    assert!(
+        !readback.iter().any(|v| *v != erased_state),
+        "Not all sectors were erased"
+    );
+
+    let mut loader = session.target().flash_loader();
+    let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
+    loader.add_data(test_start_sector_address + 1, &data)?;
+    run_flash_download(&mut session, loader, progress.clone(), true)?;
+    let mut readback = vec![0; data_size as usize];
+    session
+        .core(0)?
+        .read_8(test_start_sector_address + 1, &mut readback)?;
+    assert_eq!(readback, data);
+
+    println!("{test}: Erasing sectorwise and writing two pages double buffered ...");
+    run_flash_erase(
+        &mut session,
+        progress.clone(),
+        EraseSectors(test_start_sector_index, 2),
+    )?;
+    let mut readback = vec![0; (sector_size * 2) as usize];
+    session
+        .core(0)?
+        .read_8(test_start_sector_address, &mut readback)?;
+    assert!(
+        !readback.iter().any(|v| *v != erased_state),
+        "Not all sectors were erased"
+    );
+
+    let mut loader = session.target().flash_loader();
+    let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
+    loader.add_data(test_start_sector_address + 1, &data)?;
+    run_flash_download(&mut session, loader, progress, false)?;
+    let mut readback = vec![0; data_size as usize];
+    session
+        .core(0)?
+        .read_8(test_start_sector_address + 1, &mut readback)?;
+    assert_eq!(readback, data);
 
     Ok(())
 }

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -79,10 +79,10 @@ where
     let mut devices = pdsc.devices.0.into_iter().collect::<Vec<_>>();
     devices.sort_by(|a, b| a.0.cmp(&b.0));
 
-    for (device_name, device) in devices {
-        // Only process this, if this belongs to a supported family.
-        let currently_supported_chip_families = probe_rs::config::families();
+    // Only process this, if this belongs to a supported family.
+    let currently_supported_chip_families = probe_rs::config::families();
 
+    for (device_name, device) in devices {
         if only_supported_familes
             && !currently_supported_chip_families
                 .iter()

--- a/target-gen/src/main.rs
+++ b/target-gen/src/main.rs
@@ -103,6 +103,9 @@ enum TargetGen {
         /// The address used as the start of flash memory area to perform test.
         #[clap(long = "test-address", value_parser = parse_u64)]
         test_start_sector_address: Option<u64>,
+        /// The name of the chip to use for the test, if there are multiple to choose from.
+        #[clap(long = "chip")]
+        chip: Option<String>,
     },
     /// Loads and updates target description from YAML files.
     Reformat {
@@ -155,11 +158,13 @@ async fn main() -> Result<()> {
             template_path,
             definition_export_path,
             test_start_sector_address,
+            chip,
         } => cmd_test(
             target_artifact.as_path(),
             template_path.as_path(),
             definition_export_path.as_path(),
             test_start_sector_address,
+            chip,
         )?,
         TargetGen::Reformat { yaml_path } => {
             if yaml_path.is_dir() {


### PR DESCRIPTION
Added `--chip` in case the tested description contains multiple chips. Cleaned up a few unnecessary `.clone()`s.

This PR undoes https://github.com/probe-rs/probe-rs/pull/1771/files#diff-a54dca91b1c085f16d7b7e573bb96cb37cf95a32fe5716a5b8a825571d45ecf7R66 which tried to flash generic targets for some reason. The PR also adds (back?) the known targets, so `only_supported_familes` has something to compare against.