### PR TITLE
Remove hardcoded BinaryFormat from target descriptors

### DIFF
--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -78,6 +78,7 @@ pub struct Chip {
     #[serde(default)]
     pub jtag: Option<Jtag>,
     /// The default binary format for this chip
+    // TODO: rename to default_platform
     #[serde(default)]
     pub default_binary_format: Option<String>,
 }

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -16,17 +16,6 @@ pub struct ScanChainElement {
     pub ir_len: Option<u8>,
 }
 
-/// A finite list of all possible binary formats a target might support.
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum BinaryFormat {
-    /// Program sections are bit-for-bit copied to flash.
-    #[default]
-    Raw,
-    /// Program sections are copied to flash, with the relevant headers and metadata for the [ESP-IDF bootloader](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/app_image_format.html#app-image-structures).
-    Idf,
-}
-
 /// Configuration for JTAG probes.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Jtag {
@@ -89,7 +78,8 @@ pub struct Chip {
     #[serde(default)]
     pub jtag: Option<Jtag>,
     /// The default binary format for this chip
-    pub default_binary_format: Option<BinaryFormat>,
+    #[serde(default)]
+    pub default_binary_format: Option<String>,
 }
 
 impl Chip {
@@ -111,7 +101,7 @@ impl Chip {
             flash_algorithms: vec![],
             rtt_scan_ranges: None,
             jtag: None,
-            default_binary_format: Some(BinaryFormat::Raw),
+            default_binary_format: None,
         }
     }
 }

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -19,8 +19,8 @@ mod memory;
 pub(crate) mod serialize;
 
 pub use chip::{
-    ArmCoreAccessOptions, BinaryFormat, Chip, Core, CoreAccessOptions, Jtag,
-    RiscvCoreAccessOptions, ScanChainElement, XtensaCoreAccessOptions,
+    ArmCoreAccessOptions, Chip, Core, CoreAccessOptions, Jtag, RiscvCoreAccessOptions,
+    ScanChainElement, XtensaCoreAccessOptions,
 };
 pub use chip_family::{
     Architecture, ChipFamily, CoreType, InstructionSet, TargetDescriptionSource,

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -153,11 +153,11 @@ impl FormatOptions {
     /// Finally, if neither of the above cases are true, we default to [`Format::default()`].
     pub fn into_format(self, target: &Target) -> Format {
         let format = self.binary_format.unwrap_or_else(|| {
-            Format::from_optional(target.default_format.as_deref())
+            FormatKind::from_optional(target.default_format.as_deref())
                 .expect("Failed to parse a default binary format. This shouldn't happen.")
         });
 
-        match kind {
+        match format {
             FormatKind::Bin => Format::Bin(BinOptions {
                 base_address: self.bin_options.base_address,
                 skip: self.bin_options.skip,

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -12,12 +12,11 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use colored::Colorize;
 use itertools::Itertools;
-use probe_rs::flashing::{BinOptions, Format, IdfOptions};
+use probe_rs::flashing::{BinOptions, Format, FormatKind, IdfOptions};
 use probe_rs::{probe::list::Lister, Target};
 use report::Report;
+use serde::Deserialize;
 use serde::Serialize;
-use serde::{de::Error, Deserialize, Deserializer};
-use serde_json::Value;
 use time::{OffsetDateTime, UtcOffset};
 
 use crate::util::logging::setup_logging;
@@ -105,17 +104,6 @@ pub(crate) struct CoreOptions {
     core: usize,
 }
 
-/// A helper function to deserialize a default [`Format`] from a string.
-fn format_from_str<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<Format>, D::Error> {
-    match Value::deserialize(deserializer)? {
-        Value::String(s) => match Format::from_str(s.as_str()) {
-            Ok(format) => Ok(Some(format)),
-            Err(e) => Err(D::Error::custom(e)),
-        },
-        _ => Ok(None),
-    }
-}
-
 #[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default)]
 #[serde(default)]
 pub struct FormatOptions {
@@ -128,20 +116,19 @@ pub struct FormatOptions {
         long,
         help_heading = "DOWNLOAD CONFIGURATION"
     )]
-    #[serde(deserialize_with = "format_from_str")]
-    binary_format: Option<Format>,
+    binary_format: Option<FormatKind>,
     /// The address in memory where the binary will be put at. This is only considered when `bin` is selected as the format.
     #[clap(long, value_parser = parse_u64, help_heading = "DOWNLOAD CONFIGURATION")]
-    pub base_address: Option<u64>,
+    base_address: Option<u64>,
     /// The number of bytes to skip at the start of the binary file. This is only considered when `bin` is selected as the format.
     #[clap(long, value_parser = parse_u32, default_value = "0", help_heading = "DOWNLOAD CONFIGURATION")]
-    pub skip: u32,
+    skip: u32,
     /// The idf bootloader path
     #[clap(long, help_heading = "DOWNLOAD CONFIGURATION")]
-    pub idf_bootloader: Option<PathBuf>,
+    idf_bootloader: Option<PathBuf>,
     /// The idf partition table path
     #[clap(long, help_heading = "DOWNLOAD CONFIGURATION")]
-    pub idf_partition_table: Option<PathBuf>,
+    idf_partition_table: Option<PathBuf>,
 }
 
 impl FormatOptions {
@@ -159,13 +146,13 @@ impl FormatOptions {
                 base_address: self.base_address,
                 skip: self.skip,
             }),
-            Format::Hex => Format::Hex,
-            Format::Elf => Format::Elf,
-            Format::Idf(_) => Format::Idf(IdfOptions {
+            FormatKind::Hex => Format::Hex,
+            FormatKind::Elf => Format::Elf,
+            FormatKind::Uf2 => Format::Uf2,
+            FormatKind::Idf => Format::Idf(IdfOptions {
                 bootloader: self.idf_bootloader,
                 partition_table: self.idf_partition_table,
             }),
-            Format::Uf2 => Format::Uf2,
         }
     }
 }
@@ -262,7 +249,7 @@ fn main() -> Result<()> {
     if let Some(format_arg_pos) = args.iter().position(|arg| arg == "--format") {
         if let Some(format_arg) = args.get(format_arg_pos + 1) {
             if let Some(format_arg) = format_arg.to_str() {
-                if Format::from_str(format_arg).is_ok() {
+                if FormatKind::from_str(format_arg).is_ok() {
                     anyhow::bail!("--format has been renamed to --binary-format. Please use --binary-format {0} instead of --format {0}", format_arg);
                 }
             }

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -149,12 +149,10 @@ impl FormatOptions {
     /// If a target has a preferred format, we use that.
     /// Finally, if neither of the above cases are true, we default to [`Format::default()`].
     pub fn into_format(self, target: &Target) -> Format {
-        let format = self
-            .binary_format
-            .unwrap_or_else(|| match target.default_format {
-                probe_rs_target::BinaryFormat::Idf => Format::Idf(Default::default()),
-                probe_rs_target::BinaryFormat::Raw => Default::default(),
-            });
+        let format = self.binary_format.unwrap_or_else(|| {
+            Format::from_optional(target.default_format.as_deref())
+                .expect("Failed to parse a default binary format. This shouldn't happen.")
+        });
 
         match format {
             Format::Bin(_) => Format::Bin(BinOptions {

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -106,6 +106,28 @@ pub(crate) struct CoreOptions {
 
 #[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default)]
 #[serde(default)]
+pub struct BinaryCliOptions {
+    /// The address in memory where the binary will be put at. This is only considered when `bin` is selected as the format.
+    #[clap(long, value_parser = parse_u64, help_heading = "DOWNLOAD CONFIGURATION")]
+    base_address: Option<u64>,
+    /// The number of bytes to skip at the start of the binary file. This is only considered when `bin` is selected as the format.
+    #[clap(long, value_parser = parse_u32, default_value = "0", help_heading = "DOWNLOAD CONFIGURATION")]
+    skip: u32,
+}
+
+#[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default)]
+#[serde(default)]
+pub struct IdfCliOptions {
+    /// The idf bootloader path
+    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION")]
+    idf_bootloader: Option<PathBuf>,
+    /// The idf partition table path
+    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION")]
+    idf_partition_table: Option<PathBuf>,
+}
+
+#[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default)]
+#[serde(default)]
 pub struct FormatOptions {
     /// If a format is provided, use it.
     /// If a target has a preferred format, we use that.
@@ -117,18 +139,12 @@ pub struct FormatOptions {
         help_heading = "DOWNLOAD CONFIGURATION"
     )]
     binary_format: Option<FormatKind>,
-    /// The address in memory where the binary will be put at. This is only considered when `bin` is selected as the format.
-    #[clap(long, value_parser = parse_u64, help_heading = "DOWNLOAD CONFIGURATION")]
-    base_address: Option<u64>,
-    /// The number of bytes to skip at the start of the binary file. This is only considered when `bin` is selected as the format.
-    #[clap(long, value_parser = parse_u32, default_value = "0", help_heading = "DOWNLOAD CONFIGURATION")]
-    skip: u32,
-    /// The idf bootloader path
-    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION")]
-    idf_bootloader: Option<PathBuf>,
-    /// The idf partition table path
-    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION")]
-    idf_partition_table: Option<PathBuf>,
+
+    #[clap(flatten)]
+    bin_options: BinaryCliOptions,
+
+    #[clap(flatten)]
+    idf_options: IdfCliOptions,
 }
 
 impl FormatOptions {
@@ -141,17 +157,17 @@ impl FormatOptions {
                 .expect("Failed to parse a default binary format. This shouldn't happen.")
         });
 
-        match format {
-            Format::Bin(_) => Format::Bin(BinOptions {
-                base_address: self.base_address,
-                skip: self.skip,
+        match kind {
+            FormatKind::Bin => Format::Bin(BinOptions {
+                base_address: self.bin_options.base_address,
+                skip: self.bin_options.skip,
             }),
             FormatKind::Hex => Format::Hex,
             FormatKind::Elf => Format::Elf,
             FormatKind::Uf2 => Format::Uf2,
             FormatKind::Idf => Format::Idf(IdfOptions {
-                bootloader: self.idf_bootloader,
-                partition_table: self.idf_partition_table,
+                bootloader: self.idf_options.idf_bootloader,
+                partition_table: self.idf_options.idf_partition_table,
             }),
         }
     }

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -128,8 +128,7 @@ pub struct FormatOptions {
         long,
         help_heading = "DOWNLOAD CONFIGURATION"
     )]
-    // TODO: remove this alias in the next release after 0.24 and release of https://github.com/probe-rs/vscode/pull/86
-    #[serde(deserialize_with = "format_from_str", alias = "format")]
+    #[serde(deserialize_with = "format_from_str")]
     binary_format: Option<Format>,
     /// The address in memory where the binary will be put at. This is only considered when `bin` is selected as the format.
     #[clap(long, value_parser = parse_u64, help_heading = "DOWNLOAD CONFIGURATION")]

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -4,7 +4,7 @@ use super::{Chip, ChipFamily, ChipInfo, Core, Target, TargetDescriptionSource};
 use crate::config::CoreType;
 use once_cell::sync::Lazy;
 use parking_lot::{RwLock, RwLockReadGuard};
-use probe_rs_target::{BinaryFormat, CoreAccessOptions, RiscvCoreAccessOptions};
+use probe_rs_target::{CoreAccessOptions, RiscvCoreAccessOptions};
 use std::collections::HashMap;
 use std::io::Read;
 use std::ops::Deref;
@@ -110,7 +110,7 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
                 flash_algorithms: vec![],
                 rtt_scan_ranges: None,
                 jtag: None,
-                default_binary_format: Some(BinaryFormat::Raw),
+                default_binary_format: None,
             }],
             flash_algorithms: vec![],
             source: TargetDescriptionSource::Generic,

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -440,7 +440,7 @@ fn validate_family(family: &ChipFamily) -> Result<(), String> {
     // We can't have this in the `validate` method as we need information that is not available in
     // probe-rs-target.
     for target in family.variants() {
-        crate::flashing::Format::from_optional(target.default_binary_format.as_deref())?;
+        crate::flashing::FormatKind::from_optional(target.default_binary_format.as_deref())?;
     }
 
     Ok(())

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     rtt::ScanRegion,
 };
-use probe_rs_target::{Architecture, BinaryFormat, Chip, ChipFamily, Jtag};
+use probe_rs_target::{Architecture, Chip, ChipFamily, Jtag};
 use std::sync::Arc;
 
 /// This describes a complete target with a fixed chip model and variant.
@@ -42,7 +42,7 @@ pub struct Target {
     /// the number devices in the scan chain and their ir lengths.
     pub jtag: Option<Jtag>,
     /// The default executable format for the target.
-    pub default_format: BinaryFormat,
+    pub default_format: Option<String>,
 }
 
 impl std::fmt::Debug for Target {
@@ -109,7 +109,7 @@ impl Target {
             debug_sequence,
             rtt_scan_regions,
             jtag: chip.jtag.clone(),
-            default_format: chip.default_binary_format.clone().unwrap_or_default(),
+            default_format: chip.default_binary_format.clone(),
         }
     }
 

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -72,7 +72,7 @@ impl FromStr for FormatKind {
             "hex" | "ihex" | "intelhex" => Ok(Self::Hex),
             "elf" => Ok(Self::Elf),
             "uf2" => Ok(Self::Uf2),
-            "idf" | "esp-idf" => Ok(Self::Idf),
+            "idf" | "esp-idf" | "espidf" => Ok(Self::Idf),
             _ => Err(format!("Format '{s}' is unknown.")),
         }
     }
@@ -409,6 +409,7 @@ mod tests {
         assert_eq!(FormatKind::from_str("Elf"), Ok(FormatKind::Elf));
         assert_eq!(FormatKind::from_str("elf"), Ok(FormatKind::Elf));
         assert_eq!(FormatKind::from_str("idf"), Ok(FormatKind::Idf));
+        assert_eq!(FormatKind::from_str("espidf"), Ok(FormatKind::Idf));
         assert_eq!(FormatKind::from_str("esp-idf"), Ok(FormatKind::Idf));
         assert_eq!(FormatKind::from_str("ESP-IDF"), Ok(FormatKind::Idf));
         assert_eq!(

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -408,6 +408,9 @@ mod tests {
         assert_eq!(FormatKind::from_str("Binary"), Ok(FormatKind::Bin));
         assert_eq!(FormatKind::from_str("Elf"), Ok(FormatKind::Elf));
         assert_eq!(FormatKind::from_str("elf"), Ok(FormatKind::Elf));
+        assert_eq!(FormatKind::from_str("idf"), Ok(FormatKind::Idf));
+        assert_eq!(FormatKind::from_str("esp-idf"), Ok(FormatKind::Idf));
+        assert_eq!(FormatKind::from_str("ESP-IDF"), Ok(FormatKind::Idf));
         assert_eq!(
             FormatKind::from_str("elfbin"),
             Err("Format 'elfbin' is unknown.".to_string())

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -51,6 +51,18 @@ pub enum Format {
     Uf2,
 }
 
+impl Format {
+    /// Creates a new Format from an optional string.
+    ///
+    /// If the string is `None`, the default format is returned.
+    pub fn from_optional(s: Option<&str>) -> Result<Self, String> {
+        match s {
+            Some(format) => Self::from_str(format),
+            None => Ok(Self::default()),
+        }
+    }
+}
+
 impl FromStr for Format {
     type Err = String;
 

--- a/smoke-tester/src/tests.rs
+++ b/smoke-tester/src/tests.rs
@@ -4,7 +4,7 @@ use colored::Colorize;
 use linkme::distributed_slice;
 use probe_rs::{
     config::MemoryRegion,
-    flashing::{download_file_with_options, DownloadOptions, FlashProgress, Format},
+    flashing::{download_file_with_options, DownloadOptions, FlashProgress, FormatKind},
     Architecture, Core, MemoryInterface, Session,
 };
 
@@ -224,7 +224,7 @@ pub fn test_flashing(tracker: &TestTracker, session: &mut Session) -> Result<(),
 
     let start_time = Instant::now();
 
-    let format = Format::from_optional(session.target().default_format.as_deref()).unwrap();
+    let format = FormatKind::from_optional(session.target().default_format.as_deref()).unwrap();
 
     let result = download_file_with_options(session, test_binary, format, options);
 

--- a/smoke-tester/src/tests.rs
+++ b/smoke-tester/src/tests.rs
@@ -224,10 +224,7 @@ pub fn test_flashing(tracker: &TestTracker, session: &mut Session) -> Result<(),
 
     let start_time = Instant::now();
 
-    let format = match session.target().default_format {
-        probe_rs_target::BinaryFormat::Idf => Format::Idf(Default::default()),
-        probe_rs_target::BinaryFormat::Raw => Default::default(),
-    };
+    let format = Format::from_optional(session.target().default_format.as_deref()).unwrap();
 
     let result = download_file_with_options(session, test_binary, format, options);
 

--- a/target-gen/src/commands/snapshots/target_gen__commands__elf__test__serialization_cleanup.snap
+++ b/target-gen/src/commands/snapshots/target_gen__commands__elf__test__serialization_cleanup.snap
@@ -35,4 +35,3 @@ variants:
     - main
     access:
       execute: false
-  default_binary_format: raw


### PR DESCRIPTION
If we ever end up having vendor-specific image formats, we can't hard-code them into the target YAMLs. Instead, we store their names and validate it as part of the builtin target validation.

This PR also removes a deprecated alias that was used by the VSCode plugin.

---

The end goal is to split up format and platform support. The plan is to keep a hard-coded set of formats, and an extensible set of platforms - "raw" and IDF being the first two of these platforms. Targets may declare a default platform, but the default image format should be dictated by the platform - and right now both should default to `Elf`.

The platform support code would receive something analogous to the current `Format`, file reader/path, `FlashLoader` and `Session`. "raw" would just load the image to `FlashLoader`, while IDF would process it as it wants.

The difficult bits are integrating a dynamic set of platforms with the binary, which requires clap and serde implementations with good UX in mind.

This PR is just the first step, that removes one point where the IDF platform was hard-coded into prob-rs.