### PR TITLE
cargo-embed: better tab navigation and scrolling

### DIFF
--- a/changelog/added-cargo-embed-tab.md
+++ b/changelog/added-cargo-embed-tab.md
@@ -1,1 +1,1 @@
-cargo-embed: use `ctrl+tab` and `shift+tab` to move to next/previous tab. Use `ctrl+number` to switch to the `number`th tab.
+cargo-embed: use `ctrl+tab` and `ctrl+shift+tab` to move to next/previous tab. Use `ctrl+number` to switch to the `number`th tab.

--- a/changelog/added-cargo-embed-tab.md
+++ b/changelog/added-cargo-embed-tab.md
@@ -1,1 +1,1 @@
-cargo-embed: use `ctrl+tab` and `shift+tab` to move to next/previous tab
+cargo-embed: use `ctrl+tab` and `shift+tab` to move to next/previous tab. Use `ctrl+number` to switch to the `number`th tab.

--- a/changelog/added-cargo-embed-tab.md
+++ b/changelog/added-cargo-embed-tab.md
@@ -1,1 +1,3 @@
 cargo-embed: use `ctrl+tab` and `ctrl+shift+tab` to move to next/previous tab. Use `ctrl+number` to switch to the `number`th tab.
+cargo-embed: `PageUp` and `PageDown` now scroll a half screen's worth of lines.
+cargo-embed: handle `Up` and `Down` arrows to scroll the list one line at a time.

--- a/changelog/added-cargo-embed-tab.md
+++ b/changelog/added-cargo-embed-tab.md
@@ -1,0 +1,1 @@
+cargo-embed: use `ctrl+tab` and `shift+tab` to move to next/previous tab

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -207,7 +207,16 @@ impl App {
             KeyCode::Tab if event.modifiers.contains(KeyModifiers::CONTROL) => self.next_tab(),
             KeyCode::Tab if event.modifiers.contains(KeyModifiers::SHIFT) => self.previous_tab(),
             KeyCode::Enter => self.push_rtt(core),
-            KeyCode::Char(c) => self.current_tab_mut().push_input(c),
+            KeyCode::Char(c) => {
+                if event.modifiers.contains(KeyModifiers::CONTROL) {
+                    if let Some(digit) = c.to_digit(10).and_then(|d| d.checked_sub(1)) {
+                        self.select_tab(digit as usize);
+                        return false;
+                    }
+                }
+
+                self.current_tab_mut().push_input(c)
+            }
             KeyCode::Backspace => self.current_tab_mut().pop_input(),
             KeyCode::PageUp => self.current_tab_mut().scroll_up(),
             KeyCode::PageDown => self.current_tab_mut().scroll_down(),

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -204,14 +204,8 @@ impl App {
                 self.current_tab_mut().clear();
             }
             KeyCode::F(n) => self.select_tab(n as usize - 1),
-            KeyCode::Tab if event.modifiers.contains(KeyModifiers::CONTROL) => self.next_tab(),
-            KeyCode::Tab
-                if event
-                    .modifiers
-                    .contains(KeyModifiers::CONTROL | KeyModifiers::SHIFT) =>
-            {
-                self.previous_tab()
-            }
+            KeyCode::Tab => self.next_tab(),
+            KeyCode::BackTab => self.previous_tab(),
             KeyCode::Enter => self.push_rtt(core),
             KeyCode::Char(c) => {
                 if event.modifiers.contains(KeyModifiers::CONTROL) {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -203,12 +203,9 @@ impl App {
             KeyCode::Char('l') if event.modifiers.contains(KeyModifiers::CONTROL) => {
                 self.current_tab_mut().clear();
             }
-            KeyCode::F(n) => {
-                let n = n as usize - 1;
-                if n < self.tabs.len() {
-                    self.current_tab = n;
-                }
-            }
+            KeyCode::F(n) => self.select_tab(n as usize - 1),
+            KeyCode::Tab if event.modifiers.contains(KeyModifiers::CONTROL) => self.next_tab(),
+            KeyCode::Tab if event.modifiers.contains(KeyModifiers::SHIFT) => self.previous_tab(),
             KeyCode::Enter => self.push_rtt(core),
             KeyCode::Char(c) => self.current_tab_mut().push_input(c),
             KeyCode::Backspace => self.current_tab_mut().pop_input(),
@@ -304,6 +301,20 @@ impl App {
                 }
             }
         }
+    }
+
+    fn select_tab(&mut self, n: usize) {
+        if n < self.tabs.len() {
+            self.current_tab = n;
+        }
+    }
+
+    fn next_tab(&mut self) {
+        self.select_tab((self.current_tab + 1) % self.tabs.len());
+    }
+
+    fn previous_tab(&mut self) {
+        self.select_tab((self.current_tab + self.tabs.len() - 1) % self.tabs.len());
     }
 }
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -205,7 +205,13 @@ impl App {
             }
             KeyCode::F(n) => self.select_tab(n as usize - 1),
             KeyCode::Tab if event.modifiers.contains(KeyModifiers::CONTROL) => self.next_tab(),
-            KeyCode::Tab if event.modifiers.contains(KeyModifiers::SHIFT) => self.previous_tab(),
+            KeyCode::Tab
+                if event
+                    .modifiers
+                    .contains(KeyModifiers::CONTROL | KeyModifiers::SHIFT) =>
+            {
+                self.previous_tab()
+            }
             KeyCode::Enter => self.push_rtt(core),
             KeyCode::Char(c) => {
                 if event.modifiers.contains(KeyModifiers::CONTROL) {


### PR DESCRIPTION
Maybe, hopefully :) This PR adds key bindings in the form of `ctrl+number` and `(shift)+tab` to switch between tabs.

PgUp/Down now scrolls more, and one-line scrolls can be done with up/down arrows.