### PR TITLE
arm: Use AP specific types & enumerate Addresses rather than APs

### DIFF
--- a/changelog/added-enum-AccessPort.md
+++ b/changelog/added-enum-AccessPort.md
@@ -1,0 +1,1 @@
+Added `AccessPort` a sum-type of all access port classes

--- a/changelog/added-types-for-MemoryAp-types.md
+++ b/changelog/added-types-for-MemoryAp-types.md
@@ -1,0 +1,1 @@
+Add types for each type of `MemoryAp`.

--- a/changelog/changed-ArmCommunicationInterface-memory-ap-enumeration.md
+++ b/changelog/changed-ArmCommunicationInterface-memory-ap-enumeration.md
@@ -1,0 +1,1 @@
+Changed the type returned by `ArmCommunicationInterface` to a collection of addresses

--- a/changelog/changed-derive-on-addresses.md
+++ b/changelog/changed-derive-on-addresses.md
@@ -1,0 +1,1 @@
+Derive `PartialOrd`/`Ord` & `Hash` on addresses

--- a/changelog/changed-trait-AccessPort-to-AccessPortType.md
+++ b/changelog/changed-trait-AccessPort-to-AccessPortType.md
@@ -1,0 +1,1 @@
+Rename the trait `AccessPort` to `AccessPortType`

--- a/probe-rs/src/architecture/arm/ap/generic_ap.rs
+++ b/probe-rs/src/architecture/arm/ap/generic_ap.rs
@@ -1,9 +1,6 @@
 //! Generic access port
 
-use super::{AccessPort, ApRegister, Register};
-use crate::architecture::arm::{
-    communication_interface::RegisterParseError, FullyQualifiedApAddress,
-};
+use crate::architecture::arm::communication_interface::RegisterParseError;
 
 /// Describes the class of an access port defined in the [`ARM Debug Interface v5.2`](https://developer.arm.com/documentation/ihi0031/f/?lang=en) specification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -71,14 +68,7 @@ impl ApType {
     }
 }
 
-define_ap!(
-    /// A generic access port which implements just the register every access port has to implement
-    /// to be compliant with the ADI 5.2 specification.
-    GenericAp
-);
-
 define_ap_register!(
-    type: GenericAp,
     /// Identification Register
     ///
     /// The identification register is used to identify

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb3.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb3.rs
@@ -1,0 +1,192 @@
+use crate::architecture::arm::{
+    ap::{AccessPortType, ApAccess, ApRegAccess},
+    communication_interface::RegisterParseError,
+    ArmError, DapAccess, FullyQualifiedApAddress, Register,
+};
+
+use super::{AddressIncrement, DataSize};
+
+/// Memory AP
+///
+/// The memory AP can be used to access a memory-mapped
+/// set of debug resources of the attached system.
+#[derive(Debug)]
+pub struct AmbaAhb3 {
+    address: FullyQualifiedApAddress,
+    csw: CSW,
+    cfg: super::registers::CFG,
+}
+
+impl AmbaAhb3 {
+    /// Creates a new AmbaAhb3 with `address` as base address.
+    pub fn new<P: DapAccess>(
+        probe: &mut P,
+        address: FullyQualifiedApAddress,
+    ) -> Result<Self, ArmError> {
+        use crate::architecture::arm::Register;
+        let csw = probe.read_raw_ap_register(&address, CSW::ADDRESS)?;
+        let cfg = probe.read_raw_ap_register(&address, super::registers::CFG::ADDRESS)?;
+        let (csw, cfg) = (csw.try_into()?, cfg.try_into()?);
+
+        let me = Self { address, csw, cfg };
+        let csw = CSW {
+            AddrInc: AddressIncrement::Single,
+            ..me.csw
+        };
+        probe.write_ap_register(&me, csw)?;
+        Ok(Self { csw, ..me })
+    }
+}
+
+impl super::MemoryApType for AmbaAhb3 {
+    type CSW = CSW;
+
+    fn status<P: ApAccess + ?Sized>(&mut self, probe: &mut P) -> Result<CSW, ArmError> {
+        #[allow(clippy::assertions_on_constants)]
+        const { assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS) };
+        self.csw = probe.read_ap_register(self)?;
+        Ok(self.csw)
+    }
+
+    fn try_set_datasize<P: ApAccess + ?Sized>(
+        &mut self,
+        probe: &mut P,
+        data_size: DataSize,
+    ) -> Result<(), ArmError> {
+        match data_size {
+            DataSize::U8 | DataSize::U16 | DataSize::U32 if data_size != self.csw.Size => {
+                let csw = CSW {
+                    Size: data_size,
+                    ..self.csw
+                };
+                probe.write_ap_register(self, csw)?;
+                self.csw = csw;
+            }
+            DataSize::U64 | DataSize::U128 | DataSize::U256 => {
+                return Err(ArmError::UnsupportedTransferWidth(
+                    data_size.to_byte_count() * 8,
+                ))
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn has_large_address_extension(&self) -> bool {
+        self.cfg.LA
+    }
+
+    fn has_large_data_extension(&self) -> bool {
+        self.cfg.LD
+    }
+
+    fn supports_only_32bit_data_size(&self) -> bool {
+        // Amba AHB3 must support word, half-word and byte size transfers.
+        false
+    }
+}
+
+impl AccessPortType for AmbaAhb3 {
+    fn ap_address(&self) -> &FullyQualifiedApAddress {
+        &self.address
+    }
+}
+
+impl ApRegAccess<CSW> for AmbaAhb3 {}
+
+crate::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAhb3);
+
+define_ap_register!(
+    /// Control and Status Word register
+    ///
+    /// The control and status word register (CSW) is used
+    /// to configure memory access through the memory AP.
+    name: CSW,
+    address: 0x00,
+    fields: [
+        /// Is debug software access enabled.
+        DbgSwEnable: bool,          // [31]
+        /// HNONSEC
+        ///
+        /// Not formally defined.
+        /// If implemented should be 1 at reset.
+        /// If not implemented, should be 1 and writing 0 leads to unpredictable AHB-AP behavior.
+        HNONSEC: bool,              // [30]
+        /// Defines which Requester ID is used on `HMASTER[3:0]` signals.
+        ///
+        /// Support of this function is implementation defined.
+        MasterType: bool,           // [29]
+        /// Drives `HPROT[4]`, Allocate.
+        ///
+        /// `HPROT[4]` is an Armv5 extension to AHB. For more information, see the Arm1136JF-S™ and
+        /// Arm1136J-S ™ Technical Reference Manual.
+        Allocate: bool,             // [28]
+        /// `HPROT[3]`
+        Cacheable: bool,            // [27]
+        /// `HPROT[2]`
+        Bufferable: bool,           // [26]
+        /// `HPROT[1]`
+        Privileged: bool,           // [25]
+        /// `HPROT[0]`
+        Data: bool,                 // [24]
+        /// Secure Debug Enabled.
+        ///
+        /// This field has one of the following values:
+        /// - `0b0` Secure access is disabled.
+        /// - `0b1` Secure access is enabled.
+        /// This field is optional, and read-only. If not implemented, the bit is RES0.
+        /// If CSW.DeviceEn is 0b0, SPIDEN is ignored and the effective value of SPIDEN is 0b1.
+        /// For more information, see `Enabling access to the connected debug device or memory system`
+        /// on page C2-154.
+        ///
+        /// Note:
+        /// In ADIv5 and older versions of the architecture, the CSW.SPIDEN field is in the same bit
+        /// position as CSW.SDeviceEn, and has the same meaning. From ADIv6, the name SDeviceEn is
+        /// used to avoid confusion between this field and the SPIDEN signal on the authentication
+        /// interface.
+        SPIDEN: bool,               // [23]
+        /// A transfer is in progress.
+        /// Can be used to poll whether an aborted transaction has completed.
+        /// Read only.
+        TrInProg: bool,             // [7]
+        /// `1` if transactions can be issued through this access port at the moment.
+        /// Read only.
+        DeviceEn: bool,             // [6]
+        /// The address increment on DRW access.
+        AddrInc: AddressIncrement,  // [5:4]
+        /// The access size of this memory AP.
+        Size: DataSize,             // [2:0]
+        /// Reserved bit, kept to preserve IMPLEMENTATION DEFINED statuses.
+        _reserved_bits: u32         // mask
+    ],
+    from: value => Ok(CSW {
+        DbgSwEnable: ((value >> 31) & 0x01) != 0,
+        HNONSEC: ((value >> 30) & 0x01) != 0,
+        MasterType: ((value >> 29) & 0x01) != 0,
+        Allocate: ((value >> 28) & 0x01) != 0,
+        Cacheable: ((value >> 27) & 0x01) != 0,
+        Bufferable: ((value >> 26) & 0x01) != 0,
+        Privileged: ((value >> 25) & 0x01) != 0,
+        Data: ((value >> 24) & 0x01) != 0,
+        SPIDEN: ((value >> 23) & 0x01) != 0,
+        TrInProg: ((value >> 7) & 0x01) != 0,
+        DeviceEn: ((value >> 6) & 0x01) != 0,
+        AddrInc: AddressIncrement::from_u8(((value >> 4) & 0x03) as u8).ok_or_else(|| RegisterParseError::new("CSW", value))?,
+        Size: DataSize::try_from((value & 0x07) as u8).map_err(|_| RegisterParseError::new("CSW", value))?,
+        _reserved_bits: value & 0x007F_FF08,
+    }),
+    to: value => (u32::from(value.DbgSwEnable) << 31)
+    | (u32::from(value.HNONSEC      ) << 30)
+    | (u32::from(value.MasterType   ) << 29)
+    | (u32::from(value.Allocate     ) << 28)
+    | (u32::from(value.Cacheable    ) << 27)
+    | (u32::from(value.Bufferable   ) << 26)
+    | (u32::from(value.Privileged   ) << 25)
+    | (u32::from(value.Data         ) << 24)
+    | (u32::from(value.SPIDEN       ) << 23)
+    | (u32::from(value.TrInProg     ) <<  7)
+    | (u32::from(value.DeviceEn     ) <<  6)
+    | (u32::from(value.AddrInc as u8) <<  4)
+    | (value.Size as u32)
+    | value._reserved_bits
+);

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5.rs
@@ -1,0 +1,177 @@
+use crate::architecture::arm::{
+    ap::{AccessPortType, ApAccess, ApRegAccess},
+    communication_interface::RegisterParseError,
+    ArmError, DapAccess, FullyQualifiedApAddress, Register,
+};
+
+use super::{AddressIncrement, DataSize};
+
+/// Memory AP
+///
+/// The memory AP can be used to access a memory-mapped
+/// set of debug resources of the attached system.
+#[derive(Debug)]
+pub struct AmbaAhb5 {
+    address: FullyQualifiedApAddress,
+    csw: CSW,
+    cfg: super::registers::CFG,
+}
+
+impl AmbaAhb5 {
+    /// Creates a new AmbaAhb5 with `address` as base address.
+    pub fn new<P: DapAccess>(
+        probe: &mut P,
+        address: FullyQualifiedApAddress,
+    ) -> Result<Self, ArmError> {
+        use crate::architecture::arm::Register;
+        let csw = probe.read_raw_ap_register(&address, CSW::ADDRESS)?;
+        let cfg = probe.read_raw_ap_register(&address, super::registers::CFG::ADDRESS)?;
+        let (csw, cfg) = (csw.try_into()?, cfg.try_into()?);
+
+        let me = Self { address, csw, cfg };
+        let csw = CSW {
+            AddrInc: AddressIncrement::Single,
+            ..me.csw
+        };
+        probe.write_ap_register(&me, csw)?;
+        Ok(Self { csw, ..me })
+    }
+}
+
+impl super::MemoryApType for AmbaAhb5 {
+    type CSW = CSW;
+
+    fn status<P: ApAccess + ?Sized>(&mut self, probe: &mut P) -> Result<CSW, ArmError> {
+        #[allow(clippy::assertions_on_constants)]
+        const { assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS) };
+        self.csw = probe.read_ap_register(self)?;
+        Ok(self.csw)
+    }
+
+    fn try_set_datasize<P: ApAccess + ?Sized>(
+        &mut self,
+        probe: &mut P,
+        data_size: DataSize,
+    ) -> Result<(), ArmError> {
+        match data_size {
+            DataSize::U8 | DataSize::U16 | DataSize::U32 if data_size != self.csw.Size => {
+                let csw = CSW {
+                    Size: data_size,
+                    ..self.csw
+                };
+                probe.write_ap_register(self, csw)?;
+                self.csw = csw;
+            }
+            DataSize::U64 | DataSize::U128 | DataSize::U256 => {
+                return Err(ArmError::UnsupportedTransferWidth(
+                    data_size.to_byte_count() * 8,
+                ))
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn has_large_address_extension(&self) -> bool {
+        self.cfg.LA
+    }
+
+    fn has_large_data_extension(&self) -> bool {
+        self.cfg.LD
+    }
+
+    fn supports_only_32bit_data_size(&self) -> bool {
+        // Amba AHB5 must support word, half-word and byte size transfers.
+        false
+    }
+}
+
+impl AccessPortType for AmbaAhb5 {
+    fn ap_address(&self) -> &FullyQualifiedApAddress {
+        &self.address
+    }
+}
+
+impl ApRegAccess<CSW> for AmbaAhb5 {}
+
+crate::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAhb5);
+
+define_ap_register!(
+    /// Control and Status Word register
+    ///
+    /// The control and status word register (CSW) is used
+    /// to configure memory access through the memory AP.
+    name: CSW,
+    address: 0x00,
+    fields: [
+        /// Is debug software access enabled.
+        DbgSwEnable: bool,          // [31]
+        /// HNONSEC
+        ///
+        /// Not formally defined.
+        /// If implemented should be 1 at reset.
+        /// If not implemented, should be 1 and writing 0 leads to unpredictable AHB-AP behavior.
+        HNONSEC: bool,              // [30]
+        /// Defines which Requester ID is used on `HMASTER[3:0]` signals.
+        ///
+        /// Support of this function is implementation defined.
+        MasterType: bool,           // [29]
+        /// `HPROT[6:0]`.
+        ///
+        /// - bit 0 to 2 respectively control `HPROT`’s bit 0 to 2
+        /// - bit 3 controls bits `HPROT`’s bit 3, 4 and 6
+        /// - `HPROT[5]` is tied to 0
+        HPROT: u8,                  // [27:24]
+        /// Secure Debug Enabled.
+        ///
+        /// This field has one of the following values:
+        /// - `0b0` Secure access is disabled.
+        /// - `0b1` Secure access is enabled.
+        /// This field is optional, and read-only. If not implemented, the bit is RES0.
+        /// If CSW.DeviceEn is 0b0, SPIDEN is ignored and the effective value of SPIDEN is 0b1.
+        /// For more information, see `Enabling access to the connected debug device or memory system`
+        /// on page C2-154.
+        ///
+        /// Note:
+        /// In ADIv5 and older versions of the architecture, the CSW.SPIDEN field is in the same bit
+        /// position as CSW.SDeviceEn, and has the same meaning. From ADIv6, the name SDeviceEn is
+        /// used to avoid confusion between this field and the SPIDEN signal on the authentication
+        /// interface.
+        SPIDEN: bool,               // [23]
+        /// A transfer is in progress.
+        /// Can be used to poll whether an aborted transaction has completed.
+        /// Read only.
+        TrInProg: bool,             // [7]
+        /// `1` if transactions can be issued through this access port at the moment.
+        /// Read only.
+        DeviceEn: bool,             // [6]
+        /// The address increment on DRW access.
+        AddrInc: AddressIncrement,  // [5:4]
+        /// The access size of this memory AP.
+        Size: DataSize,             // [2:0]
+        /// Reserved bit, kept to preserve IMPLEMENTATION DEFINED statuses.
+        _reserved_bits: u32         // mask
+    ],
+    from: value => Ok(CSW {
+        DbgSwEnable: ((value >> 31) & 0x01) != 0,
+        HNONSEC: ((value >> 30) & 0x01) != 0,
+        MasterType: ((value >> 29) & 0x01) != 0,
+        HPROT: ((value >> 24) & 0x0F) as u8,
+        SPIDEN: ((value >> 23) & 0x01) != 0,
+        TrInProg: ((value >> 7) & 0x01) != 0,
+        DeviceEn: ((value >> 6) & 0x01) != 0,
+        AddrInc: AddressIncrement::from_u8(((value >> 4) & 0x03) as u8).ok_or_else(|| RegisterParseError::new("CSW", value))?,
+        Size: DataSize::try_from((value & 0x07) as u8).map_err(|_| RegisterParseError::new("CSW", value))?,
+        _reserved_bits: value & 0x107F_FF08,
+    }),
+    to: value => (u32::from(value.DbgSwEnable) << 31)
+    | (u32::from(value.HNONSEC      ) << 30)
+    | (u32::from(value.MasterType   ) << 29)
+    | (u32::from(value.HPROT        ) << 24)
+    | (u32::from(value.SPIDEN       ) << 23)
+    | (u32::from(value.TrInProg     ) <<  7)
+    | (u32::from(value.DeviceEn     ) <<  6)
+    | (u32::from(value.AddrInc as u8) <<  4)
+    | (value.Size as u32)
+    | value._reserved_bits
+);

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5_hprot.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5_hprot.rs
@@ -1,0 +1,178 @@
+use crate::architecture::arm::{
+    ap::{AccessPortType, ApAccess, ApRegAccess},
+    communication_interface::RegisterParseError,
+    ArmError, DapAccess, FullyQualifiedApAddress, Register,
+};
+
+use super::{AddressIncrement, DataSize};
+
+/// Memory AP
+///
+/// The memory AP can be used to access a memory-mapped
+/// set of debug resources of the attached system.
+#[derive(Debug)]
+pub struct AmbaAhb5Hprot {
+    address: FullyQualifiedApAddress,
+    csw: CSW,
+    cfg: super::registers::CFG,
+}
+
+impl AmbaAhb5Hprot {
+    /// Creates a new AmbaAhb5Hprot with `address` as base address.
+    pub fn new<P: DapAccess>(
+        probe: &mut P,
+        address: FullyQualifiedApAddress,
+    ) -> Result<Self, ArmError> {
+        use crate::architecture::arm::Register;
+        let csw = probe.read_raw_ap_register(&address, CSW::ADDRESS)?;
+        let cfg = probe.read_raw_ap_register(&address, super::registers::CFG::ADDRESS)?;
+        let (csw, cfg) = (csw.try_into()?, cfg.try_into()?);
+
+        let me = Self { address, csw, cfg };
+        let csw = CSW {
+            AddrInc: AddressIncrement::Single,
+            ..me.csw
+        };
+        probe.write_ap_register(&me, csw)?;
+        Ok(Self { csw, ..me })
+    }
+}
+
+impl super::MemoryApType for AmbaAhb5Hprot {
+    type CSW = CSW;
+
+    fn status<P: ApAccess + ?Sized>(&mut self, probe: &mut P) -> Result<CSW, ArmError> {
+        #[allow(clippy::assertions_on_constants)]
+        const { assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS) };
+        self.csw = probe.read_ap_register(self)?;
+        Ok(self.csw)
+    }
+
+    fn try_set_datasize<P: ApAccess + ?Sized>(
+        &mut self,
+        probe: &mut P,
+        data_size: DataSize,
+    ) -> Result<(), ArmError> {
+        match data_size {
+            DataSize::U8 | DataSize::U16 | DataSize::U32 if data_size != self.csw.Size => {
+                let csw = CSW {
+                    Size: data_size,
+                    ..self.csw
+                };
+                probe.write_ap_register(self, csw)?;
+                self.csw = csw;
+            }
+            DataSize::U64 | DataSize::U128 | DataSize::U256 => {
+                return Err(ArmError::UnsupportedTransferWidth(
+                    data_size.to_byte_count() * 8,
+                ))
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn has_large_address_extension(&self) -> bool {
+        self.cfg.LA
+    }
+
+    fn has_large_data_extension(&self) -> bool {
+        self.cfg.LD
+    }
+
+    fn supports_only_32bit_data_size(&self) -> bool {
+        // Amba AHB5 must support word, half-word and byte size transfers.
+        false
+    }
+}
+
+impl AccessPortType for AmbaAhb5Hprot {
+    fn ap_address(&self) -> &FullyQualifiedApAddress {
+        &self.address
+    }
+}
+
+impl ApRegAccess<CSW> for AmbaAhb5Hprot {}
+
+crate::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAhb5Hprot);
+
+define_ap_register!(
+    /// Control and Status Word register
+    ///
+    /// The control and status word register (CSW) is used
+    /// to configure memory access through the memory AP.
+    name: CSW,
+    address: 0x00,
+    fields: [
+        /// Is debug software access enabled.
+        DbgSwEnable: bool,          // [31]
+        /// HNONSEC
+        ///
+        /// Not formally defined.
+        /// If implemented should be 1 at reset.
+        /// If not implemented, should be 1 and writing 0 leads to unpredictable AHB-AP behavior.
+        HNONSEC: bool,              // [30]
+        /// Defines which Requester ID is used on `HMASTER[3:0]` signals.
+        ///
+        /// Support of this function is implementation defined.
+        MasterType: bool,           // [29]
+        /// `HPROT[6:0]`.
+        ///
+        /// - bit 0 to 4 drives `HPROT` bit 0 to 4 respectively.
+        /// - bit 5 is ignored and `HPROT[5]` is tied to 0
+        /// - bit 6 drives `HPROT[6]`
+        HPROT: u8,                  // [28:24,15]
+        /// Secure Debug Enabled.
+        ///
+        /// This field has one of the following values:
+        /// - `0b0` Secure access is disabled.
+        /// - `0b1` Secure access is enabled.
+        /// This field is optional, and read-only. If not implemented, the bit is RES0.
+        /// If CSW.DeviceEn is 0b0, SPIDEN is ignored and the effective value of SPIDEN is 0b1.
+        /// For more information, see `Enabling access to the connected debug device or memory system`
+        /// on page C2-154.
+        ///
+        /// Note:
+        /// In ADIv5 and older versions of the architecture, the CSW.SPIDEN field is in the same bit
+        /// position as CSW.SDeviceEn, and has the same meaning. From ADIv6, the name SDeviceEn is
+        /// used to avoid confusion between this field and the SPIDEN signal on the authentication
+        /// interface.
+        SPIDEN: bool,               // [23]
+        /// A transfer is in progress.
+        /// Can be used to poll whether an aborted transaction has completed.
+        /// Read only.
+        TrInProg: bool,             // [7]
+        /// `1` if transactions can be issued through this access port at the moment.
+        /// Read only.
+        DeviceEn: bool,             // [6]
+        /// The address increment on DRW access.
+        AddrInc: AddressIncrement,  // [5:4]
+        /// The access size of this memory AP.
+        Size: DataSize,             // [2:0]
+        /// Reserved bit, kept to preserve IMPLEMENTATION DEFINED statuses.
+        _reserved_bits: u32         // mask
+    ],
+    from: value => Ok(CSW {
+        DbgSwEnable: ((value >> 31) & 0x01) != 0,
+        HNONSEC: ((value >> 30) & 0x01) != 0,
+        MasterType: ((value >> 29) & 0x01) != 0,
+        HPROT: (((value >> 24) & 0x0F) | ((value >> (15 - 6)) & 0x40)) as u8,
+        SPIDEN: ((value >> 23) & 0x01) != 0,
+        TrInProg: ((value >> 7) & 0x01) != 0,
+        DeviceEn: ((value >> 6) & 0x01) != 0,
+        AddrInc: AddressIncrement::from_u8(((value >> 4) & 0x03) as u8).ok_or_else(|| RegisterParseError::new("CSW", value))?,
+        Size: DataSize::try_from((value & 0x07) as u8).map_err(|_| RegisterParseError::new("CSW", value))?,
+        _reserved_bits: value & 0x0007_70F8,
+    }),
+    to: value => (u32::from(value.DbgSwEnable) << 31)
+    | (u32::from(value.HNONSEC      ) << 30)
+    | (u32::from(value.MasterType   ) << 29)
+    | (u32::from(value.HPROT   & 0xF) << 24)
+    | (u32::from(value.SPIDEN       ) << 23)
+    | (u32::from(value.HPROT & 0x40 ) << (15-6))
+    | (u32::from(value.TrInProg     ) <<  7)
+    | (u32::from(value.DeviceEn     ) <<  6)
+    | (u32::from(value.AddrInc as u8) <<  4)
+    | (value.Size as u32)
+    | value._reserved_bits
+);

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_apb2_apb3.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_apb2_apb3.rs
@@ -1,0 +1,129 @@
+use crate::architecture::arm::{
+    ap::{AccessPortType, ApAccess, ApRegAccess},
+    communication_interface::RegisterParseError,
+    ArmError, DapAccess, FullyQualifiedApAddress, Register,
+};
+
+use super::{registers::AddressIncrement, DataSize};
+
+/// Memory AP
+///
+/// The memory AP can be used to access a memory-mapped
+/// set of debug resources of the attached system.
+#[derive(Debug)]
+pub struct AmbaApb2Apb3 {
+    address: FullyQualifiedApAddress,
+    csw: CSW,
+    cfg: super::registers::CFG,
+}
+
+impl AmbaApb2Apb3 {
+    /// Creates a new AmbaAhb3 with `address` as base address.
+    pub fn new<P: DapAccess>(
+        probe: &mut P,
+        address: FullyQualifiedApAddress,
+    ) -> Result<Self, ArmError> {
+        use crate::architecture::arm::Register;
+        let csw = probe.read_raw_ap_register(&address, CSW::ADDRESS)?;
+        let cfg = probe.read_raw_ap_register(&address, super::registers::CFG::ADDRESS)?;
+
+        let (csw, cfg) = (csw.try_into()?, cfg.try_into()?);
+
+        let me = Self { address, csw, cfg };
+        let csw = CSW {
+            AddrInc: AddressIncrement::Single,
+            ..me.csw
+        };
+        probe.write_ap_register(&me, csw)?;
+        Ok(Self { csw, ..me })
+    }
+}
+
+impl super::MemoryApType for AmbaApb2Apb3 {
+    type CSW = CSW;
+
+    fn status<P: ApAccess + ?Sized>(&mut self, probe: &mut P) -> Result<CSW, ArmError> {
+        #[allow(clippy::assertions_on_constants)]
+        const { assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS) };
+        self.csw = probe.read_ap_register(self)?;
+        Ok(self.csw)
+    }
+
+    fn try_set_datasize<P: ApAccess + ?Sized>(
+        &mut self,
+        _probe: &mut P,
+        data_size: DataSize,
+    ) -> Result<(), ArmError> {
+        match data_size {
+            DataSize::U32 => Ok(()),
+            _ => Err(ArmError::UnsupportedTransferWidth(
+                data_size.to_byte_count() * 8,
+            )),
+        }
+    }
+
+    fn has_large_address_extension(&self) -> bool {
+        self.cfg.LA
+    }
+
+    fn has_large_data_extension(&self) -> bool {
+        self.cfg.LD
+    }
+
+    fn supports_only_32bit_data_size(&self) -> bool {
+        // APB2 and APB3 AP only support 32bit accesses
+        true
+    }
+}
+
+impl AccessPortType for AmbaApb2Apb3 {
+    fn ap_address(&self) -> &FullyQualifiedApAddress {
+        &self.address
+    }
+}
+
+impl ApRegAccess<CSW> for AmbaApb2Apb3 {}
+
+crate::attached_regs_to_mem_ap!(memory_ap_regs => AmbaApb2Apb3);
+
+define_ap_register!(
+    /// Control and Status Word register
+    ///
+    /// The control and status word register (CSW) is used
+    /// to configure memory access through the memory AP.
+    name: CSW,
+    address: 0x00,
+    fields: [
+        /// Is debug software access enabled.
+        DbgSwEnable: bool,          // [31]
+        /// A transfer is in progress.
+        /// Can be used to poll whether an aborted transaction has completed.
+        /// Read only.
+        TrInProg: bool,             // [7]
+        /// `1` if transactions can be issued through this access port at the moment.
+        /// Read only.
+        DeviceEn: bool,             // [6]
+        /// Address Auto Increment.
+        /// This AP does not support the Packed mode of transfer.
+        AddrInc: AddressIncrement,  // [5:4]
+        /// The access size of this memory AP.
+        /// Only supports word accesses.
+        Size: DataSize,             // [2:0]
+        /// Reserved bit, kept to preserve IMPLEMENTATION DEFINED statuses.
+        _reserved_bits: u32,        // mask
+    ],
+    from: value => Ok(CSW {
+        DbgSwEnable: ((value >> 31) & 0x01) != 0,
+        TrInProg: ((value >> 7) & 0x01) != 0,
+        DeviceEn: ((value >> 6) & 0x01) != 0,
+        AddrInc: AddressIncrement::from_u8(((value >> 4) & 0x03) as u8).ok_or_else(|| RegisterParseError::new("CSW", value))?,
+        Size: DataSize::try_from((value & 0x07) as u8).map_err(|_| RegisterParseError::new("CSW", value))?,
+        _reserved_bits: (value & 0x7FFF_FF08),
+    }),
+    to: value => (u32::from(value.DbgSwEnable) << 31)
+    | (u32::from(value.TrInProg) << 7)
+    | (u32::from(value.DeviceEn) << 6)
+    | ((value.AddrInc as u32) << 4)
+    | (value.Size as u32)
+    | value._reserved_bits
+);

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_apb4_apb5.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_apb4_apb5.rs
@@ -1,0 +1,139 @@
+use crate::architecture::arm::{
+    ap::{AccessPortType, ApAccess, ApRegAccess},
+    communication_interface::RegisterParseError,
+    ArmError, DapAccess, FullyQualifiedApAddress, Register,
+};
+
+use super::{registers::AddressIncrement, DataSize};
+
+/// Memory AP
+///
+/// The memory AP can be used to access a memory-mapped
+/// set of debug resources of the attached system.
+#[derive(Debug)]
+pub struct AmbaApb4Apb5 {
+    address: FullyQualifiedApAddress,
+    csw: CSW,
+    cfg: super::registers::CFG,
+}
+
+impl AmbaApb4Apb5 {
+    /// Creates a new AmbaAhb3 with `address` as base address.
+    pub fn new<P: DapAccess>(
+        probe: &mut P,
+        address: FullyQualifiedApAddress,
+    ) -> Result<Self, ArmError> {
+        use crate::architecture::arm::Register;
+        let csw = probe.read_raw_ap_register(&address, CSW::ADDRESS)?;
+        let cfg = probe.read_raw_ap_register(&address, super::registers::CFG::ADDRESS)?;
+
+        let (csw, cfg) = (csw.try_into()?, cfg.try_into()?);
+
+        let me = Self { address, csw, cfg };
+        let csw = CSW {
+            AddrInc: AddressIncrement::Single,
+            ..me.csw
+        };
+        probe.write_ap_register(&me, csw)?;
+        Ok(Self { csw, ..me })
+    }
+}
+
+impl super::MemoryApType for AmbaApb4Apb5 {
+    type CSW = CSW;
+
+    fn status<P: ApAccess + ?Sized>(&mut self, probe: &mut P) -> Result<CSW, ArmError> {
+        #[allow(clippy::assertions_on_constants)]
+        const { assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS) };
+        self.csw = probe.read_ap_register(self)?;
+        Ok(self.csw)
+    }
+
+    fn try_set_datasize<P: ApAccess + ?Sized>(
+        &mut self,
+        _probe: &mut P,
+        data_size: DataSize,
+    ) -> Result<(), ArmError> {
+        match data_size {
+            DataSize::U32 => Ok(()),
+            _ => Err(ArmError::UnsupportedTransferWidth(data_size as usize * 8)),
+        }
+    }
+
+    fn has_large_address_extension(&self) -> bool {
+        self.cfg.LA
+    }
+
+    fn has_large_data_extension(&self) -> bool {
+        self.cfg.LD
+    }
+
+    fn supports_only_32bit_data_size(&self) -> bool {
+        // APB4 and APB5 AP only support 32bit accesses
+        true
+    }
+}
+
+impl AccessPortType for AmbaApb4Apb5 {
+    fn ap_address(&self) -> &FullyQualifiedApAddress {
+        &self.address
+    }
+}
+
+impl ApRegAccess<CSW> for AmbaApb4Apb5 {}
+
+crate::attached_regs_to_mem_ap!(memory_ap_regs => AmbaApb4Apb5);
+
+define_ap_register!(
+    /// Control and Status Word register
+    ///
+    /// The control and status word register (CSW) is used
+    /// to configure memory access through the memory AP.
+    name: CSW,
+    address: 0x00,
+    fields: [
+        /// Is debug software access enabled.
+        DbgSwEnable: bool,          // [31]
+        /// Is a Non-secure transfer requested.
+        /// If a secure transfer is requested, the behaviour depends on the value of SPIDEN.
+        /// - If SPIDEN is 1 then a secure transfer is initiated.
+        /// - IF SPIDEN is 0, then no transfer is initiated. An access to DRW or BD0-BD3 is likely
+        ///   to return an error.
+        NonSecure: bool,            // [29]
+        /// May reflect the state of the CoreSight authentication interface.
+        /// If Secure debug is not supported, this field is always 0.
+        SPIDEN: bool,               // [23]
+        /// A transfer is in progress.
+        /// Can be used to poll whether an aborted transaction has completed.
+        /// Read only.
+        TrInProg: bool,             // [7]
+        /// `1` if transactions can be issued through this access port at the moment.
+        /// Read only.
+        DeviceEn: bool,             // [6]
+        /// The address increment on DRW access.
+        AddrInc: AddressIncrement,  // [5:4]
+        /// The access size of this memory AP.
+        /// Only supports word accesses.
+        Size: DataSize,             // [2:0]
+        /// Reserved
+        _reserved_bits: u32,        // mask
+    ],
+    from: value => Ok(CSW {
+        DbgSwEnable: ((value >> 31) & 0x01) != 0,
+        NonSecure: ((value >> 29) & 0x01) != 0,
+        SPIDEN: ((value >> 23) & 0x01) != 0,
+        TrInProg: ((value >> 7) & 0x01) != 0,
+        DeviceEn: ((value >> 6) & 0x01) != 0,
+        AddrInc: AddressIncrement::from_u8(((value >> 4) & 0x03) as u8).ok_or_else(|| RegisterParseError::new("CSW", value))?,
+        Size: DataSize::try_from((value & 0x07) as u8).map_err(|_| RegisterParseError::new("CSW", value))?,
+        _reserved_bits: (value & 0x5F7F_FF08),
+    }),
+    to: value => (u32::from(value.DbgSwEnable) << 31)
+    | (u32::from(value.NonSecure) << 29)
+    | (u32::from(value.SPIDEN) << 23)
+    | (u32::from(value.TrInProg) << 7)
+    | (u32::from(value.DeviceEn) << 6)
+    | ((value.AddrInc as u32) << 4)
+    | (value.Size as u32)
+    | value._reserved_bits
+);

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_axi3_axi4.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_axi3_axi4.rs
@@ -1,0 +1,163 @@
+use crate::architecture::arm::{
+    ap::{AccessPortType, ApAccess, ApRegAccess},
+    communication_interface::RegisterParseError,
+    ArmError, DapAccess, FullyQualifiedApAddress, Register,
+};
+
+use super::{AddressIncrement, DataSize};
+
+/// Memory AP
+///
+/// The memory AP can be used to access a memory-mapped
+/// set of debug resources of the attached system.
+#[derive(Debug)]
+pub struct AmbaAxi3Axi4 {
+    address: FullyQualifiedApAddress,
+    csw: CSW,
+    cfg: super::registers::CFG,
+}
+
+impl AmbaAxi3Axi4 {
+    /// Creates a new AmbaAhb5Hprot with `address` as base address.
+    pub fn new<P: DapAccess>(
+        probe: &mut P,
+        address: FullyQualifiedApAddress,
+    ) -> Result<Self, ArmError> {
+        use crate::architecture::arm::Register;
+        let csw = probe.read_raw_ap_register(&address, CSW::ADDRESS)?;
+        let cfg = probe.read_raw_ap_register(&address, super::registers::CFG::ADDRESS)?;
+        let (csw, cfg) = (csw.try_into()?, cfg.try_into()?);
+
+        let me = Self { address, csw, cfg };
+        let csw = CSW {
+            AddrInc: AddressIncrement::Single,
+            ..me.csw
+        };
+        probe.write_ap_register(&me, csw)?;
+        Ok(Self { csw, ..me })
+    }
+}
+
+impl super::MemoryApType for AmbaAxi3Axi4 {
+    type CSW = CSW;
+
+    fn status<P: ApAccess + ?Sized>(&mut self, probe: &mut P) -> Result<CSW, ArmError> {
+        #[allow(clippy::assertions_on_constants)]
+        const { assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS) };
+        self.csw = probe.read_ap_register(self)?;
+        Ok(self.csw)
+    }
+
+    fn try_set_datasize<P: ApAccess + ?Sized>(
+        &mut self,
+        probe: &mut P,
+        data_size: DataSize,
+    ) -> Result<(), ArmError> {
+        match data_size {
+            DataSize::U8 | DataSize::U16 | DataSize::U32 if data_size != self.csw.Size => {
+                let csw = CSW {
+                    Size: data_size,
+                    ..self.csw
+                };
+                probe.write_ap_register(self, csw)?;
+                self.csw = csw;
+            }
+            DataSize::U64 | DataSize::U128 | DataSize::U256 => {
+                return Err(ArmError::UnsupportedTransferWidth(
+                    data_size.to_byte_count() * 8,
+                ))
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn has_large_address_extension(&self) -> bool {
+        self.cfg.LA
+    }
+
+    fn has_large_data_extension(&self) -> bool {
+        self.cfg.LD
+    }
+
+    fn supports_only_32bit_data_size(&self) -> bool {
+        // Amba AHB5 must support word, half-word and byte size transfers.
+        false
+    }
+}
+
+impl AccessPortType for AmbaAxi3Axi4 {
+    fn ap_address(&self) -> &FullyQualifiedApAddress {
+        &self.address
+    }
+}
+
+impl ApRegAccess<CSW> for AmbaAxi3Axi4 {}
+
+crate::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAxi3Axi4);
+
+define_ap_register!(
+    /// Control and Status Word register
+    ///
+    /// The control and status word register (CSW) is used
+    /// to configure memory access through the memory AP.
+    name: CSW,
+    address: 0x00,
+    fields: [
+        /// Is debug software access enabled.
+        DbgSwEnable: bool,          // [31]
+        Instruction: bool,          // [30]
+        /// Is the transaction request non-secure
+        ///
+        /// - If 1 a non-secure transfer is initiated.
+        /// - If 0 and SPIDEN is 1 then a secure transfer is initiated.
+        /// - If 0 and SPIDEN is 0 then no transaction is initiated.
+        NonSecure: bool,            // [29]
+        /// Is this transaction privileged
+        Privileged: bool,           // [28]
+        /// Drives `AxCACHE[3:0]` where x is R for reads and W for writes.
+        /// Amba AXI4 requires asymmetrical usage of `ARCACHE` and `AWCACHE`.
+        CACHE: u8,                  // [27:24]
+        /// Secure Debug Enabled.
+        ///
+        /// This bit reflects the state of the CoreSight authentication signal.
+        SPIDEN: bool,               // [23]
+        /// A transfer is in progress.
+        /// Can be used to poll whether an aborted transaction has completed.
+        /// Read only.
+        TrInProg: bool,             // [7]
+        /// `1` if transactions can be issued through this access port at the moment.
+        /// Read only.
+        DeviceEn: bool,             // [6]
+        /// The address increment on DRW access.
+        AddrInc: AddressIncrement,  // [5:4]
+        /// The access size of this memory AP.
+        Size: DataSize,             // [2:0]
+        /// Reserved bit, kept to preserve IMPLEMENTATION DEFINED statuses.
+        _reserved_bits: u32         // mask
+    ],
+    from: value => Ok(CSW {
+        DbgSwEnable: ((value >> 31) & 0x01) != 0,
+        Instruction: ((value >> 30) & 0x01) != 0,
+        NonSecure: ((value >> 29) & 0x01) != 0,
+        Privileged: ((value >> 28) & 0x01) != 0,
+        CACHE: ((value >> 24) & 0xF) as u8,
+        SPIDEN: ((value >> 23) & 0x01) != 0,
+        TrInProg: ((value >> 7) & 0x01) != 0,
+        DeviceEn: ((value >> 6) & 0x01) != 0,
+        AddrInc: AddressIncrement::from_u8(((value >> 4) & 0x03) as u8).ok_or_else(|| RegisterParseError::new("CSW", value))?,
+        Size: DataSize::try_from((value & 0x07) as u8).map_err(|_| RegisterParseError::new("CSW", value))?,
+        _reserved_bits: value & 0x007F_FF08,
+    }),
+    to: value => (u32::from(value.DbgSwEnable) << 31)
+    | (u32::from(value.Instruction  ) << 30)
+    | (u32::from(value.NonSecure    ) << 29)
+    | (u32::from(value.Privileged   ) << 28)
+    | (u32::from(value.CACHE        ) << 24)
+    | (u32::from(value.SPIDEN       ) << 23)
+    | (u32::from(value.TrInProg     ) <<  7)
+    | (u32::from(value.DeviceEn     ) <<  6)
+    | (u32::from(value.AddrInc as u8) <<  4)
+    | (value.Size as u32)
+    | value._reserved_bits
+);

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_axi5.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_axi5.rs
@@ -1,0 +1,173 @@
+use crate::architecture::arm::{
+    ap::{AccessPortType, ApAccess, ApRegAccess},
+    communication_interface::RegisterParseError,
+    ArmError, DapAccess, FullyQualifiedApAddress, Register,
+};
+
+use super::{AddressIncrement, DataSize};
+
+/// Memory AP
+///
+/// The memory AP can be used to access a memory-mapped
+/// set of debug resources of the attached system.
+#[derive(Debug)]
+pub struct AmbaAxi5 {
+    address: FullyQualifiedApAddress,
+    csw: CSW,
+    cfg: super::registers::CFG,
+}
+
+impl AmbaAxi5 {
+    /// Creates a new AmbaAhb5Hprot with `address` as base address.
+    pub fn new<P: DapAccess>(
+        probe: &mut P,
+        address: FullyQualifiedApAddress,
+    ) -> Result<Self, ArmError> {
+        use crate::architecture::arm::Register;
+        let csw = probe.read_raw_ap_register(&address, CSW::ADDRESS)?;
+        let cfg = probe.read_raw_ap_register(&address, super::registers::CFG::ADDRESS)?;
+        let (csw, cfg) = (csw.try_into()?, cfg.try_into()?);
+
+        let me = Self { address, csw, cfg };
+        let csw = CSW {
+            AddrInc: AddressIncrement::Single,
+            ..me.csw
+        };
+        probe.write_ap_register(&me, csw)?;
+        Ok(Self { csw, ..me })
+    }
+}
+
+impl super::MemoryApType for AmbaAxi5 {
+    type CSW = CSW;
+
+    fn status<P: ApAccess + ?Sized>(&mut self, probe: &mut P) -> Result<CSW, ArmError> {
+        #[allow(clippy::assertions_on_constants)]
+        const { assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS) };
+        self.csw = probe.read_ap_register(self)?;
+        Ok(self.csw)
+    }
+
+    fn try_set_datasize<P: ApAccess + ?Sized>(
+        &mut self,
+        probe: &mut P,
+        data_size: DataSize,
+    ) -> Result<(), ArmError> {
+        match data_size {
+            DataSize::U8 | DataSize::U16 | DataSize::U32 if data_size != self.csw.Size => {
+                let csw = CSW {
+                    Size: data_size,
+                    ..self.csw
+                };
+                probe.write_ap_register(self, csw)?;
+                self.csw = csw;
+            }
+            DataSize::U64 | DataSize::U128 | DataSize::U256 => {
+                return Err(ArmError::UnsupportedTransferWidth(
+                    data_size.to_byte_count() * 8,
+                ))
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn has_large_address_extension(&self) -> bool {
+        self.cfg.LA
+    }
+
+    fn has_large_data_extension(&self) -> bool {
+        self.cfg.LD
+    }
+
+    fn supports_only_32bit_data_size(&self) -> bool {
+        // Amba AHB5 must support word, half-word and byte size transfers.
+        false
+    }
+}
+
+impl AccessPortType for AmbaAxi5 {
+    fn ap_address(&self) -> &FullyQualifiedApAddress {
+        &self.address
+    }
+}
+
+impl ApRegAccess<CSW> for AmbaAxi5 {}
+
+crate::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAxi5);
+
+define_ap_register!(
+    /// Control and Status Word register
+    ///
+    /// The control and status word register (CSW) is used
+    /// to configure memory access through the memory AP.
+    name: CSW,
+    address: 0x00,
+    fields: [
+        /// Is debug software access enabled.
+        DbgSwEnable: bool,          // [31]
+        Instruction: bool,          // [30]
+        /// Is the transaction request non-secure
+        ///
+        /// - If 1 a non-secure transfer is initiated.
+        /// - If 0 and SPIDEN is 1 then a secure transfer is initiated.
+        /// - If 0 and SPIDEN is 0 then no transaction is initiated.
+        NonSecure: bool,            // [29]
+        /// Is this transaction privileged
+        Privileged: bool,           // [28]
+        /// Drives `AxCACHE[3:0]` where x is R for reads and W for writes.
+        /// Amba AXI4 requires asymmetrical usage of `ARCACHE` and `AWCACHE`.
+        CACHE: u8,                  // [27:24]
+        /// Secure Debug Enabled.
+        ///
+        /// This bit reflects the state of the CoreSight authentication signal.
+        SPIDEN: bool,               // [23]
+        /// Memory Tagging Control.
+        /// When tagging is enabled, system read and write accesses via DRW, BDx and DARx use T0TR
+        /// for transferring tag information.
+        MTE: bool,                  // [15]
+        /// Drives the AxDOMAIN signals.
+        Type: u8,                   // [14:13]
+        /// A transfer is in progress.
+        /// Can be used to poll whether an aborted transaction has completed.
+        /// Read only.
+        TrInProg: bool,             // [7]
+        /// `1` if transactions can be issued through this access port at the moment.
+        /// Read only.
+        DeviceEn: bool,             // [6]
+        /// The address increment on DRW access.
+        AddrInc: AddressIncrement,  // [5:4]
+        /// The access size of this memory AP.
+        Size: DataSize,             // [2:0]
+        /// Reserved bit, kept to preserve IMPLEMENTATION DEFINED statuses.
+        _reserved_bits: u32         // mask
+    ],
+    from: value => Ok(CSW {
+        DbgSwEnable: ((value >> 31) & 0x01) != 0,
+        Instruction: ((value >> 30) & 0x01) != 0,
+        NonSecure: ((value >> 29) & 0x01) != 0,
+        Privileged: ((value >> 28) & 0x01) != 0,
+        CACHE: ((value >> 24) & 0xF) as u8,
+        SPIDEN: ((value >> 23) & 0x01) != 0,
+        MTE: ((value >> 15) & 0x01) != 0,
+        Type: ((value >> 13) & 0x03) as u8,
+        TrInProg: ((value >> 7) & 0x01) != 0,
+        DeviceEn: ((value >> 6) & 0x01) != 0,
+        AddrInc: AddressIncrement::from_u8(((value >> 4) & 0x03) as u8).ok_or_else(|| RegisterParseError::new("CSW", value))?,
+        Size: DataSize::try_from((value & 0x07) as u8).map_err(|_| RegisterParseError::new("CSW", value))?,
+        _reserved_bits: value & 0x007F_FF08,
+    }),
+    to: value => (u32::from(value.DbgSwEnable) << 31)
+    | (u32::from(value.Instruction  ) << 30)
+    | (u32::from(value.NonSecure    ) << 29)
+    | (u32::from(value.Privileged   ) << 28)
+    | (u32::from(value.CACHE        ) << 24)
+    | (u32::from(value.SPIDEN       ) << 23)
+    | (u32::from(value.MTE          ) << 15)
+    | (u32::from(value.Type         ) << 13)
+    | (u32::from(value.TrInProg     ) <<  7)
+    | (u32::from(value.DeviceEn     ) <<  6)
+    | (u32::from(value.AddrInc as u8) <<  4)
+    | (value.Size as u32)
+    | value._reserved_bits
+);

--- a/probe-rs/src/architecture/arm/ap/memory_ap/registers.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/registers.rs
@@ -1,0 +1,374 @@
+use crate::architecture::arm::communication_interface::RegisterParseError;
+
+/// The unit of data that is transferred in one transfer via the DRW commands.
+///
+/// This can be configured with the CSW command.
+///
+/// ALL MCUs support `U32`. All other transfer sizes are optionally implemented.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DataSize {
+    /// 1 byte transfers are supported.
+    U8 = 0b000,
+    /// 2 byte transfers are supported.
+    U16 = 0b001,
+    /// 4 byte transfers are supported.
+    #[default]
+    U32 = 0b010,
+    /// 8 byte transfers are supported.
+    U64 = 0b011,
+    /// 16 byte transfers are supported.
+    U128 = 0b100,
+    /// 32 byte transfers are supported.
+    U256 = 0b101,
+}
+
+impl DataSize {
+    pub fn to_byte_count(self) -> usize {
+        match self {
+            DataSize::U8 => 1,
+            DataSize::U16 => 2,
+            DataSize::U32 => 4,
+            DataSize::U64 => 8,
+            DataSize::U128 => 16,
+            DataSize::U256 => 32,
+        }
+    }
+}
+
+/// Invalid data size.
+pub struct InvalidDataSizeError;
+
+impl TryFrom<u8> for DataSize {
+    type Error = InvalidDataSizeError;
+    fn try_from(value: u8) -> Result<Self, InvalidDataSizeError> {
+        match value {
+            0b000 => Ok(DataSize::U8),
+            0b001 => Ok(DataSize::U16),
+            0b010 => Ok(DataSize::U32),
+            0b011 => Ok(DataSize::U64),
+            0b100 => Ok(DataSize::U128),
+            0b101 => Ok(DataSize::U256),
+            _ => Err(InvalidDataSizeError),
+        }
+    }
+}
+
+/// The increment to the TAR that is performed after each DRW read or write.
+///
+/// This can be used to avoid successive TAR transfers for writes of consecutive addresses.
+/// This will effectively save half the bandwidth!
+///
+/// Can be configured in the CSW.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AddressIncrement {
+    /// No increments are happening after the DRW access. TAR always stays the same.
+    /// Always supported.
+    Off = 0b00,
+    /// Increments the TAR by the size of the access after each DRW access.
+    /// Always supported.
+    #[default]
+    Single = 0b01,
+    /// Enables packed access to the DRW (see C2.2.7).
+    /// Only available if sub-word access is supported by the core.
+    Packed = 0b10,
+}
+
+impl AddressIncrement {
+    /// Create a new `AddressIncrement` from a u8.
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0b00 => Some(AddressIncrement::Off),
+            0b01 => Some(AddressIncrement::Single),
+            0b10 => Some(AddressIncrement::Packed),
+            _ => None,
+        }
+    }
+}
+
+/// The format of the BASE register (see C2.6.1).
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+pub enum BaseAddrFormat {
+    /// The legacy format of very old cores. Very little cores use this.
+    #[default]
+    Legacy = 0,
+    /// The format all newer MCUs use.
+    ADIv5 = 1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[allow(dead_code)] // Present is not used yet.
+pub enum DebugEntryState {
+    #[default]
+    NotPresent = 0,
+    Present = 1,
+}
+
+define_ap_register!(
+    /// Control and Status Word register
+    ///
+    /// The control and status word register (CSW) is used
+    /// to configure memory access through the memory AP.
+    name: CSW,
+    address: 0x00,
+    fields: [
+        /// Is debug software access enabled.
+        DbgSwEnable: bool,           // 1 bit
+        /// Used with the Type field to define the bus access protection protocol.
+        ///
+        /// This field is implementation defined. See the memory ap specific definition for details.
+        Prot: u8,                  // 7 bits
+        /// Secure Debug Enabled.
+        ///
+        /// This field has one of the following values:
+        /// - `0b0` Secure access is disabled.
+        /// - `0b1` Secure access is enabled.
+        /// This field is optional, and read-only. If not implemented, the bit is RES0.
+        /// If CSW.DeviceEn is 0b0, SPIDEN is ignored and the effective value of SPIDEN is 0b1.
+        /// For more information, see `Enabling access to the connected debug device or memory system`
+        /// on page C2-154.
+        ///
+        /// Note:
+        /// In ADIv5 and older versions of the architecture, the CSW.SPIDEN field is in the same bit
+        /// position as CSW.SDeviceEn, and has the same meaning. From ADIv6, the name SDeviceEn is
+        /// used to avoid confusion between this field and the SPIDEN signal on the authentication
+        /// interface.
+        SPIDEN: bool,                // 1 bit
+        /// Reserved.
+        _RES0: u8,                 // 7 bits
+        /// `1` if memory tagging access is enabled.
+        MTE: bool,                   // 1 bits
+        /// Memory tagging type. Implementation defined.
+        Type: u8,                  // 3 bits
+        /// Mode of operation. Is set to `0b0000` normally.
+        Mode: u8,                  // 4 bits
+        /// A transfer is in progress.
+        /// Can be used to poll whether an aborted transaction has completed.
+        /// Read only.
+        TrInProg: bool,              // 1 bit
+        /// `1` if transactions can be issued through this access port at the moment.
+        /// Read only.
+        DeviceEn: bool,              // 1 bit
+        /// The address increment on DRW access.
+        AddrInc: AddressIncrement, // 2 bits
+        /// Reserved
+        _RES1: u8,                 // 1 bit
+        /// The access size of this memory AP.
+        SIZE: DataSize,            // 3 bits
+    ],
+    from: value => Ok(CSW {
+        DbgSwEnable: ((value >> 31) & 0x01) != 0,
+        Prot: ((value >> 24) & 0x7F) as u8,
+        SPIDEN: ((value >> 23) & 0x01) != 0,
+        _RES0: ((value >> 16) & 0x7F) as u8,
+        MTE: ((value >> 15) & 0x01) != 0,
+        Type: ((value >> 12) & 0x07) as u8,
+        Mode: ((value >> 8) & 0x0F) as u8,
+        TrInProg: ((value >> 7) & 0x01) != 0,
+        DeviceEn: ((value >> 6) & 0x01) != 0,
+        AddrInc: AddressIncrement::from_u8(((value >> 4) & 0x03) as u8).ok_or_else(|| RegisterParseError::new("CSW", value))?,
+        _RES1: ((value >> 3) & 1) as u8,
+        SIZE: DataSize::try_from((value & 0x07) as u8).map_err(|_| RegisterParseError::new("CSW", value))?,
+    }),
+    to: value => (u32::from(value.DbgSwEnable) << 31)
+    | (u32::from(value.Prot         ) << 24)
+    | (u32::from(value.SPIDEN       ) << 23)
+    | (u32::from(value._RES0        ) << 16)
+    | (u32::from(value.MTE          ) << 15)
+    | (u32::from(value.Type         ) << 12)
+    | (u32::from(value.Mode         ) <<  8)
+    | (u32::from(value.TrInProg     ) <<  7)
+    | (u32::from(value.DeviceEn     ) <<  6)
+    | (u32::from(value.AddrInc as u8) << 4)
+    | (u32::from(value._RES1        ) <<  1)
+    | (value.SIZE as u32)
+);
+
+define_ap_register!(
+    /// Transfer Address Register
+    ///
+    /// The transfer address register (TAR) holds the memory
+    /// address which will be accessed through a read or
+    /// write of the DRW register.
+    name: TAR,
+    address: 0x04,
+    fields: [
+        /// The register address to be used for the next access to DRW.
+        address: u32,
+    ],
+    from: value => Ok(TAR { address: value }),
+    to: value => value.address
+);
+
+define_ap_register!(
+    /// Transfer Address Register - upper word
+    ///
+    /// The transfer address register (TAR) holds the memory
+    /// address which will be accessed through a read or
+    /// write of the DRW register.
+    name: TAR2,
+    address: 0x08,
+    fields: [
+        /// The upper 32-bits of the register address to be used for the next access to DRW.
+        address: u32,
+    ],
+    from: value => Ok(TAR2 { address: value }),
+    to: value => value.address
+);
+
+define_ap_register!(
+    /// Data Read/Write register
+    ///
+    /// The data read/write register (DRW) can be used to read
+    /// or write from the memory attached to the memory access point.
+    ///
+    /// A write to the *DRW* register is translated to a memory write
+    /// to the address specified in the TAR register.
+    ///
+    /// A read from the *DRW* register is translated to a memory read
+    name: DRW,
+    address: 0x0C,
+    fields: [
+        /// The data held in the DRW corresponding to the address held in TAR.
+        data: u32,
+    ],
+    from: value => Ok(DRW { data: value }),
+    to: value => value.data
+);
+
+define_ap_register!(
+    /// Banked Data 0 register
+    name: BD0,
+    address: 0x10,
+    fields: [
+        /// The data held in this bank.
+        data: u32,
+    ],
+    from: value => Ok(BD0 { data: value }),
+    to: value => value.data
+);
+
+define_ap_register!(
+    /// Banked Data 1 register
+    name: BD1,
+    address: 0x14,
+    fields: [
+        /// The data held in this bank.
+        data: u32,
+    ],
+    from: value => Ok(BD1 { data: value }),
+    to: value => value.data
+);
+
+define_ap_register!(
+    /// Banked Data 2 register
+    name: BD2,
+    address: 0x18,
+    fields: [
+        /// The data held in this bank.
+        data: u32,
+    ],
+    from: value => Ok(BD2 { data: value }),
+    to: value => value.data
+);
+
+define_ap_register!(
+    /// Banked Data 3 register
+    name: BD3,
+    address: 0x1C,
+    fields: [
+        /// The data held in this bank.
+        data: u32,
+    ],
+    from: value => Ok(BD3 { data: value }),
+    to: value => value.data
+);
+
+define_ap_register!(
+    /// Memory Barrier Transfer register
+    ///
+    /// The memory barrier transfer register (MBT) can
+    /// be written to generate a barrier operation on the
+    /// bus connected to the AP.
+    ///
+    /// Writes to this register only have an effect if
+    /// the *Barrier Operations Extension* is implemented
+    name: MBT,
+    address: 0x20,
+    fields: [
+        /// This value is implementation defined and the ADIv5.2 spec does not explain what it does for targets with the Barrier Operations Extension implemented.
+        data: u32,
+    ],
+    from: value => Ok(MBT { data: value }),
+    to: value => value.data
+);
+
+define_ap_register!(
+    /// Base register
+    name: BASE2,
+    address: 0xF0,
+    fields: [
+        /// The second part of the base address of this access point if required.
+        BASEADDR: u32
+    ],
+    from: value => Ok(BASE2 { BASEADDR: value }),
+    to: value => value.BASEADDR
+);
+
+define_ap_register!(
+    /// Configuration register
+    ///
+    /// The configuration register (CFG) is used to determine
+    /// which extensions are included in the memory AP.
+    name: CFG,
+    address: 0xF4,
+    fields: [
+        /// Specifies whether this access port includes the large data extension (access larger than 32 bits).
+        LD: bool,
+        /// Specifies whether this access port includes the large address extension (64 bit addressing).
+        LA: bool,
+        /// Specifies whether this architecture uses big endian. Must always be zero for modern chips as the ADI v5.2 deprecates big endian.
+        BE: bool,
+    ],
+    from: value => Ok(CFG {
+        LD: ((value >> 2) & 0x01) != 0,
+        LA: ((value >> 1) & 0x01) != 0,
+        BE: (value & 0x01) != 0,
+    }),
+    to: value => ((value.LD as u32) << 2) | ((value.LA as u32) << 1) | (value.BE as u32)
+);
+
+define_ap_register!(
+    /// Base register
+    name: BASE,
+    address: 0xF8,
+    fields: [
+        /// The base address of this access point.
+        BASEADDR: u32,
+        /// Reserved.
+        _RES0: u8,
+        /// The base address format of this access point.
+        Format: BaseAddrFormat,
+        /// Does this access point exists?
+        /// This field can be used to detect access points by iterating over all possible ones until one is found which has `exists == false`.
+        present: bool,
+    ],
+    from: value => Ok(BASE {
+        BASEADDR: (value & 0xFFFF_F000) >> 12,
+        _RES0: 0,
+        Format: match ((value >> 1) & 0x01) as u8 {
+            0 => BaseAddrFormat::Legacy,
+            1 => BaseAddrFormat::ADIv5,
+            _ => panic!("This is a bug. Please report it."),
+        },
+        present: match (value & 0x01) as u8 {
+            0 => false,
+            1 => true,
+            _ => panic!("This is a bug. Please report it."),
+        },
+    }),
+   to: value =>
+        (value.BASEADDR << 12)
+        // _RES0
+        | (u32::from(value.Format as u8) << 1)
+        | u32::from(value.present)
+);

--- a/probe-rs/src/architecture/arm/ap/register_generation.rs
+++ b/probe-rs/src/architecture/arm/ap/register_generation.rs
@@ -12,7 +12,6 @@
 #[macro_export]
 macro_rules! define_ap_register {
     (
-        type: $port_type:ident,
         $(#[$outer:meta])*
         name: $name:ident,
         address: $address:expr,
@@ -29,7 +28,7 @@ macro_rules! define_ap_register {
             $($(#[$inner])*pub $field: $type,)*
         }
 
-        impl Register for $name {
+        impl $crate::architecture::arm::communication_interface::Register for $name {
             // ADDRESS is always the lower 4 bits of the register address.
             const ADDRESS: u8 = $address;
             const NAME: &'static str = stringify!($name);
@@ -47,9 +46,6 @@ macro_rules! define_ap_register {
             fn from($to_param: $name) -> u32 {
                 $to
             }
-        }
-
-        impl ApRegister<$port_type> for $name {
         }
     }
 }
@@ -74,7 +70,7 @@ macro_rules! define_ap {
             }
         }
 
-        impl AccessPort for $name {
+        impl AccessPortType for $name {
             fn ap_address(&self) -> &FullyQualifiedApAddress {
                 &self.address
             }

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -995,7 +995,8 @@ impl<'probe> MemoryInterface for Armv7a<'probe> {
 mod test {
     use crate::{
         architecture::arm::{
-            ap::MemoryAp, communication_interface::SwdSequence, sequences::DefaultArmSequence,
+            ap::memory_ap::MemoryAp, communication_interface::SwdSequence,
+            sequences::DefaultArmSequence,
         },
         probe::DebugProbeError,
     };
@@ -1169,7 +1170,25 @@ mod test {
             })
         }
 
-        fn ap(&mut self) -> MemoryAp {
+        fn try_as_parts(
+            &mut self,
+        ) -> Result<
+            (
+                &mut crate::architecture::arm::ArmCommunicationInterface<
+                    crate::architecture::arm::communication_interface::Initialized,
+                >,
+                &mut MemoryAp,
+            ),
+            DebugProbeError,
+        > {
+            todo!()
+        }
+
+        fn ap(&mut self) -> &mut MemoryAp {
+            todo!()
+        }
+
+        fn base_address(&mut self) -> Result<u64, ArmError> {
             todo!()
         }
     }

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -1683,7 +1683,8 @@ impl<'probe> MemoryInterface for Armv8a<'probe> {
 mod test {
     use crate::{
         architecture::arm::{
-            ap::MemoryAp, communication_interface::SwdSequence, sequences::DefaultArmSequence,
+            ap::memory_ap::MemoryAp, communication_interface::SwdSequence,
+            sequences::DefaultArmSequence,
         },
         probe::DebugProbeError,
     };
@@ -1834,7 +1835,7 @@ mod test {
     impl ArmMemoryInterface for MockProbe {
         fn update_core_status(&mut self, _: CoreStatus) {}
 
-        fn ap(&mut self) -> MemoryAp {
+        fn ap(&mut self) -> &mut MemoryAp {
             todo!()
         }
 
@@ -1849,6 +1850,24 @@ mod test {
             Err(DebugProbeError::NotImplemented {
                 function_name: "get_arm_communication_interface",
             })
+        }
+
+        fn try_as_parts(
+            &mut self,
+        ) -> Result<
+            (
+                &mut crate::architecture::arm::ArmCommunicationInterface<
+                    crate::architecture::arm::communication_interface::Initialized,
+                >,
+                &mut MemoryAp,
+            ),
+            DebugProbeError,
+        > {
+            todo!()
+        }
+
+        fn base_address(&mut self) -> Result<u64, ArmError> {
+            todo!()
         }
     }
 

--- a/probe-rs/src/architecture/arm/memory/mod.rs
+++ b/probe-rs/src/architecture/arm/memory/mod.rs
@@ -15,12 +15,21 @@ pub use romtable::{Component, ComponentId, CoresightComponent, PeripheralType};
 /// An ArmMemoryInterface (ArmProbeInterface + MemoryAp)
 pub trait ArmMemoryInterface: SwdSequence + MemoryInterface<ArmError> {
     /// The underlying MemoryAp.
-    fn ap(&mut self) -> MemoryAp;
+    fn ap(&mut self) -> &mut MemoryAp;
+
+    /// The underlying memory AP’s base address.
+    fn base_address(&mut self) -> Result<u64, ArmError>;
 
     /// The underlying `ArmCommunicationInterface` if this is an `ArmCommunicationInterface`.
     fn get_arm_communication_interface(
         &mut self,
     ) -> Result<&mut ArmCommunicationInterface<Initialized>, DebugProbeError>;
+
+    /// The underlying `ArmCommunicationInterface` and memory AP if the probe interface is an
+    /// `ArmCommunicationInterface`.
+    fn try_as_parts(
+        &mut self,
+    ) -> Result<(&mut ArmCommunicationInterface<Initialized>, &mut MemoryAp), DebugProbeError>;
 
     /// Inform the probe of the [`CoreStatus`] of the chip/core attached to
     /// the probe.

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -1,7 +1,7 @@
 //! CoreSight ROM table parsing and handling.
 
 use crate::architecture::arm::{
-    ap::{AccessPort, AccessPortError},
+    ap::{AccessPortError, AccessPortType},
     communication_interface::ArmProbeInterface,
     memory::ArmMemoryInterface,
     ArmError, FullyQualifiedApAddress,

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -25,8 +25,7 @@ use crate::{
     probe::DebugProbeError,
 };
 pub use communication_interface::{
-    ApInformation, ArmChipInfo, ArmCommunicationInterface, ArmProbeInterface, DapError,
-    MemoryApInformation, Register,
+    ArmChipInfo, ArmCommunicationInterface, ArmProbeInterface, DapError, Register,
 };
 pub use swo::{SwoAccess, SwoConfig, SwoMode, SwoReader};
 pub use traits::*;

--- a/probe-rs/src/architecture/arm/traits.rs
+++ b/probe-rs/src/architecture/arm/traits.rs
@@ -34,7 +34,7 @@ bitfield::bitfield! {
 }
 
 /// Debug port address.
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash, Default)]
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Clone, Copy, Hash, Default)]
 pub enum DpAddress {
     /// Access the single DP on the bus, assuming there is only one.
     /// Will cause corruption if multiple are present.
@@ -46,7 +46,7 @@ pub enum DpAddress {
 }
 
 /// Access port v2 address
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub enum ApV2Address {
     /// Last node of an APv2 address
     Leaf(u32),
@@ -64,7 +64,7 @@ impl std::fmt::Display for ApV2Address {
 }
 
 /// Access port address
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub enum ApAddress {
     /// Access port v1 address
     V1(u8),
@@ -82,7 +82,7 @@ impl std::fmt::Display for ApAddress {
 }
 
 /// Access port address.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub struct FullyQualifiedApAddress {
     /// The address of the debug port this access port belongs to.
     dp: DpAddress,

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
@@ -3,13 +3,12 @@
 use std::sync::Arc;
 
 use super::nrf::Nrf;
-use crate::architecture::arm::ap::{AccessPort, CSW};
-use crate::architecture::arm::memory::ArmMemoryInterface;
-use crate::architecture::arm::sequences::ArmDebugSequence;
-use crate::architecture::arm::ArmError;
 use crate::architecture::arm::{
-    communication_interface::Initialized, ArmCommunicationInterface, DapAccess,
-    FullyQualifiedApAddress,
+    ap::{memory_ap::registers::CSW, AccessPortType},
+    communication_interface::Initialized,
+    memory::ArmMemoryInterface,
+    sequences::ArmDebugSequence,
+    ArmCommunicationInterface, ArmError, DapAccess, FullyQualifiedApAddress,
 };
 
 /// The sequence handle for the nRF5340.
@@ -28,8 +27,7 @@ impl Nrf for Nrf5340 {
         &self,
         memory: &mut dyn ArmMemoryInterface,
     ) -> Vec<(FullyQualifiedApAddress, FullyQualifiedApAddress)> {
-        let memory_ap = memory.ap();
-        let ap_address = memory_ap.ap_address();
+        let ap_address = memory.ap().ap_address();
 
         let core_aps = [(0, 2), (1, 3)];
 
@@ -53,7 +51,7 @@ impl Nrf for Nrf5340 {
         let csw: CSW = arm_interface
             .read_raw_ap_register(ahb_ap_address, 0x00)?
             .try_into()?;
-        Ok(csw.DeviceEn != 0)
+        Ok(csw.DeviceEn)
     }
 
     fn has_network_core(&self) -> bool {

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf91.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf91.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use super::nrf::Nrf;
 use crate::architecture::arm::{
-    ap::AccessPort, communication_interface::Initialized, memory::ArmMemoryInterface,
+    ap::AccessPortType, communication_interface::Initialized, memory::ArmMemoryInterface,
     sequences::ArmDebugSequence, ArmCommunicationInterface, ArmError, DapAccess,
     FullyQualifiedApAddress,
 };

--- a/probe-rs/src/vendor/ti/sequences/cc13xx_cc26xx.rs
+++ b/probe-rs/src/vendor/ti/sequences/cc13xx_cc26xx.rs
@@ -2,7 +2,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::architecture::arm::ap::AccessPort;
+use crate::architecture::arm::ap::AccessPortType;
 use crate::architecture::arm::armv7m::{Demcr, Dhcsr};
 use crate::architecture::arm::communication_interface::DapProbe;
 use crate::architecture::arm::memory::ArmMemoryInterface;

--- a/probe-rs/src/vendor/vorago/sequences/va416xx.rs
+++ b/probe-rs/src/vendor/vorago/sequences/va416xx.rs
@@ -5,7 +5,7 @@ use probe_rs_target::CoreType;
 
 use crate::{
     architecture::arm::{
-        ap::AccessPort,
+        ap::AccessPortType,
         armv7m::Demcr,
         memory::ArmMemoryInterface,
         sequences::{cortex_m_core_start, ArmDebugSequence},
@@ -79,7 +79,7 @@ impl ArmDebugSequence for Va416xx {
         interface.flush().ok();
 
         // Re-initializing the core(s) is on us.
-        let ap = interface.ap();
+        let ap = interface.ap().ap_address().clone();
 
         let arm_interface = interface.get_arm_communication_interface()?;
         const NUM_RETRIES: u32 = 10;
@@ -96,7 +96,7 @@ impl ArmDebugSequence for Va416xx {
         }
 
         assert!(debug_base.is_none());
-        self.debug_core_start(arm_interface, ap.ap_address(), core_type, None, None)?;
+        self.debug_core_start(arm_interface, &ap, core_type, None, None)?;
 
         if demcr.vc_corereset() {
             // TODO! Find a way to call the armv7m::halt function instead


### PR DESCRIPTION
- Enumerate Memory AP addresses instead of giving the number of valid
  (Generic and Memory) APs.
  This will enable future development where APv2’s live in disjoint memory
  spaces.
- Use AP specific types
  This should allow future developments to enabled things like secure
  debug, memory tagging, etc
- Drop `ApInformation` and `MemoryApInformation`
  The AP specific types carry these information internally so these types
  are no longer required.

Follows:
- https://github.com/probe-rs/probe-rs/pull/2706