### PR TITLE
Add `--path` to cargo embed

### DIFF
--- a/changelog/added-cargo-embed-path.md
+++ b/changelog/added-cargo-embed-path.md
@@ -1,0 +1,1 @@
+Added `--path` option to cargo embed.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -34,7 +34,7 @@ struct CliOptions {
     /// Default is `warn`. Possible choices are [error, warn, info, debug, trace].
     #[arg(value_name = "level", long)]
     pub log: Option<LevelFilter>,
-    /// The path to the file to be flashed.
+    /// The path to the file to be flashed. Setting this will ignore the cargo options.
     #[arg(value_name = "path", long)]
     pub path: Option<PathBuf>,
     /// The work directory from which cargo-flash should operate from.


### PR DESCRIPTION
It's an unthinkable sin that cargo-flash has this option, but not cargo embed. I wanted to use this today to test something, so here we go.