### PR TITLE
Reset system before flashing, implement system reset for Xtensa MCUs

### DIFF
--- a/changelog/added-system-reset.md
+++ b/changelog/added-system-reset.md
@@ -1,0 +1,1 @@
+Added `Session::reset_and_halt_system` for systems that can't be properly reset by the core interface.

--- a/probe-rs/src/architecture/riscv/sequences.rs
+++ b/probe-rs/src/architecture/riscv/sequences.rs
@@ -1,10 +1,11 @@
 //! Debug sequences to operate special requirements RISC-V targets.
 
-use crate::architecture::riscv::communication_interface::RiscvError;
+use crate::architecture::riscv::communication_interface::{
+    RiscvCommunicationInterface, RiscvError,
+};
 use crate::architecture::riscv::Dmcontrol;
 use crate::Session;
 
-use super::communication_interface::RiscvCommunicationInterface;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
@@ -14,7 +15,7 @@ use std::time::Duration;
 /// Should be implemented on a custom handle for chips that require special sequence code.
 pub trait RiscvDebugSequence: Send + Sync + Debug {
     /// Executed when the probe establishes a connection to the target.
-    fn on_connect(&self, _interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
+    fn on_connect(&self, _session: &mut Session) -> Result<(), crate::Error> {
         Ok(())
     }
 

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -692,6 +692,10 @@ impl<'probe> XtensaCommunicationInterface<'probe> {
     pub(crate) fn clear_register_cache(&mut self) {
         self.state.saved_registers.clear();
     }
+
+    pub(crate) fn is_stalled(&mut self) -> Result<bool, XtensaError> {
+        self.xdm.status().map(|status| status.run_stall_sample())
+    }
 }
 
 /// DataType

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -682,10 +682,15 @@ impl<'probe> XtensaCommunicationInterface<'probe> {
     }
 
     pub(crate) fn reset_and_halt(&mut self, timeout: Duration) -> Result<(), XtensaError> {
+        self.clear_register_cache();
         self.xdm.reset_and_halt()?;
         self.wait_for_core_halted(timeout)?;
 
         Ok(())
+    }
+
+    pub(crate) fn clear_register_cache(&mut self) {
+        self.state.saved_registers.clear();
     }
 }
 

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -299,6 +299,9 @@ impl<'probe> CoreInterface for Xtensa<'probe> {
 
     fn run(&mut self) -> Result<(), Error> {
         self.skip_breakpoint_instruction()?;
+        if self.state.pc_written {
+            self.interface.clear_register_cache();
+        }
         Ok(self.interface.resume()?)
     }
 

--- a/probe-rs/src/architecture/xtensa/sequences.rs
+++ b/probe-rs/src/architecture/xtensa/sequences.rs
@@ -21,8 +21,13 @@ pub trait XtensaDebugSequence: Send + Sync + Debug {
         session.list_cores().into_iter().try_for_each(|(n, _)| {
             session
                 .core(n)
-                .and_then(|mut core| core.reset_and_halt(timeout))
-                .map(|_| ())
+                .and_then(|mut core| core.reset_and_halt(timeout))?;
+
+            // TODO: return a reconnect request?
+            let mut iface = session.get_xtensa_interface(n)?;
+            iface.enter_debug_mode()?;
+
+            Ok::<_, Error>(())
         })?;
 
         self.on_connect(session)?;

--- a/probe-rs/src/architecture/xtensa/sequences.rs
+++ b/probe-rs/src/architecture/xtensa/sequences.rs
@@ -1,6 +1,5 @@
 use std::{fmt::Debug, sync::Arc, time::Duration};
 
-use crate::architecture::xtensa::communication_interface::XtensaCommunicationInterface;
 use crate::{Error, Session};
 
 /// A interface to operate debug sequences for Xtensa targets.
@@ -8,10 +7,7 @@ use crate::{Error, Session};
 /// Should be implemented on a custom handle for chips that require special sequence code.
 pub trait XtensaDebugSequence: Send + Sync + Debug {
     /// Executed when the probe establishes a connection to the target.
-    fn on_connect(
-        &self,
-        _interface: &mut XtensaCommunicationInterface,
-    ) -> Result<(), crate::Error> {
+    fn on_connect(&self, _session: &mut Session) -> Result<(), crate::Error> {
         Ok(())
     }
 
@@ -27,7 +23,11 @@ pub trait XtensaDebugSequence: Send + Sync + Debug {
                 .core(n)
                 .and_then(|mut core| core.reset_and_halt(timeout))
                 .map(|_| ())
-        })
+        })?;
+
+        self.on_connect(session)?;
+
+        Ok(())
     }
 }
 

--- a/probe-rs/src/architecture/xtensa/sequences.rs
+++ b/probe-rs/src/architecture/xtensa/sequences.rs
@@ -1,9 +1,7 @@
 use std::{fmt::Debug, sync::Arc, time::Duration};
 
-use crate::architecture::xtensa::communication_interface::{
-    ProgramStatus, XtensaCommunicationInterface, XtensaError,
-};
-use crate::Session;
+use crate::architecture::xtensa::communication_interface::XtensaCommunicationInterface;
+use crate::{Error, Session};
 
 /// A interface to operate debug sequences for Xtensa targets.
 ///
@@ -23,24 +21,13 @@ pub trait XtensaDebugSequence: Send + Sync + Debug {
     }
 
     /// Executes a system-wide reset without debug domain (or warm-reset that preserves debug connection) via software mechanisms.
-    fn reset_system_and_halt(
-        &self,
-        interface: &mut XtensaCommunicationInterface,
-        timeout: Duration,
-    ) -> Result<(), XtensaError> {
-        interface.reset_and_halt(timeout)?;
-
-        // TODO: this is only necessary to run code, so this might not be the best place
-        // Make sure the CPU is in a known state and is able to run code we download.
-        interface.write_register({
-            let mut ps = ProgramStatus(0);
-            ps.set_intlevel(0);
-            ps.set_user_mode(true);
-            ps.set_woe(true);
-            ps
-        })?;
-
-        Ok(())
+    fn reset_and_halt_system(&self, session: &mut Session, timeout: Duration) -> Result<(), Error> {
+        session.list_cores().into_iter().try_for_each(|(n, _)| {
+            session
+                .core(n)
+                .and_then(|mut core| core.reset_and_halt(timeout))
+                .map(|_| ())
+        })
     }
 }
 

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -207,6 +207,8 @@ impl<'probe> Xdm<'probe> {
         self.write_nexus_register(DebugControlSet({
             let mut reg = DebugControlBits(0);
             reg.set_enable_ocd(true);
+            reg.set_break_in_en(true);
+            reg.set_break_out_en(true);
             reg
         }))?;
 
@@ -446,6 +448,8 @@ impl<'probe> Xdm<'probe> {
 
             control.set_enable_ocd(true);
             control.set_debug_interrupt(true);
+            control.set_break_in_en(true);
+            control.set_break_out_en(true);
 
             control
         }));
@@ -488,6 +492,8 @@ impl<'probe> Xdm<'probe> {
             let mut control = DebugControlBits(0);
 
             control.set_enable_ocd(true);
+            control.set_break_in_en(true);
+            control.set_break_out_en(true);
 
             control
         }))?;

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -214,11 +214,12 @@ impl<'probe> Xdm<'probe> {
 
         // read the device_id
         let device_id = self.read_nexus_register::<OcdId>()?.0;
+        tracing::debug!("Read OCDID: {:#010X}", device_id);
 
         if device_id == 0 || device_id == !0 {
             return Err(DebugProbeError::TargetNotFound.into());
         }
-        tracing::info!("Found Xtensa device with OCDID: 0x{:08X}", device_id);
+        tracing::info!("Found Xtensa device with OCDID: {:#010X}", device_id);
 
         let status = self.status()?;
         tracing::debug!("{:?}", status);

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -97,16 +97,16 @@ impl<'session> Flasher<'session> {
         tracing::debug!("Initializing the flash algorithm.");
         let algo = &self.flash_algorithm;
 
+        tracing::debug!("Reset and halt target");
+        self.session
+            .reset_and_halt_system(Duration::from_millis(500))
+            .map_err(FlashError::Core)?;
+
         // Attach to memory and core.
         let mut core = self
             .session
             .core(self.core_index)
             .map_err(FlashError::Core)?;
-
-        // TODO: we probably want a full system reset here to make sure peripherals don't interfere.
-        tracing::debug!("Reset and halt core {}", self.core_index);
-        core.reset_and_halt(Duration::from_millis(500))
-            .map_err(FlashError::ResetAndHalt)?;
 
         // TODO: Possible special preparation of the target such as enabling faster clocks for the flash e.g.
 

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -1087,7 +1087,6 @@ impl ChainParams {
 
         let mut found = false;
         for (index, tap) in chain.iter().enumerate() {
-            tracing::info!("{:?}", tap);
             if index == selected {
                 params.irlen = tap.irlen;
                 found = true;

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -439,7 +439,7 @@ pub(crate) trait RawJtagIo {
         self.shift_bits(tms, tdi, iter::repeat(false))?;
         let response = self.read_captured_bits()?;
 
-        tracing::debug!("Response to reset: {}", response);
+        tracing::debug!("Response to reset: {response}");
 
         Ok(())
     }
@@ -454,8 +454,9 @@ pub(crate) trait RawJtagIo {
 
         let max_ir_address = (1 << params.irlen) - 1;
 
-        tracing::debug!("Setting chain params: {:?}", params);
-        tracing::debug!("Setting max_ir_address to {}", max_ir_address);
+        tracing::debug!("Selecting JTAG TAP: {target}");
+        tracing::debug!("Setting chain params: {params:?}");
+        tracing::debug!("Setting max_ir_address to {max_ir_address}");
 
         let state = self.state_mut();
         state.max_ir_address = max_ir_address;

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -110,6 +110,7 @@ impl ArchitectureInterface {
             ArchitectureInterface::Arm(interface) => combined_state.attach_arm(target, interface),
             ArchitectureInterface::Jtag(probe, ifaces) => {
                 let idx = combined_state.interface_idx();
+                probe.select_jtag_tap(idx)?;
                 match &mut ifaces[idx] {
                     JtagInterface::Riscv(state) => {
                         let factory = probe.try_get_riscv_interface_builder()?;

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -771,6 +771,23 @@ impl Session {
             })
         })
     }
+
+    /// Resets the target device.
+    pub fn reset_and_halt_system(&mut self, timeout: Duration) -> Result<(), Error> {
+        match self.architecture() {
+            Architecture::Riscv | Architecture::Arm => { 0..self.cores.len() }.try_for_each(|n| {
+                self.core(n)
+                    .and_then(|mut core| core.reset_and_halt(timeout))
+                    .map(|_| ())
+            }),
+            Architecture::Xtensa => {
+                let DebugSequence::Xtensa(sequence) = self.target.debug_sequence.clone() else {
+                    unreachable!();
+                };
+                sequence.reset_and_halt_system(self, timeout)
+            }
+        }
+    }
 }
 
 // This test ensures that [Session] is fully [Send] + [Sync].

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -388,17 +388,8 @@ impl Session {
 
         // Connect to the cores
         match session.target.debug_sequence.clone() {
-            DebugSequence::Xtensa(sequence) => {
-                for core_id in 0..session.cores.len() {
-                    sequence.on_connect(&mut session.get_xtensa_interface(core_id)?)?;
-                }
-            }
-
-            DebugSequence::Riscv(sequence) => {
-                for core_id in 0..session.cores.len() {
-                    sequence.on_connect(&mut session.get_riscv_interface(core_id)?)?;
-                }
-            }
+            DebugSequence::Xtensa(sequence) => sequence.on_connect(&mut session)?,
+            DebugSequence::Riscv(sequence) => sequence.on_connect(&mut session)?,
             _ => unreachable!("Other architectures should have already been handled"),
         };
 

--- a/probe-rs/src/vendor/espressif/sequences/esp.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp.rs
@@ -7,7 +7,6 @@ use crate::{
         instruction::{into_binary, Instruction},
         CpuRegister, Register,
     },
-    config::DebugSequence,
     MemoryInterface, Session,
 };
 
@@ -115,14 +114,10 @@ fn attach_flash_xtensa(
     load_addr: u32,
     attach_fn: u32,
 ) -> Result<(), crate::Error> {
-    // TODO: we shouldn't need to touch sequences here.
-    let DebugSequence::Xtensa(sequence) = session.target().debug_sequence.clone() else {
-        unreachable!()
-    };
-    let interface = &mut session.get_xtensa_interface(0)?;
-
     // We're very intrusive here but the flashing process should reset the MCU again anyway
-    sequence.reset_system_and_halt(interface, Duration::from_millis(500))?;
+    session.reset_and_halt_system(Duration::from_millis(500))?;
+
+    let interface = &mut session.get_xtensa_interface(0)?;
 
     let instructions = into_binary([
         Instruction::CallX8(CpuRegister::A4),

--- a/probe-rs/src/vendor/espressif/sequences/esp32.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32.rs
@@ -5,12 +5,7 @@ use std::sync::Arc;
 use probe_rs_target::Chip;
 
 use super::esp::EspFlashSizeDetector;
-use crate::{
-    architecture::xtensa::{
-        communication_interface::XtensaCommunicationInterface, sequences::XtensaDebugSequence,
-    },
-    MemoryInterface, Session,
-};
+use crate::{architecture::xtensa::sequences::XtensaDebugSequence, MemoryInterface, Session};
 
 /// The debug sequence implementation for the ESP32.
 #[derive(Debug)]
@@ -30,39 +25,45 @@ impl ESP32 {
             },
         })
     }
-}
 
-impl XtensaDebugSequence for ESP32 {
-    fn on_connect(&self, interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
+    fn disable_wdt(&self, core: &mut impl MemoryInterface) -> Result<(), crate::Error> {
         tracing::info!("Disabling ESP32 watchdogs...");
 
         // tg0 wdg
         const TIMG0_BASE: u64 = 0x3ff5f000;
         const TIMG0_WRITE_PROT: u64 = TIMG0_BASE | 0x64;
         const TIMG0_WDTCONFIG0: u64 = TIMG0_BASE | 0x48;
-        interface.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
+        core.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
 
         // tg1 wdg
         const TIMG1_BASE: u64 = 0x3ff60000;
         const TIMG1_WRITE_PROT: u64 = TIMG1_BASE | 0x64;
         const TIMG1_WDTCONFIG0: u64 = TIMG1_BASE | 0x48;
-        interface.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
+        core.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
 
         // rtc wdg
         const RTC_CNTL_BASE: u64 = 0x3ff48000;
         const RTC_WRITE_PROT: u64 = RTC_CNTL_BASE | 0xa4;
         const RTC_WDTCONFIG0: u64 = RTC_CNTL_BASE | 0x8c;
-        interface.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(RTC_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(RTC_WDTCONFIG0, 0x0)?;
+        core.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
 
         tracing::warn!("Be careful not to reset your ESP32 while connected to the debugger! Depending on the specific device, this may render it temporarily inoperable or permanently damage it.");
 
         Ok(())
+    }
+}
+
+impl XtensaDebugSequence for ESP32 {
+    fn on_connect(&self, session: &mut Session) -> Result<(), crate::Error> {
+        let mut core = session.core(0).unwrap();
+
+        self.disable_wdt(&mut core)
     }
 
     fn detect_flash_size(&self, session: &mut Session) -> Result<Option<usize>, crate::Error> {

--- a/probe-rs/src/vendor/espressif/sequences/esp32.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32.rs
@@ -53,8 +53,6 @@ impl ESP32 {
         core.write_word_32(RTC_WDTCONFIG0, 0x0)?;
         core.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
 
-        tracing::warn!("Be careful not to reset your ESP32 while connected to the debugger! Depending on the specific device, this may render it temporarily inoperable or permanently damage it.");
-
         Ok(())
     }
 }
@@ -63,7 +61,11 @@ impl XtensaDebugSequence for ESP32 {
     fn on_connect(&self, session: &mut Session) -> Result<(), crate::Error> {
         let mut core = session.core(0).unwrap();
 
-        self.disable_wdt(&mut core)
+        self.disable_wdt(&mut core)?;
+
+        tracing::warn!("Be careful not to reset your ESP32 while connected to the debugger! Depending on the specific device, this may render it temporarily inoperable or permanently damage it.");
+
+        Ok(())
     }
 
     fn detect_flash_size(&self, session: &mut Session) -> Result<Option<usize>, crate::Error> {

--- a/probe-rs/src/vendor/espressif/sequences/esp32c2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c2.rs
@@ -31,28 +31,35 @@ impl ESP32C2 {
             },
         })
     }
+
+    fn disable_wdt(&self, core: &mut impl MemoryInterface) -> Result<(), crate::Error> {
+        tracing::info!("Disabling esp32c2 watchdogs...");
+
+        // disable super wdt
+        core.write_word_32(0x600080A4, 0x8F1D312A)?; // write protection off
+        let current = core.read_word_32(0x600080A0)?;
+        core.write_word_32(0x600080A0, current | 1 << 31)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
+        core.write_word_32(0x600080A4, 0x0)?; // write protection on
+
+        // tg0 wdg
+        core.write_word_32(0x6001f064, 0x50D83AA1)?; // write protection off
+        core.write_word_32(0x6001f048, 0x0)?;
+        core.write_word_32(0x6001f064, 0x0)?; // write protection on
+
+        // rtc wdg
+        core.write_word_32(0x6000809c, 0x50D83AA1)?; // write protection off
+        core.write_word_32(0x60008084, 0x0)?;
+        core.write_word_32(0x6000809c, 0x0)?; // write protection on
+
+        Ok(())
+    }
 }
 
 impl RiscvDebugSequence for ESP32C2 {
-    fn on_connect(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
-        tracing::info!("Disabling esp32c2 watchdogs...");
-        // disable super wdt
-        interface.write_word_32(0x600080A4, 0x8F1D312A)?; // write protection off
-        let current = interface.read_word_32(0x600080A0)?;
-        interface.write_word_32(0x600080A0, current | 1 << 31)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
-        interface.write_word_32(0x600080A4, 0x0)?; // write protection on
+    fn on_connect(&self, session: &mut Session) -> Result<(), crate::Error> {
+        let mut core = session.core(0).unwrap();
 
-        // tg0 wdg
-        interface.write_word_32(0x6001f064, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(0x6001f048, 0x0)?;
-        interface.write_word_32(0x6001f064, 0x0)?; // write protection on
-
-        // rtc wdg
-        interface.write_word_32(0x6000809c, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(0x60008084, 0x0)?;
-        interface.write_word_32(0x6000809c, 0x0)?; // write protection on
-
-        Ok(())
+        self.disable_wdt(&mut core)
     }
 
     fn detect_flash_size(&self, session: &mut Session) -> Result<Option<usize>, crate::Error> {
@@ -61,19 +68,19 @@ impl RiscvDebugSequence for ESP32C2 {
 
     fn reset_system_and_halt(
         &self,
-        interface: &mut RiscvCommunicationInterface,
+        core: &mut RiscvCommunicationInterface,
         timeout: Duration,
     ) -> Result<(), crate::Error> {
-        interface.halt(timeout)?;
+        core.halt(timeout)?;
 
         // Reset all peripherals except for the RTC block.
 
         // At this point the core is reset and halted, ready for us to issue a system reset
         // Trigger reset via RTC_CNTL_SW_SYS_RST
-        interface.write_word_32(0x6000_8000, 0x9C00_A000)?;
+        core.write_word_32(0x6000_8000, 0x9C00_A000)?;
 
         // Workaround for stuck in cpu start during calibration.
-        interface.write_word_32(0x6001_F068, 0)?;
+        core.write_word_32(0x6001_F068, 0)?;
 
         // Wait for the reset to take effect.
         std::thread::sleep(Duration::from_millis(10));
@@ -81,12 +88,12 @@ impl RiscvDebugSequence for ESP32C2 {
         let mut dmcontrol = Dmcontrol(0);
         dmcontrol.set_dmactive(true);
         dmcontrol.set_ackhavereset(true);
-        interface.write_dm_register(dmcontrol)?;
+        core.write_dm_register(dmcontrol)?;
 
-        interface.enter_debug_mode()?;
-        self.on_connect(interface)?;
+        core.enter_debug_mode()?;
+        self.disable_wdt(core)?;
 
-        interface.reset_hart_and_halt(timeout)?;
+        core.reset_hart_and_halt(timeout)?;
 
         Ok(())
     }

--- a/probe-rs/src/vendor/espressif/sequences/esp32c3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c3.rs
@@ -31,33 +31,40 @@ impl ESP32C3 {
             },
         })
     }
+
+    fn disable_wdt(&self, core: &mut impl MemoryInterface) -> Result<(), crate::Error> {
+        tracing::info!("Disabling esp32c3 watchdogs...");
+
+        // disable super wdt
+        core.write_word_32(0x600080B0, 0x8F1D312A)?; // write protection off
+        let current = core.read_word_32(0x600080AC)?;
+        core.write_word_32(0x600080AC, current | 1 << 31)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
+        core.write_word_32(0x600080B0, 0x0)?; // write protection on
+
+        // tg0 wdg
+        core.write_word_32(0x6001f064, 0x50D83AA1)?; // write protection off
+        core.write_word_32(0x6001F048, 0x0)?;
+        core.write_word_32(0x6001f064, 0x0)?; // write protection on
+
+        // tg1 wdg
+        core.write_word_32(0x60020064, 0x50D83AA1)?; // write protection off
+        core.write_word_32(0x60020048, 0x0)?;
+        core.write_word_32(0x60020064, 0x0)?; // write protection on
+
+        // rtc wdg
+        core.write_word_32(0x600080a8, 0x50D83AA1)?; // write protection off
+        core.write_word_32(0x60008090, 0x0)?;
+        core.write_word_32(0x600080a8, 0x0)?; // write protection on
+
+        Ok(())
+    }
 }
 
 impl RiscvDebugSequence for ESP32C3 {
-    fn on_connect(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
-        tracing::info!("Disabling esp32c3 watchdogs...");
-        // disable super wdt
-        interface.write_word_32(0x600080B0, 0x8F1D312A)?; // write protection off
-        let current = interface.read_word_32(0x600080AC)?;
-        interface.write_word_32(0x600080AC, current | 1 << 31)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
-        interface.write_word_32(0x600080B0, 0x0)?; // write protection on
+    fn on_connect(&self, session: &mut Session) -> Result<(), crate::Error> {
+        let mut core = session.core(0).unwrap();
 
-        // tg0 wdg
-        interface.write_word_32(0x6001f064, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(0x6001F048, 0x0)?;
-        interface.write_word_32(0x6001f064, 0x0)?; // write protection on
-
-        // tg1 wdg
-        interface.write_word_32(0x60020064, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(0x60020048, 0x0)?;
-        interface.write_word_32(0x60020064, 0x0)?; // write protection on
-
-        // rtc wdg
-        interface.write_word_32(0x600080a8, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(0x60008090, 0x0)?;
-        interface.write_word_32(0x600080a8, 0x0)?; // write protection on
-
-        Ok(())
+        self.disable_wdt(&mut core)
     }
 
     fn detect_flash_size(&self, session: &mut Session) -> Result<Option<usize>, crate::Error> {
@@ -66,19 +73,19 @@ impl RiscvDebugSequence for ESP32C3 {
 
     fn reset_system_and_halt(
         &self,
-        interface: &mut RiscvCommunicationInterface,
+        core: &mut RiscvCommunicationInterface,
         timeout: Duration,
     ) -> Result<(), crate::Error> {
-        interface.halt(timeout)?;
+        core.halt(timeout)?;
 
         // Reset all peripherals except for the RTC block.
 
         // At this point the core is reset and halted, ready for us to issue a system reset
         // Trigger reset via RTC_CNTL_SW_SYS_RST
-        interface.write_word_32(0x6000_8000, 0x9C00_A000)?;
+        core.write_word_32(0x6000_8000, 0x9C00_A000)?;
 
         // Workaround for stuck in cpu start during calibration.
-        interface.write_word_32(0x6001_F068, 0)?;
+        core.write_word_32(0x6001_F068, 0)?;
 
         // Wait for the reset to take effect.
         std::thread::sleep(Duration::from_millis(10));
@@ -86,12 +93,12 @@ impl RiscvDebugSequence for ESP32C3 {
         let mut dmcontrol = Dmcontrol(0);
         dmcontrol.set_dmactive(true);
         dmcontrol.set_ackhavereset(true);
-        interface.write_dm_register(dmcontrol)?;
+        core.write_dm_register(dmcontrol)?;
 
-        interface.enter_debug_mode()?;
-        self.on_connect(interface)?;
+        core.enter_debug_mode()?;
+        self.disable_wdt(core)?;
 
-        interface.reset_hart_and_halt(timeout)?;
+        core.reset_hart_and_halt(timeout)?;
 
         Ok(())
     }

--- a/probe-rs/src/vendor/espressif/sequences/esp32c6.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c6.rs
@@ -32,33 +32,40 @@ impl ESP32C6 {
             },
         })
     }
+
+    fn disable_wdt(&self, core: &mut impl MemoryInterface) -> Result<(), crate::Error> {
+        tracing::info!("Disabling esp32c6 watchdogs...");
+
+        // disable super wdt
+        core.write_word_32(0x600B1C20, 0x50D83AA1)?; // write protection off
+        let current = core.read_word_32(0x600B_1C1C)?;
+        core.write_word_32(0x600B_1C1C, current | 1 << 18)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
+        core.write_word_32(0x600B1C20, 0x0)?; // write protection on
+
+        // tg0 wdg
+        core.write_word_32(0x6000_8064, 0x50D83AA1)?; // write protection off
+        core.write_word_32(0x6000_8048, 0x0)?;
+        core.write_word_32(0x6000_8064, 0x0)?; // write protection on
+
+        // tg1 wdg
+        core.write_word_32(0x6000_9064, 0x50D83AA1)?; // write protection off
+        core.write_word_32(0x6000_9048, 0x0)?;
+        core.write_word_32(0x6000_9064, 0x0)?; // write protection on
+
+        // rtc wdg
+        core.write_word_32(0x600B_1C18, 0x50D83AA1)?; // write protection off
+        core.write_word_32(0x600B_1C00, 0x0)?;
+        core.write_word_32(0x600B_1C18, 0x0)?; // write protection on
+
+        Ok(())
+    }
 }
 
 impl RiscvDebugSequence for ESP32C6 {
-    fn on_connect(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
-        tracing::info!("Disabling esp32c6 watchdogs...");
-        // disable super wdt
-        interface.write_word_32(0x600B1C20, 0x50D83AA1)?; // write protection off
-        let current = interface.read_word_32(0x600B_1C1C)?;
-        interface.write_word_32(0x600B_1C1C, current | 1 << 18)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
-        interface.write_word_32(0x600B1C20, 0x0)?; // write protection on
+    fn on_connect(&self, session: &mut Session) -> Result<(), crate::Error> {
+        let mut core = session.core(0).unwrap();
 
-        // tg0 wdg
-        interface.write_word_32(0x6000_8064, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(0x6000_8048, 0x0)?;
-        interface.write_word_32(0x6000_8064, 0x0)?; // write protection on
-
-        // tg1 wdg
-        interface.write_word_32(0x6000_9064, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(0x6000_9048, 0x0)?;
-        interface.write_word_32(0x6000_9064, 0x0)?; // write protection on
-
-        // rtc wdg
-        interface.write_word_32(0x600B_1C18, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(0x600B_1C00, 0x0)?;
-        interface.write_word_32(0x600B_1C18, 0x0)?; // write protection on
-
-        Ok(())
+        self.disable_wdt(&mut core)
     }
 
     fn detect_flash_size(&self, session: &mut Session) -> Result<Option<usize>, crate::Error> {
@@ -67,42 +74,42 @@ impl RiscvDebugSequence for ESP32C6 {
 
     fn reset_system_and_halt(
         &self,
-        interface: &mut RiscvCommunicationInterface,
+        core: &mut RiscvCommunicationInterface,
         timeout: Duration,
     ) -> Result<(), crate::Error> {
-        interface.halt(timeout)?;
+        core.halt(timeout)?;
 
         // System reset, ported from OpenOCD.
-        interface.write_dm_register(Sbcs(0x48000))?;
-        interface.write_dm_register(Sbaddress0(0x600b1034))?;
-        interface.write_dm_register(Sbdata0(0x80000000_u32))?;
+        core.write_dm_register(Sbcs(0x48000))?;
+        core.write_dm_register(Sbaddress0(0x600b1034))?;
+        core.write_dm_register(Sbdata0(0x80000000_u32))?;
 
         // clear dmactive to clear sbbusy otherwise debug module gets stuck
-        interface.write_dm_register(Dmcontrol(0))?;
+        core.write_dm_register(Dmcontrol(0))?;
 
-        interface.write_dm_register(Sbcs(0x48000))?;
-        interface.write_dm_register(Sbaddress0(0x600b1038))?;
-        interface.write_dm_register(Sbdata0(0x10000000_u32))?;
+        core.write_dm_register(Sbcs(0x48000))?;
+        core.write_dm_register(Sbaddress0(0x600b1038))?;
+        core.write_dm_register(Sbdata0(0x10000000_u32))?;
 
         // clear dmactive to clear sbbusy otherwise debug module gets stuck
-        interface.write_dm_register(Dmcontrol(0))?;
+        core.write_dm_register(Dmcontrol(0))?;
 
         let mut dmcontrol = Dmcontrol(0);
         dmcontrol.set_dmactive(true);
         dmcontrol.set_resumereq(true);
-        interface.write_dm_register(dmcontrol)?;
+        core.write_dm_register(dmcontrol)?;
 
         std::thread::sleep(Duration::from_millis(10));
 
         let mut dmcontrol = Dmcontrol(0);
         dmcontrol.set_dmactive(true);
         dmcontrol.set_ackhavereset(true);
-        interface.write_dm_register(dmcontrol)?;
+        core.write_dm_register(dmcontrol)?;
 
-        interface.enter_debug_mode()?;
-        self.on_connect(interface)?;
+        core.enter_debug_mode()?;
+        self.disable_wdt(core)?;
 
-        interface.reset_hart_and_halt(timeout)?;
+        core.reset_hart_and_halt(timeout)?;
 
         Ok(())
     }

--- a/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
@@ -32,33 +32,40 @@ impl ESP32H2 {
             },
         })
     }
+
+    fn disable_wdt(&self, core: &mut impl MemoryInterface) -> Result<(), crate::Error> {
+        tracing::info!("Disabling esp32h2 watchdogs...");
+
+        // disable super wdt
+        core.write_word_32(0x600B1C20, 0x50D83AA1)?; // write protection off
+        let current = core.read_word_32(0x600B_1C1C)?;
+        core.write_word_32(0x600B_1C1C, current | 1 << 18)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
+        core.write_word_32(0x600B1C20, 0x0)?; // write protection on
+
+        // tg0 wdg
+        core.write_word_32(0x6000_8064, 0x50D83AA1)?; // write protection off
+        core.write_word_32(0x6000_8048, 0x0)?;
+        core.write_word_32(0x6000_8064, 0x0)?; // write protection on
+
+        // tg1 wdg
+        core.write_word_32(0x6000_9064, 0x50D83AA1)?; // write protection off
+        core.write_word_32(0x6000_9048, 0x0)?;
+        core.write_word_32(0x6000_9064, 0x0)?; // write protection on
+
+        // rtc wdg
+        core.write_word_32(0x600B_1C18, 0x50D83AA1)?; // write protection off
+        core.write_word_32(0x600B_1C00, 0x0)?;
+        core.write_word_32(0x600B_1C18, 0x0)?; // write protection on
+
+        Ok(())
+    }
 }
 
 impl RiscvDebugSequence for ESP32H2 {
-    fn on_connect(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
-        tracing::info!("Disabling esp32h2 watchdogs...");
-        // disable super wdt
-        interface.write_word_32(0x600B1C20, 0x50D83AA1)?; // write protection off
-        let current = interface.read_word_32(0x600B_1C1C)?;
-        interface.write_word_32(0x600B_1C1C, current | 1 << 18)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
-        interface.write_word_32(0x600B1C20, 0x0)?; // write protection on
+    fn on_connect(&self, session: &mut Session) -> Result<(), crate::Error> {
+        let mut core = session.core(0).unwrap();
 
-        // tg0 wdg
-        interface.write_word_32(0x6000_8064, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(0x6000_8048, 0x0)?;
-        interface.write_word_32(0x6000_8064, 0x0)?; // write protection on
-
-        // tg1 wdg
-        interface.write_word_32(0x6000_9064, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(0x6000_9048, 0x0)?;
-        interface.write_word_32(0x6000_9064, 0x0)?; // write protection on
-
-        // rtc wdg
-        interface.write_word_32(0x600B_1C18, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(0x600B_1C00, 0x0)?;
-        interface.write_word_32(0x600B_1C18, 0x0)?; // write protection on
-
-        Ok(())
+        self.disable_wdt(&mut core)
     }
 
     fn detect_flash_size(&self, session: &mut Session) -> Result<Option<usize>, crate::Error> {
@@ -67,42 +74,42 @@ impl RiscvDebugSequence for ESP32H2 {
 
     fn reset_system_and_halt(
         &self,
-        interface: &mut RiscvCommunicationInterface,
+        core: &mut RiscvCommunicationInterface,
         timeout: Duration,
     ) -> Result<(), crate::Error> {
-        interface.halt(timeout)?;
+        core.halt(timeout)?;
 
         // System reset, ported from OpenOCD.
-        interface.write_dm_register(Sbcs(0x48000))?;
-        interface.write_dm_register(Sbaddress0(0x600b1034))?;
-        interface.write_dm_register(Sbdata0(0x80000000_u32))?;
+        core.write_dm_register(Sbcs(0x48000))?;
+        core.write_dm_register(Sbaddress0(0x600b1034))?;
+        core.write_dm_register(Sbdata0(0x80000000_u32))?;
 
         // clear dmactive to clear sbbusy otherwise debug module gets stuck
-        interface.write_dm_register(Dmcontrol(0))?;
+        core.write_dm_register(Dmcontrol(0))?;
 
-        interface.write_dm_register(Sbcs(0x48000))?;
-        interface.write_dm_register(Sbaddress0(0x600b1038))?;
-        interface.write_dm_register(Sbdata0(0x10000000_u32))?;
+        core.write_dm_register(Sbcs(0x48000))?;
+        core.write_dm_register(Sbaddress0(0x600b1038))?;
+        core.write_dm_register(Sbdata0(0x10000000_u32))?;
 
         // clear dmactive to clear sbbusy otherwise debug module gets stuck
-        interface.write_dm_register(Dmcontrol(0))?;
+        core.write_dm_register(Dmcontrol(0))?;
 
         let mut dmcontrol = Dmcontrol(0);
         dmcontrol.set_dmactive(true);
         dmcontrol.set_resumereq(true);
-        interface.write_dm_register(dmcontrol)?;
+        core.write_dm_register(dmcontrol)?;
 
         std::thread::sleep(Duration::from_millis(10));
 
         let mut dmcontrol = Dmcontrol(0);
         dmcontrol.set_dmactive(true);
         dmcontrol.set_ackhavereset(true);
-        interface.write_dm_register(dmcontrol)?;
+        core.write_dm_register(dmcontrol)?;
 
-        interface.enter_debug_mode()?;
-        self.on_connect(interface)?;
+        core.enter_debug_mode()?;
+        self.disable_wdt(core)?;
 
-        interface.reset_hart_and_halt(timeout)?;
+        core.reset_hart_and_halt(timeout)?;
 
         Ok(())
     }

--- a/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
@@ -5,12 +5,7 @@ use std::sync::Arc;
 use probe_rs_target::Chip;
 
 use super::esp::EspFlashSizeDetector;
-use crate::{
-    architecture::xtensa::{
-        communication_interface::XtensaCommunicationInterface, sequences::XtensaDebugSequence,
-    },
-    MemoryInterface, Session,
-};
+use crate::{architecture::xtensa::sequences::XtensaDebugSequence, MemoryInterface, Session};
 
 /// The debug sequence implementation for the ESP32-S2.
 #[derive(Debug)]
@@ -30,37 +25,43 @@ impl ESP32S2 {
             },
         })
     }
-}
 
-impl XtensaDebugSequence for ESP32S2 {
-    fn on_connect(&self, interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
+    fn disable_wdt(&self, core: &mut impl MemoryInterface) -> Result<(), crate::Error> {
         tracing::info!("Disabling ESP32-S2 watchdogs...");
 
         // tg0 wdg
         const TIMG0_BASE: u64 = 0x3f41f000;
         const TIMG0_WRITE_PROT: u64 = TIMG0_BASE | 0x64;
         const TIMG0_WDTCONFIG0: u64 = TIMG0_BASE | 0x48;
-        interface.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
+        core.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
 
         // tg1 wdg
         const TIMG1_BASE: u64 = 0x3f420000;
         const TIMG1_WRITE_PROT: u64 = TIMG1_BASE | 0x64;
         const TIMG1_WDTCONFIG0: u64 = TIMG1_BASE | 0x48;
-        interface.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
+        core.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
 
         // rtc wdg
         const RTC_CNTL_BASE: u64 = 0x3f408000;
         const RTC_WRITE_PROT: u64 = RTC_CNTL_BASE | 0xac;
         const RTC_WDTCONFIG0: u64 = RTC_CNTL_BASE | 0x94;
-        interface.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(RTC_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(RTC_WDTCONFIG0, 0x0)?;
+        core.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
 
         Ok(())
+    }
+}
+
+impl XtensaDebugSequence for ESP32S2 {
+    fn on_connect(&self, session: &mut Session) -> Result<(), crate::Error> {
+        let mut core = session.core(0).unwrap();
+
+        self.disable_wdt(&mut core)
     }
 
     fn detect_flash_size(&self, session: &mut Session) -> Result<Option<usize>, crate::Error> {

--- a/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
@@ -1,6 +1,9 @@
 //! Sequence for the ESP32-S3.
 
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use probe_rs_target::Chip;
 
@@ -66,5 +69,131 @@ impl XtensaDebugSequence for ESP32S3 {
 
     fn detect_flash_size(&self, session: &mut Session) -> Result<Option<usize>, crate::Error> {
         self.inner.detect_flash_size(session)
+    }
+
+    fn reset_and_halt_system(
+        &self,
+        session: &mut Session,
+        timeout: Duration,
+    ) -> Result<(), crate::Error> {
+        const ESP32_S3_RTCCNTL_BASE: u64 = 0x60008000;
+        const ESP32_S3_RTC_CNTL_SW_CPU_STALL_REG: u64 = ESP32_S3_RTCCNTL_BASE + 0xBC;
+        const ESP32_S3_RTC_CNTL_SW_CPU_STALL_DEF: u32 = 0x0;
+
+        const RTC_CNTL_RESET_STATE_REG: u64 = ESP32_S3_RTCCNTL_BASE + 0x38;
+        const RTC_CNTL_RESET_STATE_DEF: u32 = 0x3000;
+
+        {
+            let _span = tracing::debug_span!("Halting cores").entered();
+            session
+                .list_cores()
+                .into_iter()
+                .try_for_each(|(n, _)| session.core(n)?.halt(timeout).map(|_| ()))?;
+        }
+
+        {
+            let _span = tracing::debug_span!("Unstalling cores").entered();
+            session.list_cores().into_iter().try_for_each(|(n, _)| {
+                let mut interface = session.get_xtensa_interface(n)?;
+
+                if interface.is_stalled()? {
+                    tracing::debug!("Unstalling core {n}");
+
+                    interface.write_word_32(
+                        ESP32_S3_RTC_CNTL_SW_CPU_STALL_REG,
+                        ESP32_S3_RTC_CNTL_SW_CPU_STALL_DEF,
+                    )?;
+                }
+
+                Ok::<_, crate::Error>(())
+            })?;
+        }
+
+        // A program that does the system reset and then loops,
+        // because system reset seems to disable JTAG.
+        // TODO: rework this into some readable code
+        let instructions = [
+            0x06, 0x23, 0x00, 0x00, 0x06, 0x18, 0x00, 0x00, 0x38, 0x80, 0x00, 0x60, 0xc0, 0x80,
+            0x00, 0x60, 0xc4, 0x80, 0x00, 0x60, 0x90, 0x80, 0x00, 0x60, 0x74, 0x80, 0x00, 0x60,
+            0x18, 0x32, 0x58, 0x01, 0x00, 0xa0, 0x00, 0x9c, 0x00, 0x80, 0x00, 0x60, 0xa1, 0x3a,
+            0xd8, 0x50, 0xac, 0x80, 0x00, 0x60, 0x64, 0xf0, 0x01, 0x60, 0x64, 0x00, 0x02, 0x60,
+            0x94, 0x80, 0x00, 0x60, 0x48, 0xf0, 0x01, 0x60, 0x48, 0x00, 0x02, 0x60, 0xb4, 0x80,
+            0x00, 0x60, 0x2a, 0x31, 0x1d, 0x8f, 0xb0, 0x80, 0x00, 0x60, 0x00, 0x00, 0xb0, 0x84,
+            0x04, 0x00, 0x0c, 0x60, 0x00, 0x00, 0x0c, 0x60, 0x00, 0x00, 0x0c, 0x60, 0x38, 0x80,
+            0x00, 0x60, 0x00, 0x30, 0x00, 0x00, 0x50, 0x55, 0x30, 0x41, 0xe7, 0xff, 0x59, 0x04,
+            0x41, 0xe7, 0xff, 0x59, 0x04, 0x41, 0xe6, 0xff, 0x59, 0x04, 0x41, 0xe6, 0xff, 0x59,
+            0x04, 0x41, 0xe6, 0xff, 0x31, 0xe6, 0xff, 0x39, 0x04, 0x31, 0xe6, 0xff, 0x41, 0xe6,
+            0xff, 0x39, 0x04, 0x00, 0x60, 0xeb, 0x03, 0x60, 0x61, 0x04, 0x56, 0x26, 0x05, 0x50,
+            0x55, 0x30, 0x31, 0xe3, 0xff, 0x41, 0xe3, 0xff, 0x39, 0x04, 0x41, 0xe3, 0xff, 0x39,
+            0x04, 0x41, 0xe2, 0xff, 0x39, 0x04, 0x41, 0xe2, 0xff, 0x59, 0x04, 0x41, 0xe2, 0xff,
+            0x59, 0x04, 0x41, 0xe2, 0xff, 0x59, 0x04, 0x41, 0xe1, 0xff, 0x31, 0xe2, 0xff, 0x39,
+            0x04, 0x41, 0xe1, 0xff, 0x31, 0xe2, 0xff, 0x39, 0x04, 0x41, 0xe1, 0xff, 0x59, 0x04,
+            0x41, 0xe1, 0xff, 0x0c, 0x23, 0x39, 0x04, 0x41, 0xe0, 0xff, 0x0c, 0x43, 0x39, 0x04,
+            0x0c, 0x23, 0x39, 0x04, 0x41, 0xdf, 0xff, 0x31, 0xdf, 0xff, 0x39, 0x04, 0x00, 0x70,
+            0x00, 0x46, 0xfe, 0xff,
+        ];
+
+        let mut ram_value = vec![0; std::mem::size_of_val(&instructions)];
+
+        {
+            let mut core = session.core(0)?;
+
+            {
+                let _span = tracing::debug_span!("Backing up RTC_SLOW").entered();
+                core.read(0x5000_0000, &mut ram_value)?;
+            }
+
+            {
+                let _span = tracing::debug_span!("Downloading code").entered();
+                core.write(0x5000_0000, &instructions)?;
+                core.write_core_reg(core.program_counter(), 0x5000_0004_u32)?;
+            }
+
+            {
+                let _span = tracing::debug_span!("Make sure the ready value is not what we expect")
+                    .entered();
+                let reset_state = core.read_word_32(RTC_CNTL_RESET_STATE_REG)?;
+                let new_state = reset_state & !RTC_CNTL_RESET_STATE_DEF;
+                core.write_word_32(RTC_CNTL_RESET_STATE_REG, new_state)?;
+            }
+
+            core.run()?;
+        }
+
+        std::thread::sleep(Duration::from_millis(100));
+
+        {
+            let mut core = session.core(0)?;
+
+            let start = Instant::now();
+            tracing::debug!("Waiting for program to complete");
+            loop {
+                // RTC_CNTL_RESET_STATE_REG is the last one to be set,
+                // so if it's set, the program has completed.
+                let reset_state = core.read_word_32(RTC_CNTL_RESET_STATE_REG)?;
+                tracing::debug!("Reset status register: {:#010x}", reset_state);
+                if reset_state & RTC_CNTL_RESET_STATE_DEF == RTC_CNTL_RESET_STATE_DEF {
+                    break;
+                }
+
+                if start.elapsed() >= timeout {
+                    return Err(crate::Error::Timeout);
+                }
+            }
+
+            core.reset_and_halt(timeout)?;
+        }
+
+        self.on_connect(session)?;
+
+        {
+            let _span = tracing::debug_span!("Restore RAM contents").entered();
+            let mut core = session.core(0)?;
+            core.write(0x5000_0000, &ram_value)?;
+        }
+
+        tracing::info!("Reset complete");
+
+        Ok(())
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
@@ -5,12 +5,7 @@ use std::sync::Arc;
 use probe_rs_target::Chip;
 
 use super::esp::EspFlashSizeDetector;
-use crate::{
-    architecture::xtensa::{
-        communication_interface::XtensaCommunicationInterface, sequences::XtensaDebugSequence,
-    },
-    MemoryInterface, Session,
-};
+use crate::{architecture::xtensa::sequences::XtensaDebugSequence, MemoryInterface, Session};
 
 /// The debug sequence implementation for the ESP32-S3.
 #[derive(Debug)]
@@ -30,37 +25,43 @@ impl ESP32S3 {
             },
         })
     }
-}
 
-impl XtensaDebugSequence for ESP32S3 {
-    fn on_connect(&self, interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
+    fn disable_wdt(&self, core: &mut impl MemoryInterface) -> Result<(), crate::Error> {
         tracing::info!("Disabling ESP32-S3 watchdogs...");
 
         // tg0 wdg
         const TIMG0_BASE: u64 = 0x6001f000;
         const TIMG0_WRITE_PROT: u64 = TIMG0_BASE | 0x64;
         const TIMG0_WDTCONFIG0: u64 = TIMG0_BASE | 0x48;
-        interface.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
+        core.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
 
         // tg1 wdg
         const TIMG1_BASE: u64 = 0x60020000;
         const TIMG1_WRITE_PROT: u64 = TIMG1_BASE | 0x64;
         const TIMG1_WDTCONFIG0: u64 = TIMG1_BASE | 0x48;
-        interface.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
+        core.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
 
         // rtc wdg
         const RTC_CNTL_BASE: u64 = 0x60008000;
         const RTC_WRITE_PROT: u64 = RTC_CNTL_BASE | 0xa4;
         const RTC_WDTCONFIG0: u64 = RTC_CNTL_BASE | 0x98;
-        interface.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(RTC_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(RTC_WDTCONFIG0, 0x0)?;
+        core.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
 
         Ok(())
+    }
+}
+
+impl XtensaDebugSequence for ESP32S3 {
+    fn on_connect(&self, session: &mut Session) -> Result<(), crate::Error> {
+        let mut core = session.core(0).unwrap();
+
+        self.disable_wdt(&mut core)
     }
 
     fn detect_flash_size(&self, session: &mut Session) -> Result<Option<usize>, crate::Error> {

--- a/probe-rs/targets/esp32.yaml
+++ b/probe-rs/targets/esp32.yaml
@@ -9,6 +9,10 @@ variants:
     type: xtensa
     core_access_options: !Xtensa
       jtag_tap: 0
+  - name: app
+    type: xtensa
+    core_access_options: !Xtensa
+      jtag_tap: 1
   memory_map:
   - !Nvm
     range:
@@ -16,6 +20,7 @@ variants:
       end: 0x1000000
     cores:
     - main
+    - app
     access:
       boot: true
   - !Nvm
@@ -25,6 +30,7 @@ variants:
       end: 0x3fc00000
     cores:
     - main
+    - app
     is_alias: true
   - !Ram
     name: SRAM2, Data bus
@@ -33,6 +39,7 @@ variants:
       end: 0x3ffe0000
     cores:
     - main
+    - app
   - !Ram
     name: SRAM1, Data bus
     range:
@@ -40,6 +47,7 @@ variants:
       end: 0x40000000
     cores:
     - main
+    - app
   - !Ram
     name: SRAM0, Instruction bus, non-cache
     range:
@@ -47,6 +55,7 @@ variants:
       end: 0x400a0000
     cores:
     - main
+    - app
   - !Nvm
     name: External instruction bus
     range:
@@ -54,6 +63,7 @@ variants:
       end: 0x40c00000
     cores:
     - main
+    - app
     is_alias: true
   flash_algorithms:
   - esp32-flashloader
@@ -84,5 +94,6 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  - app
   stack_overflow_check: false
   transfer_encoding: miniz

--- a/probe-rs/targets/esp32s3.yaml
+++ b/probe-rs/targets/esp32s3.yaml
@@ -14,6 +14,10 @@ variants:
     type: xtensa
     core_access_options: !Xtensa
       jtag_tap: 0
+  - name: cpu1
+    type: xtensa
+    core_access_options: !Xtensa
+      jtag_tap: 1
   memory_map:
   - !Nvm
     range:
@@ -21,6 +25,7 @@ variants:
       end: 0x4000000
     cores:
     - cpu0
+    - cpu1
     access:
       boot: true
   - !Nvm
@@ -30,6 +35,7 @@ variants:
       end: 0x3e000000
     cores:
     - cpu0
+    - cpu1
     is_alias: true
   - !Ram
     name: SRAM1 Data bus
@@ -38,6 +44,7 @@ variants:
       end: 0x3fcf0000
     cores:
     - cpu0
+    - cpu1
   - !Ram
     name: SRAM2 Data bus
     range:
@@ -45,6 +52,7 @@ variants:
       end: 0x3fd00000
     cores:
     - cpu0
+    - cpu1
   - !Ram
     name: SRAM1 Instruction bus
     range:
@@ -52,6 +60,7 @@ variants:
       end: 0x40378000
     cores:
     - cpu0
+    - cpu1
   - !Ram
     name: SRAM2 Instruction bus
     range:
@@ -59,6 +68,7 @@ variants:
       end: 0x403e0000
     cores:
     - cpu0
+    - cpu1
   - !Nvm
     name: External instruction bus
     range:
@@ -66,6 +76,7 @@ variants:
       end: 0x44000000
     cores:
     - cpu0
+    - cpu1
     is_alias: true
   flash_algorithms:
   - esp32s3-flashloader
@@ -102,5 +113,6 @@ flash_algorithms:
       address: 0x0
   cores:
   - cpu0
+  - cpu1
   stack_overflow_check: false
   transfer_encoding: miniz


### PR DESCRIPTION
Multicore Xtensas are implemented by one debug module per core. Resetting them properly is a more complex process than just "reset each core", so in this PR I define a way to implement the system reset in more flexible ways if necessary.

Let's see what breaks

cc #2450