### PR TITLE
Fix compilation when zerocopys "derive" feature is active

### DIFF
--- a/changelog/fixed-compilation-with-zerocopy.md
+++ b/changelog/fixed-compilation-with-zerocopy.md
@@ -1,0 +1,1 @@
+Fixed compilation when whe `derive` feature of the `zerocopy` crate was enabled.

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -50,7 +50,7 @@ pub use channel::*;
 use crate::{config::MemoryRegion, Core, MemoryInterface};
 use std::borrow::Cow;
 use std::ops::Range;
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 use zerocopy_derive::{FromBytes, FromZeroes};
 
 /// The RTT interface.


### PR DESCRIPTION
This fixes building `probe-rs` when the `derive` feature of the `zerocopy` crate is active. Fixes #2613.

Can be tested by compiling the example in the issue against this branch.

I don't think this needs an actual test, but let me know if you think it does and how to best add one.