### PR TITLE
target-gen: split out library, update output cleaner

### DIFF
--- a/probe-rs/targets/GD32F10x_Series.yaml
+++ b/probe-rs/targets/GD32F10x_Series.yaml
@@ -17,8 +17,6 @@ variants:
       end: 0x20001000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -46,8 +44,6 @@ variants:
       end: 0x20001800
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -75,8 +71,6 @@ variants:
       end: 0x20002800
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -104,8 +98,6 @@ variants:
       end: 0x20004000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -133,8 +125,6 @@ variants:
       end: 0x20001000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -162,8 +152,6 @@ variants:
       end: 0x20001800
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -191,8 +179,6 @@ variants:
       end: 0x20002800
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -220,8 +206,6 @@ variants:
       end: 0x20004000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -249,8 +233,6 @@ variants:
       end: 0x20008000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -278,8 +260,6 @@ variants:
       end: 0x2000c000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -307,8 +287,6 @@ variants:
       end: 0x2000c000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -336,8 +314,6 @@ variants:
       end: 0x20014000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -365,8 +341,6 @@ variants:
       end: 0x20014000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -394,8 +368,6 @@ variants:
       end: 0x20014000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -423,8 +395,6 @@ variants:
       end: 0x20014000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -452,8 +422,6 @@ variants:
       end: 0x20001000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -481,8 +449,6 @@ variants:
       end: 0x20001800
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -510,8 +476,6 @@ variants:
       end: 0x20002800
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -539,8 +503,6 @@ variants:
       end: 0x20004000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -568,8 +530,6 @@ variants:
       end: 0x20002800
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -597,8 +557,6 @@ variants:
       end: 0x20004000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -626,8 +584,6 @@ variants:
       end: 0x20008000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -655,8 +611,6 @@ variants:
       end: 0x2000c000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -684,8 +638,6 @@ variants:
       end: 0x2000c000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -713,8 +665,6 @@ variants:
       end: 0x20014000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -742,8 +692,6 @@ variants:
       end: 0x20014000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -771,8 +719,6 @@ variants:
       end: 0x20014000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -800,8 +746,6 @@ variants:
       end: 0x20014000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -829,8 +773,6 @@ variants:
       end: 0x20008000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -858,8 +800,6 @@ variants:
       end: 0x2000c000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -887,8 +827,6 @@ variants:
       end: 0x2000c000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -916,8 +854,6 @@ variants:
       end: 0x20014000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -945,8 +881,6 @@ variants:
       end: 0x20014000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -974,8 +908,6 @@ variants:
       end: 0x20014000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1003,8 +935,6 @@ variants:
       end: 0x20014000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1032,8 +962,6 @@ variants:
       end: 0x20001800
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1061,8 +989,6 @@ variants:
       end: 0x20002800
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1090,8 +1016,6 @@ variants:
       end: 0x20005000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1119,8 +1043,6 @@ variants:
       end: 0x20005000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1148,8 +1070,6 @@ variants:
       end: 0x20001800
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1177,8 +1097,6 @@ variants:
       end: 0x20002800
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1206,8 +1124,6 @@ variants:
       end: 0x20005000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1235,8 +1151,6 @@ variants:
       end: 0x20005000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1264,8 +1178,6 @@ variants:
       end: 0x2000c000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1293,8 +1205,6 @@ variants:
       end: 0x20010000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1322,8 +1232,6 @@ variants:
       end: 0x20010000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1351,8 +1259,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1380,8 +1286,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1409,8 +1313,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1438,8 +1340,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1467,8 +1367,6 @@ variants:
       end: 0x20001800
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1496,8 +1394,6 @@ variants:
       end: 0x20002800
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1525,8 +1421,6 @@ variants:
       end: 0x20005000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1554,8 +1448,6 @@ variants:
       end: 0x20005000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1583,8 +1475,6 @@ variants:
       end: 0x20005000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1612,8 +1502,6 @@ variants:
       end: 0x20005000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1641,8 +1529,6 @@ variants:
       end: 0x2000c000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1670,8 +1556,6 @@ variants:
       end: 0x20010000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1699,8 +1583,6 @@ variants:
       end: 0x20010000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1728,8 +1610,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1757,8 +1637,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1786,8 +1664,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1815,8 +1691,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1844,8 +1718,6 @@ variants:
       end: 0x2000c000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1873,8 +1745,6 @@ variants:
       end: 0x20010000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1902,8 +1772,6 @@ variants:
       end: 0x20010000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1931,8 +1799,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1960,8 +1826,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -1989,8 +1853,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2018,8 +1880,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2047,8 +1907,6 @@ variants:
       end: 0x20010000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2076,8 +1934,6 @@ variants:
       end: 0x20010000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2105,8 +1961,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2134,8 +1988,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2163,8 +2015,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2192,8 +2042,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2221,8 +2069,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2250,8 +2096,6 @@ variants:
       end: 0x20010000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2279,8 +2123,6 @@ variants:
       end: 0x20010000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2308,8 +2150,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2337,8 +2177,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2366,8 +2204,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2395,8 +2231,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2424,8 +2258,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2453,8 +2285,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2482,8 +2312,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2511,8 +2339,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2540,8 +2366,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2569,8 +2393,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2598,8 +2420,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2627,8 +2447,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2656,8 +2474,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2685,8 +2501,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2714,8 +2528,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2743,8 +2555,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2772,8 +2582,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2801,8 +2609,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2830,8 +2636,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2859,8 +2663,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2888,8 +2690,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2917,8 +2717,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2946,8 +2744,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -2975,8 +2771,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -3004,8 +2798,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -3033,8 +2825,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:
@@ -3062,8 +2852,6 @@ variants:
       end: 0x20018000
     cores:
     - main
-    access:
-      execute: true
   - !Nvm
     name: IROM1
     range:

--- a/probe-rs/targets/LPC800_Series.yaml
+++ b/probe-rs/targets/LPC800_Series.yaml
@@ -756,7 +756,6 @@ flash_algorithms:
   pc_erase_sector: 0x6d
   pc_erase_all: 0x2d
   data_section_offset: 0x130
-  stack_size: 256
   flash_properties:
     address_range:
       start: 0x0
@@ -770,6 +769,7 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  stack_size: 256
 - name: lpc8xx_16
   description: LPC8xx IAP 16kB Flash
   default: true

--- a/probe-rs/targets/STM32WL_Series.yaml
+++ b/probe-rs/targets/STM32WL_Series.yaml
@@ -624,8 +624,8 @@ flash_algorithms:
     - size: 0x800
       address: 0x0
   cores:
-    - main
-    - cm4
+  - main
+  - cm4
 - name: stm32wlxx_cm0+
   description: STM32WLxx_CM0+ Flash - cores missing from pack, manually added
   default: true
@@ -649,7 +649,7 @@ flash_algorithms:
     - size: 0x800
       address: 0x0
   cores:
-    - cm0p
+  - cm0p
 - name: stm32wlexx_128
   description: STM32WLE5x Flash
   default: true

--- a/probe-rs/targets/esp32.yaml
+++ b/probe-rs/targets/esp32.yaml
@@ -71,7 +71,6 @@ flash_algorithms:
   pc_erase_sector: 0xa8
   pc_erase_all: 0xb8
   data_section_offset: 0x400902f8
-  stack_overflow_check: false
   flash_properties:
     address_range:
       start: 0x0
@@ -85,4 +84,5 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  stack_overflow_check: false
   transfer_encoding: miniz

--- a/probe-rs/targets/esp32c2.yaml
+++ b/probe-rs/targets/esp32c2.yaml
@@ -74,7 +74,6 @@ flash_algorithms:
   pc_erase_sector: 0x14
   pc_erase_all: 0x1c
   data_section_offset: 0x4038c2a0
-  stack_overflow_check: false
   flash_properties:
     address_range:
       start: 0x0
@@ -88,4 +87,5 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  stack_overflow_check: false
   transfer_encoding: miniz

--- a/probe-rs/targets/esp32c3.yaml
+++ b/probe-rs/targets/esp32c3.yaml
@@ -76,7 +76,6 @@ flash_algorithms:
   pc_erase_sector: 0x14
   pc_erase_all: 0x1c
   data_section_offset: 0x403902a4
-  stack_overflow_check: false
   flash_properties:
     address_range:
       start: 0x0
@@ -90,4 +89,5 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  stack_overflow_check: false
   transfer_encoding: miniz

--- a/probe-rs/targets/esp32c6.yaml
+++ b/probe-rs/targets/esp32c6.yaml
@@ -57,7 +57,6 @@ flash_algorithms:
   pc_erase_sector: 0x14
   pc_erase_all: 0x1c
   data_section_offset: 0x408102a0
-  stack_overflow_check: false
   flash_properties:
     address_range:
       start: 0x0
@@ -71,4 +70,5 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  stack_overflow_check: false
   transfer_encoding: miniz

--- a/probe-rs/targets/esp32h2.yaml
+++ b/probe-rs/targets/esp32h2.yaml
@@ -57,7 +57,6 @@ flash_algorithms:
   pc_erase_sector: 0x14
   pc_erase_all: 0x1c
   data_section_offset: 0x408102a0
-  stack_overflow_check: false
   flash_properties:
     address_range:
       start: 0x0
@@ -71,4 +70,5 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  stack_overflow_check: false
   transfer_encoding: miniz

--- a/probe-rs/targets/esp32s2.yaml
+++ b/probe-rs/targets/esp32s2.yaml
@@ -92,7 +92,6 @@ flash_algorithms:
   pc_erase_sector: 0xb4
   pc_erase_all: 0xc4
   data_section_offset: 0x4002c728
-  stack_overflow_check: false
   flash_properties:
     address_range:
       start: 0x0
@@ -106,4 +105,5 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  stack_overflow_check: false
   transfer_encoding: miniz

--- a/probe-rs/targets/esp32s3.yaml
+++ b/probe-rs/targets/esp32s3.yaml
@@ -89,7 +89,6 @@ flash_algorithms:
   pc_erase_sector: 0xa8
   pc_erase_all: 0xb8
   data_section_offset: 0x403806f8
-  stack_overflow_check: false
   flash_properties:
     address_range:
       start: 0x0
@@ -103,4 +102,5 @@ flash_algorithms:
       address: 0x0
   cores:
   - cpu0
+  stack_overflow_check: false
   transfer_encoding: miniz

--- a/target-gen/src/commands/elf.rs
+++ b/target-gen/src/commands/elf.rs
@@ -227,6 +227,7 @@ pub fn serialize_to_yaml_string(family: &ChipFamily) -> Result<String> {
                 "read: false",
                 "write: false",
                 "execute: false",
+                "stack_overflow_check: false",
             ];
             if !keep_default.contains(&trimmed_line) {
                 // Skip the line
@@ -234,7 +235,12 @@ pub fn serialize_to_yaml_string(family: &ChipFamily) -> Result<String> {
             }
         } else {
             // Some fields have different default values than the type may indicate.
-            let trim_nondefault = ["read: true", "write: true", "execute: true"];
+            let trim_nondefault = [
+                "read: true",
+                "write: true",
+                "execute: true",
+                "stack_overflow_check: true",
+            ];
             if trim_nondefault.contains(&trimmed_line) {
                 // Skip the line
                 continue;

--- a/target-gen/src/fetch.rs
+++ b/target-gen/src/fetch.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use cmsis_pack::{pack_index::Vidx, utils::FromElem};
 
 /// Fetches the master VIDX/PIDX file from the ARM server and returns the parsed file.
-pub(crate) async fn get_vidx() -> Result<Vidx> {
+pub async fn get_vidx() -> Result<Vidx> {
     let reader = reqwest::Client::new()
         .get("https://www.keil.com/pack/index.pidx")
         .send()

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -11,7 +11,7 @@ use probe_rs_target::{
 use std::collections::HashMap;
 use std::{fs, io::Read, path::Path};
 
-pub(crate) enum Kind<'a, T>
+pub enum Kind<'a, T>
 where
     T: std::io::Seek + std::io::Read,
 {
@@ -223,7 +223,7 @@ fn core_to_probe_core(value: &Core) -> Result<CoreType, Error> {
 }
 
 // Process all `.pdsc` files in the given directory.
-pub(crate) fn visit_dirs(path: &Path, families: &mut Vec<ChipFamily>) -> Result<()> {
+pub fn visit_dirs(path: &Path, families: &mut Vec<ChipFamily>) -> Result<()> {
     walk_files(path, &mut |path| {
         if has_extension(path, "pack") {
             log::info!("Found .pdsc file: {}", path.display());
@@ -257,7 +257,7 @@ fn has_extension(path: &Path, ext: &str) -> bool {
     path.extension().map_or(false, |e| e == ext)
 }
 
-pub(crate) fn visit_file(path: &Path, families: &mut Vec<ChipFamily>) -> Result<()> {
+pub fn visit_file(path: &Path, families: &mut Vec<ChipFamily>) -> Result<()> {
     log::info!("Trying to open pack file: {}.", path.display());
     // If we get a file, try to unpack it.
     let file = fs::File::open(path)?;
@@ -283,10 +283,7 @@ pub(crate) fn visit_file(path: &Path, families: &mut Vec<ChipFamily>) -> Result<
     extract_families(package, Kind::Archive(&mut archive), families, false)
 }
 
-pub(crate) async fn visit_arm_files(
-    families: &mut Vec<ChipFamily>,
-    filter: Option<String>,
-) -> Result<()> {
+pub async fn visit_arm_files(families: &mut Vec<ChipFamily>, filter: Option<String>) -> Result<()> {
     //TODO: The multi-threaded logging makes it very difficult to track which errors/warnings belong where - needs some rework.
     let packs = crate::fetch::get_vidx().await?;
 

--- a/target-gen/src/lib.rs
+++ b/target-gen/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod algorithm_binary;
+pub mod commands;
+pub mod fetch;
+pub mod flash_device;
+pub mod generate;
+pub mod parser;

--- a/target-gen/src/main.rs
+++ b/target-gen/src/main.rs
@@ -1,10 +1,3 @@
-pub mod algorithm_binary;
-pub mod commands;
-pub mod fetch;
-pub mod flash_device;
-pub mod generate;
-pub mod parser;
-
 use anyhow::{ensure, Context, Result};
 use clap::Parser;
 use probe_rs_target::ChipFamily;
@@ -16,9 +9,12 @@ use std::{
 };
 use tracing_subscriber::{filter::LevelFilter, EnvFilter};
 
-use crate::commands::{
-    elf::{cmd_elf, serialize_to_yaml_string},
-    test::cmd_test,
+use target_gen::{
+    commands::{
+        elf::{cmd_elf, serialize_to_yaml_string},
+        test::cmd_test,
+    },
+    generate,
 };
 
 #[derive(clap::Parser)]
@@ -239,7 +235,7 @@ fn cmd_pack(input: &Path, out_dir: &Path) -> Result<()> {
 /// Generated target descriptions will be placed in `out_dir`.
 async fn cmd_arm(out_dir: Option<PathBuf>, chip_family: Option<String>, list: bool) -> Result<()> {
     if list {
-        let mut packs = crate::fetch::get_vidx().await?;
+        let mut packs = target_gen::fetch::get_vidx().await?;
         println!("Available ARM CMSIS Pack files:");
         packs.pdsc_index.sort_by(|a, b| a.name.cmp(&b.name));
         for pack in packs.pdsc_index.iter() {


### PR DESCRIPTION
target-gen has a few functions I want to use in https://github.com/bugadani/stm-probers.