### PR TITLE
Update VA416xx YAML file

### DIFF
--- a/probe-rs/targets/VA416xx_Series.yaml
+++ b/probe-rs/targets/VA416xx_Series.yaml
@@ -11,14 +11,14 @@ variants:
       psel: 0x0
   memory_map:
   - !Ram
-    name: IRAM1
+    name: SRAM1
     range:
       start: 0x1fff8000
       end: 0x20000000
     cores:
     - main
   - !Nvm
-    name: IROM1
+    name: NVM
     range:
       start: 0x0
       end: 0x40000
@@ -27,7 +27,7 @@ variants:
     access:
       boot: true
   - !Generic
-    name: IRAM2
+    name: SRAM2
     range:
       start: 0x20000000
       end: 0x20008000
@@ -37,6 +37,37 @@ variants:
   - va416_spi_fram_256kb
   - va416_ebiboot_fram_256kb
   - va416_ebi_fram_512kb
+- name: VA416xx_RAM
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0x0
+  memory_map:
+  - !Ram
+    name: SRAM1
+    range:
+      start: 0x1fff8000
+      end: 0x20000000
+    cores:
+    - main
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x0
+      end: 0x40000
+    cores:
+    - main
+    access:
+      boot: true
+  - !Generic
+    name: SRAM2
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
 flash_algorithms:
 - name: va416_spi_fram_256kb
   description: VA416_SPI_FRAM_256KB


### PR DESCRIPTION
- Better naming for memory regions
- Introduce `VA416xx_RAM` variant where region 0x0-0x40000 is marked as Ram instead of Nvm. These regions are aliased for the VA416xx target.