### PR TITLE
Align some timeout loops to be test-after-loop

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/itm.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/itm.rs
@@ -1,5 +1,7 @@
 //! Provides ITM tracing capabilities.
 
+use std::time::{Duration, Instant};
+
 use probe_rs::architecture::arm::{component::TraceSink, swo::SwoConfig};
 use probe_rs::probe::list::Lister;
 
@@ -102,13 +104,13 @@ impl Cmd {
                     itm::DecoderOptions { ignore_eof: true },
                 );
 
-                let start = std::time::Instant::now();
-                let stop = std::time::Duration::from_millis(duration);
+                let start = Instant::now();
+                let stop = Duration::from_millis(duration);
                 for packet in decoder.singles() {
+                    println!("{packet:?}");
                     if start.elapsed() > stop {
                         return Ok(());
                     }
-                    println!("{packet:?}");
                 }
             }
         };

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -466,13 +466,15 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
         // Wait until halted state is active again.
         let start = Instant::now();
 
-        while start.elapsed() < timeout {
-            if self.core_halted()? {
-                return Ok(());
+        while !self.core_halted()? {
+            if start.elapsed() >= timeout {
+                return Err(Error::Arm(ArmError::Timeout));
             }
+            // Wait a bit before polling again.
             std::thread::sleep(Duration::from_millis(1));
         }
-        Err(Error::Arm(ArmError::Timeout))
+
+        Ok(())
     }
 
     fn core_halted(&mut self) -> Result<bool, Error> {

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -650,13 +650,13 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
         let start = Instant::now();
 
         while !self.core_halted()? {
-            if start.elapsed() < timeout {
-                // Wait a bit before polling again.
-                std::thread::sleep(Duration::from_millis(1));
-            } else {
+            if start.elapsed() >= timeout {
                 return Err(Error::Arm(ArmError::Timeout));
             }
+            // Wait a bit before polling again.
+            std::thread::sleep(Duration::from_millis(1));
         }
+
         Ok(())
     }
 

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -1028,16 +1028,15 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
         // Wait until halted state is active again.
         let start = Instant::now();
 
-        let address = Edscr::get_mmio_address_from_base(self.base_address)?;
-
-        while start.elapsed() < timeout {
-            let edscr = Edscr(self.memory.read_word_32(address)?);
-            if edscr.halted() {
-                return Ok(());
+        while !self.core_halted()? {
+            if start.elapsed() >= timeout {
+                return Err(Error::Arm(ArmError::Timeout));
             }
+            // Wait a bit before polling again.
             std::thread::sleep(Duration::from_millis(1));
         }
-        Err(Error::Arm(ArmError::Timeout))
+
+        Ok(())
     }
 
     fn core_halted(&mut self) -> Result<bool, Error> {

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -90,14 +90,15 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         // Wait until halted state is active again.
         let start = Instant::now();
 
-        while start.elapsed() < timeout {
-            if self.core_halted()? {
-                return Ok(());
+        while !self.core_halted()? {
+            if start.elapsed() >= timeout {
+                return Err(Error::Arm(ArmError::Timeout));
             }
-
+            // Wait a bit before polling again.
             std::thread::sleep(Duration::from_millis(1));
         }
-        Err(Error::Arm(ArmError::Timeout))
+
+        Ok(())
     }
 
     fn core_halted(&mut self) -> Result<bool, Error> {

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -261,7 +261,7 @@ impl<'probe> CoreInterface for Xtensa<'probe> {
     }
 
     fn core_halted(&mut self) -> Result<bool, Error> {
-        Ok(self.interface.is_halted()?)
+        Ok(self.interface.core_halted()?)
     }
 
     fn status(&mut self) -> Result<CoreStatus, Error> {

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, time::Duration};
 
 use crate::{
     architecture::xtensa::arch::instruction::{Instruction, InstructionEncoding},
@@ -194,7 +194,7 @@ impl<'probe> Xdm<'probe> {
                 break;
             }
 
-            if now.elapsed().as_millis() > 500 {
+            if now.elapsed() > Duration::from_millis(500) {
                 return Err(XtensaError::Timeout);
             }
         }

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -140,15 +140,6 @@ impl JtagAdapter {
 
         let mut reply = Vec::with_capacity(self.in_bit_counts.len());
         while reply.len() < self.in_bit_counts.len() {
-            if t0.elapsed() > timeout {
-                tracing::warn!(
-                    "Read {} bytes, expected {}",
-                    reply.len(),
-                    self.in_bit_counts.len()
-                );
-                return Err(DebugProbeError::Timeout);
-            }
-
             let read = self
                 .device
                 .read_to_end(&mut reply)
@@ -156,6 +147,15 @@ impl JtagAdapter {
 
             if read > 0 {
                 t0 = Instant::now();
+            }
+
+            if t0.elapsed() > timeout {
+                tracing::warn!(
+                    "Read {} bytes, expected {}",
+                    reply.len(),
+                    self.in_bit_counts.len()
+                );
+                return Err(DebugProbeError::Timeout);
             }
         }
 

--- a/probe-rs/src/vendor/infineon/sequences/xmc4000.rs
+++ b/probe-rs/src/vendor/infineon/sequences/xmc4000.rs
@@ -314,7 +314,8 @@ impl ArmDebugSequence for XMC4000 {
             if !dhcsr.s_reset_st() {
                 tracing::debug!("Detected reset via S_RESET_ST");
                 break;
-            } else if start.elapsed() > Duration::from_millis(500) {
+            }
+            if start.elapsed() > Duration::from_millis(500) {
                 tracing::error!("XMC4000 did not reset as commanded");
                 return Err(ArmError::Timeout);
             }


### PR DESCRIPTION
Apparently, when CPU load is high, test-before-loop can cause timeouts without giving the loop at least one chance to complete successfully.