### PR TITLE
Make bincode optional, disable build deps when not needed

### DIFF
--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -24,7 +24,7 @@ default = ["builtin-targets"]
 gdb-server = ["dep:gdbstub"]
 
 # Enable all built in targets.
-builtin-targets = ["dep:bincode"]
+builtin-targets = ["dep:bincode", "dep:serde_yaml", "dep:probe-rs-target"]
 
 # Enable helpers for testing
 test = []
@@ -81,10 +81,10 @@ hexdump = { version = "0.1", optional = true }
 gdbstub = { version = "0.7", optional = true }
 
 [build-dependencies]
-probe-rs-target.workspace = true
+probe-rs-target = { workspace = true, optional = true }
 
 bincode = { version = "1", optional = true }
-serde_yaml = "0.9"
+serde_yaml = { version = "0.9", optional = true }
 
 [dev-dependencies]
 pretty_env_logger = "0.5"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -24,7 +24,7 @@ default = ["builtin-targets"]
 gdb-server = ["dep:gdbstub"]
 
 # Enable all built in targets.
-builtin-targets = []
+builtin-targets = ["dep:bincode"]
 
 # Enable helpers for testing
 test = []
@@ -35,7 +35,7 @@ docsplay.workspace = true
 thiserror.workspace = true
 probe-rs-target.workspace = true
 
-bincode = "1"
+bincode = { version = "1", optional = true }
 bitfield = "0.15"
 bitvec = "1"
 gimli = { version = "0.30", default-features = false, features = [
@@ -83,7 +83,7 @@ gdbstub = { version = "0.7", optional = true }
 [build-dependencies]
 probe-rs-target.workspace = true
 
-bincode = "1"
+bincode = { version = "1", optional = true }
 serde_yaml = "0.9"
 
 [dev-dependencies]

--- a/probe-rs/build.rs
+++ b/probe-rs/build.rs
@@ -1,12 +1,4 @@
 //! This build script compiles the target definitions into a binary format.
-
-use std::env;
-use std::fs::{read_dir, read_to_string};
-use std::io;
-use std::path::Path;
-
-use probe_rs_target::ChipFamily;
-
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
@@ -17,10 +9,31 @@ fn main() {
     println!("cargo:rerun-if-changed=targets");
     println!("cargo:rerun-if-env-changed=PROBE_RS_TARGETS_DIR");
 
-    let mut families = Vec::new();
+    handle_builtin_targets();
+}
 
-    // Test if we have to generate built-in targets
-    if env::var("CARGO_FEATURE_BUILTIN_TARGETS").is_ok() {
+#[cfg(not(feature = "builtin-targets"))]
+fn handle_builtin_targets() {
+    // Nothing to do here
+}
+
+#[cfg(feature = "builtin-targets")]
+fn handle_builtin_targets() {
+    builtin_targets::process();
+}
+
+#[cfg(feature = "builtin-targets")]
+mod builtin_targets {
+
+    use std::env;
+    use std::fs::{read_dir, read_to_string};
+    use std::io;
+    use std::path::Path;
+
+    use probe_rs_target::ChipFamily;
+
+    pub fn process() {
+        let mut families = Vec::new();
         let mut process_target_yaml = |file: &Path| {
             let string = read_to_string(file).unwrap_or_else(|error| {
                 panic!(
@@ -45,44 +58,43 @@ fn main() {
             println!("cargo:rerun-if-changed={additional_target_dir}");
             visit_dirs(additional_target_dir, &mut process_target_yaml).unwrap();
         }
+        let families_bin =
+            bincode::serialize(&families).expect("Failed to serialize families as bincode");
+
+        let out_dir = env::var("OUT_DIR").unwrap();
+        let dest_path = Path::new(&out_dir).join("targets.bincode");
+        std::fs::write(dest_path, &families_bin).unwrap();
+
+        // Check if we can deserialize the bincode again, otherwise the binary will not be usable.
+        if let Err(deserialize_error) = bincode::deserialize::<Vec<ChipFamily>>(&families_bin) {
+            panic!(
+           "Failed to deserialize supported target definitions from bincode: {deserialize_error:?}"
+       );
+        }
     }
 
-    let families_bin =
-        bincode::serialize(&families).expect("Failed to serialize families as bincode");
-
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let dest_path = Path::new(&out_dir).join("targets.bincode");
-    std::fs::write(dest_path, &families_bin).unwrap();
-
-    // Check if we can deserialize the bincode again, otherwise the binary will not be usable.
-    if let Err(deserialize_error) = bincode::deserialize::<Vec<ChipFamily>>(&families_bin) {
-        panic!(
-            "Failed to deserialize supported target definitions from bincode: {deserialize_error:?}"
-        );
-    }
-}
-
-/// Call `process` on all files in a directory and its subdirectories.
-fn visit_dirs(dir: impl AsRef<Path>, process: &mut impl FnMut(&Path)) -> io::Result<()> {
-    // Inner function to avoid generating multiple implementations for the different path types.
-    fn visit_dirs_impl(dir: &Path, process: &mut impl FnMut(&Path)) -> io::Result<()> {
-        for entry in read_dir(dir)? {
-            let entry = entry?;
-            let path = entry.path();
-            if path.is_dir() {
-                visit_dirs_impl(&path, process)?;
-            } else {
-                process(&path);
+    /// Call `process` on all files in a directory and its subdirectories.
+    fn visit_dirs(dir: impl AsRef<Path>, process: &mut impl FnMut(&Path)) -> io::Result<()> {
+        // Inner function to avoid generating multiple implementations for the different path types.
+        fn visit_dirs_impl(dir: &Path, process: &mut impl FnMut(&Path)) -> io::Result<()> {
+            for entry in read_dir(dir)? {
+                let entry = entry?;
+                let path = entry.path();
+                if path.is_dir() {
+                    visit_dirs_impl(&path, process)?;
+                } else {
+                    process(&path);
+                }
             }
+
+            Ok(())
         }
 
-        Ok(())
-    }
+        let dir = dir.as_ref();
+        if !dir.is_dir() {
+            return Ok(());
+        }
 
-    let dir = dir.as_ref();
-    if !dir.is_dir() {
-        return Ok(());
+        visit_dirs_impl(dir, process)
     }
-
-    visit_dirs_impl(dir, process)
 }

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -124,12 +124,22 @@ struct Registry {
     families: Vec<ChipFamily>,
 }
 
+#[cfg(feature = "builtin-targets")]
+fn builtin_targets() -> Vec<ChipFamily> {
+    const BUILTIN_TARGETS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/targets.bincode"));
+
+    bincode::deserialize(BUILTIN_TARGETS)
+        .expect("Failed to deserialize builtin targets. This is a bug")
+}
+
+#[cfg(not(feature = "builtin-targets"))]
+fn builtin_targets() -> Vec<ChipFamily> {
+    vec![]
+}
+
 impl Registry {
     fn from_builtin_families() -> Self {
-        const BUILTIN_TARGETS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/targets.bincode"));
-
-        let mut families = bincode::deserialize(BUILTIN_TARGETS)
-            .expect("Failed to deserialize builtin targets. This is a bug");
+        let mut families = builtin_targets();
 
         add_generic_targets(&mut families);
 


### PR DESCRIPTION
Small speedup if the built-in targets are disabled, couple of seconds maybe.