### PR TITLE
More cargo-embed rework

### DIFF
--- a/changelog/added-cargo-embed-probe.md
+++ b/changelog/added-cargo-embed-probe.md
@@ -1,0 +1,1 @@
+Added `probe` option under `[general]` to specify a complete probe selector.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
@@ -5,6 +5,8 @@
 # usb_pid = "1337"
 # Serial number
 # serial = "12345678"
+# ... or use a complete probe selector, like:
+# probe = "1337:1337:12345678"
 # The protocol to be used for communicating with the target.
 protocol = "Swd"
 # The speed in kHz of the data link to the target.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -3,7 +3,7 @@ use figment::{
     providers::{Format, Json, Toml, Yaml},
     Figment,
 };
-use probe_rs::probe::WireProtocol;
+use probe_rs::probe::{DebugProbeSelector, WireProtocol};
 use probe_rs::rtt::ChannelMode;
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
@@ -34,9 +34,13 @@ pub struct Config {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Probe {
+    #[deprecated]
     pub usb_vid: Option<String>,
+    #[deprecated]
     pub usb_pid: Option<String>,
+    #[deprecated]
     pub serial: Option<String>,
+    pub probe: Option<DebugProbeSelector>,
     pub protocol: WireProtocol,
     pub speed: Option<u32>,
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -135,18 +135,7 @@ fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
         Artifact::from_path_buf(path_buf)
     } else {
         // Build the project, and extract the path of the built artifact.
-        build_artifact(&work_dir, &opt.cargo_options).map_err(|error| {
-            if let Some(ref work_dir) = opt.work_dir {
-                OperationError::FailedToBuildExternalCargoProject {
-                    source: error,
-                    // This unwrap is okay, because if we get this error, the path was properly canonicalized on the internal
-                    // `cargo build` step.
-                    path: work_dir.canonicalize().unwrap(),
-                }
-            } else {
-                OperationError::FailedToBuildCargoProject(error)
-            }
-        })?
+        build_artifact(&work_dir, &opt.cargo_options, opt.work_dir.is_some())?
     };
 
     logging::println(format!("      {} {}", "Config".green().bold(), config_name));

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -198,19 +198,6 @@ fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
     let (mut session, probe_options) = match probe_options.simple_attach(&lister) {
         Ok((session, probe_options)) => (session, probe_options),
 
-        Err(OperationError::MultipleProbesFound { list }) => {
-            use std::fmt::Write;
-
-            return Err(anyhow!("The following devices were found:\n \
-                    {} \
-                        \
-                    Use '--probe VID:PID'\n \
-                                            \
-                    You can also set the [default.probe] config attribute \
-                    (in your Embed.toml) to select which probe to use. \
-                    For usage examples see https://github.com/probe-rs/probe-rs/blob/master/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml .",
-                    list.iter().enumerate().fold(String::new(), |mut s, (num, link)| { let _ = writeln!(s, "[{num}]: {link}"); s })));
-        }
         Err(OperationError::AttachingFailed {
             source,
             connect_under_reset,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -11,7 +11,7 @@ use crate::util::cargo::Artifact;
 use crate::util::common_options::{
     BinaryDownloadOptions, CargoOptions, OperationError, ProbeOptions,
 };
-use crate::util::flash;
+use crate::util::flash::{self, build_loader};
 use crate::util::logging::{setup_logging, LevelFilter};
 use crate::util::{cargo::build_artifact, logging};
 
@@ -110,13 +110,12 @@ fn main_try(args: &[OsString]) -> Result<(), OperationError> {
     let (mut session, probe_options) = opt.probe_options.simple_attach(&lister)?;
 
     // Flash the binary
-    let loader = flash::build_loader(
+    let loader = build_loader(
         &mut session,
         artifact.path(),
         opt.format_options,
         artifact.instruction_set,
-    )
-    .unwrap();
+    )?;
     flash::run_flash_download(
         &mut session,
         artifact.path(),

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -95,18 +95,7 @@ fn main_try(args: &[OsString]) -> Result<(), OperationError> {
         Artifact::from_path_buf(path_buf)
     } else {
         // Build the project, and extract the path of the built artifact.
-        build_artifact(&work_dir, &opt.cargo_options).map_err(|error| {
-            if let Some(ref work_dir) = opt.work_dir {
-                OperationError::FailedToBuildExternalCargoProject {
-                    source: error,
-                    // This unwrap is okay, because if we get this error, the path was properly canonicalized on the internal
-                    // `cargo build` step.
-                    path: work_dir.canonicalize().unwrap(),
-                }
-            } else {
-                OperationError::FailedToBuildCargoProject(error)
-            }
-        })?
+        build_artifact(&work_dir, &opt.cargo_options, opt.work_dir.is_some())?
     };
 
     logging::eprintln(format!(

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -75,9 +75,6 @@ fn main_try(args: &[OsString]) -> Result<(), OperationError> {
     // Parse the commandline options.
     let opt = CliOptions::parse_from(args);
 
-    // Initialize the logger with the loglevel given on the commandline.
-    let _log_guard = setup_logging(None, opt.log);
-
     // Change the work dir if the user asked to do so.
     if let Some(ref work_dir) = opt.work_dir {
         std::env::set_current_dir(work_dir).map_err(|error| {
@@ -88,6 +85,9 @@ fn main_try(args: &[OsString]) -> Result<(), OperationError> {
         })?;
     }
     let work_dir = std::env::current_dir()?;
+
+    // Initialize the logger with the loglevel given on the commandline.
+    let _log_guard = setup_logging(None, opt.log);
 
     // Get the path to the binary we want to flash.
     // This can either be give from the arguments or can be a cargo build artifact.

--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -453,17 +453,8 @@ pub enum OperationError {
     #[error("No connected probes were found.")]
     NoProbesFound,
 
-    #[error("Failed to open the ELF file '{path}' for flashing.")]
-    #[allow(dead_code)]
-    FailedToOpenElf {
-        #[source]
-        source: std::io::Error,
-        path: PathBuf,
-    },
-
     #[error("Failed to load the ELF data.")]
-    #[allow(dead_code)]
-    FailedToLoadElfData(#[source] FileDownloadError),
+    FailedToLoadElfData(#[from] FileDownloadError),
 
     #[error("Failed to open the debug probe.")]
     FailedToOpenProbe(#[from] DebugProbeError),

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -11,8 +11,10 @@ use std::{
     str::FromStr,
 };
 
-use super::*;
-use crate::session::Session;
+use crate::{
+    flashing::{FlashError, FlashProgress},
+    session::Session,
+};
 
 /// Extended options for flashing a binary file.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Default)]

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use crate::{
-    flashing::{FlashError, FlashProgress},
+    flashing::{FlashError, FlashLoader, FlashProgress},
     session::Session,
 };
 


### PR DESCRIPTION
- Add `probe` to `Embed.toml`. This allows us to extend the format in the future, if we need to
- Deprecate the old probe triple
- Deduplicate artifact building
- Remove dead error and unnecessary anyhow use