### PR TITLE
Do not hardcode algorithm name in `target-gen test`

### DIFF
--- a/changelog/added-name-to-test.md
+++ b/changelog/added-name-to-test.md
@@ -1,0 +1,1 @@
+Added `--name` option to `target-gen test`

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -23,6 +23,7 @@ pub fn cmd_test(
     definition_export_path: &Path,
     test_start_sector_address: Option<u64>,
     chip: Option<String>,
+    name: Option<String>,
 ) -> Result<()> {
     ensure_is_file(target_artifact)?;
     ensure_is_file(template_path)?;
@@ -48,7 +49,7 @@ pub fn cmd_test(
         true,
         Some(definition_export_path),
         true,
-        None,
+        name,
     )?;
 
     if let Err(error) = generate_debug_info(target_artifact) {

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -17,8 +17,6 @@ use xshell::{cmd, Shell};
 
 use crate::commands::elf::cmd_elf;
 
-const ALGORITHM_NAME: &str = "algorithm-test";
-
 pub fn cmd_test(
     target_artifact: &Path,
     template_path: &Path,
@@ -50,7 +48,7 @@ pub fn cmd_test(
         true,
         Some(definition_export_path),
         true,
-        Some(String::from(ALGORITHM_NAME)),
+        None,
     )?;
 
     if let Err(error) = generate_debug_info(target_artifact) {

--- a/target-gen/src/main.rs
+++ b/target-gen/src/main.rs
@@ -106,6 +106,9 @@ enum TargetGen {
         /// The name of the chip to use for the test, if there are multiple to choose from.
         #[clap(long = "chip")]
         chip: Option<String>,
+        /// Name of the flash algorithm to test
+        #[clap(long = "name", short = 'n')]
+        name: Option<String>,
     },
     /// Loads and updates target description from YAML files.
     Reformat {
@@ -159,12 +162,14 @@ async fn main() -> Result<()> {
             definition_export_path,
             test_start_sector_address,
             chip,
+            name,
         } => cmd_test(
             target_artifact.as_path(),
             template_path.as_path(),
             definition_export_path.as_path(),
             test_start_sector_address,
             chip,
+            name,
         )?,
         TargetGen::Reformat { yaml_path } => {
             if yaml_path.is_dir() {


### PR DESCRIPTION
target-gen no longer tries to update a hard-coded `algorithm-test` algorithm. Instead, the name is inferred from the .elf's file stem, or can be specified by the user