### PR TITLE
Remove redundant memory map from RTT constructors

### DIFF
--- a/changelog/changed-rtt-attach.md
+++ b/changelog/changed-rtt-attach.md
@@ -1,0 +1,1 @@
+Removed the `memory_map` argument from `Rtt::attach` and `Rtt::attach_region`.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -10,7 +10,6 @@ use probe_rs::gdb_server::GdbInstanceConfiguration;
 use probe_rs::probe::list::Lister;
 use probe_rs::rtt::ScanRegion;
 use probe_rs::{probe::DebugProbeSelector, Session};
-use probe_rs_target::MemoryRegion;
 use std::ffi::OsString;
 use std::fs;
 use std::{
@@ -362,16 +361,10 @@ fn run_rttui_app(
         });
     }
 
-    let memory_map = {
-        let session_handle = session.lock();
-        session_handle.target().memory_map.clone()
-    };
-
     let Some(rtt) = attach_to_rtt_shared(
         session,
         core_id,
         config.rtt.timeout,
-        &memory_map,
         &ScanRegion::Ram,
         elf_path,
         &rtt_config,
@@ -448,7 +441,6 @@ fn attach_to_rtt_shared(
     session: &FairMutex<Session>,
     core_id: usize,
     timeout: Duration,
-    memory_map: &[MemoryRegion],
     rtt_region: &ScanRegion,
     elf_file: &Path,
     rtt_config: &RttConfig,
@@ -464,7 +456,7 @@ fn attach_to_rtt_shared(
         rtt_region.clone()
     };
 
-    let rtt = try_attach_to_rtt_shared(session, core_id, memory_map, timeout, &scan_region)?;
+    let rtt = try_attach_to_rtt_shared(session, core_id, timeout, &scan_region)?;
 
     let Some(rtt) = rtt else {
         return Ok(None);

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -440,9 +440,7 @@ fn try_attach_rtt(
 
     let scan_region = ScanRegion::Exact(header_address);
 
-    let memory_regions = core.memory_regions().cloned().collect::<Vec<_>>();
-
-    let rtt = Rtt::attach_region(core, &memory_regions[..], &scan_region)
+    let rtt = Rtt::attach_region(core, &scan_region)
         .map_err(|error| anyhow!("Error attempting to attach to RTT: {}", error))?;
 
     tracing::info!("RTT initialized.");

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -204,7 +204,6 @@ impl<'session> Flasher<'session> {
         &mut self,
         clock: Option<u32>,
     ) -> Result<ActiveFlasher<'_, O>, FlashError> {
-        let memory_map = self.session.target().memory_map.clone();
         // Attach to memory and core.
         let core = self
             .session
@@ -215,7 +214,6 @@ impl<'session> Flasher<'session> {
         let mut flasher = ActiveFlasher::<O> {
             core,
             rtt: None,
-            memory_map,
             progress: self.progress.clone(),
             flash_algorithm: self.flash_algorithm.clone(),
             _operation: core::marker::PhantomData,
@@ -559,7 +557,6 @@ fn into_reg(val: u64) -> Result<u32, FlashError> {
 pub(super) struct ActiveFlasher<'probe, O: Operation> {
     core: Core<'probe>,
     rtt: Option<crate::rtt::Rtt>,
-    memory_map: Vec<MemoryRegion>,
     progress: FlashProgress,
     flash_algorithm: FlashAlgorithm,
     _operation: core::marker::PhantomData<O>,
@@ -715,7 +712,6 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
                 std::thread::sleep(Duration::from_millis(1));
                 let rtt = match crate::rtt::Rtt::attach_region(
                     &mut self.core,
-                    &self.memory_map,
                     &crate::rtt::ScanRegion::Exact(rtt_address),
                 ) {
                     Ok(rtt) => Some(rtt),


### PR DESCRIPTION
`Core` already contains the target's memory map. This PR changes RTT code to use this map, which is actually an improvement in the sense that from now on RTT shouldn't try to access memory that the core itself can't access.