### PR TITLE
add test-log to dev-deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +948,18 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -2239,7 +2260,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
 dependencies = [
- "env_logger",
+ "env_logger 0.10.2",
  "log",
 ]
 
@@ -2284,6 +2305,7 @@ dependencies = [
  "svg",
  "termtree",
  "test-case",
+ "test-log",
  "thiserror",
  "tracing",
  "typed-path",
@@ -3386,6 +3408,28 @@ dependencies = [
  "quote",
  "syn 2.0.60",
  "test-case-core",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
+dependencies = [
+ "env_logger 0.11.3",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -106,6 +106,7 @@ clap = { version = "4", features = ["derive"] }
 itm = { version = "0.9.0-rc.1", default-features = false }
 pretty_assertions = "1"
 test-case = "3"
+test-log = { version = "0.2.16", features = [ "trace" ] }
 termtree = "0.5"
 insta = { version = "1.38", default-features = false, features = ["yaml"] }
 

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -1057,7 +1057,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[test_log::test]
     fn read_8() {
         let mut mock = MockMemoryAp::with_pattern_and_size(256);
         mock.memory[..DATA8.len()].copy_from_slice(DATA8);

--- a/probe-rs/src/probe/jlink/bits.rs
+++ b/probe-rs/src/probe/jlink/bits.rs
@@ -101,7 +101,7 @@ mod tests {
             v.into_iter().collapse_bytes().collect()
         }
 
-        assert_eq!(collapse([]), []);
+        assert_eq!(collapse([]), [] as [u8; 0]);
         assert_eq!(collapse([true]), [0x01]);
         assert_eq!(collapse([false, true]), [0x02]);
         assert_eq!(collapse([true, false]), [0x01]);


### PR DESCRIPTION
This sets up the necessary fixture for `tracing` to print during tests
(if the appropriate env variable is set)