### PR TITLE
Cleanup error handling

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/mod.rs
@@ -9,8 +9,11 @@ mod test;
 
 use anyhow::Result;
 use probe_rs::{
-    architecture::arm::ap::AccessPortError, flashing::FileDownloadError, probe::list::Lister,
-    probe::DebugProbeError, CoreDumpError, Error,
+    architecture::arm::ap::AccessPortError,
+    debug::DebugError,
+    flashing::FileDownloadError,
+    probe::{list::Lister, DebugProbeError},
+    CoreDumpError, Error,
 };
 use server::startup::debug;
 use std::{
@@ -33,6 +36,8 @@ pub enum DebuggerError {
     },
     #[error(transparent)]
     DebugProbe(#[from] DebugProbeError),
+    #[error(transparent)]
+    DebugError(#[from] DebugError),
     #[error(transparent)]
     FileDownload(#[from] FileDownloadError),
     #[error("Received an invalid requeset")]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -232,11 +232,10 @@ impl SessionData {
             };
 
             // We need to poll the core to determine its status.
-            let current_core_status = target_core.poll_core(debug_adapter).map_err(|error| {
-                let error = DebuggerError::ProbeRs(error);
-                let _ = debug_adapter.show_error_message(&error);
-                error
-            })?;
+            let current_core_status =
+                target_core.poll_core(debug_adapter).inspect_err(|error| {
+                    let _ = debug_adapter.show_error_message(&error);
+                })?;
 
             // If appropriate, check for RTT data.
             if core_config.rtt_config.enabled {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -234,7 +234,7 @@ impl SessionData {
             // We need to poll the core to determine its status.
             let current_core_status =
                 target_core.poll_core(debug_adapter).inspect_err(|error| {
-                    let _ = debug_adapter.show_error_message(&error);
+                    let _ = debug_adapter.show_error_message(error);
                 })?;
 
             // If appropriate, check for RTT data.

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["tests/"]
 
 [features]
 default = ["builtin-targets", "debug"]
-gdb-server = ["dep:gdbstub"]
+gdb-server = ["dep:gdbstub", "dep:anyhow"]
 
 # Enable all built in targets.
 builtin-targets = ["dep:bincode", "dep:serde_yaml", "dep:probe-rs-target"]
@@ -38,7 +38,6 @@ debug = [
 test = []
 
 [dependencies]
-anyhow.workspace = true
 docsplay.workspace = true
 thiserror.workspace = true
 probe-rs-target.workspace = true
@@ -78,6 +77,7 @@ hexdump = { version = "0.1", optional = true }
 
 # gdb server
 gdbstub = { version = "0.7", optional = true }
+anyhow = { workspace = true, optional = true }
 
 # debug
 gimli = { version = "0.30", default-features = false, features = [
@@ -97,6 +97,7 @@ bincode = { version = "1", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 
 [dev-dependencies]
+anyhow.workspace = true
 pretty_env_logger = "0.5"
 fastrand = "2.1"
 serde_json = "1"

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -120,7 +120,7 @@ pub fn get_arm_components(
             ApInformation::MemoryAp(MemoryApInformation {
                 debug_base_address: 0,
                 ..
-            }) => Err(Error::Other(anyhow::anyhow!("AP has a base address of 0"))),
+            }) => Err(Error::Other("AP has a base address of 0".to_string())),
             ApInformation::MemoryAp(MemoryApInformation {
                 address,
                 debug_base_address,
@@ -133,7 +133,7 @@ pub fn get_arm_components(
             }
             ApInformation::Other { address, .. } => {
                 // Return an error, only possible to get Component from MemoryAP
-                Err(Error::Other(anyhow::anyhow!(
+                Err(Error::Other(format!(
                     "AP {:#x?} is not a MemoryAP, unable to get ARM component.",
                     address
                 )))

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -25,7 +25,6 @@ use crate::{
     Architecture, CoreInformation, CoreInterface, CoreRegister, CoreStatus, CoreType,
     InstructionSet, MemoryInterface,
 };
-use anyhow::Result;
 use std::{
     mem::size_of,
     sync::Arc,
@@ -132,9 +131,9 @@ impl<'probe> Armv7a<'probe> {
     }
 
     /// Execute an instruction
-    fn execute_instruction(&mut self, instruction: u32) -> Result<Dbgdscr, Error> {
+    fn execute_instruction(&mut self, instruction: u32) -> Result<Dbgdscr, ArmError> {
         if !self.state.current_state.is_halted() {
-            return Err(Error::Arm(ArmError::CoreNotHalted));
+            return Err(ArmError::CoreNotHalted);
         }
 
         // Enable ITR if needed
@@ -168,7 +167,7 @@ impl<'probe> Armv7a<'probe> {
 
             self.memory.write_word_32(address, dbgdrcr.into())?;
 
-            return Err(Error::Arm(Armv7aError::DataAbort.into()));
+            return Err(Armv7aError::DataAbort.into());
         }
 
         Ok(dbgdscr)

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -20,7 +20,6 @@ use crate::{
     memory::valid_32bit_address,
     BreakpointCause, CoreRegister, CoreType, InstructionSet, MemoryInterface,
 };
-use anyhow::anyhow;
 use bitfield::bitfield;
 use std::{
     mem::size_of,
@@ -949,7 +948,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
                     breakpoint = FpRev2CompX::from(register_value).bpaddr() << 1;
                 } else {
                     tracing::warn!("This chip uses FPBU revision {}, which is not yet supported. HW breakpoints are not available.", ctrl_reg.rev());
-                    return Err(Error::Other(anyhow!("This chip uses FPBU revision {}, which is not yet supported. HW breakpoints are not available.", ctrl_reg.rev())));
+                    return Err(Error::Other(format!("This chip uses FPBU revision {}, which is not yet supported. HW breakpoints are not available.", ctrl_reg.rev())));
                 }
                 breakpoints.push(Some(breakpoint as u64));
             } else {
@@ -979,7 +978,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
 
         // First make sure they are asking for a breakpoint on a half-word boundary.
         if (addr & 0x1) > 0 {
-            return Err(Error::Other(anyhow!(
+            return Err(Error::Other(format!(
                 "The requested breakpoint address 0x{:08x} is not on a half-word boundary",
                 addr
             )));
@@ -995,7 +994,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
             val = FpRev2CompX::breakpoint_configuration(addr).into();
         } else {
             tracing::warn!("This chip uses FPBU revision {}, which is not yet supported. HW breakpoints are not available.", ctrl_reg.rev());
-            return Err(Error::Other(anyhow!("This chip uses FPBU revision {}, which is not yet supported. HW breakpoints are not available.", ctrl_reg.rev())));
+            return Err(Error::Other(format!("This chip uses FPBU revision {}, which is not yet supported. HW breakpoints are not available.", ctrl_reg.rev())));
         }
 
         // This is fine as FpRev1CompX and Rev2CompX are just two different

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -21,7 +21,6 @@ use crate::{
     Architecture, CoreInformation, CoreInterface, CoreRegister, CoreStatus, CoreType,
     InstructionSet, MemoryInterface,
 };
-use anyhow::Result;
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -1340,10 +1339,12 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
     }
 
     fn clear_hw_breakpoint(&mut self, bp_unit_index: usize) -> Result<(), Error> {
-        let bp_value_addr =
-            Dbgbvr::get_mmio_address_from_base(self.base_address)? + (bp_unit_index * 16) as u64;
-        let bp_control_addr =
-            Dbgbcr::get_mmio_address_from_base(self.base_address)? + (bp_unit_index * 16) as u64;
+        let bp_value_addr = Dbgbvr::get_mmio_address_from_base(self.base_address)
+            .map_err(ArmError::from)?
+            + (bp_unit_index * 16) as u64;
+        let bp_control_addr = Dbgbcr::get_mmio_address_from_base(self.base_address)
+            .map_err(ArmError::from)?
+            + (bp_unit_index * 16) as u64;
 
         self.memory.write_word_32(bp_value_addr, 0)?;
         self.memory.write_word_32(bp_value_addr + 4, 0)?;

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -1339,12 +1339,10 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
     }
 
     fn clear_hw_breakpoint(&mut self, bp_unit_index: usize) -> Result<(), Error> {
-        let bp_value_addr = Dbgbvr::get_mmio_address_from_base(self.base_address)
-            .map_err(ArmError::from)?
-            + (bp_unit_index * 16) as u64;
-        let bp_control_addr = Dbgbcr::get_mmio_address_from_base(self.base_address)
-            .map_err(ArmError::from)?
-            + (bp_unit_index * 16) as u64;
+        let bp_value_addr =
+            Dbgbvr::get_mmio_address_from_base(self.base_address)? + (bp_unit_index * 16) as u64;
+        let bp_control_addr =
+            Dbgbcr::get_mmio_address_from_base(self.base_address)? + (bp_unit_index * 16) as u64;
 
         self.memory.write_word_32(bp_value_addr, 0)?;
         self.memory.write_word_32(bp_value_addr + 4, 0)?;

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -18,7 +18,6 @@ use crate::{
     Architecture, BreakpointCause, CoreInformation, CoreInterface, CoreRegister, CoreStatus,
     CoreType, HaltReason, InstructionSet, MemoryInterface, MemoryMappedRegister,
 };
-use anyhow::Result;
 use bitfield::bitfield;
 use std::{
     mem::size_of,
@@ -331,7 +330,9 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
 
     fn write_core_reg(&mut self, address: RegisterId, value: RegisterValue) -> Result<(), Error> {
         if self.state.current_state.is_halted() {
-            super::cortex_m::write_core_reg(&mut *self.memory, address, value.try_into()?)
+            super::cortex_m::write_core_reg(&mut *self.memory, address, value.try_into()?)?;
+
+            Ok(())
         } else {
             Err(Error::Arm(ArmError::CoreNotHalted))
         }

--- a/probe-rs/src/architecture/arm/core/cortex_m.rs
+++ b/probe-rs/src/architecture/arm/core/cortex_m.rs
@@ -151,7 +151,7 @@ impl IdPfr1 {
     }
 }
 
-pub(crate) fn read_core_reg(memory: &mut dyn ArmProbe, addr: RegisterId) -> Result<u32, Error> {
+pub(crate) fn read_core_reg(memory: &mut dyn ArmProbe, addr: RegisterId) -> Result<u32, ArmError> {
     // Write the DCRSR value to select the register we want to read.
     let mut dcrsr_val = Dcrsr(0);
     dcrsr_val.set_regwnr(false); // Perform a read.
@@ -170,7 +170,7 @@ pub(crate) fn write_core_reg(
     memory: &mut dyn ArmProbe,
     addr: RegisterId,
     value: u32,
-) -> Result<(), Error> {
+) -> Result<(), ArmError> {
     memory.write_word_32(Dcrdr::get_mmio_address(), value)?;
 
     // write the DCRSR value to select the register we want to write.

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -19,7 +19,7 @@ use self::{
     sequences::ArmDebugSequenceError,
     {armv7a::Armv7aError, armv8a::Armv8aError},
 };
-use crate::probe::DebugProbeError;
+use crate::{core::memory_mapped_registers::RegisterAddressOutOfBounds, probe::DebugProbeError};
 pub use communication_interface::{
     ApInformation, ArmChipInfo, ArmCommunicationInterface, ArmProbeInterface, DapError,
     MemoryApInformation, Register,
@@ -156,9 +156,17 @@ pub enum ArmError {
     #[error("The operation requires the following extension(s): {0:?}.")]
     ExtensionRequired(&'static [&'static str]),
 
-    /// Some other error occurred.
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
+    /// An error occured while calculating the address of a register.
+    #[error("Error calculating register address.")]
+    RegisterAddressOutOfBounds(#[from] RegisterAddressOutOfBounds),
+
+    /// Some required functionality is not implemented.
+    #[error("Not implemented: {0}")]
+    NotImplemented(&'static str),
+
+    /// Another ARM error occured
+    #[error("{0}")]
+    Other(String),
 }
 
 impl ArmError {

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -939,9 +939,9 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
                     target_id,
                     dlpidr
                 );
-                return Err(ArmError::Other(anyhow::anyhow!(
-                    "Target ID and DLPIDR do not match, failed to select debug port"
-                )));
+                return Err(ArmError::Other(
+                    "Target ID and DLPIDR do not match, failed to select debug port".to_string(),
+                ));
             }
         }
 
@@ -982,10 +982,7 @@ pub trait DebugEraseSequence: Send + Sync {
     /// Some devices require the probe to be disconnected and re-attached after a successful chip-erase in
     /// which case it will return `Error::Probe(DebugProbeError::ReAttachRequired)`
     fn erase_all(&self, _interface: &mut dyn ArmProbeInterface) -> Result<(), ArmError> {
-        Err(DebugProbeError::NotImplemented {
-            function_name: "erase_all",
-        }
-        .into())
+        Err(ArmError::NotImplemented("erase_all"))
     }
 }
 

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     CoreInterface, CoreRegister, CoreStatus, CoreType, Error, HaltReason, InstructionSet,
     MemoryInterface, MemoryMappedRegister, SemihostingCommand,
 };
-use anyhow::{anyhow, Result};
+use anyhow::anyhow;
 use bitfield::bitfield;
 use communication_interface::{AbstractCommandErrorKind, RiscvCommunicationInterface, RiscvError};
 use registers::{FP, RA, RISCV_CORE_REGSISTERS, SP};

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -244,8 +244,7 @@ impl<'state> CoreInterface for Riscv32<'state> {
         } else {
             Err(Error::Other(
                 "Some cores are running while some are halted, this should not happen.".to_string(),
-            )
-            .into())
+            ))
         }
     }
 

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -12,7 +12,6 @@ use crate::{
     CoreInterface, CoreRegister, CoreStatus, CoreType, Error, HaltReason, InstructionSet,
     MemoryInterface, MemoryMappedRegister, SemihostingCommand,
 };
-use anyhow::anyhow;
 use bitfield::bitfield;
 use communication_interface::{AbstractCommandErrorKind, RiscvCommunicationInterface, RiscvError};
 use registers::{FP, RA, RISCV_CORE_REGSISTERS, SP};
@@ -243,10 +242,10 @@ impl<'state> CoreInterface for Riscv32<'state> {
         } else if status.allrunning() {
             Ok(CoreStatus::Running)
         } else {
-            Err(
-                anyhow!("Some cores are running while some are halted, this should not happen.")
-                    .into(),
+            Err(Error::Other(
+                "Some cores are running while some are halted, this should not happen.".to_string(),
             )
+            .into())
         }
     }
 

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -39,15 +39,6 @@ pub enum XtensaError {
     BatchedResultNotAvailable,
 }
 
-impl From<XtensaError> for DebugProbeError {
-    fn from(e: XtensaError) -> DebugProbeError {
-        match e {
-            XtensaError::DebugProbe(err) => err,
-            other_error => DebugProbeError::Other(other_error.into()),
-        }
-    }
-}
-
 impl From<XtensaError> for ProbeRsError {
     fn from(err: XtensaError) -> Self {
         match err {
@@ -157,8 +148,8 @@ impl<'probe> XtensaCommunicationInterface<'probe> {
     }
 
     /// Read the targets IDCODE.
-    pub fn read_idcode(&mut self) -> Result<u32, DebugProbeError> {
-        Ok(self.xdm.read_idcode()?)
+    pub fn read_idcode(&mut self) -> Result<u32, XtensaError> {
+        self.xdm.read_idcode()
     }
 
     /// Enter debug mode.
@@ -729,7 +720,7 @@ impl<'probe> MemoryInterface for XtensaCommunicationInterface<'probe> {
         false
     }
 
-    fn read_word_64(&mut self, address: u64) -> anyhow::Result<u64, crate::Error> {
+    fn read_word_64(&mut self, address: u64) -> Result<u64, crate::Error> {
         let mut out = [0; 8];
         self.read(address, &mut out)?;
 
@@ -750,25 +741,25 @@ impl<'probe> MemoryInterface for XtensaCommunicationInterface<'probe> {
         Ok(u16::from_le_bytes(out))
     }
 
-    fn read_word_8(&mut self, address: u64) -> anyhow::Result<u8, crate::Error> {
+    fn read_word_8(&mut self, address: u64) -> Result<u8, crate::Error> {
         let mut out = 0;
         self.read(address, std::slice::from_mut(&mut out))?;
         Ok(out)
     }
 
-    fn read_64(&mut self, address: u64, data: &mut [u64]) -> anyhow::Result<(), crate::Error> {
+    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), crate::Error> {
         self.read_8(address, as_bytes_mut(data))
     }
 
-    fn read_32(&mut self, address: u64, data: &mut [u32]) -> anyhow::Result<(), crate::Error> {
+    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), crate::Error> {
         self.read_8(address, as_bytes_mut(data))
     }
 
-    fn read_16(&mut self, address: u64, data: &mut [u16]) -> anyhow::Result<(), crate::Error> {
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), crate::Error> {
         self.read_8(address, as_bytes_mut(data))
     }
 
-    fn read_8(&mut self, address: u64, data: &mut [u8]) -> anyhow::Result<(), crate::Error> {
+    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), crate::Error> {
         self.read(address, data)
     }
 
@@ -778,43 +769,43 @@ impl<'probe> MemoryInterface for XtensaCommunicationInterface<'probe> {
         Ok(())
     }
 
-    fn write_word_64(&mut self, address: u64, data: u64) -> anyhow::Result<(), crate::Error> {
+    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), crate::Error> {
         self.write(address, &data.to_le_bytes())
     }
 
-    fn write_word_32(&mut self, address: u64, data: u32) -> anyhow::Result<(), crate::Error> {
+    fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), crate::Error> {
         self.write(address, &data.to_le_bytes())
     }
 
-    fn write_word_16(&mut self, address: u64, data: u16) -> anyhow::Result<(), crate::Error> {
+    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), crate::Error> {
         self.write(address, &data.to_le_bytes())
     }
 
-    fn write_word_8(&mut self, address: u64, data: u8) -> anyhow::Result<(), crate::Error> {
+    fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), crate::Error> {
         self.write(address, &[data])
     }
 
-    fn write_64(&mut self, address: u64, data: &[u64]) -> anyhow::Result<(), crate::Error> {
+    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), crate::Error> {
         self.write_8(address, as_bytes(data))
     }
 
-    fn write_32(&mut self, address: u64, data: &[u32]) -> anyhow::Result<(), crate::Error> {
+    fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), crate::Error> {
         self.write_8(address, as_bytes(data))
     }
 
-    fn write_16(&mut self, address: u64, data: &[u16]) -> anyhow::Result<(), crate::Error> {
+    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), crate::Error> {
         self.write_8(address, as_bytes(data))
     }
 
-    fn write_8(&mut self, address: u64, data: &[u8]) -> anyhow::Result<(), crate::Error> {
+    fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), crate::Error> {
         self.write(address, data)
     }
 
-    fn supports_8bit_transfers(&self) -> anyhow::Result<bool, crate::Error> {
+    fn supports_8bit_transfers(&self) -> Result<bool, crate::Error> {
         Ok(true)
     }
 
-    fn flush(&mut self) -> anyhow::Result<(), crate::Error> {
+    fn flush(&mut self) -> Result<(), crate::Error> {
         Ok(())
     }
 }

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -483,7 +483,9 @@ impl<'probe> Core<'probe> {
                 next_available_hw_breakpoint += 1;
             }
         }
-        Err(Error::Other(format!("No available hardware breakpoints")))
+        Err(Error::Other(
+            "No available hardware breakpoints".to_string(),
+        ))
     }
 
     /// Set a hardware breakpoint

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -7,7 +7,6 @@ use crate::{
     error::Error,
     CoreType, InstructionSet, MemoryInterface, Target,
 };
-use anyhow::anyhow;
 pub use probe_rs_target::{Architecture, CoreAccessOptions};
 use probe_rs_target::{
     ArmCoreAccessOptions, MemoryRegion, RiscvCoreAccessOptions, XtensaCoreAccessOptions,
@@ -484,7 +483,7 @@ impl<'probe> Core<'probe> {
                 next_available_hw_breakpoint += 1;
             }
         }
-        Err(Error::Other(anyhow!("No available hardware breakpoints")))
+        Err(Error::Other(format!("No available hardware breakpoints")))
     }
 
     /// Set a hardware breakpoint
@@ -544,7 +543,7 @@ impl<'probe> Core<'probe> {
                 self.inner.clear_hw_breakpoint(bp_position)?;
                 Ok(())
             }
-            None => Err(Error::Other(anyhow!(
+            None => Err(Error::Other(format!(
                 "No breakpoint found at address {:#010x}",
                 address
             ))),

--- a/probe-rs/src/core/dump.rs
+++ b/probe-rs/src/core/dump.rs
@@ -15,7 +15,6 @@ use crate::{
     Core, CoreType, Error, InstructionSet, MemoryInterface,
 };
 use crate::{RegisterId, RegisterValue};
-use anyhow::anyhow;
 use probe_rs_target::MemoryRange;
 use scroll::Cread;
 use serde::{Deserialize, Serialize};
@@ -203,7 +202,7 @@ impl CoreDump {
             }
         }
         // If we get here, then no range with the requested memory address and size was found.
-        Err(crate::Error::Other(anyhow!("The coredump does not include the memory for address {address:#x} of size {size_in_bytes:#x}")))
+        Err(crate::Error::Other(format!("The coredump does not include the memory for address {address:#x} of size {size_in_bytes:#x}")))
     }
 
     /// Read the requested memory range from the coredump, and return the data in the requested buffer.
@@ -218,9 +217,7 @@ impl CoreDump {
         let value_size = std::mem::size_of::<T>();
 
         for (n, data) in data.iter_mut().enumerate() {
-            let x: T = memory.cread_with::<T>(n * value_size, scroll::LE);
-
-            *data = x;
+            *data = memory.cread_with::<T>(n * value_size, scroll::LE);
         }
         Ok(())
     }

--- a/probe-rs/src/core/dump.rs
+++ b/probe-rs/src/core/dump.rs
@@ -17,12 +17,11 @@ use crate::{
 use crate::{RegisterId, RegisterValue};
 use anyhow::anyhow;
 use probe_rs_target::MemoryRange;
-use scroll::Pread;
+use scroll::Cread;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     fs::OpenOptions,
-    mem::size_of_val,
     ops::Range,
     path::{Path, PathBuf},
 };
@@ -195,10 +194,12 @@ impl CoreDump {
         &self,
         address: u64,
         size_in_bytes: u64,
-    ) -> Result<(u64, &Vec<u8>), crate::Error> {
+    ) -> Result<&[u8], crate::Error> {
         for (range, memory) in &self.data {
             if range.contains_range(&(address..(address + size_in_bytes))) {
-                return Ok((range.start, memory));
+                let offset = (address - range.start) as usize;
+
+                return Ok(&memory[offset..][..size_in_bytes as usize]);
             }
         }
         // If we get here, then no range with the requested memory address and size was found.
@@ -207,23 +208,19 @@ impl CoreDump {
 
     /// Read the requested memory range from the coredump, and return the data in the requested buffer.
     /// The word-size of the read is determined by the size of the items in the `data` buffer.
-    fn read_memory_range<'a, T>(
-        &'a self,
-        address: u64,
-        data: &'a mut [T],
-    ) -> Result<(), crate::Error>
+    fn read_memory_range<T>(&self, address: u64, data: &mut [T]) -> Result<(), crate::Error>
     where
-        <T as scroll::ctx::TryFromCtx<'a, scroll::Endian>>::Error:
-            std::convert::From<scroll::Error>,
-        <T as scroll::ctx::TryFromCtx<'a, scroll::Endian>>::Error: std::fmt::Display,
-        T: scroll::ctx::TryFromCtx<'a, scroll::Endian>,
+        T: scroll::ctx::FromCtx<scroll::Endian>,
     {
-        let (memory_offset, memory) =
-            self.get_memory_from_coredump(address, (size_of_val(data)) as u64)?;
+        let memory =
+            self.get_memory_from_coredump(address, (std::mem::size_of_val(data)) as u64)?;
+
+        let value_size = std::mem::size_of::<T>();
+
         for (n, data) in data.iter_mut().enumerate() {
-            *data = memory
-                .pread_with::<T>((address - memory_offset) as usize + n * 4, scroll::LE)
-                .map_err(|e| anyhow!("{e}"))?;
+            let x: T = memory.cread_with::<T>(n * value_size, scroll::LE);
+
+            *data = x;
         }
         Ok(())
     }

--- a/probe-rs/src/core/registers.rs
+++ b/probe-rs/src/core/registers.rs
@@ -1,7 +1,7 @@
 //! Core registers are represented by the `CoreRegister` struct, and collected in a `RegisterFile` for each of the supported architectures.
 
 use crate::Error;
-use anyhow::{anyhow, Result};
+use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,

--- a/probe-rs/src/core/registers.rs
+++ b/probe-rs/src/core/registers.rs
@@ -1,7 +1,6 @@
 //! Core registers are represented by the `CoreRegister` struct, and collected in a `RegisterFile` for each of the supported architectures.
 
 use crate::Error;
-use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
@@ -248,10 +247,9 @@ impl RegisterValue {
                     *value = reg_val;
                     Ok(())
                 } else {
-                    Err(Error::Other(anyhow!(
+                    Err(Error::Other(format!(
                         "Overflow error: Attempting to add {} bytes to Register value {}",
-                        bytes,
-                        self
+                        bytes, self
                     )))
                 }
             }
@@ -260,10 +258,9 @@ impl RegisterValue {
                     *value = reg_val;
                     Ok(())
                 } else {
-                    Err(Error::Other(anyhow!(
+                    Err(Error::Other(format!(
                         "Overflow error: Attempting to add {} bytes to Register value {}",
-                        bytes,
-                        self
+                        bytes, self
                     )))
                 }
             }
@@ -272,10 +269,9 @@ impl RegisterValue {
                     *value = reg_val;
                     Ok(())
                 } else {
-                    Err(Error::Other(anyhow!(
+                    Err(Error::Other(format!(
                         "Overflow error: Attempting to add {} bytes to Register value {}",
-                        bytes,
-                        self
+                        bytes, self
                     )))
                 }
             }
@@ -290,10 +286,9 @@ impl RegisterValue {
                     *value = reg_val;
                     Ok(())
                 } else {
-                    Err(Error::Other(anyhow!(
+                    Err(Error::Other(format!(
                         "Overflow error: Attempting to subtract {} bytes to Register value {}",
-                        bytes,
-                        self
+                        bytes, self
                     )))
                 }
             }
@@ -302,10 +297,9 @@ impl RegisterValue {
                     *value = reg_val;
                     Ok(())
                 } else {
-                    Err(Error::Other(anyhow!(
+                    Err(Error::Other(format!(
                         "Overflow error: Attempting to subtract {} bytes to Register value {}",
-                        bytes,
-                        self
+                        bytes, self
                     )))
                 }
             }
@@ -314,10 +308,9 @@ impl RegisterValue {
                     *value = reg_val;
                     Ok(())
                 } else {
-                    Err(Error::Other(anyhow!(
+                    Err(Error::Other(format!(
                         "Overflow error: Attempting to subtract {} bytes to Register value {}",
-                        bytes,
-                        self
+                        bytes, self
                     )))
                 }
             }
@@ -417,10 +410,10 @@ impl TryInto<u32> for RegisterValue {
             Self::U32(v) => Ok(v),
             Self::U64(v) => v
                 .try_into()
-                .map_err(|_| crate::Error::Other(anyhow!("Value '{}' too large for u32", v))),
+                .map_err(|_| crate::Error::Other(format!("Value '{}' too large for u32", v))),
             Self::U128(v) => v
                 .try_into()
-                .map_err(|_| crate::Error::Other(anyhow!("Value '{}' too large for u32", v))),
+                .map_err(|_| crate::Error::Other(format!("Value '{}' too large for u32", v))),
         }
     }
 }
@@ -434,7 +427,7 @@ impl TryInto<u64> for RegisterValue {
             Self::U64(v) => Ok(v),
             Self::U128(v) => v
                 .try_into()
-                .map_err(|_| crate::Error::Other(anyhow!("Value '{}' too large for u64", v))),
+                .map_err(|_| crate::Error::Other(format!("Value '{}' too large for u64", v))),
         }
     }
 }

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -12,9 +12,8 @@ use crate::{
         registers, stack_frame::StackFrameInfo, unit_info::RangeExt, SourceLocation,
         VerifiedBreakpoint,
     },
-    MemoryInterface,
+    Error, MemoryInterface,
 };
-use anyhow::anyhow;
 use gimli::{
     BaseAddresses, DebugFrame, DebugInfoOffset, UnwindContext, UnwindSection, UnwindTableRow,
 };
@@ -289,7 +288,7 @@ impl DebugInfo {
 
                 let Some(unit_info) = unit_infos.next() else {
                     // No unit infos
-                    return Err(DebugError::Other(anyhow::anyhow!("Missing unit infos")));
+                    return Err(DebugError::Other(format!("Missing unit infos")));
                 };
 
                 let mut entries = unit_info.unit.entries();
@@ -917,7 +916,7 @@ impl DebugInfo {
                 return Ok((unit_info, function_dies));
             }
         }
-        Err(DebugError::Other(anyhow::anyhow!(
+        Err(DebugError::Other(format!(
             "No function DIE's at address {address:#x}."
         )))
     }
@@ -927,16 +926,15 @@ impl DebugInfo {
         for unit_info in &self.unit_infos {
             if let Some(unit_offset) = offset.to_unit_offset(&unit_info.unit.header) {
                 return unit_info.unit.entry(unit_offset).map_err(|error| {
-                    DebugError::Other(anyhow::anyhow!(
+                    DebugError::Other(format!(
                         "Error reading DIE at debug info offset {:#x} : {}",
-                        offset.0,
-                        error
+                        offset.0, error
                     ))
                 });
             }
         }
 
-        Err(DebugError::Other(anyhow::anyhow!(
+        Err(DebugError::Other(format!(
             "DIE at debug info offset {:#010x} not found",
             offset.0
         )))
@@ -989,10 +987,9 @@ pub fn get_unwind_info<'a>(
     frame_program_counter: u64,
 ) -> Result<&'a gimli::UnwindTableRow<GimliReaderOffset>, DebugError> {
     let transform_error = |error| {
-        DebugError::Other(anyhow::anyhow!(
+        DebugError::Other(format!(
             "UNWIND: Error reading FrameDescriptorEntry at PC={} : {}",
-            frame_program_counter,
-            error
+            frame_program_counter, error
         ))
     };
 
@@ -1125,20 +1122,18 @@ pub fn unwind_register(
                         .get_register_value_by_role(&RegisterRole::ProgramCounter)
                     else {
                         return ControlFlow::Break(
-                            anyhow!(
+                            crate::Error::Other(format!(
                                 "UNWIND: Tried to unwind return address value where current program counter is unknown."
-                            )
-                            .into(),
+                            ))
                         );
                     };
                     let Ok(current_lr) = callee_frame_registers
                         .get_register_value_by_role(&RegisterRole::ReturnAddress)
                     else {
                         return ControlFlow::Break(
-                            anyhow!(
+                            crate::Error::Other(format!(
                                 "UNWIND: Tried to unwind return address value where current return address is unknown."
-                            )
-                            .into(),
+                            ))
                         );
                     };
                     *unwound_return_address = if current_pc == current_lr & !0b1 {
@@ -1202,9 +1197,9 @@ pub fn unwind_register(
         RegisterRule::Offset(address_offset) => {
             // "The previous value of this register is saved at the address CFA+N where CFA is the current CFA value and N is a signed offset"
             let Some(unwind_cfa) = unwind_cfa else {
-                return ControlFlow::Break(
-                    anyhow!("UNWIND: Tried to unwind `RegisterRule` at CFA = None.").into(),
-                );
+                return ControlFlow::Break(crate::Error::Other(format!(
+                    "UNWIND: Tried to unwind `RegisterRule` at CFA = None."
+                )));
             };
             let address_size = callee_frame_registers.get_address_size_bytes();
             let previous_frame_register_address =
@@ -1225,9 +1220,10 @@ pub fn unwind_register(
                         .map(|_| RegisterValue::U64(u64::from_le_bytes(buff)))
                 }
                 _ => {
-                    return ControlFlow::Break(
-                        anyhow!("UNWIND: Address size {} not supported.", address_size).into(),
-                    );
+                    return ControlFlow::Break(Error::Other(format!(
+                        "UNWIND: Address size {} not supported.",
+                        address_size
+                    )));
                 }
             };
 
@@ -1250,14 +1246,13 @@ pub fn unwind_register(
                     );
 
                     return ControlFlow::Break(
-                        anyhow!(
+                        Error::Other(format!(
                             "UNWIND: Failed to read value for register {} from address {} ({} bytes): {}",
                             debug_register.get_register_name(),
                             RegisterValue::from(previous_frame_register_address),
                             4,
                             error
-                        )
-                        .into(),
+                        )),
                     );
                 }
             }

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -288,7 +288,7 @@ impl DebugInfo {
 
                 let Some(unit_info) = unit_infos.next() else {
                     // No unit infos
-                    return Err(DebugError::Other(format!("Missing unit infos")));
+                    return Err(DebugError::Other("Missing unit infos".to_string()));
                 };
 
                 let mut entries = unit_info.unit.entries();

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -1122,18 +1122,18 @@ pub fn unwind_register(
                         .get_register_value_by_role(&RegisterRole::ProgramCounter)
                     else {
                         return ControlFlow::Break(
-                            crate::Error::Other(format!(
-                                "UNWIND: Tried to unwind return address value where current program counter is unknown."
-                            ))
+                            crate::Error::Other(
+                                "UNWIND: Tried to unwind return address value where current program counter is unknown.".to_string()
+                            )
                         );
                     };
                     let Ok(current_lr) = callee_frame_registers
                         .get_register_value_by_role(&RegisterRole::ReturnAddress)
                     else {
                         return ControlFlow::Break(
-                            crate::Error::Other(format!(
-                                "UNWIND: Tried to unwind return address value where current return address is unknown."
-                            ))
+                            crate::Error::Other(
+                                "UNWIND: Tried to unwind return address value where current return address is unknown.".to_string()
+                            )
                         );
                     };
                     *unwound_return_address = if current_pc == current_lr & !0b1 {
@@ -1197,9 +1197,9 @@ pub fn unwind_register(
         RegisterRule::Offset(address_offset) => {
             // "The previous value of this register is saved at the address CFA+N where CFA is the current CFA value and N is a signed offset"
             let Some(unwind_cfa) = unwind_cfa else {
-                return ControlFlow::Break(crate::Error::Other(format!(
-                    "UNWIND: Tried to unwind `RegisterRule` at CFA = None."
-                )));
+                return ControlFlow::Break(crate::Error::Other(
+                    "UNWIND: Tried to unwind `RegisterRule` at CFA = None.".to_string(),
+                ));
             };
             let address_size = callee_frame_registers.get_address_size_bytes();
             let previous_frame_register_address =

--- a/probe-rs/src/debug/debug_step.rs
+++ b/probe-rs/src/debug/debug_step.rs
@@ -47,9 +47,9 @@ impl SteppingMode {
                 .read_core_reg(core.program_counter().id())?
                 .try_into()?,
             _ => {
-                return Err(DebugError::Other(format!(
-                    "Core must be halted before stepping."
-                )))
+                return Err(DebugError::Other(
+                    "Core must be halted before stepping.".to_string(),
+                ))
             }
         };
         let origin_program_counter = program_counter;

--- a/probe-rs/src/debug/exception_handling.rs
+++ b/probe-rs/src/debug/exception_handling.rs
@@ -2,9 +2,9 @@
 
 use probe_rs_target::CoreType;
 
-use crate::{Error, MemoryInterface};
+use crate::MemoryInterface;
 
-use super::{DebugInfo, DebugRegisters, StackFrame};
+use super::{DebugError, DebugInfo, DebugRegisters, StackFrame};
 
 pub(crate) mod armv6m;
 /// Where applicable, this defines shared logic for implementing exception handling across the various ARMv6-m and ARMv7-m [`crate::CoreType`]'s.
@@ -36,7 +36,7 @@ impl ExceptionInterface for UnimplementedExceptionHandler {
         _memory: &mut dyn MemoryInterface,
         _stackframe_registers: &DebugRegisters,
         _debug_info: &DebugInfo,
-    ) -> Result<Option<ExceptionInfo>, Error> {
+    ) -> Result<Option<ExceptionInfo>, DebugError> {
         // For architectures where the exception handling has not been implemented in probe-rs,
         // this will result in maintaining the current `unwind` behavior, i.e. unwinding will include up
         // to the first frame that was called from an exception handler.
@@ -48,15 +48,15 @@ impl ExceptionInterface for UnimplementedExceptionHandler {
         _memory: &mut dyn MemoryInterface,
         _stackframe_registers: &crate::debug::DebugRegisters,
         _raw_exception: u32,
-    ) -> Result<crate::debug::DebugRegisters, crate::Error> {
-        Err(Error::NotImplemented("calling frame registers"))
+    ) -> Result<crate::debug::DebugRegisters, DebugError> {
+        Err(DebugError::NotImplemented("calling frame registers"))
     }
 
     fn raw_exception(
         &self,
         _stackframe_registers: &crate::debug::DebugRegisters,
-    ) -> Result<u32, crate::Error> {
-        Err(Error::NotImplemented(
+    ) -> Result<u32, DebugError> {
+        Err(DebugError::NotImplemented(
             "Not implemented for this architecture.",
         ))
     }
@@ -65,8 +65,8 @@ impl ExceptionInterface for UnimplementedExceptionHandler {
         &self,
         _raw_exception: u32,
         _memory: &mut dyn MemoryInterface,
-    ) -> Result<String, crate::Error> {
-        Err(Error::NotImplemented("exception description"))
+    ) -> Result<String, DebugError> {
+        Err(DebugError::NotImplemented("exception description"))
     }
 }
 
@@ -97,7 +97,7 @@ pub trait ExceptionInterface {
         memory: &mut dyn MemoryInterface,
         stackframe_registers: &DebugRegisters,
         debug_info: &DebugInfo,
-    ) -> Result<Option<ExceptionInfo>, Error>;
+    ) -> Result<Option<ExceptionInfo>, DebugError>;
 
     /// Using the `stackframe_registers` for a "called frame", retrieve updated register values for the "calling frame".
     fn calling_frame_registers(
@@ -105,13 +105,13 @@ pub trait ExceptionInterface {
         memory: &mut dyn MemoryInterface,
         stackframe_registers: &crate::debug::DebugRegisters,
         raw_exception: u32,
-    ) -> Result<crate::debug::DebugRegisters, crate::Error>;
+    ) -> Result<crate::debug::DebugRegisters, DebugError>;
 
     /// Retrieve the architecture specific exception number.
     fn raw_exception(
         &self,
         stackframe_registers: &crate::debug::DebugRegisters,
-    ) -> Result<u32, crate::Error>;
+    ) -> Result<u32, DebugError>;
 
     /// Convert the architecture specific exception number into a human readable description.
     /// Where possible, the implementation may read additional registers from the core, to provide additional context.
@@ -119,5 +119,5 @@ pub trait ExceptionInterface {
         &self,
         raw_exception: u32,
         memory: &mut dyn MemoryInterface,
-    ) -> Result<String, crate::Error>;
+    ) -> Result<String, DebugError>;
 }

--- a/probe-rs/src/debug/exception_handling/armv7m.rs
+++ b/probe-rs/src/debug/exception_handling/armv7m.rs
@@ -1,6 +1,6 @@
 use super::{armv6m_armv7m_shared, ExceptionInfo, ExceptionInterface};
 use crate::{
-    debug::{DebugInfo, DebugRegisters},
+    debug::{DebugError, DebugInfo, DebugRegisters},
     memory_mapped_bitfield_register, Error, MemoryInterface, MemoryMappedRegister,
 };
 
@@ -321,7 +321,7 @@ impl ExceptionInterface for ArmV7MExceptionHandler {
         memory_interface: &mut dyn MemoryInterface,
         stackframe_registers: &DebugRegisters,
         debug_info: &DebugInfo,
-    ) -> Result<Option<ExceptionInfo>, Error> {
+    ) -> Result<Option<ExceptionInfo>, DebugError> {
         armv6m_armv7m_shared::exception_details(
             self,
             memory_interface,
@@ -335,7 +335,7 @@ impl ExceptionInterface for ArmV7MExceptionHandler {
         memory_interface: &mut dyn MemoryInterface,
         stackframe_registers: &crate::debug::DebugRegisters,
         raw_exception: u32,
-    ) -> Result<crate::debug::DebugRegisters, crate::Error> {
+    ) -> Result<crate::debug::DebugRegisters, DebugError> {
         let mut updated_registers = stackframe_registers.clone();
 
         // Identify the correct location for the exception context. This is different between Armv6-M and Armv7-M.
@@ -359,15 +359,18 @@ impl ExceptionInterface for ArmV7MExceptionHandler {
     fn raw_exception(
         &self,
         stackframe_registers: &crate::debug::DebugRegisters,
-    ) -> Result<u32, Error> {
-        armv6m_armv7m_shared::raw_exception(stackframe_registers)
+    ) -> Result<u32, DebugError> {
+        let value = armv6m_armv7m_shared::raw_exception(stackframe_registers)?;
+        Ok(value)
     }
 
     fn exception_description(
         &self,
         raw_exception: u32,
         memory_interface: &mut dyn MemoryInterface,
-    ) -> Result<String, crate::Error> {
-        ExceptionReason::from(raw_exception).expanded_description(memory_interface)
+    ) -> Result<String, DebugError> {
+        let description =
+            ExceptionReason::from(raw_exception).expanded_description(memory_interface)?;
+        Ok(description)
     }
 }

--- a/probe-rs/src/debug/language.rs
+++ b/probe-rs/src/debug/language.rs
@@ -99,7 +99,7 @@ impl ProgrammingLanguage for UnknownLanguage {
         _memory: &mut dyn MemoryInterface,
         _new_value: &str,
     ) -> Result<(), DebugError> {
-        Err(DebugError::Other(anyhow::anyhow!(
+        Err(DebugError::Other(format!(
             "Updating variables for language {} is not supported.",
             self.0
         )))

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -39,6 +39,7 @@ use gimli::EvaluationResult;
 use serde::Serialize;
 use typed_path::TypedPathBuf;
 
+use std::num::ParseIntError;
 use std::{
     io,
     num::NonZeroU32,
@@ -82,9 +83,13 @@ pub enum DebugError {
         /// A message that can be displayed to the user to help them understand the reason for the incomplete results.
         message: String,
     },
+
+    #[error("Not implemented: {0}")]
+    NotImplemented(&'static str),
+
     /// Some other error occurred.
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
+    #[error("{0}")]
+    Other(String),
 }
 
 /// A copy of [`gimli::ColumnType`] which uses [`u64`] instead of [`NonZeroU64`](std::num::NonZeroU64).
@@ -156,7 +161,7 @@ impl From<i64> for ObjectRef {
 }
 
 impl std::str::FromStr for ObjectRef {
-    type Err = anyhow::Error;
+    type Err = ParseIntError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let value = s.parse::<i64>()?;

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -84,6 +84,7 @@ pub enum DebugError {
         message: String,
     },
 
+    /// Required functionality is not implemented
     #[error("Not implemented: {0}")]
     NotImplemented(&'static str),
 

--- a/probe-rs/src/debug/source_instructions.rs
+++ b/probe-rs/src/debug/source_instructions.rs
@@ -158,7 +158,7 @@ impl VerifiedBreakpoint {
             }
         }
         // If we get here, we have not found a valid breakpoint location.
-        Err(DebugError::Other(anyhow::anyhow!("No valid breakpoint information found for file: {}, line: {line:?}, column: {column:?}", path.to_path().display())))
+        Err(DebugError::Other(format!("No valid breakpoint information found for file: {}, line: {line:?}, column: {column:?}", path.to_path().display())))
     }
 }
 

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -54,9 +54,9 @@ impl UnitInfo {
     }
 
     pub(crate) fn debug_info_offset(&self) -> Result<DebugInfoOffset, DebugError> {
-        self.unit.header.offset().as_debug_info_offset().ok_or_else(|| DebugError::Other(format!(
-            "Failed to convert unit header offset to debug info offset. This is a bug, please report it."
-        )))
+        self.unit.header.offset().as_debug_info_offset().ok_or_else(|| DebugError::Other(
+            "Failed to convert unit header offset to debug info offset. This is a bug, please report it.".to_string()
+        ))
     }
 
     /// Get the compilation unit DIEs for the function containing the given address.

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -54,7 +54,7 @@ impl UnitInfo {
     }
 
     pub(crate) fn debug_info_offset(&self) -> Result<DebugInfoOffset, DebugError> {
-        self.unit.header.offset().as_debug_info_offset().ok_or_else(|| DebugError::Other(anyhow::anyhow!(
+        self.unit.header.offset().as_debug_info_offset().ok_or_else(|| DebugError::Other(format!(
             "Failed to convert unit header offset to debug info offset. This is a bug, please report it."
         )))
     }
@@ -822,7 +822,7 @@ impl UnitInfo {
                 gimli::DW_AT_lower_bound => match attr.value().udata_value() {
                     Some(bound) => lower_bound = Some(bound),
                     None => {
-                        return Err(DebugError::Other(anyhow::anyhow!(
+                        return Err(DebugError::Other(format!(
                             "Unimplemented: Attribute Value for DW_AT_lower_bound: {:?}",
                             attr.value()
                         )));
@@ -831,7 +831,7 @@ impl UnitInfo {
                 gimli::DW_AT_count => match attr.value().udata_value() {
                     Some(count) => upper_bound = Some(count),
                     None => {
-                        return Err(DebugError::Other(anyhow::anyhow!(
+                        return Err(DebugError::Other(format!(
                             "Unimplemented: Attribute Value for DW_AT_count: {:?}",
                             attr.value()
                         )));
@@ -842,7 +842,7 @@ impl UnitInfo {
                         // Rust ranges are exclusive, but the DWARF upper bound is inclusive.
                         Some(bound) => upper_bound = Some(bound + 1),
                         None => {
-                            return Err(DebugError::Other(anyhow::anyhow!(
+                            return Err(DebugError::Other(format!(
                                 "Unimplemented: Attribute Value for DW_AT_upper_bound: {:?}",
                                 attr.value()
                             )));

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -1,7 +1,6 @@
 use crate::debug::{language::ProgrammingLanguage, unit_info::UnitInfo};
 
 use super::*;
-use anyhow::anyhow;
 use gimli::{DebugInfoOffset, DwLang, UnitOffset};
 use itertools::Itertools;
 use std::ops::Range;
@@ -558,10 +557,10 @@ impl Variable {
         let valid_memory = self.memory_location.valid();
         if !valid_value || !valid_type || !valid_memory {
             // Insufficient data available.
-            Err(anyhow!(
+            Err(DebugError::Other(format!(
                 "Cannot update variable: {:?}, with supplied information (value={:?}, type={:?}, memory location={:#010x?}).",
                 self.name, self.value, self.type_name, self.memory_location
-            ).into())
+            )))
         } else {
             // We have everything we need to update the variable value.
             language::from_dwarf(self.language)

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -2,6 +2,7 @@ use crate::architecture::arm::ArmError;
 use crate::architecture::riscv::communication_interface::RiscvError;
 use crate::architecture::xtensa::communication_interface::XtensaError;
 use crate::config::RegistryError;
+use crate::core::memory_mapped_registers::RegisterAddressOutOfBounds;
 use crate::probe::DebugProbeError;
 
 /// The overarching error type which contains all possible errors as variants.
@@ -29,6 +30,9 @@ pub enum Error {
     GenericCoreError(String),
     /// Errors accessing core register: {0}
     Register(String),
+
+    /// Error calculating the address of a register
+    RegisterAddressOutOfBounds(#[from] RegisterAddressOutOfBounds),
     /// The {0} capability has not yet been implemented for this architecture.
     ///
     /// Because of the large varieties of supported architectures, it is not always possible for

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -32,6 +32,7 @@ pub enum Error {
     Register(String),
 
     /// Error calculating the address of a register
+    #[error(transparent)]
     RegisterAddressOutOfBounds(#[from] RegisterAddressOutOfBounds),
     /// The {0} capability has not yet been implemented for this architecture.
     ///
@@ -42,7 +43,7 @@ pub enum Error {
     NotImplemented(&'static str),
     /// Some uncategorized error occurred.
     #[display("{0}")]
-    Other(#[from] anyhow::Error),
+    Other(String),
     /// A timeout occurred.
     // TODO: Errors below should be core specific
     Timeout,

--- a/probe-rs/src/gdb_server/stub.rs
+++ b/probe-rs/src/gdb_server/stub.rs
@@ -1,5 +1,4 @@
 use crate::{CoreType, Session};
-use anyhow::Result;
 use parking_lot::FairMutex;
 
 use std::net::{SocketAddr, ToSocketAddrs};
@@ -84,7 +83,7 @@ impl GdbInstanceConfiguration {
 pub fn run<'a>(
     session: &FairMutex<Session>,
     instances: impl Iterator<Item = &'a GdbInstanceConfiguration>,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     // Turn our group list into GDB targets
     let mut targets = instances
         .map(|instance| {

--- a/probe-rs/src/gdb_server/target/desc/mod.rs
+++ b/probe-rs/src/gdb_server/target/desc/mod.rs
@@ -26,9 +26,10 @@ impl TargetDescriptionXmlOverride for RuntimeTarget<'_> {
     ) -> gdbstub::target::TargetResult<usize, Self> {
         let annex = String::from_utf8_lossy(annex);
         if annex != "target.xml" {
-            return Err(TargetError::Fatal(
-                anyhow!("Unsupported annex: '{}'", annex).into(),
-            ));
+            return Err(TargetError::Fatal(anyhow!(
+                "Unsupported annex: '{}'",
+                annex
+            )));
         }
 
         let xml = self.target_desc.get_target_xml();

--- a/probe-rs/src/gdb_server/target/traits.rs
+++ b/probe-rs/src/gdb_server/target/traits.rs
@@ -1,28 +1,7 @@
 use super::RuntimeTarget;
 use crate::Error;
 
-use gdbstub::stub::GdbStubError;
 use gdbstub::target::{TargetError, TargetResult};
-
-pub(crate) trait ProbeRsErrorExt<T> {
-    fn into_error(self) -> Result<T, Error>;
-}
-
-impl<T> ProbeRsErrorExt<T> for Result<T, std::io::Error> {
-    fn into_error(self) -> Result<T, Error> {
-        self.map_err(|e| Error::Other(e.into()))
-    }
-}
-
-impl<T> ProbeRsErrorExt<T> for Result<T, GdbStubError<Error, std::io::Error>> {
-    fn into_error(self) -> Result<T, Error> {
-        match self {
-            Ok(v) => Ok(v),
-            Err(e) if e.is_target_error() => Err(e.into_target_error().unwrap()),
-            Err(other) => Err(anyhow::Error::new(other).into()),
-        }
-    }
-}
 
 pub(crate) trait GdbErrorExt<T> {
     fn into_target_result(self) -> TargetResult<T, RuntimeTarget<'static>>;
@@ -34,7 +13,7 @@ impl<T> GdbErrorExt<T> for Result<T, Error> {
     fn into_target_result(self) -> TargetResult<T, RuntimeTarget<'static>> {
         match self {
             Ok(v) => Ok(v),
-            Err(e) => Err(TargetError::Fatal(e)),
+            Err(e) => Err(TargetError::Fatal(e.into())),
         }
     }
 
@@ -56,7 +35,7 @@ impl<T> GdbErrorExt<T> for Result<T, Error> {
                 // EIO
                 Err(TargetError::Errno(122))
             }
-            Err(e) => Err(TargetError::Fatal(e)),
+            Err(e) => Err(TargetError::Fatal(e.into())),
         }
     }
 }

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -1,6 +1,5 @@
 use crate::error::Error;
 
-use anyhow::{anyhow, Result};
 use scroll::Pread;
 
 /// An interface to be implemented for drivers that allow target memory access.
@@ -67,7 +66,7 @@ pub trait MemoryInterface {
         // provide an implementation that avoids heap allocation and endian
         // conversions. Must be overridden for big endian targets.
         if data.len() % 8 != 0 {
-            return Err(Error::Other(anyhow!(
+            return Err(Error::Other(format!(
                 "Call to read_mem_64bit with data.len() not a multiple of 8"
             )));
         }
@@ -89,7 +88,7 @@ pub trait MemoryInterface {
         // provide an implementation that avoids heap allocation and endian
         // conversions. Must be overridden for big endian targets.
         if data.len() % 4 != 0 {
-            return Err(Error::Other(anyhow!(
+            return Err(Error::Other(format!(
                 "Call to read_mem_32bit with data.len() not a multiple of 4"
             )));
         }
@@ -180,7 +179,7 @@ pub trait MemoryInterface {
         // provide an implementation that avoids heap allocation and endian
         // conversions. Must be overridden for big endian targets.
         if data.len() % 8 != 0 {
-            return Err(Error::Other(anyhow!(
+            return Err(Error::Other(format!(
                 "Call to read_mem_64bit with data.len() not a multiple of 8"
             )));
         }
@@ -203,7 +202,7 @@ pub trait MemoryInterface {
         // provide an implementation that avoids heap allocation and endian
         // conversions. Must be overridden for big endian targets.
         if data.len() % 4 != 0 {
-            return Err(Error::Other(anyhow!(
+            return Err(Error::Other(format!(
                 "Call to read_mem_32bit with data.len() not a multiple of 4"
             )));
         }
@@ -370,7 +369,7 @@ where
 pub(crate) fn valid_32bit_address(address: u64) -> Result<u32, Error> {
     let address: u32 = address
         .try_into()
-        .map_err(|_| anyhow!("Address {:#08x} out of range", address))?;
+        .map_err(|_| Error::Other(format!("Address {:#08x} out of range", address)))?;
 
     Ok(address)
 }

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -66,9 +66,10 @@ pub trait MemoryInterface {
         // provide an implementation that avoids heap allocation and endian
         // conversions. Must be overridden for big endian targets.
         if data.len() % 8 != 0 {
-            return Err(Error::Other(format!(
-                "Call to read_mem_64bit with data.len() not a multiple of 8"
-            )));
+            return Err(
+                Error::Other("Call to read_mem_64bit with data.len() not a multiple of 8")
+                    .to_string()),
+            );
         }
         let mut buffer = vec![0u64; data.len() / 8];
         self.read_64(address, &mut buffer)?;
@@ -179,9 +180,9 @@ pub trait MemoryInterface {
         // provide an implementation that avoids heap allocation and endian
         // conversions. Must be overridden for big endian targets.
         if data.len() % 8 != 0 {
-            return Err(Error::Other(format!(
-                "Call to read_mem_64bit with data.len() not a multiple of 8"
-            )));
+            return Err(Error::Other(
+                "Call to read_mem_64bit with data.len() not a multiple of 8".to_string(),
+            ));
         }
         let mut buffer = vec![0u64; data.len() / 8];
         for (bytes, value) in data.chunks_exact(8).zip(buffer.iter_mut()) {

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -66,10 +66,9 @@ pub trait MemoryInterface {
         // provide an implementation that avoids heap allocation and endian
         // conversions. Must be overridden for big endian targets.
         if data.len() % 8 != 0 {
-            return Err(
-                Error::Other("Call to read_mem_64bit with data.len() not a multiple of 8")
-                    .to_string()),
-            );
+            return Err(Error::Other(
+                "Call to read_mem_64bit with data.len() not a multiple of 8".to_string(),
+            ));
         }
         let mut buffer = vec![0u64; data.len() / 8];
         self.read_64(address, &mut buffer)?;
@@ -89,9 +88,9 @@ pub trait MemoryInterface {
         // provide an implementation that avoids heap allocation and endian
         // conversions. Must be overridden for big endian targets.
         if data.len() % 4 != 0 {
-            return Err(Error::Other(format!(
-                "Call to read_mem_32bit with data.len() not a multiple of 4"
-            )));
+            return Err(Error::Other(
+                "Call to read_mem_32bit with data.len() not a multiple of 4".to_string(),
+            ));
         }
         let mut buffer = vec![0u32; data.len() / 4];
         self.read_32(address, &mut buffer)?;
@@ -203,9 +202,9 @@ pub trait MemoryInterface {
         // provide an implementation that avoids heap allocation and endian
         // conversions. Must be overridden for big endian targets.
         if data.len() % 4 != 0 {
-            return Err(Error::Other(format!(
-                "Call to read_mem_32bit with data.len() not a multiple of 4"
-            )));
+            return Err(Error::Other(
+                "Call to read_mem_32bit with data.len() not a multiple of 4".to_string(),
+            ));
         }
         let mut buffer = vec![0u32; data.len() / 4];
         for (bytes, value) in data.chunks_exact(4).zip(buffer.iter_mut()) {

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -316,13 +316,14 @@ impl Probe {
             |e| match e {
                 Error::Arm(ArmError::Timeout)
                 | Error::Riscv(RiscvError::Timeout)
-                | Error::Xtensa(XtensaError::Timeout) => Error::Other(format!(
+                | Error::Xtensa(XtensaError::Timeout) => Error::Other(
                     "Timeout while attaching to target under reset. \
                     This can happen if the target is not responding to the reset sequence. \
                     Ensure the chip's reset pin is connected, or try attaching without reset \
                     (`connectUnderReset = false` for DAP Clients, or remove `connect-under-reset` \
                         option from CLI options.)."
-                )),
+                        .to_string(),
+                ),
                 e => e,
             },
         )

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -181,7 +181,8 @@ pub enum DebugProbeError {
     /// An error occured handling the JTAG scan chain.
     JtagScanChain(#[from] ScanChainError),
 
-    /// Another error occurred.
+    /// Some other error occured
+    #[display("{0}")]
     Other(String),
 
     /// A timeout occurred during probe operation.
@@ -315,7 +316,7 @@ impl Probe {
             |e| match e {
                 Error::Arm(ArmError::Timeout)
                 | Error::Riscv(RiscvError::Timeout)
-                | Error::Xtensa(XtensaError::Timeout) => Error::Other(anyhow::anyhow!(
+                | Error::Xtensa(XtensaError::Timeout) => Error::Other(format!(
                     "Timeout while attaching to target under reset. \
                     This can happen if the target is not responding to the reset sequence. \
                     Ensure the chip's reset pin is connected, or try attaching without reset \

--- a/probe-rs/src/probe/arm_debug_interface.rs
+++ b/probe-rs/src/probe/arm_debug_interface.rs
@@ -998,7 +998,7 @@ impl<Probe: DebugProbe + RawProtocolIo + JTAGAccess + 'static> RawDapAccess for 
                         "Error in access {}/{} of block access: {:?}",
                         i + 1,
                         values.len(),
-                        anyhow::anyhow!(err)
+                        err
                     );
                     return Err(err.into());
                 }

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -2,7 +2,6 @@
 
 use std::iter;
 
-use anyhow::anyhow;
 use bitfield::bitfield;
 use bitvec::prelude::*;
 use probe_rs_target::ScanChainElement;
@@ -496,7 +495,7 @@ fn shift_ir(
 
     // Check the bit length, enough data has to be available
     if data.len() * 8 < len || len == 0 {
-        return Err(DebugProbeError::Other(anyhow!(
+        return Err(DebugProbeError::Other(format!(
             "Invalid data length. IR bits: {}, expected: {}",
             data.len(),
             len
@@ -550,7 +549,7 @@ fn shift_dr(
 
     // Check the bit length, enough data has to be available
     if data.len() * 8 < register_bits || register_bits == 0 {
-        return Err(DebugProbeError::Other(anyhow!(
+        return Err(DebugProbeError::Other(format!(
             "Invalid data length. DR bits: {}, expected: {}",
             data.len(),
             register_bits
@@ -614,7 +613,7 @@ fn prepare_write_register(
 ) -> Result<usize, DebugProbeError> {
     if protocol.state().current_ir_reg != address {
         if address > protocol.state().max_ir_address {
-            return Err(DebugProbeError::Other(anyhow!(
+            return Err(DebugProbeError::Other(format!(
                 "Invalid instruction register access: {}",
                 address
             )));
@@ -644,7 +643,7 @@ impl<Probe: DebugProbe + RawJtagIo + 'static> JTAGAccess for Probe {
 
         tracing::debug!("DR: {:?}", response);
 
-        let idcodes = extract_idcodes(&response).map_err(|e| DebugProbeError::Other(e.into()))?;
+        let idcodes = extract_idcodes(&response)?;
 
         tracing::info!(
             "JTAG DR scan complete, found {} TAPs. {:?}",
@@ -692,8 +691,7 @@ impl<Probe: DebugProbe + RawJtagIo + 'static> JTAGAccess for Probe {
                         .collect::<Vec<usize>>()
                 })
                 .as_deref(),
-        )
-        .map_err(|e| DebugProbeError::Other(e.into()))?;
+        )?;
 
         tracing::info!("Found {} TAPs on reset scan", idcodes.len());
         tracing::debug!("Detected IR lens: {:?}", ir_lens);

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -319,9 +319,9 @@ impl DebugProbe for FakeProbe {
     fn scan_chain(&self) -> Result<&[ScanChainElement], DebugProbeError> {
         match &self.scan_chain {
             Some(chain) => Ok(chain),
-            None => Err(DebugProbeError::Other(anyhow::anyhow!(
-                "No scan chain set for fake probe"
-            ))),
+            None => Err(DebugProbeError::Other(
+                "No scan chain set for fake probe".to_string(),
+            )),
         }
     }
 

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -17,7 +17,6 @@ use crate::{
         ProbeCreationError, ProbeFactory, ScanChainElement, WireProtocol,
     },
 };
-use anyhow::anyhow;
 use bitvec::prelude::*;
 use nusb::DeviceInfo;
 use std::{
@@ -160,7 +159,7 @@ impl JtagAdapter {
         }
 
         if reply.len() != self.in_bit_counts.len() {
-            return Err(DebugProbeError::Other(anyhow!(
+            return Err(DebugProbeError::Other(format!(
                 "Read more data than expected. Expected {} bytes, got {} bytes",
                 self.in_bit_counts.len(),
                 reply.len()

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -746,7 +746,7 @@ impl JLink {
         tracing::debug!("Buffer length for j-link transfer: {}", buf.len());
 
         if buf.len() > self.max_mem_block_size as usize {
-            return Err(DebugProbeError::Other(anyhow::anyhow!("Maximum transfer size for this probe is {} bytes, but current transfer is {} bytes", self.max_mem_block_size, buf.len())));
+            return Err(DebugProbeError::Other(format!("Maximum transfer size for this probe is {} bytes, but current transfer is {} bytes", self.max_mem_block_size, buf.len())));
         } else {
             tracing::debug!(
                 "Transferring {} bytes, max is {}",

--- a/probe-rs/src/test.rs
+++ b/probe-rs/src/test.rs
@@ -78,30 +78,30 @@ impl MemoryInterface for MockMemory {
         false
     }
 
-    fn read_word_64(&mut self, _address: u64) -> anyhow::Result<u64, crate::Error> {
+    fn read_word_64(&mut self, _address: u64) -> Result<u64, crate::Error> {
         todo!()
     }
 
-    fn read_word_32(&mut self, address: u64) -> anyhow::Result<u32, crate::Error> {
+    fn read_word_32(&mut self, address: u64) -> Result<u32, crate::Error> {
         let mut bytes = [0u8; 4];
         self.read_8(address, &mut bytes)?;
 
         Ok(u32::from_le_bytes(bytes))
     }
 
-    fn read_word_8(&mut self, _address: u64) -> anyhow::Result<u8, crate::Error> {
+    fn read_word_8(&mut self, _address: u64) -> Result<u8, crate::Error> {
         todo!()
     }
 
-    fn read_word_16(&mut self, _address: u64) -> anyhow::Result<u16, crate::Error> {
+    fn read_word_16(&mut self, _address: u64) -> Result<u16, crate::Error> {
         todo!()
     }
 
-    fn read_64(&mut self, _address: u64, _data: &mut [u64]) -> anyhow::Result<(), crate::Error> {
+    fn read_64(&mut self, _address: u64, _data: &mut [u64]) -> Result<(), crate::Error> {
         todo!()
     }
 
-    fn read_32(&mut self, address: u64, data: &mut [u32]) -> anyhow::Result<(), crate::Error> {
+    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), crate::Error> {
         let mut buff = vec![0u8; data.len() * 4];
 
         self.read_8(address, &mut buff)?;
@@ -113,11 +113,11 @@ impl MemoryInterface for MockMemory {
         Ok(())
     }
 
-    fn read_16(&mut self, _address: u64, _data: &mut [u16]) -> anyhow::Result<(), crate::Error> {
+    fn read_16(&mut self, _address: u64, _data: &mut [u16]) -> Result<(), crate::Error> {
         todo!()
     }
 
-    fn read_8(&mut self, address: u64, data: &mut [u8]) -> anyhow::Result<(), crate::Error> {
+    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), crate::Error> {
         let stored_data = match self
             .values
             .binary_search_by_key(&address, |(addr, _data)| *addr)
@@ -164,39 +164,39 @@ impl MemoryInterface for MockMemory {
         Ok(true)
     }
 
-    fn write_word_64(&mut self, _address: u64, _data: u64) -> anyhow::Result<(), crate::Error> {
+    fn write_word_64(&mut self, _address: u64, _data: u64) -> Result<(), crate::Error> {
         todo!()
     }
 
-    fn write_word_32(&mut self, _address: u64, _data: u32) -> anyhow::Result<(), crate::Error> {
+    fn write_word_32(&mut self, _address: u64, _data: u32) -> Result<(), crate::Error> {
         todo!()
     }
 
-    fn write_word_16(&mut self, _address: u64, _data: u16) -> anyhow::Result<(), crate::Error> {
+    fn write_word_16(&mut self, _address: u64, _data: u16) -> Result<(), crate::Error> {
         todo!()
     }
 
-    fn write_word_8(&mut self, _address: u64, _data: u8) -> anyhow::Result<(), crate::Error> {
+    fn write_word_8(&mut self, _address: u64, _data: u8) -> Result<(), crate::Error> {
         todo!()
     }
 
-    fn write_64(&mut self, _address: u64, _data: &[u64]) -> anyhow::Result<(), crate::Error> {
+    fn write_64(&mut self, _address: u64, _data: &[u64]) -> Result<(), crate::Error> {
         todo!()
     }
 
-    fn write_32(&mut self, _address: u64, _data: &[u32]) -> anyhow::Result<(), crate::Error> {
+    fn write_32(&mut self, _address: u64, _data: &[u32]) -> Result<(), crate::Error> {
         todo!()
     }
 
-    fn write_16(&mut self, _address: u64, _data: &[u16]) -> anyhow::Result<(), crate::Error> {
+    fn write_16(&mut self, _address: u64, _data: &[u16]) -> Result<(), crate::Error> {
         todo!()
     }
 
-    fn write_8(&mut self, _address: u64, _data: &[u8]) -> anyhow::Result<(), crate::Error> {
+    fn write_8(&mut self, _address: u64, _data: &[u8]) -> Result<(), crate::Error> {
         todo!()
     }
 
-    fn flush(&mut self) -> anyhow::Result<(), crate::Error> {
+    fn flush(&mut self) -> Result<(), crate::Error> {
         todo!()
     }
 }

--- a/probe-rs/src/vendor/microchip/sequences/atsam.rs
+++ b/probe-rs/src/vendor/microchip/sequences/atsam.rs
@@ -24,8 +24,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::Result;
-
 bitfield! {
     /// Device Service Unit Control Register, DSU - CTRL
     #[derive(Copy, Clone)]

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
@@ -231,7 +231,6 @@ impl MIMXRT11xx {
         reg: crate::core::registers::CoreRegister,
     ) -> Result<u32, ArmError> {
         crate::architecture::arm::core::cortex_m::read_core_reg(probe, reg.into())
-            .map_err(|err| ArmError::Other(err.into()))
     }
 
     /// Assumes that the core is halted.
@@ -241,8 +240,7 @@ impl MIMXRT11xx {
         reg: crate::core::registers::CoreRegister,
         value: u32,
     ) -> Result<(), ArmError> {
-        crate::architecture::arm::core::cortex_m::write_core_reg(probe, reg.into(), value)
-            .map_err(|err| ArmError::Other(err.into()))?;
+        crate::architecture::arm::core::cortex_m::write_core_reg(probe, reg.into(), value)?;
         probe.flush()?;
         Ok(())
     }


### PR DESCRIPTION
Try to only use the `DebugProbeError`for things which are somewhat related to debug probes, replace uses of `anyhow` with simple strings where we didn't really need it.