### PR TITLE
Risc-V: halt core before writing memory

### DIFF
--- a/changelog/fixed-writing-riscv-rtt.md
+++ b/changelog/fixed-writing-riscv-rtt.md
@@ -1,0 +1,1 @@
+Fixed error while trying to write to RTT on a RISC-V chip

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -237,7 +237,7 @@ impl App {
 
     pub fn push_rtt(&mut self, core: &mut Core) {
         if let Err(error) = self.tabs[self.current_tab].send_input(core) {
-            tracing::warn!("Failed to send input to RTT channel: {error}");
+            tracing::warn!("Failed to send input to RTT channel: {error:?}");
         }
     }
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -236,7 +236,9 @@ impl App {
     }
 
     pub fn push_rtt(&mut self, core: &mut Core) {
-        _ = self.tabs[self.current_tab].send_input(core);
+        if let Err(error) = self.tabs[self.current_tab].send_input(core) {
+            tracing::warn!("Failed to send input to RTT channel: {error}");
+        }
     }
 
     pub(crate) fn clean_up(&mut self, core: &mut Core) -> Result<()> {

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -410,8 +410,8 @@ impl RttActiveUpChannel {
             match self.up_channel.read(core, self.rtt_buffer.0.as_mut()) {
                 Ok(0) => return None,
                 Ok(count) => return Some(count),
-                Err(err) if loop_count == RETRY_COUNT => {
-                    tracing::error!("\nError reading from RTT: {}", err);
+                Err(error) if loop_count == RETRY_COUNT => {
+                    tracing::error!("\nError reading from RTT: {:?}", anyhow::anyhow!(error));
                     return None;
                 }
                 _ => thread::sleep(Duration::from_millis(50)),

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -192,24 +192,6 @@ impl<'state> Riscv32<'state> {
 
         Ok(tselect_index)
     }
-
-    fn halted_access<R>(
-        &mut self,
-        op: impl FnOnce(&mut Self) -> Result<R, crate::Error>,
-    ) -> Result<R, crate::Error> {
-        let was_running = !self.core_halted()?;
-        if was_running {
-            self.halt(Duration::from_millis(100))?;
-        }
-
-        let result = op(self);
-
-        if was_running {
-            self.resume_core()?;
-        }
-
-        result
-    }
 }
 
 impl<'state> CoreInterface for Riscv32<'state> {
@@ -220,9 +202,7 @@ impl<'state> CoreInterface for Riscv32<'state> {
     }
 
     fn core_halted(&mut self) -> Result<bool, crate::Error> {
-        let dmstatus: Dmstatus = self.interface.read_dm_register()?;
-
-        Ok(dmstatus.allhalted())
+        Ok(self.interface.core_halted()?)
     }
 
     fn status(&mut self) -> Result<crate::core::CoreStatus, crate::Error> {
@@ -688,39 +668,39 @@ impl MemoryInterface for Riscv32<'_> {
     }
 
     fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
-        self.halted_access(|core| core.interface.write_word_64(address, data))
+        self.interface.write_word_64(address, data)
     }
 
     fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), Error> {
-        self.halted_access(|core| core.interface.write_word_32(address, data))
+        self.interface.write_word_32(address, data)
     }
 
     fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
-        self.halted_access(|core| core.interface.write_word_16(address, data))
+        self.interface.write_word_16(address, data)
     }
 
     fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
-        self.halted_access(|core| core.interface.write_word_8(address, data))
+        self.interface.write_word_8(address, data)
     }
 
     fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error> {
-        self.halted_access(|core| core.interface.write_64(address, data))
+        self.interface.write_64(address, data)
     }
 
     fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
-        self.halted_access(|core| core.interface.write_32(address, data))
+        self.interface.write_32(address, data)
     }
 
     fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
-        self.halted_access(|core| core.interface.write_16(address, data))
+        self.interface.write_16(address, data)
     }
 
     fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
-        self.halted_access(|core| core.interface.write_8(address, data))
+        self.interface.write_8(address, data)
     }
 
     fn write(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
-        self.halted_access(|core| core.interface.write(address, data))
+        self.interface.write(address, data)
     }
 
     fn supports_8bit_transfers(&self) -> Result<bool, Error> {

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -192,6 +192,24 @@ impl<'state> Riscv32<'state> {
 
         Ok(tselect_index)
     }
+
+    fn halted_access<R>(
+        &mut self,
+        op: impl FnOnce(&mut Self) -> Result<R, crate::Error>,
+    ) -> Result<R, crate::Error> {
+        let was_running = !self.core_halted()?;
+        if was_running {
+            self.halt(Duration::from_millis(100))?;
+        }
+
+        let result = op(self);
+
+        if was_running {
+            self.resume_core()?;
+        }
+
+        result
+    }
 }
 
 impl<'state> CoreInterface for Riscv32<'state> {
@@ -670,39 +688,39 @@ impl MemoryInterface for Riscv32<'_> {
     }
 
     fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
-        self.interface.write_word_64(address, data)
+        self.halted_access(|core| core.interface.write_word_64(address, data))
     }
 
     fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), Error> {
-        self.interface.write_word_32(address, data)
+        self.halted_access(|core| core.interface.write_word_32(address, data))
     }
 
     fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
-        self.interface.write_word_16(address, data)
+        self.halted_access(|core| core.interface.write_word_16(address, data))
     }
 
     fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
-        self.interface.write_word_8(address, data)
+        self.halted_access(|core| core.interface.write_word_8(address, data))
     }
 
     fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error> {
-        self.interface.write_64(address, data)
+        self.halted_access(|core| core.interface.write_64(address, data))
     }
 
     fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
-        self.interface.write_32(address, data)
+        self.halted_access(|core| core.interface.write_32(address, data))
     }
 
     fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
-        self.interface.write_16(address, data)
+        self.halted_access(|core| core.interface.write_16(address, data))
     }
 
     fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
-        self.interface.write_8(address, data)
+        self.halted_access(|core| core.interface.write_8(address, data))
     }
 
     fn write(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
-        self.interface.write(address, data)
+        self.halted_access(|core| core.interface.write(address, data))
     }
 
     fn supports_8bit_transfers(&self) -> Result<bool, Error> {


### PR DESCRIPTION
I'm not sure if this is specific to esp32c2, but writing memory while running just throws errors. As far as I understand, the chip has no background memory access, even though reading seems to work just fine.