### PR TITLE
arm: Rename ApAddress to FullyQualifiedApAddress

### DIFF
--- a/changelog/added-ap-v2-addresses.md
+++ b/changelog/added-ap-v2-addresses.md
@@ -1,0 +1,1 @@
+`probe-rs` now has basic support to represent Access Port V2 address format.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -1422,7 +1422,7 @@ mod test {
 
         // Indicate that the core is unlocked
         fake_probe.expect_operation(Operation::ReadRawApRegister {
-            ap: FullyQualifiedApAddress::with_default_dp(1),
+            ap: FullyQualifiedApAddress::v1_with_default_dp(1),
             address: 0xC,
             result: 1,
         });
@@ -1485,7 +1485,7 @@ mod test {
 
         // Indicate that the core is unlocked
         fake_probe.expect_operation(Operation::ReadRawApRegister {
-            ap: FullyQualifiedApAddress::with_default_dp(1),
+            ap: FullyQualifiedApAddress::v1_with_default_dp(1),
             address: 0xC,
             result: 1,
         });
@@ -1535,7 +1535,7 @@ mod test {
 
         // Indicate that the core is unlocked
         fake_probe.expect_operation(Operation::ReadRawApRegister {
-            ap: FullyQualifiedApAddress::with_default_dp(1),
+            ap: FullyQualifiedApAddress::v1_with_default_dp(1),
             address: 0xC,
             result: 1,
         });
@@ -1607,7 +1607,7 @@ mod test {
 
         // Indicate that the core is unlocked
         fake_probe.expect_operation(Operation::ReadRawApRegister {
-            ap: FullyQualifiedApAddress::with_default_dp(1),
+            ap: FullyQualifiedApAddress::v1_with_default_dp(1),
             address: 0xC,
             result: 1,
         });
@@ -1677,7 +1677,7 @@ mod test {
 
         // Indicate that the core is unlocked
         fake_probe.expect_operation(Operation::ReadRawApRegister {
-            ap: FullyQualifiedApAddress::with_default_dp(1),
+            ap: FullyQualifiedApAddress::v1_with_default_dp(1),
             address: 0xC,
             result: 1,
         });
@@ -1767,7 +1767,7 @@ mod test {
 
         // Indicate that the core is unlocked
         fake_probe.expect_operation(Operation::ReadRawApRegister {
-            ap: FullyQualifiedApAddress::with_default_dp(1),
+            ap: FullyQualifiedApAddress::v1_with_default_dp(1),
             address: 0xC,
             result: 1,
         });

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -982,7 +982,7 @@ mod test {
         test::TestLister,
     };
     use probe_rs::{
-        architecture::arm::ApAddress,
+        architecture::arm::FullyQualifiedApAddress,
         integration::{FakeProbe, Operation},
         probe::{
             list::Lister, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
@@ -1422,7 +1422,7 @@ mod test {
 
         // Indicate that the core is unlocked
         fake_probe.expect_operation(Operation::ReadRawApRegister {
-            ap: ApAddress::with_default_dp(1),
+            ap: FullyQualifiedApAddress::with_default_dp(1),
             address: 0xC,
             result: 1,
         });
@@ -1485,7 +1485,7 @@ mod test {
 
         // Indicate that the core is unlocked
         fake_probe.expect_operation(Operation::ReadRawApRegister {
-            ap: ApAddress::with_default_dp(1),
+            ap: FullyQualifiedApAddress::with_default_dp(1),
             address: 0xC,
             result: 1,
         });
@@ -1535,7 +1535,7 @@ mod test {
 
         // Indicate that the core is unlocked
         fake_probe.expect_operation(Operation::ReadRawApRegister {
-            ap: ApAddress::with_default_dp(1),
+            ap: FullyQualifiedApAddress::with_default_dp(1),
             address: 0xC,
             result: 1,
         });
@@ -1607,7 +1607,7 @@ mod test {
 
         // Indicate that the core is unlocked
         fake_probe.expect_operation(Operation::ReadRawApRegister {
-            ap: ApAddress::with_default_dp(1),
+            ap: FullyQualifiedApAddress::with_default_dp(1),
             address: 0xC,
             result: 1,
         });
@@ -1677,7 +1677,7 @@ mod test {
 
         // Indicate that the core is unlocked
         fake_probe.expect_operation(Operation::ReadRawApRegister {
-            ap: ApAddress::with_default_dp(1),
+            ap: FullyQualifiedApAddress::with_default_dp(1),
             address: 0xC,
             result: 1,
         });
@@ -1767,7 +1767,7 @@ mod test {
 
         // Indicate that the core is unlocked
         fake_probe.expect_operation(Operation::ReadRawApRegister {
-            ap: ApAddress::with_default_dp(1),
+            ap: FullyQualifiedApAddress::with_default_dp(1),
             address: 0xC,
             result: 1,
         });

--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -295,10 +295,7 @@ fn show_arm_info(interface: &mut dyn ArmProbeInterface, dp: DpAddress) -> Result
     let num_access_ports = interface.num_access_ports(dp)?;
 
     for ap_index in 0..num_access_ports {
-        let ap = FullyQualifiedApAddress {
-            ap: probe_rs::architecture::arm::ApAddress::V1(ap_index as u8),
-            dp,
-        };
+        let ap = FullyQualifiedApAddress::v1_with_dp(dp, ap_index as u8);
         let access_port = GenericAp::new(ap);
 
         let ap_information = interface.ap_information(&access_port)?;
@@ -310,7 +307,7 @@ fn show_arm_info(interface: &mut dyn ArmProbeInterface, dp: DpAddress) -> Result
                 device_enabled,
                 ..
             }) => {
-                let mut ap_nodes = Tree::new(format!("{} MemoryAP", address.ap));
+                let mut ap_nodes = Tree::new(format!("{} MemoryAP", address.ap_v1()?));
 
                 if *device_enabled {
                     match handle_memory_ap(&access_port.into(), *debug_base_address, interface) {
@@ -335,7 +332,7 @@ fn show_arm_info(interface: &mut dyn ArmProbeInterface, dp: DpAddress) -> Result
 
                 tree.push(format!(
                     "{} Unknown AP (Designer: {}, Class: {:?}, Type: {}, Variant: {:#x}, Revision: {:#x})",
-                    address.ap,
+                    address.ap_v1()?,
                     jep.get().unwrap_or("<unknown>"),
                     idr.CLASS,
                     ap_type,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -14,7 +14,8 @@ use probe_rs::{
                 Component, ComponentId, CoresightComponent, PeripheralType,
             },
             sequences::DefaultArmSequence,
-            ApAddress, ApInformation, ArmProbeInterface, DpAddress, MemoryApInformation, Register,
+            ApInformation, ArmProbeInterface, DpAddress, FullyQualifiedApAddress,
+            MemoryApInformation, Register,
         },
         riscv::communication_interface::RiscvCommunicationInterface,
         xtensa::communication_interface::{
@@ -294,7 +295,7 @@ fn show_arm_info(interface: &mut dyn ArmProbeInterface, dp: DpAddress) -> Result
     let num_access_ports = interface.num_access_ports(dp)?;
 
     for ap_index in 0..num_access_ports {
-        let ap = ApAddress {
+        let ap = FullyQualifiedApAddress {
             ap: ap_index as u8,
             dp,
         };

--- a/probe-rs/examples/nrf53_recover.rs
+++ b/probe-rs/examples/nrf53_recover.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use probe_rs::{
-    architecture::arm::{ApAddress, DpAddress, FullyQualifiedApAddress},
+    architecture::arm::{DpAddress, FullyQualifiedApAddress},
     probe::list::Lister,
 };
 
@@ -24,22 +24,10 @@ fn main() -> Result<()> {
         .initialize_unspecified(DpAddress::Default)
         .unwrap();
 
-    const APP_MEM: FullyQualifiedApAddress = FullyQualifiedApAddress {
-        ap: ApAddress::V1(0),
-        dp: DpAddress::Default,
-    };
-    const NET_MEM: FullyQualifiedApAddress = FullyQualifiedApAddress {
-        ap: ApAddress::V1(1),
-        dp: DpAddress::Default,
-    };
-    const APP_CTRL: FullyQualifiedApAddress = FullyQualifiedApAddress {
-        ap: ApAddress::V1(2),
-        dp: DpAddress::Default,
-    };
-    const NET_CTRL: FullyQualifiedApAddress = FullyQualifiedApAddress {
-        ap: ApAddress::V1(3),
-        dp: DpAddress::Default,
-    };
+    const APP_MEM: FullyQualifiedApAddress = FullyQualifiedApAddress::v1_with_default_dp(0);
+    const NET_MEM: FullyQualifiedApAddress = FullyQualifiedApAddress::v1_with_default_dp(1);
+    const APP_CTRL: FullyQualifiedApAddress = FullyQualifiedApAddress::v1_with_default_dp(2);
+    const NET_CTRL: FullyQualifiedApAddress = FullyQualifiedApAddress::v1_with_default_dp(3);
 
     const ERASEALL: u8 = 0x04;
     const ERASEALLSTATUS: u8 = 0x08;

--- a/probe-rs/examples/nrf53_recover.rs
+++ b/probe-rs/examples/nrf53_recover.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use probe_rs::{
-    architecture::arm::{DpAddress, FullyQualifiedApAddress},
+    architecture::arm::{ApAddress, DpAddress, FullyQualifiedApAddress},
     probe::list::Lister,
 };
 
@@ -25,19 +25,19 @@ fn main() -> Result<()> {
         .unwrap();
 
     const APP_MEM: FullyQualifiedApAddress = FullyQualifiedApAddress {
-        ap: 0,
+        ap: ApAddress::V1(0),
         dp: DpAddress::Default,
     };
     const NET_MEM: FullyQualifiedApAddress = FullyQualifiedApAddress {
-        ap: 1,
+        ap: ApAddress::V1(1),
         dp: DpAddress::Default,
     };
     const APP_CTRL: FullyQualifiedApAddress = FullyQualifiedApAddress {
-        ap: 2,
+        ap: ApAddress::V1(2),
         dp: DpAddress::Default,
     };
     const NET_CTRL: FullyQualifiedApAddress = FullyQualifiedApAddress {
-        ap: 3,
+        ap: ApAddress::V1(3),
         dp: DpAddress::Default,
     };
 
@@ -45,11 +45,11 @@ fn main() -> Result<()> {
     const ERASEALLSTATUS: u8 = 0x08;
     const IDR: u8 = 0xFC;
 
-    for &ap in &[APP_MEM, NET_MEM, APP_CTRL, NET_CTRL] {
+    for ap in &[APP_MEM, NET_MEM, APP_CTRL, NET_CTRL] {
         println!("IDR {:?} {:x}", ap, iface.read_raw_ap_register(ap, IDR)?);
     }
 
-    for &ap in &[APP_CTRL, NET_CTRL] {
+    for ap in &[APP_CTRL, NET_CTRL] {
         // Start erase
         iface.write_raw_ap_register(ap, ERASEALL, 1)?;
         // Wait for erase done

--- a/probe-rs/examples/nrf53_recover.rs
+++ b/probe-rs/examples/nrf53_recover.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use probe_rs::{
-    architecture::arm::{ApAddress, DpAddress},
+    architecture::arm::{DpAddress, FullyQualifiedApAddress},
     probe::list::Lister,
 };
 
@@ -24,19 +24,19 @@ fn main() -> Result<()> {
         .initialize_unspecified(DpAddress::Default)
         .unwrap();
 
-    const APP_MEM: ApAddress = ApAddress {
+    const APP_MEM: FullyQualifiedApAddress = FullyQualifiedApAddress {
         ap: 0,
         dp: DpAddress::Default,
     };
-    const NET_MEM: ApAddress = ApAddress {
+    const NET_MEM: FullyQualifiedApAddress = FullyQualifiedApAddress {
         ap: 1,
         dp: DpAddress::Default,
     };
-    const APP_CTRL: ApAddress = ApAddress {
+    const APP_CTRL: FullyQualifiedApAddress = FullyQualifiedApAddress {
         ap: 2,
         dp: DpAddress::Default,
     };
-    const NET_CTRL: ApAddress = ApAddress {
+    const NET_CTRL: FullyQualifiedApAddress = FullyQualifiedApAddress {
         ap: 3,
         dp: DpAddress::Default,
     };

--- a/probe-rs/examples/raw_dap_access.rs
+++ b/probe-rs/examples/raw_dap_access.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use probe_rs::{
-    architecture::arm::{sequences::DefaultArmSequence, ApAddress, DpAddress},
+    architecture::arm::{sequences::DefaultArmSequence, DpAddress, FullyQualifiedApAddress},
     probe::list::Lister,
 };
 
@@ -24,7 +24,7 @@ fn main() -> Result<()> {
         .initialize(DefaultArmSequence::create(), DpAddress::Default)
         .map_err(|(_interface, e)| e)?;
 
-    let port = ApAddress {
+    let port = FullyQualifiedApAddress {
         dp: DpAddress::Default,
         ap: 1,
     };

--- a/probe-rs/examples/raw_dap_access.rs
+++ b/probe-rs/examples/raw_dap_access.rs
@@ -2,7 +2,9 @@
 
 use anyhow::Result;
 use probe_rs::{
-    architecture::arm::{sequences::DefaultArmSequence, DpAddress, FullyQualifiedApAddress},
+    architecture::arm::{
+        sequences::DefaultArmSequence, ApAddress, DpAddress, FullyQualifiedApAddress,
+    },
     probe::list::Lister,
 };
 
@@ -24,9 +26,9 @@ fn main() -> Result<()> {
         .initialize(DefaultArmSequence::create(), DpAddress::Default)
         .map_err(|(_interface, e)| e)?;
 
-    let port = FullyQualifiedApAddress {
+    let port = &FullyQualifiedApAddress {
         dp: DpAddress::Default,
-        ap: 1,
+        ap: ApAddress::V1(1),
     };
 
     const RESET: u8 = 0;

--- a/probe-rs/examples/raw_dap_access.rs
+++ b/probe-rs/examples/raw_dap_access.rs
@@ -2,9 +2,7 @@
 
 use anyhow::Result;
 use probe_rs::{
-    architecture::arm::{
-        sequences::DefaultArmSequence, ApAddress, DpAddress, FullyQualifiedApAddress,
-    },
+    architecture::arm::{sequences::DefaultArmSequence, DpAddress, FullyQualifiedApAddress},
     probe::list::Lister,
 };
 
@@ -26,10 +24,7 @@ fn main() -> Result<()> {
         .initialize(DefaultArmSequence::create(), DpAddress::Default)
         .map_err(|(_interface, e)| e)?;
 
-    let port = &FullyQualifiedApAddress {
-        dp: DpAddress::Default,
-        ap: ApAddress::V1(1),
-    };
+    let port = &FullyQualifiedApAddress::v1_with_default_dp(1);
 
     const RESET: u8 = 0;
     const ERASEALL: u8 = 4;

--- a/probe-rs/src/architecture/arm/ap/generic_ap.rs
+++ b/probe-rs/src/architecture/arm/ap/generic_ap.rs
@@ -1,7 +1,9 @@
 //! Generic access port
 
 use super::{AccessPort, ApRegister, Register};
-use crate::architecture::arm::{communication_interface::RegisterParseError, ApAddress};
+use crate::architecture::arm::{
+    communication_interface::RegisterParseError, FullyQualifiedApAddress,
+};
 
 /// Describes the class of an access port defined in the [`ARM Debug Interface v5.2`](https://developer.arm.com/documentation/ihi0031/f/?lang=en) specification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -61,7 +61,7 @@ impl ApAccess for MockMemoryAp {
     /// Mocks the read_register method of a AP.
     ///
     /// Returns an Error if any bad instructions or values are chosen.
-    fn read_ap_register<PORT, R>(&mut self, _port: PORT) -> Result<R, ArmError>
+    fn read_ap_register<PORT, R>(&mut self, _port: &PORT) -> Result<R, ArmError>
     where
         PORT: AccessPort,
         R: ApRegister<PORT>,
@@ -131,11 +131,7 @@ impl ApAccess for MockMemoryAp {
     /// Mocks the write_register method of a AP.
     ///
     /// Returns an Error if any bad instructions or values are chosen.
-    fn write_ap_register<PORT, R>(
-        &mut self,
-        _port: impl Into<PORT>,
-        register: R,
-    ) -> Result<(), ArmError>
+    fn write_ap_register<PORT, R>(&mut self, _port: &PORT, register: R) -> Result<(), ArmError>
     where
         PORT: AccessPort,
         R: ApRegister<PORT>,
@@ -209,7 +205,7 @@ impl ApAccess for MockMemoryAp {
 
     fn write_ap_register_repeated<PORT, R>(
         &mut self,
-        port: impl Into<PORT> + Clone,
+        port: &PORT,
         _register: R,
         values: &[u32],
     ) -> Result<(), ArmError>
@@ -218,7 +214,7 @@ impl ApAccess for MockMemoryAp {
         R: ApRegister<PORT>,
     {
         for value in values {
-            self.write_ap_register(port.clone(), R::try_from(*value).unwrap())?
+            self.write_ap_register(port, R::try_from(*value).unwrap())?
         }
 
         Ok(())
@@ -226,7 +222,7 @@ impl ApAccess for MockMemoryAp {
 
     fn read_ap_register_repeated<PORT, R>(
         &mut self,
-        port: impl Into<PORT> + Clone,
+        port: &PORT,
         _register: R,
         values: &mut [u32],
     ) -> Result<(), ArmError>
@@ -234,10 +230,8 @@ impl ApAccess for MockMemoryAp {
         PORT: AccessPort,
         R: ApRegister<PORT>,
     {
-        let port = port.into();
-
         for value in values {
-            let register_value: R = self.read_ap_register(port.clone())?;
+            let register_value: R = self.read_ap_register(port)?;
             *value = register_value.into()
         }
 

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -21,10 +21,10 @@ impl MemoryAp {
     where
         A: ApAccess,
     {
-        let base_register: BASE = interface.read_ap_register(*self)?;
+        let base_register: BASE = interface.read_ap_register(self)?;
 
         let mut base_address = if BaseaddrFormat::ADIv5 == base_register.Format {
-            let base2: BASE2 = interface.read_ap_register(*self)?;
+            let base2: BASE2 = interface.read_ap_register(self)?;
 
             u64::from(base2.BASEADDR) << 32
         } else {
@@ -39,7 +39,7 @@ impl MemoryAp {
 impl From<GenericAp> for MemoryAp {
     fn from(other: GenericAp) -> Self {
         MemoryAp {
-            address: other.ap_address(),
+            address: other.ap_address().clone(),
         }
     }
 }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -3,7 +3,9 @@
 pub(crate) mod mock;
 
 use super::{AccessPort, ApAccess, ApRegister, GenericAp, Register};
-use crate::architecture::arm::{communication_interface::RegisterParseError, ApAddress, ArmError};
+use crate::architecture::arm::{
+    communication_interface::RegisterParseError, ArmError, FullyQualifiedApAddress,
+};
 
 define_ap!(
     /// Memory AP

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -210,14 +210,14 @@ where
             let is_valid = u32::from(idr) != 0;
 
             if !is_valid {
-                tracing::debug!("AP {} is not valid, IDR = 0", access_port.ap_address().ap);
+                tracing::debug!("AP {} is not valid, IDR = 0", access_port.ap_address().ap());
             }
             is_valid
         }
         Err(e) => {
             tracing::debug!(
                 "Error reading IDR register from AP {}: {}",
-                access_port.ap_address().ap,
+                access_port.ap_address().ap(),
                 e
             );
             false
@@ -233,12 +233,7 @@ where
     AP: ApAccess,
 {
     (0..=255)
-        .map(|ap| {
-            GenericAp::new(FullyQualifiedApAddress {
-                dp,
-                ap: crate::architecture::arm::ApAddress::V1(ap),
-            })
-        })
+        .map(|ap| GenericAp::new(FullyQualifiedApAddress::v1_with_dp(dp, ap)))
         .take_while(|port| access_port_is_valid(debug_port, port))
         .collect::<Vec<GenericAp>>()
 }
@@ -250,12 +245,7 @@ where
     P: Fn(IDR) -> bool,
 {
     (0..=255)
-        .map(|ap| {
-            GenericAp::new(FullyQualifiedApAddress {
-                dp,
-                ap: crate::architecture::arm::ApAddress::V1(ap),
-            })
-        })
+        .map(|ap| GenericAp::new(FullyQualifiedApAddress::v1_with_dp(dp, ap)))
         .find(|ap| {
             if let Ok(idr) = debug_port.read_ap_register(ap) {
                 f(idr)

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -14,8 +14,8 @@ pub use memory_ap::{
 };
 
 use super::{
-    communication_interface::RegisterParseError, ApAddress, ArmError, DapAccess, DpAddress,
-    Register,
+    communication_interface::RegisterParseError, ArmError, DapAccess, DpAddress,
+    FullyQualifiedApAddress, Register,
 };
 
 /// Some error during AP handling occurred.
@@ -89,7 +89,7 @@ pub trait ApRegister<PORT: AccessPort>: Register + Sized {}
 /// Use the [`define_ap!`] macro to implement this.
 pub trait AccessPort: Clone {
     /// Returns the address of the access port.
-    fn ap_address(&self) -> ApAddress;
+    fn ap_address(&self) -> FullyQualifiedApAddress;
 }
 
 /// A trait to be implemented by access port drivers to implement access port operations.
@@ -241,7 +241,7 @@ where
     AP: ApAccess,
 {
     (0..=255)
-        .map(|ap| GenericAp::new(ApAddress { dp, ap }))
+        .map(|ap| GenericAp::new(FullyQualifiedApAddress { dp, ap }))
         .take_while(|port| access_port_is_valid(debug_port, *port))
         .collect::<Vec<GenericAp>>()
 }
@@ -253,7 +253,7 @@ where
     P: Fn(IDR) -> bool,
 {
     (0..=255)
-        .map(|ap| GenericAp::new(ApAddress { dp, ap }))
+        .map(|ap| GenericAp::new(FullyQualifiedApAddress { dp, ap }))
         .find(|ap| {
             if let Ok(idr) = debug_port.read_ap_register(*ap) {
                 f(idr)

--- a/probe-rs/src/architecture/arm/ap/register_generation.rs
+++ b/probe-rs/src/architecture/arm/ap/register_generation.rs
@@ -64,18 +64,18 @@ macro_rules! define_ap {
         $(#[$outer])*
         #[derive(Clone, Copy, Debug)]
         pub struct $name {
-            address: ApAddress,
+            address: FullyQualifiedApAddress,
         }
 
         impl $name {
             #[doc = concat!("Creates a new ", stringify!($name), " with `address` as base address.")]
-            pub const fn new(address: ApAddress) -> Self {
+            pub const fn new(address: FullyQualifiedApAddress) -> Self {
                 Self { address }
             }
         }
 
         impl AccessPort for $name {
-            fn ap_address(&self) -> ApAddress {
+            fn ap_address(&self) -> FullyQualifiedApAddress {
                 self.address
             }
         }

--- a/probe-rs/src/architecture/arm/ap/register_generation.rs
+++ b/probe-rs/src/architecture/arm/ap/register_generation.rs
@@ -62,7 +62,7 @@ macro_rules! define_ap {
         $name:ident
     ) => {
         $(#[$outer])*
-        #[derive(Clone, Copy, Debug)]
+        #[derive(Clone, Debug)]
         pub struct $name {
             address: FullyQualifiedApAddress,
         }
@@ -75,8 +75,8 @@ macro_rules! define_ap {
         }
 
         impl AccessPort for $name {
-            fn ap_address(&self) -> FullyQualifiedApAddress {
-                self.address
+            fn ap_address(&self) -> &FullyQualifiedApAddress {
+                &self.address
             }
         }
     };

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -12,7 +12,8 @@ use super::{
         Component,
     },
     sequences::{ArmDebugSequence, DefaultArmSequence},
-    ApAddress, ArmError, DapAccess, DpAddress, PortType, RawDapAccess, SwoAccess, SwoConfig,
+    ArmError, DapAccess, DpAddress, FullyQualifiedApAddress, PortType, RawDapAccess, SwoAccess,
+    SwoConfig,
 };
 use crate::{
     architecture::arm::ap::DataSize,
@@ -227,7 +228,7 @@ pub enum ApInformation {
     /// Information about an AP with an unknown class.
     Other {
         /// Zero-based port number of the access port. This is used in the debug port to select an AP.
-        address: ApAddress,
+        address: FullyQualifiedApAddress,
         /// Content of the [`IDR`] register describing this AP.
         idr: IDR,
     },
@@ -313,7 +314,7 @@ impl ApInformation {
 #[derive(Debug, Clone)]
 pub struct MemoryApInformation {
     /// Zero-based port number of the access port. This is used in the debug port to select an AP.
-    pub address: ApAddress,
+    pub address: FullyQualifiedApAddress,
 
     /// Some Memory APs only support 32 bit wide access to data, while others
     /// also support other widths. Based on this, 8 bit data access can either
@@ -693,7 +694,7 @@ impl<'interface> ArmCommunicationInterface<Initialized> {
 
     fn select_ap_and_ap_bank(
         &mut self,
-        ap: ApAddress,
+        ap: FullyQualifiedApAddress,
         ap_register_address: u8,
     ) -> Result<(), ArmError> {
         let dp_state = self.select_dp(ap.dp)?;
@@ -811,7 +812,7 @@ impl DapAccess for ArmCommunicationInterface<Initialized> {
 
     fn read_raw_ap_register(
         &mut self,
-        ap: ApAddress,
+        ap: FullyQualifiedApAddress,
         address: u8,
     ) -> std::result::Result<u32, ArmError> {
         self.select_ap_and_ap_bank(ap, address)?;
@@ -825,7 +826,7 @@ impl DapAccess for ArmCommunicationInterface<Initialized> {
 
     fn read_raw_ap_register_repeated(
         &mut self,
-        ap: ApAddress,
+        ap: FullyQualifiedApAddress,
         address: u8,
         values: &mut [u32],
     ) -> Result<(), ArmError> {
@@ -838,7 +839,7 @@ impl DapAccess for ArmCommunicationInterface<Initialized> {
 
     fn write_raw_ap_register(
         &mut self,
-        ap: ApAddress,
+        ap: FullyQualifiedApAddress,
         address: u8,
         value: u32,
     ) -> Result<(), ArmError> {
@@ -852,7 +853,7 @@ impl DapAccess for ArmCommunicationInterface<Initialized> {
 
     fn write_raw_ap_register_repeated(
         &mut self,
-        ap: ApAddress,
+        ap: FullyQualifiedApAddress,
         address: u8,
         values: &[u32],
     ) -> Result<(), ArmError> {

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -697,7 +697,7 @@ impl<'interface> ArmCommunicationInterface<Initialized> {
         ap: &FullyQualifiedApAddress,
         ap_register_address: u8,
     ) -> Result<(), ArmError> {
-        let dp_state = self.select_dp(ap.dp)?;
+        let dp_state = self.select_dp(ap.dp())?;
 
         let port = ap.ap_v1()?;
         let ap_bank = ap_register_address >> 4;
@@ -727,7 +727,7 @@ impl<'interface> ArmCommunicationInterface<Initialized> {
             select.set_ap_bank_sel(dp_state.current_apbanksel);
             select.set_dp_bank_sel(dp_state.current_dpbanksel);
 
-            self.write_dp_register(ap.dp, select)?;
+            self.write_dp_register(ap.dp(), select)?;
         }
 
         Ok(())
@@ -742,7 +742,7 @@ impl<'interface> ArmCommunicationInterface<Initialized> {
     ) -> Result<Option<&ApInformation>, ArmError> {
         let addr = access_port.ap_address();
 
-        let state = self.select_dp(addr.dp)?;
+        let state = self.select_dp(addr.dp())?;
 
         Ok(state.ap_information.get(addr.ap_v1()? as usize))
     }

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -111,10 +111,9 @@ pub fn get_arm_components(
 
     for ap_index in 0..(interface.num_access_ports(dp)? as u8) {
         let ap_information = interface
-            .ap_information(&GenericAp::new(FullyQualifiedApAddress {
-                dp,
-                ap: crate::architecture::arm::ApAddress::V1(ap_index),
-            }))?
+            .ap_information(&GenericAp::new(FullyQualifiedApAddress::v1_with_dp(
+                dp, ap_index,
+            )))?
             .clone();
 
         let component = match ap_information {

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -111,7 +111,10 @@ pub fn get_arm_components(
 
     for ap_index in 0..(interface.num_access_ports(dp)? as u8) {
         let ap_information = interface
-            .ap_information(GenericAp::new(FullyQualifiedApAddress { dp, ap: ap_index }))?
+            .ap_information(&GenericAp::new(FullyQualifiedApAddress {
+                dp,
+                ap: crate::architecture::arm::ApAddress::V1(ap_index),
+            }))?
             .clone();
 
         let component = match ap_information {
@@ -125,7 +128,7 @@ pub fn get_arm_components(
                 ..
             }) => {
                 let ap = MemoryAp::new(address);
-                let mut memory = interface.memory_interface(ap)?;
+                let mut memory = interface.memory_interface(&ap)?;
                 let component = Component::try_parse(&mut *memory, debug_base_address)?;
                 Ok(CoresightComponent::new(component, ap))
             }

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -12,7 +12,7 @@ use super::ap::{GenericAp, MemoryAp};
 use super::memory::romtable::{CoresightComponent, PeripheralType, RomTableError};
 use super::memory::Component;
 use super::ArmError;
-use super::{ApAddress, ApInformation, DpAddress, MemoryApInformation};
+use super::{ApInformation, DpAddress, FullyQualifiedApAddress, MemoryApInformation};
 use crate::architecture::arm::core::armv6m::Demcr;
 use crate::architecture::arm::{ArmProbeInterface, SwoConfig, SwoMode};
 use crate::{Core, Error, MemoryInterface, MemoryMappedRegister};
@@ -111,7 +111,7 @@ pub fn get_arm_components(
 
     for ap_index in 0..(interface.num_access_ports(dp)? as u8) {
         let ap_information = interface
-            .ap_information(GenericAp::new(ApAddress { dp, ap: ap_index }))?
+            .ap_information(GenericAp::new(FullyQualifiedApAddress { dp, ap: ap_index }))?
             .clone();
 
         let component = match ap_information {

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -217,7 +217,7 @@ where
         interface: &'interface mut AP,
         ap_information: MemoryApInformation,
     ) -> Result<ADIMemoryInterface<'interface, AP>, AccessPortError> {
-        let address = ap_information.address;
+        let address = ap_information.address.clone();
         Ok(Self {
             interface,
             ap_information,
@@ -304,9 +304,9 @@ where
         AP: ApAccess,
     {
         self.interface
-            .read_ap_register(self.memory_ap)
+            .read_ap_register(&self.memory_ap)
             .map_err(AccessPortError::register_read_error::<R, _>)
-            .map_err(|error| ArmError::from_access_port(error, self.memory_ap))
+            .map_err(|error| ArmError::from_access_port(error, &self.memory_ap))
     }
 
     /// Read multiple 32 bit values from the DRW register on the given AP.
@@ -321,9 +321,9 @@ where
             Ok(())
         } else {
             self.interface
-                .read_ap_register_repeated(self.memory_ap, DRW { data: 0 }, values)
+                .read_ap_register_repeated(&self.memory_ap, DRW { data: 0 }, values)
                 .map_err(AccessPortError::register_read_error::<DRW, _>)
-                .map_err(|err| ArmError::from_access_port(err, self.memory_ap))
+                .map_err(|err| ArmError::from_access_port(err, &self.memory_ap))
         }
     }
 
@@ -334,9 +334,9 @@ where
         AP: ApAccess,
     {
         self.interface
-            .write_ap_register(self.memory_ap, register)
+            .write_ap_register(&self.memory_ap, register)
             .map_err(AccessPortError::register_write_error::<R, _>)
-            .map_err(|e| ArmError::from_access_port(e, self.memory_ap))
+            .map_err(|e| ArmError::from_access_port(e, &self.memory_ap))
     }
 
     /// Write multiple 32 bit values to the DRW register on the given AP.
@@ -349,9 +349,9 @@ where
             self.write_ap_register(DRW { data: values[0] })
         } else {
             self.interface
-                .write_ap_register_repeated(self.memory_ap, DRW { data: 0 }, values)
+                .write_ap_register_repeated(&self.memory_ap, DRW { data: 0 }, values)
                 .map_err(AccessPortError::register_write_error::<DRW, _>)
-                .map_err(|e| ArmError::from_access_port(e, self.memory_ap))
+                .map_err(|e| ArmError::from_access_port(e, &self.memory_ap))
         }
     }
 
@@ -839,7 +839,7 @@ where
 
     /// Returns the underlying [`ApAddress`].
     fn ap(&mut self) -> MemoryAp {
-        self.memory_ap
+        self.memory_ap.clone()
     }
 
     fn get_arm_communication_interface(
@@ -864,7 +864,7 @@ mod tests {
 
     const DUMMY_AP: MemoryAp = MemoryAp::new(FullyQualifiedApAddress {
         dp: DpAddress::Default,
-        ap: 0,
+        ap: crate::architecture::arm::traits::ApAddress::V1(0),
     });
 
     impl<'interface> ADIMemoryInterface<'interface, MockMemoryAp> {
@@ -873,7 +873,7 @@ mod tests {
             mock: &'interface mut MockMemoryAp,
         ) -> ADIMemoryInterface<'interface, MockMemoryAp> {
             let ap_information = MemoryApInformation {
-                address: DUMMY_AP.ap_address(),
+                address: DUMMY_AP.ap_address().clone(),
                 supports_only_32bit_data_size: false,
                 supports_hnonsec: false,
                 debug_base_address: 0xf000_0000,

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -853,14 +853,16 @@ where
 mod tests {
     use scroll::Pread;
 
-    use crate::architecture::arm::{ap::AccessPort, ApAddress, DpAddress, MemoryApInformation};
+    use crate::architecture::arm::{
+        ap::AccessPort, DpAddress, FullyQualifiedApAddress, MemoryApInformation,
+    };
 
     use super::super::super::ap::memory_ap::mock::MockMemoryAp;
     use super::super::super::ap::memory_ap::MemoryAp;
     use super::ADIMemoryInterface;
     use super::ArmProbe;
 
-    const DUMMY_AP: MemoryAp = MemoryAp::new(ApAddress {
+    const DUMMY_AP: MemoryAp = MemoryAp::new(FullyQualifiedApAddress {
         dp: DpAddress::Default,
         ap: 0,
     });

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -853,19 +853,14 @@ where
 mod tests {
     use scroll::Pread;
 
-    use crate::architecture::arm::{
-        ap::AccessPort, DpAddress, FullyQualifiedApAddress, MemoryApInformation,
-    };
+    use crate::architecture::arm::{ap::AccessPort, FullyQualifiedApAddress, MemoryApInformation};
 
     use super::super::super::ap::memory_ap::mock::MockMemoryAp;
     use super::super::super::ap::memory_ap::MemoryAp;
     use super::ADIMemoryInterface;
     use super::ArmProbe;
 
-    const DUMMY_AP: MemoryAp = MemoryAp::new(FullyQualifiedApAddress {
-        dp: DpAddress::Default,
-        ap: crate::architecture::arm::traits::ApAddress::V1(0),
-    });
+    const DUMMY_AP: MemoryAp = MemoryAp::new(FullyQualifiedApAddress::v1_with_default_dp(0));
 
     impl<'interface> ADIMemoryInterface<'interface, MockMemoryAp> {
         /// Creates a new MemoryInterface for given AccessPort.

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -508,7 +508,7 @@ impl CoresightComponent {
         interface: &mut dyn ArmProbeInterface,
         offset: u32,
     ) -> Result<u32, ArmError> {
-        let mut memory = interface.memory_interface(self.ap)?;
+        let mut memory = interface.memory_interface(&self.ap)?;
         let value = memory.read_word_32(self.component.id().component_address + offset as u64)?;
         Ok(value)
     }
@@ -520,7 +520,7 @@ impl CoresightComponent {
         offset: u32,
         value: u32,
     ) -> Result<(), ArmError> {
-        let mut memory = interface.memory_interface(self.ap)?;
+        let mut memory = interface.memory_interface(&self.ap)?;
         memory.write_word_32(self.component.id().component_address + offset as u64, value)?;
         Ok(())
     }

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -50,7 +50,7 @@ pub enum ArmError {
     #[error("Error using access port.")]
     AccessPort {
         /// Address of the access port
-        address: ApAddress,
+        address: FullyQualifiedApAddress,
         /// Source of the error.
         source: AccessPortError,
     },
@@ -107,7 +107,7 @@ pub enum ArmError {
 
     /// The AP with the specified address does not exist.
     #[error("The AP with address {0:?} does not exist.")]
-    ApDoesNotExist(ApAddress),
+    ApDoesNotExist(FullyQualifiedApAddress),
 
     /// The AP has the wrong type for the operation.
     #[error("Wrong AP type.")]

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -109,6 +109,10 @@ pub enum ArmError {
     #[error("The AP with address {0:?} does not exist.")]
     ApDoesNotExist(FullyQualifiedApAddress),
 
+    /// The AP has the wrong version for the operation.
+    #[error("Wrong AP version.")]
+    WrongApVersion,
+
     /// The AP has the wrong type for the operation.
     #[error("Wrong AP type.")]
     WrongApType,
@@ -159,9 +163,9 @@ pub enum ArmError {
 
 impl ArmError {
     /// Constructs [`ArmError::MemoryNotAligned`] from the address and the required alignment.
-    pub fn from_access_port(err: AccessPortError, ap: impl AccessPort) -> Self {
+    pub fn from_access_port(err: AccessPortError, ap: &impl AccessPort) -> Self {
         ArmError::AccessPort {
-            address: ap.ap_address(),
+            address: ap.ap_address().clone(),
             source: err,
         }
     }

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -649,7 +649,7 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
         debug_base: Option<u64>,
         cti_base: Option<u64>,
     ) -> Result<(), ArmError> {
-        let mut core = interface.memory_interface(core_ap)?;
+        let mut core = interface.memory_interface(&core_ap)?;
 
         // Dispatch based on core type (Cortex-A vs M)
         match core_type {
@@ -771,7 +771,7 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
     fn debug_device_unlock(
         &self,
         _interface: &mut dyn ArmProbeInterface,
-        _default_ap: MemoryAp,
+        _default_ap: &MemoryAp,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
         tracing::debug!("debug_device_unlock - empty by default");

--- a/probe-rs/src/architecture/arm/traits.rs
+++ b/probe-rs/src/architecture/arm/traits.rs
@@ -85,21 +85,40 @@ impl std::fmt::Display for ApAddress {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FullyQualifiedApAddress {
     /// The address of the debug port this access port belongs to.
-    pub dp: DpAddress,
+    dp: DpAddress,
     /// The access port number.
-    pub ap: ApAddress,
+    ap: ApAddress,
 }
 
 impl FullyQualifiedApAddress {
-    /// Create a new `ApAddress` belonging to the default debug port.
-    pub fn with_default_dp(ap: u8) -> Self {
+    /// Create a new `FullyQualifiedApAddress` belonging to the default debug port.
+    pub const fn v1_with_default_dp(ap: u8) -> Self {
         Self {
             dp: DpAddress::Default,
             ap: ApAddress::V1(ap),
         }
     }
 
-    /// Returns the ap address if its version is 1
+    /// Create a new `FullyQualifiedApAddress` belonging to the given debug port using Ap Address
+    /// in the version 1 format.
+    pub const fn v1_with_dp(dp: DpAddress, ap: u8) -> Self {
+        Self {
+            dp,
+            ap: ApAddress::V1(ap),
+        }
+    }
+
+    /// Returns the Debug port’s address.
+    pub fn dp(&self) -> DpAddress {
+        self.dp
+    }
+
+    /// Returns the Access Port address.
+    pub fn ap(&self) -> &ApAddress {
+        &self.ap
+    }
+
+    /// Returns the ap address if its version is 1.
     pub fn ap_v1(&self) -> Result<u8, ArmError> {
         if let ApAddress::V1(ap) = self.ap {
             Ok(ap)

--- a/probe-rs/src/architecture/arm/traits.rs
+++ b/probe-rs/src/architecture/arm/traits.rs
@@ -47,14 +47,14 @@ pub enum DpAddress {
 
 /// Access port address.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct ApAddress {
+pub struct FullyQualifiedApAddress {
     /// The address of the debug port this access port belongs to.
     pub dp: DpAddress,
     /// The access port number.
     pub ap: u8,
 }
 
-impl ApAddress {
+impl FullyQualifiedApAddress {
     /// Create a new `ApAddress` belonging to the default debug port.
     pub fn with_default_dp(ap: u8) -> Self {
         Self {
@@ -204,7 +204,11 @@ pub trait DapAccess {
     ///
     /// Highest 4 bits of `addr` are interpreted as the bank number, implementations
     /// will do bank switching if necessary.
-    fn read_raw_ap_register(&mut self, ap: ApAddress, addr: u8) -> Result<u32, ArmError>;
+    fn read_raw_ap_register(
+        &mut self,
+        ap: FullyQualifiedApAddress,
+        addr: u8,
+    ) -> Result<u32, ArmError>;
 
     /// Read multiple values from the same Access Port register.
     ///
@@ -215,7 +219,7 @@ pub trait DapAccess {
     /// will do bank switching if necessary.
     fn read_raw_ap_register_repeated(
         &mut self,
-        ap: ApAddress,
+        ap: FullyQualifiedApAddress,
         addr: u8,
         values: &mut [u32],
     ) -> Result<(), ArmError> {
@@ -231,7 +235,7 @@ pub trait DapAccess {
     /// will do bank switching if necessary.
     fn write_raw_ap_register(
         &mut self,
-        ap: ApAddress,
+        ap: FullyQualifiedApAddress,
         addr: u8,
         value: u32,
     ) -> Result<(), ArmError>;
@@ -245,7 +249,7 @@ pub trait DapAccess {
     /// will do bank switching if necessary.
     fn write_raw_ap_register_repeated(
         &mut self,
-        ap: ApAddress,
+        ap: FullyQualifiedApAddress,
         addr: u8,
         values: &[u32],
     ) -> Result<(), ArmError> {

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -5,7 +5,7 @@ use crate::{
         arm::{
             ap::MemoryAp,
             sequences::{ArmDebugSequence, DefaultArmSequence},
-            ApAddress, DpAddress,
+            DpAddress, FullyQualifiedApAddress,
         },
         riscv::sequences::{DefaultRiscvSequence, RiscvDebugSequence},
         xtensa::sequences::{DefaultXtensaSequence, XtensaDebugSequence},
@@ -232,13 +232,15 @@ pub(crate) trait CoreExt {
 impl CoreExt for Core {
     fn memory_ap(&self) -> Option<MemoryAp> {
         match &self.core_access_options {
-            probe_rs_target::CoreAccessOptions::Arm(options) => Some(MemoryAp::new(ApAddress {
-                dp: match options.psel {
-                    0 => DpAddress::Default,
-                    x => DpAddress::Multidrop(x),
-                },
-                ap: options.ap,
-            })),
+            probe_rs_target::CoreAccessOptions::Arm(options) => {
+                Some(MemoryAp::new(FullyQualifiedApAddress {
+                    dp: match options.psel {
+                        0 => DpAddress::Default,
+                        x => DpAddress::Multidrop(x),
+                    },
+                    ap: options.ap,
+                }))
+            }
             probe_rs_target::CoreAccessOptions::Riscv(_) => None,
             probe_rs_target::CoreAccessOptions::Xtensa(_) => None,
         }

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -238,7 +238,7 @@ impl CoreExt for Core {
                         0 => DpAddress::Default,
                         x => DpAddress::Multidrop(x),
                     },
-                    ap: options.ap,
+                    ap: crate::architecture::arm::ApAddress::V1(options.ap),
                 }))
             }
             probe_rs_target::CoreAccessOptions::Riscv(_) => None,

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -233,13 +233,13 @@ impl CoreExt for Core {
     fn memory_ap(&self) -> Option<MemoryAp> {
         match &self.core_access_options {
             probe_rs_target::CoreAccessOptions::Arm(options) => {
-                Some(MemoryAp::new(FullyQualifiedApAddress {
-                    dp: match options.psel {
+                Some(MemoryAp::new(FullyQualifiedApAddress::v1_with_dp(
+                    match options.psel {
                         0 => DpAddress::Default,
                         x => DpAddress::Multidrop(x),
                     },
-                    ap: crate::architecture::arm::ApAddress::V1(options.ap),
-                }))
+                    options.ap,
+                )))
             }
             probe_rs_target::CoreAccessOptions::Riscv(_) => None,
             probe_rs_target::CoreAccessOptions::Xtensa(_) => None,

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -3,7 +3,7 @@ use crate::{
         arm::{
             ap::MemoryAp,
             core::{CortexAState, CortexMState},
-            ArmProbeInterface, DpAddress, FullyQualifiedApAddress,
+            ApAddress, ArmProbeInterface, DpAddress, FullyQualifiedApAddress,
         },
         riscv::{
             communication_interface::{RiscvCommunicationInterface, RiscvError},
@@ -47,7 +47,7 @@ impl CombinedCoreState {
 
         let name = &target.cores[self.id].name;
 
-        let memory = arm_interface.memory_interface(self.arm_memory_ap())?;
+        let memory = arm_interface.memory_interface(&self.arm_memory_ap())?;
 
         let ResolvedCoreOptions::Arm { options, sequence } = &self.core_state.core_access_options
         else {
@@ -147,7 +147,7 @@ impl CombinedCoreState {
             );
         };
 
-        let mut memory_interface = interface.memory_interface(self.arm_memory_ap())?;
+        let mut memory_interface = interface.memory_interface(&self.arm_memory_ap())?;
 
         let reset_catch_span = tracing::debug_span!("reset_catch_set", id = self.id()).entered();
         sequence.reset_catch_set(&mut *memory_interface, self.core_type(), options.debug_base)?;
@@ -266,7 +266,10 @@ impl CoreState {
             x => DpAddress::Multidrop(x),
         };
 
-        let ap = FullyQualifiedApAddress { dp, ap: options.ap };
+        let ap = FullyQualifiedApAddress {
+            dp,
+            ap: ApAddress::V1(options.ap),
+        };
 
         MemoryAp::new(ap)
     }

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -3,7 +3,7 @@ use crate::{
         arm::{
             ap::MemoryAp,
             core::{CortexAState, CortexMState},
-            ApAddress, ArmProbeInterface, DpAddress, FullyQualifiedApAddress,
+            ArmProbeInterface, DpAddress, FullyQualifiedApAddress,
         },
         riscv::{
             communication_interface::{RiscvCommunicationInterface, RiscvError},
@@ -266,10 +266,7 @@ impl CoreState {
             x => DpAddress::Multidrop(x),
         };
 
-        let ap = FullyQualifiedApAddress {
-            dp,
-            ap: ApAddress::V1(options.ap),
-        };
+        let ap = FullyQualifiedApAddress::v1_with_dp(dp, options.ap);
 
         MemoryAp::new(ap)
     }

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -3,7 +3,7 @@ use crate::{
         arm::{
             ap::MemoryAp,
             core::{CortexAState, CortexMState},
-            ApAddress, ArmProbeInterface, DpAddress,
+            ArmProbeInterface, DpAddress, FullyQualifiedApAddress,
         },
         riscv::{
             communication_interface::{RiscvCommunicationInterface, RiscvError},
@@ -266,7 +266,7 @@ impl CoreState {
             x => DpAddress::Multidrop(x),
         };
 
-        let ap = ApAddress { dp, ap: options.ap };
+        let ap = FullyQualifiedApAddress { dp, ap: options.ap };
 
         MemoryAp::new(ap)
     }

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -269,7 +269,7 @@ impl FakeProbe {
 
     fn read_raw_ap_register(
         &mut self,
-        expected_ap: FullyQualifiedApAddress,
+        expected_ap: &FullyQualifiedApAddress,
         expected_address: u8,
     ) -> Result<u32, ArmError> {
         let operation = self.next_operation();
@@ -280,7 +280,7 @@ impl FakeProbe {
                 address,
                 result,
             }) => {
-                assert_eq!(ap, expected_ap);
+                assert_eq!(&ap, expected_ap);
                 assert_eq!(address, expected_address);
 
                 Ok(result)
@@ -483,10 +483,10 @@ impl UninitializedArmProbe for FakeArmInterface<Uninitialized> {
 impl ArmProbeInterface for FakeArmInterface<Initialized> {
     fn memory_interface(
         &mut self,
-        access_port: MemoryAp,
+        access_port: &MemoryAp,
     ) -> Result<Box<dyn ArmProbe + '_>, ArmError> {
         let ap_information = MemoryApInformation {
-            address: access_port.ap_address(),
+            address: access_port.ap_address().clone(),
             supports_only_32bit_data_size: false,
             debug_base_address: 0xf000_0000,
             supports_hnonsec: false,
@@ -508,7 +508,7 @@ impl ArmProbeInterface for FakeArmInterface<Initialized> {
 
     fn ap_information(
         &mut self,
-        _access_port: crate::architecture::arm::ap::GenericAp,
+        _access_port: &crate::architecture::arm::ap::GenericAp,
     ) -> Result<&crate::architecture::arm::ApInformation, ArmError> {
         todo!()
     }
@@ -566,7 +566,7 @@ impl DapAccess for FakeArmInterface<Initialized> {
 
     fn read_raw_ap_register(
         &mut self,
-        _ap: FullyQualifiedApAddress,
+        _ap: &FullyQualifiedApAddress,
         _address: u8,
     ) -> Result<u32, ArmError> {
         self.probe.read_raw_ap_register(_ap, _address)
@@ -574,7 +574,7 @@ impl DapAccess for FakeArmInterface<Initialized> {
 
     fn read_raw_ap_register_repeated(
         &mut self,
-        _ap: FullyQualifiedApAddress,
+        _ap: &FullyQualifiedApAddress,
         _address: u8,
         _values: &mut [u32],
     ) -> Result<(), ArmError> {
@@ -583,7 +583,7 @@ impl DapAccess for FakeArmInterface<Initialized> {
 
     fn write_raw_ap_register(
         &mut self,
-        _ap: FullyQualifiedApAddress,
+        _ap: &FullyQualifiedApAddress,
         _address: u8,
         _value: u32,
     ) -> Result<(), ArmError> {
@@ -592,7 +592,7 @@ impl DapAccess for FakeArmInterface<Initialized> {
 
     fn write_raw_ap_register_repeated(
         &mut self,
-        _ap: FullyQualifiedApAddress,
+        _ap: &FullyQualifiedApAddress,
         _address: u8,
         _values: &[u32],
     ) -> Result<(), ArmError> {

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -12,8 +12,8 @@ use crate::{
         },
         memory::adi_v5_memory_interface::{ADIMemoryInterface, ArmProbe},
         sequences::ArmDebugSequence,
-        ApAddress, ArmError, ArmProbeInterface, DapAccess, DpAddress, MemoryApInformation,
-        PortType, RawDapAccess, SwoAccess,
+        ArmError, ArmProbeInterface, DapAccess, DpAddress, FullyQualifiedApAddress,
+        MemoryApInformation, PortType, RawDapAccess, SwoAccess,
     },
     probe::{DebugProbe, DebugProbeError, Probe, WireProtocol},
     Error, MemoryMappedRegister,
@@ -192,7 +192,7 @@ impl ArmProbe for &mut MockCore {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Operation {
     ReadRawApRegister {
-        ap: ApAddress,
+        ap: FullyQualifiedApAddress,
         address: u8,
         result: u32,
     },
@@ -269,7 +269,7 @@ impl FakeProbe {
 
     fn read_raw_ap_register(
         &mut self,
-        expected_ap: ApAddress,
+        expected_ap: FullyQualifiedApAddress,
         expected_address: u8,
     ) -> Result<u32, ArmError> {
         let operation = self.next_operation();
@@ -564,13 +564,17 @@ impl DapAccess for FakeArmInterface<Initialized> {
         todo!()
     }
 
-    fn read_raw_ap_register(&mut self, _ap: ApAddress, _address: u8) -> Result<u32, ArmError> {
+    fn read_raw_ap_register(
+        &mut self,
+        _ap: FullyQualifiedApAddress,
+        _address: u8,
+    ) -> Result<u32, ArmError> {
         self.probe.read_raw_ap_register(_ap, _address)
     }
 
     fn read_raw_ap_register_repeated(
         &mut self,
-        _ap: ApAddress,
+        _ap: FullyQualifiedApAddress,
         _address: u8,
         _values: &mut [u32],
     ) -> Result<(), ArmError> {
@@ -579,7 +583,7 @@ impl DapAccess for FakeArmInterface<Initialized> {
 
     fn write_raw_ap_register(
         &mut self,
-        _ap: ApAddress,
+        _ap: FullyQualifiedApAddress,
         _address: u8,
         _value: u32,
     ) -> Result<(), ArmError> {
@@ -588,7 +592,7 @@ impl DapAccess for FakeArmInterface<Initialized> {
 
     fn write_raw_ap_register_repeated(
         &mut self,
-        _ap: ApAddress,
+        _ap: FullyQualifiedApAddress,
         _address: u8,
         _values: &[u32],
     ) -> Result<(), ArmError> {

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1464,7 +1464,7 @@ impl DapAccess for StlinkArmDebug {
         ap: &FullyQualifiedApAddress,
         address: u8,
     ) -> Result<u32, ArmError> {
-        if ap.dp != DpAddress::Default {
+        if ap.dp() != DpAddress::Default {
             return Err(DebugProbeError::from(StlinkError::MultidropNotSupported).into());
         }
 
@@ -1479,7 +1479,7 @@ impl DapAccess for StlinkArmDebug {
         address: u8,
         value: u32,
     ) -> Result<(), ArmError> {
-        if ap.dp != DpAddress::Default {
+        if ap.dp() != DpAddress::Default {
             return Err(DebugProbeError::from(StlinkError::MultidropNotSupported).into());
         }
 
@@ -1509,7 +1509,7 @@ impl ArmProbeInterface for StlinkArmDebug {
         access_port: &GenericAp,
     ) -> Result<&crate::architecture::arm::communication_interface::ApInformation, ArmError> {
         let addr = access_port.ap_address();
-        if addr.dp != DpAddress::Default {
+        if addr.dp() != DpAddress::Default {
             return Err(DebugProbeError::from(StlinkError::MultidropNotSupported).into());
         }
 

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -16,8 +16,8 @@ use crate::{
         },
         memory::Component,
         sequences::ArmDebugSequence,
-        ApAddress, ApInformation, ArmChipInfo, DapAccess, DpAddress, Pins, SwoAccess, SwoConfig,
-        SwoMode,
+        ApInformation, ArmChipInfo, DapAccess, DpAddress, FullyQualifiedApAddress, Pins, SwoAccess,
+        SwoConfig, SwoMode,
     },
     probe::{DebugProbeInfo, DebugProbeSelector, Probe, ProbeFactory},
     Error as ProbeRsError,
@@ -1458,7 +1458,11 @@ impl DapAccess for StlinkArmDebug {
         Ok(())
     }
 
-    fn read_raw_ap_register(&mut self, ap: ApAddress, address: u8) -> Result<u32, ArmError> {
+    fn read_raw_ap_register(
+        &mut self,
+        ap: FullyQualifiedApAddress,
+        address: u8,
+    ) -> Result<u32, ArmError> {
         if ap.dp != DpAddress::Default {
             return Err(DebugProbeError::from(StlinkError::MultidropNotSupported).into());
         }
@@ -1470,7 +1474,7 @@ impl DapAccess for StlinkArmDebug {
 
     fn write_raw_ap_register(
         &mut self,
-        ap: ApAddress,
+        ap: FullyQualifiedApAddress,
         address: u8,
         value: u32,
     ) -> Result<(), ArmError> {

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -220,7 +220,7 @@ impl Session {
 
         // Enable debug mode
         let unlock_res =
-            sequence_handle.debug_device_unlock(&mut *interface, default_memory_ap, &permissions);
+            sequence_handle.debug_device_unlock(&mut *interface, &default_memory_ap, &permissions);
         drop(unlock_span);
 
         match unlock_res {
@@ -246,7 +246,7 @@ impl Session {
                 let reset_hardware_deassert =
                     tracing::debug_span!("reset_hardware_deassert").entered();
 
-                let mut memory_interface = interface.memory_interface(default_memory_ap)?;
+                let mut memory_interface = interface.memory_interface(&default_memory_ap)?;
 
                 // TODO: A timeout here indicates that the reset pin is probably not properly
                 //       connected.

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -182,7 +182,7 @@ impl Session {
             ))
         })?;
 
-        let default_dp = default_memory_ap.ap_address().dp;
+        let default_dp = default_memory_ap.ap_address().dp();
 
         let sequence_handle = match &target.debug_sequence {
             DebugSequence::Arm(sequence) => sequence.clone(),

--- a/probe-rs/src/vendor/infineon/mod.rs
+++ b/probe-rs/src/vendor/infineon/mod.rs
@@ -59,7 +59,7 @@ fn try_detect_xmc4xxx(
     }
 
     // FIXME: This is a bit shaky but good enough for now.
-    let access_port = &MemoryAp::new(FullyQualifiedApAddress::with_default_dp(0));
+    let access_port = &MemoryAp::new(FullyQualifiedApAddress::v1_with_default_dp(0));
     let mut memory_interface = interface.memory_interface(access_port)?;
 
     // First, read the SCU peripheral ID register to verify that this is an XMC4000.

--- a/probe-rs/src/vendor/infineon/mod.rs
+++ b/probe-rs/src/vendor/infineon/mod.rs
@@ -5,8 +5,8 @@ use probe_rs_target::{chip_detection::ChipDetectionMethod, Chip};
 
 use crate::{
     architecture::arm::{
-        ap::MemoryAp, memory::adi_v5_memory_interface::ArmProbe, ApAddress, ArmChipInfo, ArmError,
-        ArmProbeInterface,
+        ap::MemoryAp, memory::adi_v5_memory_interface::ArmProbe, ArmChipInfo, ArmError,
+        ArmProbeInterface, FullyQualifiedApAddress,
     },
     config::{registry, DebugSequence},
     error::Error,
@@ -59,7 +59,7 @@ fn try_detect_xmc4xxx(
     }
 
     // FIXME: This is a bit shaky but good enough for now.
-    let access_port = MemoryAp::new(ApAddress::with_default_dp(0));
+    let access_port = MemoryAp::new(FullyQualifiedApAddress::with_default_dp(0));
     let mut memory_interface = interface.memory_interface(access_port)?;
 
     // First, read the SCU peripheral ID register to verify that this is an XMC4000.

--- a/probe-rs/src/vendor/infineon/mod.rs
+++ b/probe-rs/src/vendor/infineon/mod.rs
@@ -59,7 +59,7 @@ fn try_detect_xmc4xxx(
     }
 
     // FIXME: This is a bit shaky but good enough for now.
-    let access_port = MemoryAp::new(FullyQualifiedApAddress::with_default_dp(0));
+    let access_port = &MemoryAp::new(FullyQualifiedApAddress::with_default_dp(0));
     let mut memory_interface = interface.memory_interface(access_port)?;
 
     // First, read the SCU peripheral ID register to verify that this is an XMC4000.

--- a/probe-rs/src/vendor/microchip/mod.rs
+++ b/probe-rs/src/vendor/microchip/mod.rs
@@ -48,7 +48,7 @@ impl Vendor for Microchip {
         // This device has an Atmel DSU - Read and parse the DSU DID register
         let did = DsuDid(
             interface
-                .memory_interface(access_port)?
+                .memory_interface(&access_port)?
                 .read_word_32(DsuDid::ADDRESS)?,
         );
 

--- a/probe-rs/src/vendor/microchip/mod.rs
+++ b/probe-rs/src/vendor/microchip/mod.rs
@@ -3,7 +3,7 @@
 use probe_rs_target::{chip_detection::ChipDetectionMethod, Chip};
 
 use crate::{
-    architecture::arm::{ap::MemoryAp, ApAddress, ArmChipInfo, ArmProbeInterface},
+    architecture::arm::{ap::MemoryAp, ArmChipInfo, ArmProbeInterface, FullyQualifiedApAddress},
     config::{registry, DebugSequence},
     vendor::{
         microchip::sequences::atsam::{AtSAM, DsuDid},
@@ -44,7 +44,7 @@ impl Vendor for Microchip {
         }
 
         // FIXME: This is a bit shaky but good enough for now.
-        let access_port = MemoryAp::new(ApAddress::with_default_dp(0));
+        let access_port = MemoryAp::new(FullyQualifiedApAddress::with_default_dp(0));
         // This device has an Atmel DSU - Read and parse the DSU DID register
         let did = DsuDid(
             interface

--- a/probe-rs/src/vendor/microchip/mod.rs
+++ b/probe-rs/src/vendor/microchip/mod.rs
@@ -44,7 +44,7 @@ impl Vendor for Microchip {
         }
 
         // FIXME: This is a bit shaky but good enough for now.
-        let access_port = MemoryAp::new(FullyQualifiedApAddress::with_default_dp(0));
+        let access_port = MemoryAp::new(FullyQualifiedApAddress::v1_with_default_dp(0));
         // This device has an Atmel DSU - Read and parse the DSU DID register
         let did = DsuDid(
             interface

--- a/probe-rs/src/vendor/microchip/sequences/atsam.rs
+++ b/probe-rs/src/vendor/microchip/sequences/atsam.rs
@@ -9,7 +9,7 @@ use crate::{
             communication_interface::{DapProbe, SwdSequence},
             memory::adi_v5_memory_interface::ArmProbe,
             sequences::{ArmDebugSequence, ArmDebugSequenceError, DebugEraseSequence},
-            ArmError, ArmProbeInterface, DpAddress, FullyQualifiedApAddress, Pins,
+            ArmError, ArmProbeInterface, FullyQualifiedApAddress, Pins,
         },
     },
     probe::DebugProbeError,
@@ -534,10 +534,7 @@ impl ArmDebugSequence for AtSAM {
 
 impl DebugEraseSequence for AtSAM {
     fn erase_all(&self, interface: &mut dyn ArmProbeInterface) -> Result<(), ArmError> {
-        let mem_ap = &MemoryAp::new(FullyQualifiedApAddress {
-            dp: DpAddress::Default,
-            ap: crate::architecture::arm::ApAddress::V1(0),
-        });
+        let mem_ap = &MemoryAp::new(FullyQualifiedApAddress::v1_with_default_dp(0));
 
         let mut memory = interface.memory_interface(mem_ap)?;
 

--- a/probe-rs/src/vendor/microchip/sequences/atsam.rs
+++ b/probe-rs/src/vendor/microchip/sequences/atsam.rs
@@ -9,7 +9,7 @@ use crate::{
             communication_interface::{DapProbe, SwdSequence},
             memory::adi_v5_memory_interface::ArmProbe,
             sequences::{ArmDebugSequence, ArmDebugSequenceError, DebugEraseSequence},
-            ApAddress, ArmError, ArmProbeInterface, DpAddress, Pins,
+            ArmError, ArmProbeInterface, DpAddress, FullyQualifiedApAddress, Pins,
         },
     },
     probe::DebugProbeError,
@@ -534,7 +534,7 @@ impl ArmDebugSequence for AtSAM {
 
 impl DebugEraseSequence for AtSAM {
     fn erase_all(&self, interface: &mut dyn ArmProbeInterface) -> Result<(), ArmError> {
-        let mem_ap = MemoryAp::new(ApAddress {
+        let mem_ap = MemoryAp::new(FullyQualifiedApAddress {
             dp: DpAddress::Default,
             ap: 0,
         });

--- a/probe-rs/src/vendor/microchip/sequences/atsam.rs
+++ b/probe-rs/src/vendor/microchip/sequences/atsam.rs
@@ -464,7 +464,7 @@ impl ArmDebugSequence for AtSAM {
         _debug_base: Option<u64>,
         _cti_base: Option<u64>,
     ) -> Result<(), ArmError> {
-        let mut core = interface.memory_interface(core_ap)?;
+        let mut core = interface.memory_interface(&core_ap)?;
 
         self.release_reset_extension(&mut *core)
     }
@@ -512,7 +512,7 @@ impl ArmDebugSequence for AtSAM {
     fn debug_device_unlock(
         &self,
         interface: &mut dyn ArmProbeInterface,
-        default_ap: architecture::arm::ap::MemoryAp,
+        default_ap: &architecture::arm::ap::MemoryAp,
         permissions: &Permissions,
     ) -> Result<(), ArmError> {
         // First check if the device is locked
@@ -534,9 +534,9 @@ impl ArmDebugSequence for AtSAM {
 
 impl DebugEraseSequence for AtSAM {
     fn erase_all(&self, interface: &mut dyn ArmProbeInterface) -> Result<(), ArmError> {
-        let mem_ap = MemoryAp::new(FullyQualifiedApAddress {
+        let mem_ap = &MemoryAp::new(FullyQualifiedApAddress {
             dp: DpAddress::Default,
-            ap: 0,
+            ap: crate::architecture::arm::ApAddress::V1(0),
         });
 
         let mut memory = interface.memory_interface(mem_ap)?;

--- a/probe-rs/src/vendor/nordicsemi/mod.rs
+++ b/probe-rs/src/vendor/nordicsemi/mod.rs
@@ -52,7 +52,7 @@ impl Vendor for NordicSemi {
 
         // FIXME: This is a bit shaky but good enough for now.
         let access_port = MemoryAp::new(FullyQualifiedApAddress::with_default_dp(0));
-        let mut memory_interface = probe.memory_interface(access_port)?;
+        let mut memory_interface = probe.memory_interface(&access_port)?;
 
         // Cache to avoid reading the same register multiple times
         let mut register_values: HashMap<u32, u32> = HashMap::new();

--- a/probe-rs/src/vendor/nordicsemi/mod.rs
+++ b/probe-rs/src/vendor/nordicsemi/mod.rs
@@ -9,8 +9,8 @@ use probe_rs_target::{
 
 use crate::{
     architecture::arm::{
-        ap::MemoryAp, memory::adi_v5_memory_interface::ArmProbe, ApAddress, ArmChipInfo,
-        ArmProbeInterface,
+        ap::MemoryAp, memory::adi_v5_memory_interface::ArmProbe, ArmChipInfo, ArmProbeInterface,
+        FullyQualifiedApAddress,
     },
     config::{registry, DebugSequence},
     vendor::{
@@ -51,7 +51,7 @@ impl Vendor for NordicSemi {
         }
 
         // FIXME: This is a bit shaky but good enough for now.
-        let access_port = MemoryAp::new(ApAddress::with_default_dp(0));
+        let access_port = MemoryAp::new(FullyQualifiedApAddress::with_default_dp(0));
         let mut memory_interface = probe.memory_interface(access_port)?;
 
         // Cache to avoid reading the same register multiple times

--- a/probe-rs/src/vendor/nordicsemi/mod.rs
+++ b/probe-rs/src/vendor/nordicsemi/mod.rs
@@ -51,7 +51,7 @@ impl Vendor for NordicSemi {
         }
 
         // FIXME: This is a bit shaky but good enough for now.
-        let access_port = MemoryAp::new(FullyQualifiedApAddress::with_default_dp(0));
+        let access_port = MemoryAp::new(FullyQualifiedApAddress::v1_with_default_dp(0));
         let mut memory_interface = probe.memory_interface(&access_port)?;
 
         // Cache to avoid reading the same register multiple times

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
@@ -6,7 +6,7 @@ use crate::{
         communication_interface::Initialized,
         memory::adi_v5_memory_interface::ArmProbe,
         sequences::{ArmDebugSequence, ArmDebugSequenceError},
-        ApAddress, ArmCommunicationInterface, ArmError, ArmProbeInterface, DapAccess,
+        ArmCommunicationInterface, ArmError, ArmProbeInterface, DapAccess, FullyQualifiedApAddress,
     },
     session::MissingPermissions,
 };
@@ -14,14 +14,17 @@ use std::fmt::Debug;
 
 pub trait Nrf: Sync + Send + Debug {
     /// Returns the ahb_ap and ctrl_ap of every core
-    fn core_aps(&self, interface: &mut dyn ArmProbe) -> Vec<(ApAddress, ApAddress)>;
+    fn core_aps(
+        &self,
+        interface: &mut dyn ArmProbe,
+    ) -> Vec<(FullyQualifiedApAddress, FullyQualifiedApAddress)>;
 
     /// Returns true when the core is unlocked and false when it is locked.
     fn is_core_unlocked(
         &self,
         arm_interface: &mut ArmCommunicationInterface<Initialized>,
-        ahb_ap_address: ApAddress,
-        ctrl_ap_address: ApAddress,
+        ahb_ap_address: FullyQualifiedApAddress,
+        ctrl_ap_address: FullyQualifiedApAddress,
     ) -> Result<bool, ArmError>;
 
     /// Returns true if a network core is present
@@ -42,7 +45,7 @@ const RELEASE_FORCEOFF: u32 = 0;
 /// The `ap_address` must be of the ctrl ap of the core.
 fn unlock_core(
     arm_interface: &mut ArmCommunicationInterface<Initialized>,
-    ap_address: ApAddress,
+    ap_address: FullyQualifiedApAddress,
     permissions: &crate::Permissions,
 ) -> Result<(), ArmError> {
     permissions

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
@@ -23,8 +23,8 @@ pub trait Nrf: Sync + Send + Debug {
     fn is_core_unlocked(
         &self,
         arm_interface: &mut ArmCommunicationInterface<Initialized>,
-        ahb_ap_address: FullyQualifiedApAddress,
-        ctrl_ap_address: FullyQualifiedApAddress,
+        ahb_ap_address: &FullyQualifiedApAddress,
+        ctrl_ap_address: &FullyQualifiedApAddress,
     ) -> Result<bool, ArmError>;
 
     /// Returns true if a network core is present
@@ -45,7 +45,7 @@ const RELEASE_FORCEOFF: u32 = 0;
 /// The `ap_address` must be of the ctrl ap of the core.
 fn unlock_core(
     arm_interface: &mut ArmCommunicationInterface<Initialized>,
-    ap_address: FullyQualifiedApAddress,
+    ap_address: &FullyQualifiedApAddress,
     permissions: &crate::Permissions,
 ) -> Result<(), ArmError> {
     permissions
@@ -82,7 +82,7 @@ impl<T: Nrf> ArmDebugSequence for T {
     fn debug_device_unlock(
         &self,
         interface: &mut dyn ArmProbeInterface,
-        default_ap: MemoryAp,
+        default_ap: &MemoryAp,
         permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
         let mut interface = interface.memory_interface(default_ap)?;
@@ -92,7 +92,7 @@ impl<T: Nrf> ArmDebugSequence for T {
         // These keys should be queried from the user if required and once that mechanism is implemented
 
         for (core_index, (core_ahb_ap_address, core_ctrl_ap_address)) in
-            self.core_aps(&mut *interface).iter().copied().enumerate()
+            self.core_aps(&mut *interface).iter().enumerate()
         {
             tracing::info!("Checking if core {} is unlocked", core_index);
             if self.is_core_unlocked(

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf52.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf52.rs
@@ -41,7 +41,7 @@ impl Nrf52 {
     fn is_core_unlocked(
         &self,
         iface: &mut dyn ArmProbeInterface,
-        ctrl_ap: FullyQualifiedApAddress,
+        ctrl_ap: &FullyQualifiedApAddress,
     ) -> Result<bool, ArmError> {
         let status = iface.read_raw_ap_register(ctrl_ap, APPROTECTSTATUS)?;
         Ok(status != 0)
@@ -87,11 +87,11 @@ impl ArmDebugSequence for Nrf52 {
     fn debug_device_unlock(
         &self,
         iface: &mut dyn ArmProbeInterface,
-        _default_ap: MemoryAp,
+        _default_ap: &MemoryAp,
         permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
-        let ctrl_ap = FullyQualifiedApAddress {
-            ap: 1,
+        let ctrl_ap = &FullyQualifiedApAddress {
+            ap: crate::architecture::arm::ApAddress::V1(1),
             dp: DpAddress::Default,
         };
 
@@ -155,7 +155,7 @@ impl ArmDebugSequence for Nrf52 {
             }
         };
 
-        let mut memory = interface.memory_interface(components[0].ap)?;
+        let mut memory = interface.memory_interface(&components[0].ap)?;
         let mut config = clock::TraceConfig::read(&mut *memory)?;
         config.set_traceportspeed(portspeed);
         if matches!(sink, TraceSink::Tpiu(_)) {

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf52.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf52.rs
@@ -7,7 +7,7 @@ use crate::architecture::arm::{
     component::TraceSink,
     memory::CoresightComponent,
     sequences::{ArmDebugSequence, ArmDebugSequenceError},
-    ArmError, ArmProbeInterface, DpAddress, FullyQualifiedApAddress,
+    ArmError, ArmProbeInterface, FullyQualifiedApAddress,
 };
 use crate::session::MissingPermissions;
 
@@ -90,10 +90,7 @@ impl ArmDebugSequence for Nrf52 {
         _default_ap: &MemoryAp,
         permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
-        let ctrl_ap = &FullyQualifiedApAddress {
-            ap: crate::architecture::arm::ApAddress::V1(1),
-            dp: DpAddress::Default,
-        };
+        let ctrl_ap = &FullyQualifiedApAddress::v1_with_default_dp(1);
 
         tracing::info!("Checking if core is unlocked");
         if self.is_core_unlocked(iface, ctrl_ap)? {

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf52.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf52.rs
@@ -7,7 +7,7 @@ use crate::architecture::arm::{
     component::TraceSink,
     memory::CoresightComponent,
     sequences::{ArmDebugSequence, ArmDebugSequenceError},
-    ApAddress, ArmError, ArmProbeInterface, DpAddress,
+    ArmError, ArmProbeInterface, DpAddress, FullyQualifiedApAddress,
 };
 use crate::session::MissingPermissions;
 
@@ -41,7 +41,7 @@ impl Nrf52 {
     fn is_core_unlocked(
         &self,
         iface: &mut dyn ArmProbeInterface,
-        ctrl_ap: ApAddress,
+        ctrl_ap: FullyQualifiedApAddress,
     ) -> Result<bool, ArmError> {
         let status = iface.read_raw_ap_register(ctrl_ap, APPROTECTSTATUS)?;
         Ok(status != 0)
@@ -90,7 +90,7 @@ impl ArmDebugSequence for Nrf52 {
         _default_ap: MemoryAp,
         permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
-        let ctrl_ap = ApAddress {
+        let ctrl_ap = FullyQualifiedApAddress {
             ap: 1,
             dp: DpAddress::Default,
         };

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
@@ -6,11 +6,11 @@ use super::nrf::Nrf;
 use crate::architecture::arm::ap::{AccessPort, CSW};
 use crate::architecture::arm::memory::adi_v5_memory_interface::ArmProbe;
 use crate::architecture::arm::sequences::ArmDebugSequence;
-use crate::architecture::arm::ArmError;
 use crate::architecture::arm::{
     communication_interface::Initialized, ArmCommunicationInterface, DapAccess,
     FullyQualifiedApAddress,
 };
+use crate::architecture::arm::{ApAddress, ArmError};
 
 /// The sequence handle for the nRF5340.
 #[derive(Debug)]
@@ -28,7 +28,8 @@ impl Nrf for Nrf5340 {
         &self,
         memory: &mut dyn ArmProbe,
     ) -> Vec<(FullyQualifiedApAddress, FullyQualifiedApAddress)> {
-        let ap_address = memory.ap().ap_address();
+        let memory_ap = memory.ap();
+        let ap_address = memory_ap.ap_address();
 
         let core_aps = [(0, 2), (1, 3)];
 
@@ -37,12 +38,12 @@ impl Nrf for Nrf5340 {
             .map(|(core_ahb_ap, core_ctrl_ap)| {
                 (
                     FullyQualifiedApAddress {
-                        ap: core_ahb_ap,
-                        ..ap_address
+                        ap: ApAddress::V1(core_ahb_ap),
+                        ..ap_address.clone()
                     },
                     FullyQualifiedApAddress {
-                        ap: core_ctrl_ap,
-                        ..ap_address
+                        ap: ApAddress::V1(core_ctrl_ap),
+                        ..ap_address.clone()
                     },
                 )
             })
@@ -52,8 +53,8 @@ impl Nrf for Nrf5340 {
     fn is_core_unlocked(
         &self,
         arm_interface: &mut ArmCommunicationInterface<Initialized>,
-        ahb_ap_address: FullyQualifiedApAddress,
-        _ctrl_ap_address: FullyQualifiedApAddress,
+        ahb_ap_address: &FullyQualifiedApAddress,
+        _ctrl_ap_address: &FullyQualifiedApAddress,
     ) -> Result<bool, ArmError> {
         let csw: CSW = arm_interface
             .read_raw_ap_register(ahb_ap_address, 0x00)?

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
@@ -8,7 +8,8 @@ use crate::architecture::arm::memory::adi_v5_memory_interface::ArmProbe;
 use crate::architecture::arm::sequences::ArmDebugSequence;
 use crate::architecture::arm::ArmError;
 use crate::architecture::arm::{
-    communication_interface::Initialized, ApAddress, ArmCommunicationInterface, DapAccess,
+    communication_interface::Initialized, ArmCommunicationInterface, DapAccess,
+    FullyQualifiedApAddress,
 };
 
 /// The sequence handle for the nRF5340.
@@ -23,7 +24,10 @@ impl Nrf5340 {
 }
 
 impl Nrf for Nrf5340 {
-    fn core_aps(&self, memory: &mut dyn ArmProbe) -> Vec<(ApAddress, ApAddress)> {
+    fn core_aps(
+        &self,
+        memory: &mut dyn ArmProbe,
+    ) -> Vec<(FullyQualifiedApAddress, FullyQualifiedApAddress)> {
         let ap_address = memory.ap().ap_address();
 
         let core_aps = [(0, 2), (1, 3)];
@@ -32,11 +36,11 @@ impl Nrf for Nrf5340 {
             .into_iter()
             .map(|(core_ahb_ap, core_ctrl_ap)| {
                 (
-                    ApAddress {
+                    FullyQualifiedApAddress {
                         ap: core_ahb_ap,
                         ..ap_address
                     },
-                    ApAddress {
+                    FullyQualifiedApAddress {
                         ap: core_ctrl_ap,
                         ..ap_address
                     },
@@ -48,8 +52,8 @@ impl Nrf for Nrf5340 {
     fn is_core_unlocked(
         &self,
         arm_interface: &mut ArmCommunicationInterface<Initialized>,
-        ahb_ap_address: ApAddress,
-        _ctrl_ap_address: ApAddress,
+        ahb_ap_address: FullyQualifiedApAddress,
+        _ctrl_ap_address: FullyQualifiedApAddress,
     ) -> Result<bool, ArmError> {
         let csw: CSW = arm_interface
             .read_raw_ap_register(ahb_ap_address, 0x00)?

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
@@ -6,11 +6,11 @@ use super::nrf::Nrf;
 use crate::architecture::arm::ap::{AccessPort, CSW};
 use crate::architecture::arm::memory::adi_v5_memory_interface::ArmProbe;
 use crate::architecture::arm::sequences::ArmDebugSequence;
+use crate::architecture::arm::ArmError;
 use crate::architecture::arm::{
     communication_interface::Initialized, ArmCommunicationInterface, DapAccess,
     FullyQualifiedApAddress,
 };
-use crate::architecture::arm::{ApAddress, ArmError};
 
 /// The sequence handle for the nRF5340.
 #[derive(Debug)]
@@ -37,14 +37,8 @@ impl Nrf for Nrf5340 {
             .into_iter()
             .map(|(core_ahb_ap, core_ctrl_ap)| {
                 (
-                    FullyQualifiedApAddress {
-                        ap: ApAddress::V1(core_ahb_ap),
-                        ..ap_address.clone()
-                    },
-                    FullyQualifiedApAddress {
-                        ap: ApAddress::V1(core_ctrl_ap),
-                        ..ap_address.clone()
-                    },
+                    FullyQualifiedApAddress::v1_with_dp(ap_address.dp(), core_ahb_ap),
+                    FullyQualifiedApAddress::v1_with_dp(ap_address.dp(), core_ctrl_ap),
                 )
             })
             .collect()

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf91.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf91.rs
@@ -6,11 +6,11 @@ use super::nrf::Nrf;
 use crate::architecture::arm::ap::AccessPort;
 use crate::architecture::arm::memory::adi_v5_memory_interface::ArmProbe;
 use crate::architecture::arm::sequences::ArmDebugSequence;
+use crate::architecture::arm::ArmError;
 use crate::architecture::arm::{
     communication_interface::Initialized, ArmCommunicationInterface, DapAccess,
     FullyQualifiedApAddress,
 };
-use crate::architecture::arm::{ApAddress, ArmError};
 
 /// The sequence handle for the nRF9160.
 #[derive(Debug)]
@@ -37,14 +37,8 @@ impl Nrf for Nrf9160 {
             .into_iter()
             .map(|(core_ahb_ap, core_ctrl_ap)| {
                 (
-                    FullyQualifiedApAddress {
-                        ap: ApAddress::V1(core_ahb_ap),
-                        ..ap_address.clone()
-                    },
-                    FullyQualifiedApAddress {
-                        ap: ApAddress::V1(core_ctrl_ap),
-                        ..ap_address.clone()
-                    },
+                    FullyQualifiedApAddress::v1_with_dp(ap_address.dp(), core_ahb_ap),
+                    FullyQualifiedApAddress::v1_with_dp(ap_address.dp(), core_ctrl_ap),
                 )
             })
             .collect()

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf91.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf91.rs
@@ -8,7 +8,8 @@ use crate::architecture::arm::memory::adi_v5_memory_interface::ArmProbe;
 use crate::architecture::arm::sequences::ArmDebugSequence;
 use crate::architecture::arm::ArmError;
 use crate::architecture::arm::{
-    communication_interface::Initialized, ApAddress, ArmCommunicationInterface, DapAccess,
+    communication_interface::Initialized, ArmCommunicationInterface, DapAccess,
+    FullyQualifiedApAddress,
 };
 
 /// The sequence handle for the nRF9160.
@@ -23,7 +24,10 @@ impl Nrf9160 {
 }
 
 impl Nrf for Nrf9160 {
-    fn core_aps(&self, memory: &mut dyn ArmProbe) -> Vec<(ApAddress, ApAddress)> {
+    fn core_aps(
+        &self,
+        memory: &mut dyn ArmProbe,
+    ) -> Vec<(FullyQualifiedApAddress, FullyQualifiedApAddress)> {
         let ap_address = memory.ap().ap_address();
 
         let core_aps = [(0, 4)];
@@ -32,11 +36,11 @@ impl Nrf for Nrf9160 {
             .into_iter()
             .map(|(core_ahb_ap, core_ctrl_ap)| {
                 (
-                    ApAddress {
+                    FullyQualifiedApAddress {
                         ap: core_ahb_ap,
                         ..ap_address
                     },
-                    ApAddress {
+                    FullyQualifiedApAddress {
                         ap: core_ctrl_ap,
                         ..ap_address
                     },
@@ -48,8 +52,8 @@ impl Nrf for Nrf9160 {
     fn is_core_unlocked(
         &self,
         arm_interface: &mut ArmCommunicationInterface<Initialized>,
-        _ahb_ap_address: ApAddress,
-        ctrl_ap_address: ApAddress,
+        _ahb_ap_address: FullyQualifiedApAddress,
+        ctrl_ap_address: FullyQualifiedApAddress,
     ) -> Result<bool, ArmError> {
         let approtect_status = arm_interface.read_raw_ap_register(ctrl_ap_address, 0x00C)?;
         Ok(approtect_status != 0)

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
@@ -211,7 +211,7 @@ impl MIMXRT11xx {
                 return Err(ArmError::Timeout);
             }
 
-            match interface.read_ap_register(ap) {
+            match interface.read_ap_register(&ap) {
                 Ok(CSW { DeviceEn, .. }) if DeviceEn != 0 => {
                     tracing::debug!("Device enabled after {}ms with {errors} errors and {disables} invalid statuses", start.elapsed().as_millis());
                     return Ok(());

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
@@ -271,7 +271,7 @@ fn wait_for_stop_after_reset(memory: &mut dyn ArmProbe) -> Result<(), ArmError> 
 
     thread::sleep(Duration::from_millis(10));
 
-    let dp = memory.ap().ap_address().dp;
+    let dp = memory.ap().ap_address().dp();
     let ap = memory.ap();
     let interface = memory.get_arm_communication_interface()?;
 
@@ -326,10 +326,7 @@ fn enable_debug_mailbox(
 ) -> Result<(), ArmError> {
     tracing::info!("LPC55xx connect script start");
 
-    let ap = FullyQualifiedApAddress {
-        dp,
-        ap: crate::architecture::arm::ApAddress::V1(2),
-    };
+    let ap = FullyQualifiedApAddress::v1_with_dp(dp, 2);
 
     let status: IDR = interface.read_ap_register(&GenericAp::new(ap.clone()))?;
 
@@ -449,7 +446,7 @@ impl MIMXRT5xxS {
         thread::sleep(Duration::from_millis(100));
 
         let ap: MemoryAp = probe.ap();
-        let dp = ap.ap_address().dp;
+        let dp = ap.ap_address().dp();
         let start = Instant::now();
         while !self.csw_debug_ready(probe.get_arm_communication_interface()?, &ap)?
             && start.elapsed() < Duration::from_millis(300)
@@ -575,10 +572,7 @@ impl MIMXRT5xxS {
 
         tracing::debug!("enabling MIMXRT5xxS DebugMailbox");
 
-        let ap_addr = &FullyQualifiedApAddress {
-            dp,
-            ap: crate::architecture::arm::ApAddress::V1(2),
-        };
+        let ap_addr = &FullyQualifiedApAddress::v1_with_dp(dp, 2);
 
         // CMSIS Pack implementation reads APIDR and DPIDR and passes each
         // to the "Message" function, but otherwise does nothing with those
@@ -648,10 +642,7 @@ impl ArmDebugSequence for MIMXRT5xxS {
             // Clear WDATAERR, STICKYORUN, STICKYCMP, and STICKYERR bits of CTRL/STAT Register by write to ABORT register
             interface.write_raw_dp_register(dp, SW_DP_ABORT, 0x0000001E)?;
 
-            let ap = FullyQualifiedApAddress {
-                dp,
-                ap: crate::architecture::arm::ApAddress::V1(0),
-            };
+            let ap = FullyQualifiedApAddress::v1_with_dp(dp, 0);
             let mem_ap = MemoryAp::new(ap);
             self.enable_debug_mailbox(interface, dp, &mem_ap)?;
         }

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
@@ -275,7 +275,7 @@ fn wait_for_stop_after_reset(memory: &mut dyn ArmProbe) -> Result<(), ArmError> 
     let ap = memory.ap();
     let interface = memory.get_arm_communication_interface()?;
 
-    let ap0_csw: CSW = interface.read_ap_register(ap)?;
+    let ap0_csw: CSW = interface.read_ap_register(&ap)?;
 
     let ap0_disabled = ap0_csw.DeviceEn == 0;
 
@@ -326,9 +326,12 @@ fn enable_debug_mailbox(
 ) -> Result<(), ArmError> {
     tracing::info!("LPC55xx connect script start");
 
-    let ap = FullyQualifiedApAddress { dp, ap: 2 };
+    let ap = FullyQualifiedApAddress {
+        dp,
+        ap: crate::architecture::arm::ApAddress::V1(2),
+    };
 
-    let status: IDR = interface.read_ap_register(GenericAp::new(ap))?;
+    let status: IDR = interface.read_ap_register(&GenericAp::new(ap.clone()))?;
 
     tracing::info!("APIDR: {:?}", status);
     tracing::info!("APIDR: 0x{:08X}", u32::from(status));
@@ -338,22 +341,22 @@ fn enable_debug_mailbox(
     tracing::info!("DPIDR: 0x{:08X}", status);
 
     // Active DebugMailbox
-    interface.write_raw_ap_register(ap, 0x0, 0x0000_0021)?;
+    interface.write_raw_ap_register(&ap, 0x0, 0x0000_0021)?;
     interface.flush()?;
 
     // DAP_Delay(30000)
     thread::sleep(Duration::from_millis(30));
 
-    let _ = interface.read_raw_ap_register(ap, 0)?;
+    let _ = interface.read_raw_ap_register(&ap, 0)?;
 
     // Enter Debug session
-    interface.write_raw_ap_register(ap, 0x4, 0x0000_0007)?;
+    interface.write_raw_ap_register(&ap, 0x4, 0x0000_0007)?;
     interface.flush()?;
 
     // DAP_Delay(30000)
     thread::sleep(Duration::from_millis(30));
 
-    let _ = interface.read_raw_ap_register(ap, 8)?;
+    let _ = interface.read_raw_ap_register(&ap, 8)?;
 
     tracing::info!("LPC55xx connect srcipt end");
     Ok(())
@@ -448,13 +451,13 @@ impl MIMXRT5xxS {
         let ap: MemoryAp = probe.ap();
         let dp = ap.ap_address().dp;
         let start = Instant::now();
-        while !self.csw_debug_ready(probe.get_arm_communication_interface()?, ap)?
+        while !self.csw_debug_ready(probe.get_arm_communication_interface()?, &ap)?
             && start.elapsed() < Duration::from_millis(300)
         {
             // Wait for either condition
         }
         let enabled_mailbox =
-            self.enable_debug_mailbox(probe.get_arm_communication_interface()?, dp, ap)?;
+            self.enable_debug_mailbox(probe.get_arm_communication_interface()?, dp, &ap)?;
 
         // Halt the core in case it didn't stop at a breakpiont.
         tracing::trace!("halting MIMXRT5xxS Cortex-M33 core");
@@ -467,7 +470,7 @@ impl MIMXRT5xxS {
 
         if enabled_mailbox {
             // We'll double-check now to make sure we're in a reasonable state.
-            if !self.csw_debug_ready(probe.get_arm_communication_interface()?, ap)? {
+            if !self.csw_debug_ready(probe.get_arm_communication_interface()?, &ap)? {
                 tracing::warn!("MIMXRT5xxS is still not ready to debug, even after using DebugMailbox to activate session");
             }
         }
@@ -545,7 +548,7 @@ impl MIMXRT5xxS {
     fn csw_debug_ready(
         &self,
         interface: &mut ArmCommunicationInterface<Initialized>,
-        ap: MemoryAp,
+        ap: &MemoryAp,
     ) -> Result<bool, ArmError> {
         let csw = interface.read_raw_ap_register(ap.ap_address(), 0x00)?;
 
@@ -562,7 +565,7 @@ impl MIMXRT5xxS {
         &self,
         interface: &mut ArmCommunicationInterface<Initialized>,
         dp: DpAddress,
-        mem_ap: MemoryAp,
+        mem_ap: &MemoryAp,
     ) -> Result<bool, ArmError> {
         // Check AHB-AP CSW DbgStatus to decide if need enable DebugMailbox
         if self.csw_debug_ready(interface, mem_ap)? {
@@ -572,7 +575,10 @@ impl MIMXRT5xxS {
 
         tracing::debug!("enabling MIMXRT5xxS DebugMailbox");
 
-        let ap_addr = FullyQualifiedApAddress { dp, ap: 2 };
+        let ap_addr = &FullyQualifiedApAddress {
+            dp,
+            ap: crate::architecture::arm::ApAddress::V1(2),
+        };
 
         // CMSIS Pack implementation reads APIDR and DPIDR and passes each
         // to the "Message" function, but otherwise does nothing with those
@@ -642,9 +648,12 @@ impl ArmDebugSequence for MIMXRT5xxS {
             // Clear WDATAERR, STICKYORUN, STICKYCMP, and STICKYERR bits of CTRL/STAT Register by write to ABORT register
             interface.write_raw_dp_register(dp, SW_DP_ABORT, 0x0000001E)?;
 
-            let ap = FullyQualifiedApAddress { dp, ap: 0 };
+            let ap = FullyQualifiedApAddress {
+                dp,
+                ap: crate::architecture::arm::ApAddress::V1(0),
+            };
             let mem_ap = MemoryAp::new(ap);
-            self.enable_debug_mailbox(interface, dp, mem_ap)?;
+            self.enable_debug_mailbox(interface, dp, &mem_ap)?;
         }
 
         tracing::trace!("MIMXRT5xxS debug port start was successful");

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
@@ -14,7 +14,7 @@ use crate::{
         dp::{Abort, Ctrl, DpAccess, Select, DPIDR},
         memory::adi_v5_memory_interface::ArmProbe,
         sequences::ArmDebugSequence,
-        ApAddress, ArmCommunicationInterface, ArmError, DapAccess, DpAddress, Pins,
+        ArmCommunicationInterface, ArmError, DapAccess, DpAddress, FullyQualifiedApAddress, Pins,
     },
     core::MemoryMappedRegister,
 };
@@ -326,7 +326,7 @@ fn enable_debug_mailbox(
 ) -> Result<(), ArmError> {
     tracing::info!("LPC55xx connect script start");
 
-    let ap = ApAddress { dp, ap: 2 };
+    let ap = FullyQualifiedApAddress { dp, ap: 2 };
 
     let status: IDR = interface.read_ap_register(GenericAp::new(ap))?;
 
@@ -572,7 +572,7 @@ impl MIMXRT5xxS {
 
         tracing::debug!("enabling MIMXRT5xxS DebugMailbox");
 
-        let ap_addr = ApAddress { dp, ap: 2 };
+        let ap_addr = FullyQualifiedApAddress { dp, ap: 2 };
 
         // CMSIS Pack implementation reads APIDR and DPIDR and passes each
         // to the "Message" function, but otherwise does nothing with those
@@ -642,7 +642,7 @@ impl ArmDebugSequence for MIMXRT5xxS {
             // Clear WDATAERR, STICKYORUN, STICKYCMP, and STICKYERR bits of CTRL/STAT Register by write to ABORT register
             interface.write_raw_dp_register(dp, SW_DP_ABORT, 0x0000001E)?;
 
-            let ap = ApAddress { dp, ap: 0 };
+            let ap = FullyQualifiedApAddress { dp, ap: 0 };
             let mem_ap = MemoryAp::new(ap);
             self.enable_debug_mailbox(interface, dp, mem_ap)?;
         }

--- a/probe-rs/src/vendor/st/sequences/stm32_armv6.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32_armv6.rs
@@ -112,7 +112,7 @@ impl ArmDebugSequence for Stm32Armv6 {
     fn debug_device_unlock(
         &self,
         interface: &mut dyn ArmProbeInterface,
-        default_ap: MemoryAp,
+        default_ap: &MemoryAp,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
         let mut memory = interface.memory_interface(default_ap)?;

--- a/probe-rs/src/vendor/st/sequences/stm32_armv7.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32_armv7.rs
@@ -72,7 +72,7 @@ impl ArmDebugSequence for Stm32Armv7 {
     fn debug_device_unlock(
         &self,
         interface: &mut dyn ArmProbeInterface,
-        default_ap: MemoryAp,
+        default_ap: &MemoryAp,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
         let mut memory = interface.memory_interface(default_ap)?;
@@ -106,7 +106,7 @@ impl ArmDebugSequence for Stm32Armv7 {
         components: &[CoresightComponent],
         sink: &TraceSink,
     ) -> Result<(), ArmError> {
-        let mut memory = interface.memory_interface(components[0].ap)?;
+        let mut memory = interface.memory_interface(&components[0].ap)?;
         let mut cr = dbgmcu::Control::read(&mut *memory)?;
 
         if matches!(sink, TraceSink::Tpiu(_) | TraceSink::Swo(_)) {

--- a/probe-rs/src/vendor/st/sequences/stm32h7.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32h7.rs
@@ -149,16 +149,16 @@ impl ArmDebugSequence for Stm32h7 {
     fn debug_device_unlock(
         &self,
         interface: &mut dyn ArmProbeInterface,
-        _default_ap: MemoryAp,
+        _default_ap: &MemoryAp,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
         // Power up the debug components through AP2, which is the default AP debug port.
         let ap = MemoryAp::new(FullyQualifiedApAddress {
             dp: DpAddress::Default,
-            ap: 2,
+            ap: crate::architecture::arm::ApAddress::V1(2),
         });
 
-        let mut memory = interface.memory_interface(ap)?;
+        let mut memory = interface.memory_interface(&ap)?;
         self.enable_debug_components(&mut *memory, true)?;
 
         Ok(())

--- a/probe-rs/src/vendor/st/sequences/stm32h7.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32h7.rs
@@ -12,7 +12,7 @@ use crate::architecture::arm::{
         PeripheralType,
     },
     sequences::ArmDebugSequence,
-    ApAddress, ArmError, ArmProbeInterface, DpAddress,
+    ArmError, ArmProbeInterface, DpAddress, FullyQualifiedApAddress,
 };
 
 // Base address of the trace funnel that directs trace data to the SWO peripheral.
@@ -153,7 +153,7 @@ impl ArmDebugSequence for Stm32h7 {
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
         // Power up the debug components through AP2, which is the default AP debug port.
-        let ap = MemoryAp::new(ApAddress {
+        let ap = MemoryAp::new(FullyQualifiedApAddress {
             dp: DpAddress::Default,
             ap: 2,
         });

--- a/probe-rs/src/vendor/st/sequences/stm32h7.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32h7.rs
@@ -12,7 +12,7 @@ use crate::architecture::arm::{
         PeripheralType,
     },
     sequences::ArmDebugSequence,
-    ArmError, ArmProbeInterface, DpAddress, FullyQualifiedApAddress,
+    ArmError, ArmProbeInterface, FullyQualifiedApAddress,
 };
 
 // Base address of the trace funnel that directs trace data to the SWO peripheral.
@@ -153,10 +153,7 @@ impl ArmDebugSequence for Stm32h7 {
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
         // Power up the debug components through AP2, which is the default AP debug port.
-        let ap = MemoryAp::new(FullyQualifiedApAddress {
-            dp: DpAddress::Default,
-            ap: crate::architecture::arm::ApAddress::V1(2),
-        });
+        let ap = MemoryAp::new(FullyQualifiedApAddress::v1_with_default_dp(2));
 
         let mut memory = interface.memory_interface(&ap)?;
         self.enable_debug_components(&mut *memory, true)?;


### PR DESCRIPTION
APv2 addresses are chains of 32bits addresses.