### PR TITLE
Add arm debug sequence for stm32-armv8

### DIFF
--- a/changelog/added-arm-debug-sequence-for-stm32-armv8.md
+++ b/changelog/added-arm-debug-sequence-for-stm32-armv8.md
@@ -1,0 +1,1 @@
+Added ARM debug sequence for stm32-armv8

--- a/probe-rs/src/vendor/st/mod.rs
+++ b/probe-rs/src/vendor/st/mod.rs
@@ -8,6 +8,7 @@ use crate::{
         st::sequences::{
             stm32_armv6::{Stm32Armv6, Stm32Armv6Family},
             stm32_armv7::Stm32Armv7,
+            stm32_armv8::Stm32Armv8,
             stm32h7::Stm32h7,
         },
         Vendor,
@@ -42,6 +43,11 @@ impl Vendor for St {
             DebugSequence::Arm(Stm32Armv7::create())
         } else if chip.name.starts_with("STM32H7") {
             DebugSequence::Arm(Stm32h7::create())
+        } else if chip.name.starts_with("STM32H5")
+            || chip.name.starts_with("STM32L5")
+            || chip.name.starts_with("STM32U5")
+        {
+            DebugSequence::Arm(Stm32Armv8::create())
         } else {
             return None;
         };

--- a/probe-rs/src/vendor/st/sequences/mod.rs
+++ b/probe-rs/src/vendor/st/sequences/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod stm32_armv6;
 pub mod stm32_armv7;
+pub mod stm32_armv8;
 pub mod stm32h7;

--- a/probe-rs/src/vendor/st/sequences/stm32_armv8.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32_armv8.rs
@@ -1,0 +1,118 @@
+//! Sequences for ARMv8 STM32s: STM32H5, STM32L5, STM32U5
+//!
+//! This covers devices where DBGMCU is at 0xE004400 and has the TRACE_MODE, TRACE_EN,
+//! TRACE_IOEN, DBG_STANDBY, DBG_STOP bits.
+//!
+
+use std::sync::Arc;
+
+use probe_rs_target::CoreType;
+
+use crate::architecture::arm::{
+    ap::MemoryAp,
+    component::TraceSink,
+    memory::{adi_v5_memory_interface::ArmProbe, CoresightComponent},
+    sequences::ArmDebugSequence,
+    ArmError, ArmProbeInterface,
+};
+
+/// Marker structure for ARMv8 STM32 devices.
+#[derive(Debug)]
+pub struct Stm32Armv8 {}
+
+impl Stm32Armv8 {
+    /// Create the sequencer for ARMv8 STM32 families.
+    pub fn create() -> Arc<Self> {
+        Arc::new(Self {})
+    }
+}
+
+mod dbgmcu {
+    use crate::architecture::arm::{memory::adi_v5_memory_interface::ArmProbe, ArmError};
+    use bitfield::bitfield;
+
+    /// The base address of the DBGMCU component
+    const DBGMCU: u64 = 0xE0044000;
+
+    bitfield! {
+        /// The control register (CR) of the DBGMCU. This register is described in "RM0456: STM32U5
+        /// family reference manual" section 75.12.4
+        pub struct Control(u32);
+        impl Debug;
+
+        pub u8, trace_mode, set_tracemode: 7, 6;
+        pub u8, trace_en, set_traceen: 5;
+        pub u8, trace_ioen, set_traceioen: 4;
+        pub u8, dbg_standby, enable_standby_debug: 2;
+        pub u8, dbg_stop, enable_stop_debug: 1;
+    }
+
+    impl Control {
+        /// The offset of the Control register in the DBGMCU block.
+        const ADDRESS: u64 = 0x04;
+
+        /// Read the control register from memory.
+        pub fn read(memory: &mut dyn ArmProbe) -> Result<Self, ArmError> {
+            let contents = memory.read_word_32(DBGMCU + Self::ADDRESS)?;
+            Ok(Self(contents))
+        }
+
+        /// Write the control register to memory.
+        pub fn write(&mut self, memory: &mut dyn ArmProbe) -> Result<(), ArmError> {
+            memory.write_word_32(DBGMCU + Self::ADDRESS, self.0)
+        }
+    }
+}
+
+impl ArmDebugSequence for Stm32Armv8 {
+    fn debug_device_unlock(
+        &self,
+        interface: &mut dyn ArmProbeInterface,
+        default_ap: &MemoryAp,
+        _permissions: &crate::Permissions,
+    ) -> Result<(), ArmError> {
+        let mut memory = interface.memory_interface(default_ap)?;
+        let mut cr = dbgmcu::Control::read(&mut *memory)?;
+        cr.enable_standby_debug(true);
+        cr.enable_stop_debug(true);
+        cr.write(&mut *memory)?;
+
+        Ok(())
+    }
+
+    fn debug_core_stop(
+        &self,
+        memory: &mut dyn ArmProbe,
+        _core_type: CoreType,
+    ) -> Result<(), ArmError> {
+        let mut cr = dbgmcu::Control::read(&mut *memory)?;
+        cr.enable_standby_debug(false);
+        cr.enable_stop_debug(false);
+        cr.write(&mut *memory)?;
+
+        Ok(())
+    }
+
+    fn trace_start(
+        &self,
+        interface: &mut dyn ArmProbeInterface,
+        components: &[CoresightComponent],
+        sink: &TraceSink,
+    ) -> Result<(), ArmError> {
+        let mut memory = interface.memory_interface(&components[0].ap)?;
+        let mut cr = dbgmcu::Control::read(&mut *memory)?;
+
+        if matches!(sink, TraceSink::Tpiu(_) | TraceSink::Swo(_)) {
+            cr.set_traceen(true);
+            cr.set_traceioen(true);
+            cr.set_tracemode(0);
+        } else {
+            cr.set_traceen(false);
+            cr.set_traceioen(false);
+            cr.set_tracemode(0);
+        }
+
+        cr.write(&mut *memory)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Add arm debug sequence for stm32-armv8

This PR implements ArmDebugSequence for stm32-armv8, since  DBGMCU_CR of stm32-armv8 (stm32l5, stm32u5) is slightly different than the one for stm32-armv7