### PR TITLE
Update G0 and G4

### DIFF
--- a/probe-rs/targets/STM32G0_Series.yaml
+++ b/probe-rs/targets/STM32G0_Series.yaml
@@ -3,7 +3,7 @@ manufacturer:
   id: 0x20
   cc: 0x0
 generated_from_pack: true
-pack_file_release: 1.4.0
+pack_file_release: 1.5.0
 variants:
 - name: STM32G030C6Tx
   cores:
@@ -21,6 +21,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -50,6 +51,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -79,6 +81,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -108,6 +111,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -137,6 +141,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -166,6 +171,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -195,6 +201,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -224,6 +231,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -253,6 +261,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -282,6 +291,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -311,6 +321,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -340,6 +351,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -369,6 +381,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -398,6 +411,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -427,6 +441,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -456,6 +471,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -485,6 +501,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -514,6 +531,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -543,6 +561,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -572,6 +591,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -601,6 +621,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -630,6 +651,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -659,6 +681,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -688,6 +711,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -717,6 +741,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -746,6 +771,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -775,6 +801,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -804,6 +831,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -833,6 +861,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -862,6 +891,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -891,6 +921,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -920,6 +951,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -949,6 +981,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -978,6 +1011,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1007,6 +1041,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1036,6 +1071,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1065,6 +1101,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1094,6 +1131,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1123,6 +1161,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1152,6 +1191,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1181,6 +1221,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1210,6 +1251,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1239,6 +1281,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1268,6 +1311,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1297,6 +1341,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1326,6 +1371,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1355,6 +1401,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1384,6 +1431,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1413,6 +1461,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1442,6 +1491,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1471,6 +1521,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1500,6 +1551,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1529,6 +1581,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1558,6 +1611,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1587,6 +1641,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1616,6 +1671,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1645,6 +1701,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1674,6 +1731,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1703,6 +1761,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1732,6 +1791,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1761,6 +1821,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1790,6 +1851,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1819,6 +1881,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1848,6 +1911,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1877,6 +1941,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1906,6 +1971,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1935,6 +2001,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1964,6 +2031,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1993,6 +2061,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2022,6 +2091,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2051,6 +2121,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2080,6 +2151,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2109,6 +2181,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2138,6 +2211,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2167,6 +2241,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2196,6 +2271,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2225,6 +2301,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2254,6 +2331,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2283,6 +2361,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2312,6 +2391,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2341,6 +2421,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2370,6 +2451,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2399,6 +2481,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2428,6 +2511,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2457,6 +2541,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2486,6 +2571,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2515,6 +2601,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2544,6 +2631,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2573,6 +2661,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2602,6 +2691,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2631,6 +2721,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2660,6 +2751,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2689,6 +2781,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2718,6 +2811,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2747,6 +2841,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2776,6 +2871,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2805,6 +2901,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2834,6 +2931,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2863,6 +2961,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2892,6 +2991,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2921,6 +3021,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2950,6 +3051,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2979,6 +3081,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3008,6 +3111,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3037,6 +3141,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3066,6 +3171,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3095,6 +3201,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3124,6 +3231,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3153,6 +3261,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3182,6 +3291,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3211,6 +3321,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3240,6 +3351,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3269,6 +3381,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3298,6 +3411,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3327,6 +3441,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3356,6 +3471,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3385,6 +3501,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3414,6 +3531,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3443,6 +3561,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3472,6 +3591,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3501,6 +3621,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3530,6 +3651,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3559,6 +3681,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3588,6 +3711,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3617,6 +3741,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3646,6 +3771,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3675,6 +3801,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3704,6 +3831,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3733,6 +3861,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3762,6 +3891,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3791,6 +3921,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3820,6 +3951,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3849,6 +3981,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3878,6 +4011,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3907,6 +4041,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3936,6 +4071,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3965,6 +4101,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3994,6 +4131,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4023,6 +4161,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4052,6 +4191,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4081,6 +4221,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4110,6 +4251,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4139,6 +4281,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4168,6 +4311,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4197,6 +4341,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4226,6 +4371,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4255,6 +4401,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4284,6 +4431,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4313,6 +4461,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4342,6 +4491,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4371,6 +4521,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4400,6 +4551,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4429,6 +4581,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4458,6 +4611,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4487,6 +4641,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4516,6 +4671,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4545,6 +4701,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4574,6 +4731,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4603,6 +4761,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4632,6 +4791,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4661,6 +4821,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4690,6 +4851,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4719,6 +4881,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4748,6 +4911,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4777,6 +4941,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4806,6 +4971,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4835,6 +5001,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4864,6 +5031,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4893,6 +5061,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4922,6 +5091,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4951,6 +5121,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4980,6 +5151,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -5009,6 +5181,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -5038,6 +5211,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -5067,6 +5241,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -5096,6 +5271,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -5125,6 +5301,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -5154,6 +5331,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -5183,6 +5361,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -5212,6 +5391,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -5241,6 +5421,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -5270,6 +5451,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -5288,6 +5470,7 @@ flash_algorithms:
   description: STM32G0Bx_512
   default: true
   instructions: crZqSmpJimBqSopgAOAAvwppkgOSD/rRZ0pKRFBgZ0gAjAAEgAmQYEAI0GBkSABoAwVkSBsNGBgf0AooHdAQKBvQASAQYAhqgALADxBhCGrAAwjUXUhcSgJgUhACYAYiQmBbSoJgCGoAAwTUWkhZSUFgfyEBYAAgcEcAIOLnTkhIREBoAWhKSEkcBNABaAEiEgSRQwFgQWkBItIHEUNBYb/zT48AIHBHASBwR0BIS0oCYcETQWFBaQEjGwQZQ0Fhv/NPjwDgAL8BaYkDiQ/60QFpEUIC0AJhASBwRwAgcEcwtTVLASRLRBpo5AQBKgzRGWkBKQLQmWihQgbR3WhZaE0ZhUIB2AEhAOAAIQEqAdCaaAbgGmkBKgLQmmiiQgDR2mguS1IeEEAhSsAKE2HAAEkDgBwIQ1BhUGkBIQkECENQYb/zT48A4AC/EGmAA4AP+tEQaRhAAdATYQEgML0wtckdE0vJCB1NyQAdYQEkXGEU4BRoBGBUaERgv/NPjwDgAL8caaQDpA/60RxpLEIC0B1hASAwvQgwCDkIMgAp6NFYaUAIQABYYQAgML0jAWdFACACQKuJ780EAAAAwHX/HwBYAUCq+///qqoAAAAwAED/DwAA/wEAAAAsAED6wwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  load_address: 0x20000020
   pc_init: 0x1
   pc_uninit: 0x7f
   pc_program_page: 0x15f
@@ -5308,6 +5491,7 @@ flash_algorithms:
 - name: stm32g0xx_otp
   description: STM32G0xx Flash OTP
   instructions: v/NPj3BHG0gZSYFgGkmBYBpJAWEAIHBHASAWScAHSGEAIHBHASBwRwAgcEfwtckdEEzJCBFNyQAlYQEmACcT4GZhE2gDYFNoQ2C/80+PI2nbA/zUZ2EjaStCAtAlYQEg8L0IMAg5CDIAKenRACDwvSMBZ0UAIAJAq4nvzfrDAAAAAAAA
+  load_address: 0x20000020
   pc_init: 0x7
   pc_uninit: 0x19
   pc_program_page: 0x2d
@@ -5327,6 +5511,7 @@ flash_algorithms:
 - name: stm32g0x0_sb_opt
   description: STM32G0x0 SB Flash Options
   instructions: v/NPj3BHLUgrSYFgLEmBYCxJwWAsScFgLEkBYQAgcEcBISZIyQdBYUEEQWEAIHBHASBwRyFIJUoCYSVJAWJ/IcFiAWMBIUkEQWG/80+PAWnJA/zUACFBYQFpEUIE0AFpEUMBYQEgcEcAIHBHACBwRzC1lGgTaFFoEEgUSgJhFU0rQANiFEsZQMFiHEAEYwEhSQRBYb/zT48BackD/NQBaRFCBNABaRFDAWEBIDC9ACAwvUAYcEcAACMBZ0UAIAJAq4nvzTsqGQh/bl1M+sMAAKr+/////38/fwB/AAAAAAA=
+  load_address: 0x20000020
   pc_init: 0x7
   pc_uninit: 0x21
   pc_program_page: 0x71
@@ -5347,6 +5532,7 @@ flash_algorithms:
 - name: stm32g0x0_db_opt
   description: STM32G0x0 DB Flash Options
   instructions: v/NPj3BHM0gxSYFgMkmBYDJJwWAyScFgMkkBYQAgcEcBISxIyQdBYUEEQWEAIHBHASBwRydIK0oCYStJAWJ/IcFiAWMjS0Az2WAZYQEhSQRBYb/zT48BackD/NQAIUFhAWkRQgTQAWkRQwFhASBwRwAgcEcAIHBH8LUVaFRok2jRaBRIEmkXTwdhGE41QAViF00sQMRiK0ADYw5LKUBAM9lgKkAaYQEhSQRBYb/zT48BackD/NQBaTlCBNABaTlDAWEBIPC9ACDwvUAYcEcAACMBZ0UAIAJAq4nvzTsqGQh/bl1M+sMAAKr+/////38/fwB/AAAAAAA=
+  load_address: 0x20000020
   pc_init: 0x7
   pc_uninit: 0x21
   pc_program_page: 0x79
@@ -5367,6 +5553,7 @@ flash_algorithms:
 - name: stm32g0x1_sb_opt
   description: STM32G0x1 SB Flash Options
   instructions: v/NPj3BHPkg8SYFgPUmBYD1JwWA9ScFgPUkBYQAgcEcBITdIyQdBYUEEQWEAIHBHASBwRzJINksDYTZJAWL/IcFiAWM0SUFiACKCYkFjgmMrSYAxCmABIUkEQWG/80+PAWnJA/zUQmEBaRlCBNABaRlDAWEBIHBHACBwRwAgcEfwtZeJloq8RheLFWi+RlRok2gRaRpI0mkdTwdhH089QAViH00sQMRiK0ADY2dG+wXbDUNiG0sZQIFi8QXJDUFjd0b5BckNgWMXSQpADEmAMQpgmQtBYb/zT48BackD/NQCaQtJCkIE0AJpCkMCYQEg8L0AIPC9QBhwRwAAIwFnRQAgAkCrie/NOyoZCH9uXUz6wwAAqv7///8BAAD//38/fwB/AP8BAID/APEPAAAAAA==
+  load_address: 0x20000020
   pc_init: 0x7
   pc_uninit: 0x21
   pc_program_page: 0x81
@@ -5387,6 +5574,7 @@ flash_algorithms:
 - name: stm32g0x1_db_opt
   description: STM32G0x1 DB Flash Options
   instructions: v/NPj3BHVUhTSYFgVEmBYFRJwWBUScFgVEkBYQAgcEcBIU5IyQdBYUEEQWEAIHBHASBwRzC1SUhMTQVhTEkBYv8kxGIEY8sNQ2IAIoJiQ2OCY0JJgDEKYEBJQDHMYAxhS2CKYEthimEBIUkEQWG/80+PAWnJA/zUQmEBaSlCBNABaSlDAWEBIDC9ACAwvQAgcEfwtYawF2hWaJBoBZCQiQSQEGmERpCKA5AQiwKQEI3VaRRqU2oBkBCO0WqGRpKOAJImSClKAmEqShdAB2IqShZAxmIFnhZABmMEnvYF9g1GYiZPZkY+QIZiA572BfYNRmMCnvYF9g2GYyFONUAXToA2NWAVTRRAQDXsYBNAK2EBmtIF0g1qYDlAqWBxRskFyQ1pYQCa0QXJDalhuQtBYb/zT48BackD/NQBaQtKEUIF0AFpEUMBYQEgBrDwvQAg++dAGHBHAAAjAWdFACACQKuJ7807KhkIf25dTPrDAACq/v////9/P38AfwD/AQCA/wDxDwAAAAA=
+  load_address: 0x20000020
   pc_init: 0x7
   pc_uninit: 0x21
   pc_program_page: 0x93

--- a/probe-rs/targets/STM32G4_Series.yaml
+++ b/probe-rs/targets/STM32G4_Series.yaml
@@ -3,7 +3,7 @@ manufacturer:
   id: 0x20
   cc: 0x0
 generated_from_pack: true
-pack_file_release: 1.5.0
+pack_file_release: 1.6.0
 variants:
 - name: STM32G431C6Tx
   cores:
@@ -21,6 +21,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -49,6 +50,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -77,6 +79,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -105,6 +108,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -133,6 +137,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -142,7 +147,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32g4xx_128
+  - stm32g47x-8x_512
   - stm32g4xx_sb_opt
   - mt25ql512abb_stm32g474e-eval
 - name: STM32G431CBUx
@@ -161,6 +166,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -170,7 +176,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32g4xx_128
+  - stm32g47x-8x_512
   - stm32g4xx_sb_opt
   - mt25ql512abb_stm32g474e-eval
 - name: STM32G431CBYx
@@ -189,6 +195,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -198,7 +205,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32g4xx_128
+  - stm32g47x-8x_512
   - stm32g4xx_sb_opt
   - mt25ql512abb_stm32g474e-eval
 - name: STM32G431K6Tx
@@ -217,6 +224,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -245,6 +253,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -273,6 +282,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -301,6 +311,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -329,6 +340,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -338,7 +350,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32g4xx_128
+  - stm32g47x-8x_512
   - stm32g4xx_sb_opt
   - mt25ql512abb_stm32g474e-eval
 - name: STM32G431KBUx
@@ -357,6 +369,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -366,7 +379,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32g4xx_128
+  - stm32g47x-8x_512
   - stm32g4xx_sb_opt
   - mt25ql512abb_stm32g474e-eval
 - name: STM32G431M6Tx
@@ -385,6 +398,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -413,6 +427,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -441,6 +456,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -450,7 +466,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32g4xx_128
+  - stm32g47x-8x_512
   - stm32g4xx_sb_opt
   - mt25ql512abb_stm32g474e-eval
 - name: STM32G431R6Ix
@@ -469,6 +485,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -497,6 +514,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -525,6 +543,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -553,6 +572,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -581,6 +601,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -590,7 +611,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32g4xx_128
+  - stm32g47x-8x_512
   - stm32g4xx_sb_opt
   - mt25ql512abb_stm32g474e-eval
 - name: STM32G431RBTx
@@ -609,6 +630,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -618,7 +640,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32g4xx_128
+  - stm32g47x-8x_512
   - stm32g4xx_sb_opt
   - mt25ql512abb_stm32g474e-eval
 - name: STM32G431V6Tx
@@ -637,6 +659,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -665,6 +688,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -693,6 +717,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -702,7 +727,7 @@ variants:
     cores:
     - main
   flash_algorithms:
-  - stm32g4xx_128
+  - stm32g47x-8x_512
   - stm32g4xx_sb_opt
   - mt25ql512abb_stm32g474e-eval
 - name: STM32G441CBTx
@@ -721,6 +746,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -749,6 +775,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -777,6 +804,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -805,6 +833,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -833,6 +862,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -861,6 +891,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -889,6 +920,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -917,6 +949,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -945,6 +978,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -973,6 +1007,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1001,6 +1036,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1029,6 +1065,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1057,6 +1094,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1085,6 +1123,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1113,6 +1152,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1141,6 +1181,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1169,6 +1210,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1197,6 +1239,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1225,6 +1268,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1253,6 +1297,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1281,6 +1326,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1309,6 +1355,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1337,6 +1384,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1365,6 +1413,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1393,6 +1442,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1421,6 +1471,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1449,6 +1500,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1477,6 +1529,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1505,6 +1558,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1533,6 +1587,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1561,6 +1616,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1589,6 +1645,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1617,6 +1674,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1645,6 +1703,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1673,6 +1732,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1701,6 +1761,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1729,6 +1790,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1757,6 +1819,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1785,6 +1848,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1813,6 +1877,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1841,6 +1906,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1869,6 +1935,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1897,6 +1964,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1925,6 +1993,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1953,6 +2022,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -1981,6 +2051,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2009,6 +2080,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2037,6 +2109,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2065,6 +2138,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2093,6 +2167,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2121,6 +2196,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2149,6 +2225,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2177,6 +2254,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2205,6 +2283,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2233,6 +2312,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2261,6 +2341,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2289,6 +2370,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2317,6 +2399,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2345,6 +2428,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2373,6 +2457,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2401,6 +2486,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2429,6 +2515,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2457,6 +2544,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2485,6 +2573,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2513,6 +2602,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2541,6 +2631,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2569,6 +2660,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2597,6 +2689,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2625,6 +2718,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2653,6 +2747,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2681,6 +2776,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2709,6 +2805,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2737,6 +2834,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2765,6 +2863,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2793,6 +2892,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2821,6 +2921,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2849,6 +2950,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2877,6 +2979,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2905,6 +3008,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2933,6 +3037,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2961,6 +3066,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -2989,6 +3095,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3017,6 +3124,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3045,6 +3153,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3073,6 +3182,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3101,6 +3211,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3129,6 +3240,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3157,6 +3269,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3185,6 +3298,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3213,6 +3327,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3241,6 +3356,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3269,6 +3385,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3297,6 +3414,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3325,6 +3443,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3353,6 +3472,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3381,6 +3501,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3409,6 +3530,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3437,6 +3559,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3465,6 +3588,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3493,6 +3617,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3521,6 +3646,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3549,6 +3675,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3577,6 +3704,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3605,6 +3733,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3633,6 +3762,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3661,6 +3791,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3689,6 +3820,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3717,6 +3849,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3745,6 +3878,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3773,6 +3907,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3801,6 +3936,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3829,6 +3965,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3857,6 +3994,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3885,6 +4023,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3913,6 +4052,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3941,6 +4081,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3969,6 +4110,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -3997,6 +4139,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4025,6 +4168,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4053,6 +4197,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4081,6 +4226,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4109,6 +4255,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4137,6 +4284,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4165,6 +4313,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4193,6 +4342,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4221,6 +4371,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4249,6 +4400,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4277,6 +4429,7 @@ variants:
     cores:
     - main
     access:
+      write: false
       boot: true
   - !Ram
     name: SRAM
@@ -4288,33 +4441,6 @@ variants:
   flash_algorithms:
   - stm32g47x-8x_512
   - stm32g4xx_sb_opt
-  - mt25ql512abb_stm32g474e-eval
-- name: STM32GBK1CBTx
-  cores:
-  - name: main
-    type: armv7em
-    core_access_options: !Arm
-      ap: 0
-      psel: 0x0
-  memory_map:
-  - !Nvm
-    name: Main_Flash
-    range:
-      start: 0x8000000
-      end: 0x8020000
-    cores:
-    - main
-    access:
-      boot: true
-  - !Ram
-    name: SRAM
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  flash_algorithms:
-  - stm32g47x-8x_512
   - mt25ql512abb_stm32g474e-eval
 flash_algorithms:
 - name: stm32g47x-8x_512
@@ -4402,26 +4528,3 @@ flash_algorithms:
     sectors:
     - size: 0x54
       address: 0x0
-- name: stm32g4xx_128
-  description: STM32G4xx 128 Flash
-  default: true
-  instructions: ELUDRnZId0ygYHdIoGAgRgBqwLKqKBfQdEjgYHRI4GAgRgBqIPD/ACBiIEYAakDwqgAgYiBGQGlA9AAwYGEgRkBpQPAAYGBhAL9mSABpAPSAMAAo+dEQvQFGYkhAaUDwAEBgSlBhACBwRwNGASBwRwPgTPL7MFtJCGFaSABpAPSAMAAo9dEEIFZJSGEIRkBpQPSAMEhhAL9SSABpAPSAMAAo+dFPSABpRPL6MQhAILEIRkxJCGEBIHBHSkhAaSDwBABISUhhACD25wFGTPL7MERLGGEYRkBpQPACAFhhRUhIRABogUIJ08oKgDoC8H8CGEZAaUD0AGBYYQfgwfPGIjhIQGkg9ABgNktYYTVIQGkg9H5wM0tYYRhGQGlA6sIAWGEYRkBpQPSAMFhhAL8tSABpAPSAMAAo+dEAvylIAGkA9IAwACj50SZIAGlE8vozGEAgsRhGI0sYYQEgcEchSEBpIPACAB9LWGEAIPbnELUDRsgdIPAHAQC/GkgAaQD0gDAAKPnRTPL7MBZMIGEgRkBpQPABAGBhGOAQaBhgUGhYYAC/D0gAaQD0gDAAKPnRCDMIMgg5C0gAaQDwAQAosUTy+jAHTCBhASAQvQAp5NEESEBpIPABAAJMYGEAIPTnIwFnRQAgAkCrie/NOyoZCH9uXUwEAAAAAAAAAAAABAgAAAAAAAAAAA==
-  pc_init: 0x1
-  pc_uninit: 0x59
-  pc_program_page: 0x16f
-  pc_erase_sector: 0xcb
-  pc_erase_all: 0x71
-  data_section_offset: 0x1f8
-  flash_properties:
-    address_range:
-      start: 0x8000000
-      end: 0x8020000
-    page_size: 0x400
-    erased_byte_value: 0xff
-    program_page_timeout: 400
-    erase_sector_timeout: 400
-    sectors:
-    - size: 0x800
-      address: 0x0
-  cores:
-  - main


### PR DESCRIPTION
The main change is the removal of STM32GBK1CBTx

This update also undoes #2061 so I'm very much uncomfortable with immediately pushing it in.

@jrmoulton can I please ask you to test that the PR doesn't unfix the STM32G431KBU?
@dlaw did you manage to get any additional information from Keil? The pack update is newer than your bug report so I'm hoping this is more correct than the previous one.

Rebased on top of #2677 