### PR TITLE
Fix a bunch of chip-detection bugs

### DIFF
--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -141,7 +141,7 @@ pub enum ArmError {
     TracingUnconfigured,
 
     /// Error parsing a register.
-    #[error("Error parsing a registere.")]
+    #[error("Error parsing a register.")]
     RegisterParse(#[from] RegisterParseError),
 
     /// Error reading ROM table.

--- a/probe-rs/src/probe/arm_debug_interface.rs
+++ b/probe-rs/src/probe/arm_debug_interface.rs
@@ -204,7 +204,7 @@ fn perform_jtag_transfer<P: JTAGAccess + RawProtocolIo>(
         s if s == JTAG_STATUS_WAIT => TransferStatus::Failed(DapError::WaitResponse),
         s if s == JTAG_STATUS_OK => TransferStatus::Ok,
         _ => {
-            tracing::error!("Unexpected DAP response: {}", status);
+            tracing::debug!("Unexpected DAP response: {}", status);
 
             TransferStatus::Failed(DapError::NoAcknowledge)
         }
@@ -515,7 +515,7 @@ fn perform_raw_transfers_retry<P: DebugProbe + RawProtocolIo + JTAGAccess>(
 
                     continue 'transfer;
                 }
-                _ => break, // on any other error, we're done.
+                _ => break 'transfer, // on any other error, we're done.
             }
         }
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -832,8 +832,10 @@ fn get_target_from_selector(
             let (returned_probe, found_target) = crate::vendor::auto_determine_target(probe)?;
             probe = returned_probe;
 
-            // Now we can deassert reset in case we asserted it before. This is always okay.
-            probe.target_reset_deassert()?;
+            if AttachMethod::UnderReset == attach_method {
+                // Now we can deassert reset in case we asserted it before.
+                probe.target_reset_deassert()?;
+            }
 
             if let Some(target) = found_target {
                 target


### PR DESCRIPTION
It was quite impossible for probe-rs to detect anything non-ARM (an esp32c2 in this case), because the process errored before getting that far. This PR turns errors into "no chip found" situations, as well as avoids spamming the user with a particular error when using a bitbanging probe.