### PR TITLE
Increase stack sizes for MIMXRT10xx targets

### DIFF
--- a/changelog/fixed-mimxrt10xx-stack-size.md
+++ b/changelog/fixed-mimxrt10xx-stack-size.md
@@ -1,0 +1,1 @@
+MIMXRT10xx: Increase stack sizes for flashing algorithms.

--- a/probe-rs/targets/MIMXRT1010.yaml
+++ b/probe-rs/targets/MIMXRT1010.yaml
@@ -54,3 +54,4 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  stack_size: 1024

--- a/probe-rs/targets/MIMXRT1015.yaml
+++ b/probe-rs/targets/MIMXRT1015.yaml
@@ -54,3 +54,4 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  stack_size: 1024

--- a/probe-rs/targets/MIMXRT1020.yaml
+++ b/probe-rs/targets/MIMXRT1020.yaml
@@ -54,3 +54,4 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  stack_size: 1024

--- a/probe-rs/targets/MIMXRT1050.yaml
+++ b/probe-rs/targets/MIMXRT1050.yaml
@@ -104,3 +104,4 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  stack_size: 4096

--- a/probe-rs/targets/MIMXRT1060.yaml
+++ b/probe-rs/targets/MIMXRT1060.yaml
@@ -61,3 +61,4 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  stack_size: 1024

--- a/probe-rs/targets/MIMXRT1064.yaml
+++ b/probe-rs/targets/MIMXRT1064.yaml
@@ -54,3 +54,4 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  stack_size: 1024


### PR DESCRIPTION
The new stack overflow checks (#2599) caught (at least) a 16 byte overflow in the 1010 flashing algorithm. To avoid this possibility for other users, this commit doubles stack sizes for most MIMXRT10xx targets. The 1050 already specified a 4K stack size for the Hyperflash algorithm, so I'm applying the same size for the QuadSPI algorithm.

I tested against a 1010 target, and I'm guessing the stack sizes for the remaining MCUs. CC @teburd @cstrahan just in case the 1K stack size isn't enough for a 1060.