### PR TITLE
Update to rustc 1.80.0 and fix clippy

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands.rs
@@ -18,13 +18,15 @@ use std::{fmt::Display, ops::Range, path::Path, str::FromStr, time::Duration};
 /// The handler is a function that takes a reference to the target core, and a reference to the response body.
 /// The response body is used to populate the response to the client.
 /// The handler returns a Result<[`Response`], [`DebuggerError`]>.
+///
 /// We use the [`Response`] type here, so that we can have a consistent interface for processing the result as follows:
 /// - The `command`, `success`, and `message` fields are the most commonly used fields for all the REPL commands.
 /// - The `body` field is used if we need to pass back other DAP body types, e.g. [`BreakpointEventBody`].
 /// - The remainder of the fields are unused/ignored.
-/// The majority of the REPL command results will be populated into the response body.
 ///
-/// TODO: Make this less confusing by having a different struct for this.
+/// The majority of the REPL command results will be populated into the response body.
+//
+// TODO: Make this less confusing by having a different struct for this.
 pub(crate) type ReplHandler = fn(
     target_core: &mut CoreHandle,
     command_arguments: &str,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -36,11 +36,11 @@ pub struct CoreData {
     /// Track the last_known_status of the core.
     /// The debug client needs to be notified when the core changes state, and this can happen in one of two ways:
     /// 1. By polling the core status periodically (in [`crate::cmd::dap_server::server::debugger::Debugger::process_next_request()`]).
-    ///   For instance, when the client sets the core running, and the core halts because of a breakpoint, we need to notify the client.
+    ///    For instance, when the client sets the core running, and the core halts because of a breakpoint, we need to notify the client.
     /// 2. Some requests, like [`DebugAdapter::next()`], has an implicit action of setting the core running, before it waits for it to halt at the next statement.
-    ///   To ensure the [`CoreHandle::poll_core()`] behaves correctly, it will set the `last_known_status` to [`CoreStatus::Running`],
-    ///   and execute the request normally, with the expectation that the core will be halted, and that 1. above will detect this new status.
-    ///   These 'implicit' updates of `last_known_status` will not(and should not) result in a notification to the client.
+    ///    To ensure the [`CoreHandle::poll_core()`] behaves correctly, it will set the `last_known_status` to [`CoreStatus::Running`],
+    ///    and execute the request normally, with the expectation that the core will be halted, and that 1. above will detect this new status.
+    ///    These 'implicit' updates of `last_known_status` will not(and should not) result in a notification to the client.
     pub last_known_status: CoreStatus,
     pub target_name: String,
     pub debug_info: DebugInfo,

--- a/probe-rs/src/architecture/arm/component/itm.rs
+++ b/probe-rs/src/architecture/arm/component/itm.rs
@@ -19,10 +19,10 @@ pub const _ITM_PID: [u8; 8] = [0x1, 0xB0, 0x3b, 0x0, 0x4, 0x0, 0x0, 0x0];
 /// - Software trace. Software can write directly to ITM stimulus registers to generate packets.
 /// - Hardware trace. The DWT generates these packets, and the ITM outputs them.
 /// - Time stamping. Timestamps are generated relative to packets.
-/// The ITM contains a 21-bit counter to generate the timestamp.
-/// The Cortex-M4 clock or the bitclock rate of the Serial Wire Viewer (SWV) output clocks the counter.
+///   The ITM contains a 21-bit counter to generate the timestamp.
+///   The Cortex-M4 clock or the bitclock rate of the Serial Wire Viewer (SWV) output clocks the counter.
 /// - Global system timestamping. Timestamps can optionally be generated using a system-wide 48-bit count value.
-/// The same count value can be used to insert timestamps in the ETM trace stream, allowing coarse-grain correlation.
+///   The same count value can be used to insert timestamps in the ETM trace stream, allowing coarse-grain correlation.
 pub struct Itm<'a> {
     component: &'a CoresightComponent,
     interface: &'a mut dyn ArmProbeInterface,

--- a/probe-rs/src/core/memory_mapped_registers.rs
+++ b/probe-rs/src/core/memory_mapped_registers.rs
@@ -40,7 +40,7 @@ pub trait MemoryMappedRegister<T>: Clone + From<T> + Into<T> + Sized + std::fmt:
 /// Create a [`MemoryMappedRegister`] type, with the required method implementations for:
 /// - Trait implementations required by [`MemoryMappedRegister`]
 /// - Includes a `bitfield!` mapping for bitfield access to optionally defined fields.
-/// When no bitfields are defined, the default `.0` field must be used.
+///   When no bitfields are defined, the default `.0` field must be used.
 ///
 /// # Example
 /// ```

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -502,9 +502,9 @@ impl DebugInfo {
     ///
     /// The unwind loop will continue until we meet one of the following conditions:
     /// - We can no longer unwind a valid PC value to be used for the next frame.
-    /// - We encounter a LR register value of 0x0 or 0xFFFFFFFF(Arm 'Reset' value for that register).
+    /// - We encounter a LR register value of 0x0 or 0xFFFFFFFF (Arm 'Reset' value for that register).
     /// - We can not intelligently calculate a valid LR register value from the other registers,
-    ///   or the gimli::RegisterRule result is a value of 0x0.
+    ///   or the `gimli::RegisterRule` result is a value of 0x0.
     ///   Note: [DWARF](https://dwarfstd.org) 6.4.4 - CIE defines the return register address
     ///   used in the `gimli::RegisterRule` tables for unwind operations.
     ///   Theoretically, if we encounter a function that has `Undefined` `gimli::RegisterRule` for
@@ -515,9 +515,10 @@ impl DebugInfo {
     ///   Example 1: local functions in main.rs will have LR rule as `Undefined`.
     ///   Example 2: main()-> ! that is called from a trampoline will have a valid LR rule.
     /// - Similarly, certain error conditions encountered in `StackFrameIterator` will also break out of the unwind loop.
+    ///
     /// Note: In addition to populating the `StackFrame`s, this function will also
-    ///   populate the `DebugInfo::VariableCache` with `Variable`s for available Registers
-    ///   as well as static and function variables.
+    /// populate the `DebugInfo::VariableCache` with `Variable`s for available Registers
+    /// as well as static and function variables.
     /// TODO: Separate logic for stackframe creation and cache population
     pub fn unwind(
         &self,

--- a/probe-rs/src/debug/debug_step.rs
+++ b/probe-rs/src/debug/debug_step.rs
@@ -154,6 +154,7 @@ impl SteppingMode {
     /// - To determine valid halt points for breakpoints and stepping, we only use instructions that qualify as:
     ///   - The beginning of a statement that is neither inside the prologue, nor inside the epilogue.
     /// - Based on this, we will attempt to return the "most appropriate" address for the [`SteppingMode`], given the available information in the instruction sequence.
+    ///
     /// All data is calculated using the [`gimli::read::CompleteLineProgram`] as well as, function call data from the debug info frame section.
     ///
     /// NOTE about errors returned: Sometimes the target program_counter is at a location where the debug_info program row data does not contain valid statements

--- a/probe-rs/src/debug/function_die.rs
+++ b/probe-rs/src/debug/function_die.rs
@@ -21,6 +21,7 @@ pub(crate) struct FunctionDie<'abbrev, 'unit> {
     /// The optional specification DIE for the function, if it has one.
     /// - For regular functions, this applies to the `function_die`.
     /// - For inlined functions, this applies to the `abstract_die`.
+    ///
     /// The specification DIE will contain separately declared attributes,
     /// e.g. for the function name.
     /// See DWARF spec, 2.13.2.

--- a/probe-rs/src/debug/source_instructions.rs
+++ b/probe-rs/src/debug/source_instructions.rs
@@ -54,19 +54,19 @@ impl VerifiedBreakpoint {
     /// - The correct program instructions, may be in any of the compilation units of the current program.
     /// - The debug information may not contain data for the "specific source" location requested:
     ///   - DWARFv5 standard, section 6.2, allows omissions based on certain conditions. In this case,
-    ///    we need to find the closest "relevant" source location that has valid debug information.
+    ///     we need to find the closest "relevant" source location that has valid debug information.
     ///   - The requested location may not be a valid source location, e.g. when the
-    ///    debug information has been optimized away. In this case we will return an appropriate error.
+    ///     debug information has been optimized away. In this case we will return an appropriate error.
     /// #### The logic used to find the "most relevant" source location is as follows:
     /// 1. Filter  [`UnitInfo`] , by using [`LineProgramHeader`] to match units that include the requested path.
     /// 2. For each matching compilation unit, get the [`LineProgram`] and [`Vec<LineSequence>`].
     /// 3. Filter the [`Vec<LineSequence>`] entries to only include sequences that match the requested path.
     /// 3. Convert remaining [`LineSequence`], to [`InstructionSequence`].
     /// 4. Return the first [`InstructionSequence`] that contains the requested source location.
-    ///   4a. This may be an exact match on file/line/column, or,
-    ///   4b. Failing an exact match, a match on file/line only.
-    ///   4c. Failing that, a match on file only, where the line number is the "next" available instruction,
-    ///       on the next available line of the specified file.
+    ///    4a. This may be an exact match on file/line/column, or,
+    ///    4b. Failing an exact match, a match on file/line only.
+    ///    4c. Failing that, a match on file only, where the line number is the "next" available instruction,
+    ///        on the next available line of the specified file.
     pub(crate) fn for_source_location(
         debug_info: &DebugInfo,
         path: &TypedPathBuf,

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -1508,10 +1508,11 @@ impl UnitInfo {
     }
 
     /// - Find the location using either DW_AT_location, DW_AT_data_member_location, or DW_AT_frame_base attribute.
+    ///
     /// Return values are implemented as follows:
-    /// - Result<_, DebugError>: This happens when we encounter an error we did not expect, and will propagate upwards until the debugger request is failed. NOT GRACEFUL, and should be avoided.
-    /// - Result<ExpressionResult::Value(),_>:  The value is statically stored in the binary, and can be returned, and has no relevant memory location.
-    /// - Result<ExpressionResult::Location(),_>:  One of the variants of VariableLocation, and needs to be interpreted for handling the 'expected' errors we encounter during evaluation.
+    /// - `Result<_, DebugError>`: This happens when we encounter an error we did not expect, and will propagate upwards until the debugger request is failed. **NOT GRACEFUL**, and should be avoided.
+    /// - `Result<ExpressionResult::Value(),_>`: The value is statically stored in the binary, and can be returned, and has no relevant memory location.
+    /// - `Result<ExpressionResult::Location(),_>`: One of the variants of VariableLocation, and needs to be interpreted for handling the 'expected' errors we encounter during evaluation.
     pub(crate) fn extract_location(
         &self,
         debug_info: &DebugInfo,

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -121,7 +121,7 @@ pub enum VariableNodeType {
     /// Use the `header_offset` and `entries_offset` as direct references for recursing the variable
     /// children.
     /// - Rule: All top level variables in a [StackFrame] are automatically deferred, i.e
-    /// [VariableName::LocalScopeRoot], [VariableName::RegistersRoot].
+    ///   [VariableName::LocalScopeRoot], [VariableName::RegistersRoot].
     DirectLookup(DebugInfoOffset, UnitOffset),
     /// Look up information from all compilation units. This is used to resolve static variables, so
     /// when [`VariableName::StaticScopeRoot`] is used.
@@ -132,7 +132,7 @@ pub enum VariableNodeType {
     ///         variable_node_type to indicate that no further recursion is possible/required. This
     ///         can be because the variable is a 'base' data type, or because there was some kind of
     ///         error in processing the current node, so we don't want to incur cascading errors.
-    /// TODO: Find code instances where we use magic values (e.g. u32::MAX) and replace with DoNotRecurse logic if appropriate.
+    // TODO: Find code instances where we use magic values (e.g. u32::MAX) and replace with DoNotRecurse logic if appropriate.
     DoNotRecurse,
     /// Unless otherwise specified, always recurse the children of every node until we get to the
     /// base data type.

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -57,32 +57,48 @@ use zerocopy::{FromBytes, FromZeroes};
 
 /// The RTT interface.
 ///
-/// Use [`Rtt::attach`] or [`Rtt::attach_region`] to attach to a probe-rs [`Core`] and detect the channels, as they were
-///     configured on the target.
-/// The timing of when this is called is really important, or else unexpected results can be expected.
+/// Use [`Rtt::attach`] or [`Rtt::attach_region`] to attach to a probe-rs [`Core`] and detect the
+///     channels, as they were configured on the target. The timing of when this is called is really
+///     important, or else unexpected results can be expected.
 ///
 /// ## Examples of how timing between host and target effects the results
 ///
-/// 1. **Scenario: Ideal configuration** The host RTT interface is created AFTER the target program has successfully executing the RTT
-/// initialization, by calling an api such as [rtt:target](https://github.com/mvirkkunen/rtt-target)`::rtt_init_print!()`
-///     * At this point, both the RTT Control Block and the RTT Channel configurations are present in the target memory, and
-/// this RTT interface can be expected to work as expected.
+/// 1. **Scenario: Ideal configuration**: The host RTT interface is created **AFTER** the target
+///     program has successfully executing the RTT initialization, by calling an api such as
+///     [`rtt_target::rtt_init_print!()`](https://docs.rs/rtt-target/0.5.0/rtt_target/macro.rtt_init_print.html).
 ///
-/// 2. **Scenario: Failure to detect RTT Control Block** The target has been configured correctly, BUT the host creates this interface BEFORE
-/// the target program has initialized RTT.
-///     * This most commonly occurs when the target halts processing before initializing RTT. For example, this could happen ...
-///         * During debugging, if the user sets a breakpoint in the code before the RTT initialization.
-///         * After flashing, if the user has configured `probe-rs` to `reset_after_flashing` AND `halt_after_reset`. On most targets, this
-/// will result in the target halting with reason `Exception` and will delay the subsequent RTT initialization.
-///         * If RTT initialization on the target is delayed because of time consuming processing or excessive interrupt handling. This can
-/// usually be prevented by moving the RTT initialization code to the very beginning of the target program logic.
-///     * The result of such a timing issue is that `probe-rs` will fail to initialize RTT with an [`probe-rs-rtt::Error::ControlBlockNotFound`]
+///     At this point, both the RTT Control Block and the RTT Channel configurations are present in
+///     the target memory, and this RTT interface can be expected to work as expected.
 ///
-/// 3. **Scenario: Incorrect Channel names and incorrect Channel buffer sizes** This scenario usually occurs when two conditions coincide. Firstly, the same timing mismatch as described in point #2 above, and secondly, the target memory has NOT been cleared since a previous version of the binary program has been flashed to the target.
-///     * What happens here is that the RTT Control Block is validated by reading a previously initialized RTT ID from the target memory. The next step in the logic is then to read the Channel configuration from the RTT Control block which is usually contains unreliable data
-/// at this point. The symptoms will appear as:
-///         * RTT Channel names are incorrect and/or contain unprintable characters.
-///         * RTT Channel names are correct, but no data, or corrupted data, will be reported from RTT, because the buffer sizes are incorrect.
+/// 2. **Scenario: Failure to detect RTT Control Block**: The target has been configured correctly,
+///     **BUT** the host creates this interface **BEFORE** the target program has initialized RTT.
+///
+///     This most commonly occurs when the target halts processing before initializing RTT. For
+///     example, this could happen ...
+///       * During debugging, if the user sets a breakpoint in the code before the RTT
+///         initialization.
+///       * After flashing, if the user has configured `probe-rs` to `reset_after_flashing` AND
+///         `halt_after_reset`. On most targets, this will result in the target halting with
+///         reason `Exception` and will delay the subsequent RTT initialization.
+///       * If RTT initialization on the target is delayed because of time consuming processing or
+///         excessive interrupt handling. This can usually be prevented by moving the RTT
+///         initialization code to the very beginning of the target program logic.
+///
+///     The result of such a timing issue is that `probe-rs` will fail to initialize RTT with an
+///     [`Error::ControlBlockNotFound`]
+///
+/// 3. **Scenario: Incorrect Channel names and incorrect Channel buffer sizes**: This scenario
+///     usually occurs when two conditions coincide. Firstly, the same timing mismatch as described
+///     in point #2 above, and secondly, the target memory has NOT been cleared since a previous
+///     version of the binary program has been flashed to the target.
+///
+///     What happens here is that the RTT Control Block is validated by reading a previously
+///     initialized RTT ID from the target memory. The next step in the logic is then to read the
+///     Channel configuration from the RTT Control block which is usually contains unreliable data
+///     at this point. The symptoms will appear as:
+///       * RTT Channel names are incorrect and/or contain unprintable characters.
+///       * RTT Channel names are correct, but no data, or corrupted data, will be reported from
+///         RTT, because the buffer sizes are incorrect.
 #[derive(Debug)]
 pub struct Rtt {
     ptr: u64,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.79"
+channel = "1.80.0"
 
 components = ["rustfmt", "clippy"]
 # Target used for tests


### PR DESCRIPTION
Clippy now checks indentation in documentation, because why not. PR includes a few drive-by fixes, too.