### PR TITLE
Remove assert_cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,21 +150,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "assert_cmd"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
-dependencies = [
- "anstyle",
- "bstr",
- "doc-comment",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
-
-[[package]]
 name = "async-io"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,17 +298,6 @@ checksum = "7c33ef624481a2d2252fd352266c050e83203343d0884622f7ba09782abbfa83"
 dependencies = [
  "itertools 0.9.0",
  "smallvec",
-]
-
-[[package]]
-name = "bstr"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
-dependencies = [
- "memchr",
- "regex-automata 0.4.6",
- "serde",
 ]
 
 [[package]]
@@ -869,12 +843,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,12 +889,6 @@ name = "dissimilar"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "440d59c0c6d96354061909b4769b2ca03868dbaee203e7b779d9021ebbde3058"
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "docsplay"
@@ -1117,15 +1079,6 @@ checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1995,12 +1948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,36 +2222,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "predicates"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
-dependencies = [
- "anstyle",
- "difflib",
- "float-cmp",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
-dependencies = [
- "predicates-core",
- "termtree",
-]
 
 [[package]]
 name = "pretty_assertions"
@@ -3380,7 +3297,6 @@ name = "target-gen"
 version = "0.24.0"
 dependencies = [
  "anyhow",
- "assert_cmd",
  "clap",
  "cmsis-pack",
  "colored",
@@ -3390,7 +3306,6 @@ dependencies = [
  "jep106",
  "log",
  "parse_int",
- "predicates",
  "probe-rs",
  "probe-rs-target",
  "reqwest",
@@ -3949,15 +3864,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "want"

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -53,8 +53,6 @@ xshell = { version = "0.2", default-features = false }
 parse_int = "0.6"
 
 [dev-dependencies]
-assert_cmd = "2.0.14"
-predicates = "3.1.0"
 tempfile = "3.0"
 insta = { version = "1.38", default-features = false, features = ["yaml"] }
 

--- a/target-gen/tests/extract_pack.rs
+++ b/target-gen/tests/extract_pack.rs
@@ -1,18 +1,77 @@
-use assert_cmd::Command;
+use std::{env, ffi::OsString, path::PathBuf};
 
 const NORDIC_SAMPLE_PACK: &str =
     "tests/test_data/NordicSemiconductor.nRF_DeviceFamilyPack.8.32.1.pack";
 
+struct Command {
+    bin: PathBuf,
+    args: Vec<OsString>,
+}
+
+// Adapted from
+// https://github.com/rust-lang/cargo/blob/485670b3983b52289a2f353d589c57fae2f60f82/tests/testsuite/support/mod.rs#L507
+fn target_dir() -> PathBuf {
+    env::current_exe()
+        .ok()
+        .map(|mut path| {
+            path.pop();
+            if path.ends_with("deps") {
+                path.pop();
+            }
+            path
+        })
+        .unwrap()
+}
+
+impl Command {
+    fn cargo_bin(name: &str) -> Command {
+        let bin = env::var_os(format!("CARGO_BIN_EXE_{name}"))
+            .map(|p| p.into())
+            .unwrap_or_else(|| target_dir().join(format!("{name}{}", env::consts::EXE_SUFFIX)));
+
+        Command {
+            bin,
+            args: Vec::new(),
+        }
+    }
+
+    fn arg(mut self, arg: impl Into<OsString>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    fn run(self) -> CommandResult {
+        let output = std::process::Command::new(self.bin)
+            .args(&self.args)
+            .output()
+            .expect("failed to execute command");
+
+        CommandResult {
+            status: output.status,
+            stdout: String::from_utf8(output.stdout).expect("stdout is not valid UTF-8"),
+            stderr: String::from_utf8(output.stderr).expect("stderr is not valid UTF-8"),
+        }
+    }
+}
+
+struct CommandResult {
+    status: std::process::ExitStatus,
+    stdout: String,
+    stderr: String,
+}
+
 #[test]
 fn missing_output_directory() {
-    let mut cmd = Command::cargo_bin("target-gen").unwrap();
-
     // extract an example pack
-    cmd.arg("pack").arg(NORDIC_SAMPLE_PACK);
+    let result = Command::cargo_bin("target-gen")
+        .arg("pack")
+        .arg(NORDIC_SAMPLE_PACK)
+        .run();
 
-    cmd.assert().failure().stderr(predicates::str::contains(
-        "the following required arguments were not provided:",
-    ));
+    assert!(!result.status.success());
+    assert!(result
+        .stderr
+        .contains("the following required arguments were not provided:"));
 }
 
 #[test]
@@ -20,12 +79,13 @@ fn extract_target_specs() {
     // create a temporary directory
     let temp = tempfile::TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("target-gen").unwrap();
-
     // extract an example pack
-    cmd.arg("pack").arg(NORDIC_SAMPLE_PACK).arg(temp.path());
+    let result = Command::cargo_bin("target-gen")
+        .arg("pack")
+        .arg(NORDIC_SAMPLE_PACK)
+        .arg(temp.path())
+        .run();
 
-    cmd.assert().success().stdout(predicates::str::contains(
-        "Generated 4 target definition(s):",
-    ));
+    assert!(result.status.success());
+    assert!(result.stdout.contains("Generated 4 target definition(s):"));
 }


### PR DESCRIPTION
I don't think 2 uses in target-gen warrant the dependency and its tree and right now it's holding up renovate.