### PR TITLE
Factorize memory interfaces implementations

### DIFF
--- a/changelog/changed-factorize-MemoryInterface-slight-variations.md
+++ b/changelog/changed-factorize-MemoryInterface-slight-variations.md
@@ -1,0 +1,1 @@
+Factorize the variants of `MemoryInterface` where only the return type changes into `MemoryInterface` with a generic type defaulting to `probe_rs::Error`.

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -9,7 +9,7 @@ use crate::{
     error::Error,
     memory::valid_32bit_address,
     Architecture, BreakpointCause, CoreInformation, CoreInterface, CoreRegister, CoreStatus,
-    CoreType, HaltReason, InstructionSet, MemoryInterface, MemoryMappedRegister,
+    CoreType, HaltReason, InstructionSet, MemoryMappedRegister,
 };
 use bitfield::bitfield;
 use std::{
@@ -908,100 +908,11 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
     }
 }
 
-impl<'probe> MemoryInterface for Armv6m<'probe> {
-    fn supports_native_64bit_access(&mut self) -> bool {
-        self.memory.supports_native_64bit_access()
+impl super::CoreMemoryInterface for Armv6m<'_> {
+    fn memory(&self) -> &dyn ArmMemoryInterface {
+        &*self.memory
     }
-    fn read_word_64(&mut self, address: u64) -> Result<u64, Error> {
-        let value = self.memory.read_word_64(address)?;
-        Ok(value)
-    }
-    fn read_word_32(&mut self, address: u64) -> Result<u32, Error> {
-        let value = self.memory.read_word_32(address)?;
-        Ok(value)
-    }
-    fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
-        let value = self.memory.read_word_16(address)?;
-        Ok(value)
-    }
-    fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
-        let value = self.memory.read_word_8(address)?;
-        Ok(value)
-    }
-
-    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), Error> {
-        self.memory.read_64(address, data)?;
-        Ok(())
-    }
-
-    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error> {
-        self.memory.read_32(address, data)?;
-        Ok(())
-    }
-
-    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error> {
-        self.memory.read_16(address, data)?;
-        Ok(())
-    }
-
-    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
-        self.memory.read_8(address, data)?;
-        Ok(())
-    }
-
-    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
-        self.memory.write_word_64(address, data)?;
-        Ok(())
-    }
-
-    fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), Error> {
-        self.memory.write_word_32(address, data)?;
-        Ok(())
-    }
-
-    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
-        self.memory.write_word_16(address, data)?;
-        Ok(())
-    }
-
-    fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
-        self.memory.write_word_8(address, data)?;
-        Ok(())
-    }
-
-    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error> {
-        self.memory.write_64(address, data)?;
-        Ok(())
-    }
-
-    fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
-        self.memory.write_32(address, data)?;
-        Ok(())
-    }
-
-    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
-        self.memory.write_16(address, data)?;
-        Ok(())
-    }
-
-    fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
-        self.memory.write_8(address, data)?;
-        Ok(())
-    }
-
-    fn write(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
-        self.memory.write(address, data)?;
-        Ok(())
-    }
-
-    fn supports_8bit_transfers(&self) -> Result<bool, Error> {
-        let value = self.memory.supports_8bit_transfers()?;
-        Ok(value)
-    }
-
-    fn flush(&mut self) -> Result<(), Error> {
-        self.memory.flush()?;
-
-        Ok(())
+    fn memory_mut(&mut self) -> &mut dyn ArmMemoryInterface {
+        &mut *self.memory
     }
 }

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -767,11 +767,11 @@ impl<'probe> CoreInterface for Armv7a<'probe> {
         }
     }
 
-    fn fpu_support(&mut self) -> Result<bool, crate::error::Error> {
+    fn fpu_support(&mut self) -> Result<bool, Error> {
         Ok(self.state.fp_reg_count != 0)
     }
 
-    fn floating_point_register_count(&mut self) -> Result<usize, crate::error::Error> {
+    fn floating_point_register_count(&mut self) -> Result<usize, Error> {
         Ok(self.state.fp_reg_count)
     }
 
@@ -818,7 +818,7 @@ impl<'probe> MemoryInterface for Armv7a<'probe> {
         false
     }
 
-    fn read_word_64(&mut self, address: u64) -> Result<u64, crate::error::Error> {
+    fn read_word_64(&mut self, address: u64) -> Result<u64, Error> {
         let mut ret: u64 = self.read_word_32(address)? as u64;
         ret |= (self.read_word_32(address + 4)? as u64) << 32;
 
@@ -865,7 +865,7 @@ impl<'probe> MemoryInterface for Armv7a<'probe> {
         Ok(data.to_le_bytes()[byte_offset as usize])
     }
 
-    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), crate::error::Error> {
+    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), Error> {
         for (i, word) in data.iter_mut().enumerate() {
             *word = self.read_word_64(address + ((i as u64) * 8))?;
         }
@@ -897,7 +897,7 @@ impl<'probe> MemoryInterface for Armv7a<'probe> {
         Ok(())
     }
 
-    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), crate::error::Error> {
+    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
         let data_low = data as u32;
         let data_high = (data >> 32) as u32;
 
@@ -949,7 +949,7 @@ impl<'probe> MemoryInterface for Armv7a<'probe> {
         self.write_word_32(word_start, word)
     }
 
-    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), crate::error::Error> {
+    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error> {
         for (i, word) in data.iter().enumerate() {
             self.write_word_64(address + ((i as u64) * 8), *word)?;
         }
@@ -1042,9 +1042,7 @@ mod test {
         }
     }
 
-    impl ArmMemoryInterface for MockProbe {
-        fn update_core_status(&mut self, _: CoreStatus) {}
-
+    impl MemoryInterface<ArmError> for MockProbe {
         fn read_8(&mut self, _address: u64, _data: &mut [u8]) -> Result<(), ArmError> {
             todo!()
         }
@@ -1138,9 +1136,25 @@ mod test {
             todo!()
         }
 
+        fn read_64(&mut self, _address: u64, _data: &mut [u64]) -> Result<(), ArmError> {
+            todo!()
+        }
+
+        fn write_64(&mut self, _address: u64, _data: &[u64]) -> Result<(), ArmError> {
+            todo!()
+        }
+
         fn supports_8bit_transfers(&self) -> Result<bool, ArmError> {
             Ok(false)
         }
+
+        fn supports_native_64bit_access(&mut self) -> bool {
+            false
+        }
+    }
+
+    impl ArmMemoryInterface for MockProbe {
+        fn update_core_status(&mut self, _: CoreStatus) {}
 
         fn get_arm_communication_interface(
             &mut self,
@@ -1155,20 +1169,8 @@ mod test {
             })
         }
 
-        fn read_64(&mut self, _address: u64, _data: &mut [u64]) -> Result<(), ArmError> {
-            todo!()
-        }
-
-        fn write_64(&mut self, _address: u64, _data: &[u64]) -> Result<(), ArmError> {
-            todo!()
-        }
-
         fn ap(&mut self) -> MemoryAp {
             todo!()
-        }
-
-        fn supports_native_64bit_access(&mut self) -> bool {
-            false
         }
     }
 

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     error::Error,
     memory::valid_32bit_address,
-    BreakpointCause, CoreRegister, CoreType, InstructionSet, MemoryInterface,
+    BreakpointCause, CoreRegister, CoreType, InstructionSet,
 };
 use bitfield::bitfield;
 use std::{
@@ -1134,91 +1134,12 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
     }
 }
 
-impl<'probe> MemoryInterface for Armv7m<'probe> {
-    fn supports_native_64bit_access(&mut self) -> bool {
-        self.memory.supports_native_64bit_access()
+impl super::CoreMemoryInterface for Armv7m<'_> {
+    fn memory(&self) -> &dyn ArmMemoryInterface {
+        &*self.memory
     }
-
-    fn read_word_64(&mut self, address: u64) -> Result<u64, Error> {
-        self.memory.read_word_64(address).map_err(Error::from)
-    }
-
-    fn read_word_32(&mut self, address: u64) -> Result<u32, Error> {
-        self.memory.read_word_32(address).map_err(Error::from)
-    }
-
-    fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
-        self.memory.read_word_16(address).map_err(Error::from)
-    }
-
-    fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
-        self.memory.read_word_8(address).map_err(Error::from)
-    }
-
-    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), Error> {
-        self.memory.read_64(address, data).map_err(Error::from)
-    }
-
-    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error> {
-        self.memory.read_32(address, data).map_err(Error::from)
-    }
-
-    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error> {
-        self.memory.read_16(address, data).map_err(Error::from)
-    }
-
-    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
-        self.memory.read_8(address, data).map_err(Error::from)
-    }
-
-    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
-        self.memory
-            .write_word_64(address, data)
-            .map_err(Error::from)
-    }
-
-    fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), Error> {
-        self.memory
-            .write_word_32(address, data)
-            .map_err(Error::from)
-    }
-
-    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
-        self.memory
-            .write_word_16(address, data)
-            .map_err(Error::from)
-    }
-
-    fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
-        self.memory.write_word_8(address, data).map_err(Error::from)
-    }
-
-    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error> {
-        self.memory.write_64(address, data).map_err(Error::from)
-    }
-
-    fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
-        self.memory.write_32(address, data).map_err(Error::from)
-    }
-
-    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
-        self.memory.write_16(address, data).map_err(Error::from)
-    }
-
-    fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
-        self.memory.write_8(address, data).map_err(Error::from)
-    }
-
-    fn write(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
-        self.memory.write(address, data).map_err(Error::from)
-    }
-
-    fn supports_8bit_transfers(&self) -> Result<bool, Error> {
-        self.memory.supports_8bit_transfers().map_err(Error::from)
-    }
-
-    fn flush(&mut self) -> Result<(), Error> {
-        self.memory.flush().map_err(Error::from)
+    fn memory_mut(&mut self) -> &mut dyn ArmMemoryInterface {
+        &mut *self.memory
     }
 }
 

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -16,7 +16,7 @@ use crate::{
     error::Error,
     memory::valid_32bit_address,
     Architecture, BreakpointCause, CoreInformation, CoreInterface, CoreRegister, CoreStatus,
-    CoreType, HaltReason, InstructionSet, MemoryInterface, MemoryMappedRegister,
+    CoreType, HaltReason, InstructionSet, MemoryMappedRegister,
 };
 use bitfield::bitfield;
 use std::{
@@ -540,91 +540,12 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
     }
 }
 
-impl<'probe> MemoryInterface for Armv8m<'probe> {
-    fn supports_native_64bit_access(&mut self) -> bool {
-        self.memory.supports_native_64bit_access()
+impl super::CoreMemoryInterface for Armv8m<'_> {
+    fn memory(&self) -> &dyn ArmMemoryInterface {
+        &*self.memory
     }
-
-    fn read_word_64(&mut self, address: u64) -> Result<u64, Error> {
-        self.memory.read_word_64(address).map_err(Error::from)
-    }
-
-    fn read_word_32(&mut self, address: u64) -> Result<u32, Error> {
-        self.memory.read_word_32(address).map_err(Error::from)
-    }
-
-    fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
-        self.memory.read_word_16(address).map_err(Error::from)
-    }
-
-    fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
-        self.memory.read_word_8(address).map_err(Error::from)
-    }
-
-    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), Error> {
-        self.memory.read_64(address, data).map_err(Error::from)
-    }
-
-    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error> {
-        self.memory.read_32(address, data).map_err(Error::from)
-    }
-
-    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error> {
-        self.memory.read_16(address, data).map_err(Error::from)
-    }
-
-    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
-        self.memory.read_8(address, data).map_err(Error::from)
-    }
-
-    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
-        self.memory
-            .write_word_64(address, data)
-            .map_err(Error::from)
-    }
-
-    fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), Error> {
-        self.memory
-            .write_word_32(address, data)
-            .map_err(Error::from)
-    }
-
-    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
-        self.memory
-            .write_word_16(address, data)
-            .map_err(Error::from)
-    }
-
-    fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
-        self.memory.write_word_8(address, data).map_err(Error::from)
-    }
-
-    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error> {
-        self.memory.write_64(address, data).map_err(Error::from)
-    }
-
-    fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
-        self.memory.write_32(address, data).map_err(Error::from)
-    }
-
-    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
-        self.memory.write_16(address, data).map_err(Error::from)
-    }
-
-    fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
-        self.memory.write_8(address, data).map_err(Error::from)
-    }
-
-    fn write(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
-        self.memory.write(address, data).map_err(Error::from)
-    }
-
-    fn supports_8bit_transfers(&self) -> Result<bool, Error> {
-        self.memory.supports_8bit_transfers().map_err(Error::from)
-    }
-
-    fn flush(&mut self) -> Result<(), Error> {
-        self.memory.flush().map_err(Error::from)
+    fn memory_mut(&mut self) -> &mut dyn ArmMemoryInterface {
+        &mut *self.memory
     }
 }
 

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -2,8 +2,37 @@ use crate::error::Error;
 
 use scroll::Pread;
 
+/// {function_name} was called with data length that is not a multiple of {alignment}
+#[derive(Debug, thiserror::Error, docsplay::Display)]
+pub struct InvalidDataLengthError {
+    /// Name of the function that caused the error.
+    pub function_name: &'static str,
+    /// The alignment required on the data length.
+    pub alignment: usize,
+}
+impl InvalidDataLengthError {
+    pub fn new(function_name: &'static str, alignment: usize) -> Self {
+        Self {
+            function_name,
+            alignment,
+        }
+    }
+}
+
+/// Memory access to address {address:#X?} was not aligned to {alignment} bytes.
+#[derive(Debug, thiserror::Error, docsplay::Display)]
+pub struct MemoryNotAlignedError {
+    /// The address of the register.
+    pub address: u64,
+    /// The required alignment in bytes (address increments).
+    pub alignment: usize,
+}
+
 /// An interface to be implemented for drivers that allow target memory access.
-pub trait MemoryInterface {
+pub trait MemoryInterface<ERR = Error>
+where
+    ERR: std::error::Error + From<InvalidDataLengthError> + From<MemoryNotAlignedError>,
+{
     /// Does this interface support native 64-bit wide accesses
     ///
     /// If false all 64-bit operations may be split into 32 or 8 bit operations.
@@ -15,60 +44,74 @@ pub trait MemoryInterface {
     ///
     /// The address where the read should be performed at has to be a multiple of 8.
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
-    fn read_word_64(&mut self, address: u64) -> Result<u64, Error>;
+    fn read_word_64(&mut self, address: u64) -> Result<u64, ERR> {
+        let mut word = 0;
+        self.read_64(address, std::slice::from_mut(&mut word))?;
+        Ok(word)
+    }
 
     /// Read a 32bit word of at `address`.
     ///
     /// The address where the read should be performed at has to be a multiple of 4.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
-    fn read_word_32(&mut self, address: u64) -> Result<u32, Error>;
+    fn read_word_32(&mut self, address: u64) -> Result<u32, ERR> {
+        let mut word = 0;
+        self.read_32(address, std::slice::from_mut(&mut word))?;
+        Ok(word)
+    }
 
     /// Read a 16bit word of at `address`.
     ///
     /// The address where the read should be performed at has to be a multiple of 2.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
-    fn read_word_16(&mut self, address: u64) -> Result<u16, Error>;
+    fn read_word_16(&mut self, address: u64) -> Result<u16, ERR> {
+        let mut word = 0;
+        self.read_16(address, std::slice::from_mut(&mut word))?;
+        Ok(word)
+    }
 
     /// Read an 8bit word of at `address`.
-    fn read_word_8(&mut self, address: u64) -> Result<u8, Error>;
+    fn read_word_8(&mut self, address: u64) -> Result<u8, ERR> {
+        let mut word = 0;
+        self.read_8(address, std::slice::from_mut(&mut word))?;
+        Ok(word)
+    }
 
     /// Read a block of 64bit words at `address`.
     ///
     /// The number of words read is `data.len()`.
     /// The address where the read should be performed at has to be a multiple of 8.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
-    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), Error>;
+    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), ERR>;
 
     /// Read a block of 32bit words at `address`.
     ///
     /// The number of words read is `data.len()`.
     /// The address where the read should be performed at has to be a multiple of 4.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
-    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error>;
+    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), ERR>;
 
     /// Read a block of 16bit words at `address`.
     ///
     /// The number of words read is `data.len()`.
     /// The address where the read should be performed at has to be a multiple of 2.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
-    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error>;
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), ERR>;
 
     /// Read a block of 8bit words at `address`.
-    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error>;
+    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), ERR>;
 
     /// Reads bytes using 64 bit memory access.
     ///
     /// The address where the read should be performed at has to be a multiple of 8.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
-    fn read_mem_64bit(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
+    fn read_mem_64bit(&mut self, address: u64, data: &mut [u8]) -> Result<(), ERR> {
         // Default implementation uses `read_64`, then converts u64 values back
         // to bytes. Assumes target is little endian. May be overridden to
         // provide an implementation that avoids heap allocation and endian
         // conversions. Must be overridden for big endian targets.
         if data.len() % 8 != 0 {
-            return Err(Error::Other(
-                "Call to read_mem_64bit with data.len() not a multiple of 8".to_string(),
-            ));
+            return Err(InvalidDataLengthError::new("read_mem_64bit", 8).into());
         }
         let mut buffer = vec![0u64; data.len() / 8];
         self.read_64(address, &mut buffer)?;
@@ -82,15 +125,13 @@ pub trait MemoryInterface {
     ///
     /// The address where the read should be performed at has to be a multiple of 4.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
-    fn read_mem_32bit(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
+    fn read_mem_32bit(&mut self, address: u64, data: &mut [u8]) -> Result<(), ERR> {
         // Default implementation uses `read_32`, then converts u32 values back
         // to bytes. Assumes target is little endian. May be overridden to
         // provide an implementation that avoids heap allocation and endian
         // conversions. Must be overridden for big endian targets.
         if data.len() % 4 != 0 {
-            return Err(Error::Other(
-                "Call to read_mem_32bit with data.len() not a multiple of 4".to_string(),
-            ));
+            return Err(InvalidDataLengthError::new("read_mem_32bit", 4).into());
         }
         let mut buffer = vec![0u32; data.len() / 4];
         self.read_32(address, &mut buffer)?;
@@ -110,7 +151,7 @@ pub trait MemoryInterface {
     /// used.
     ///
     ///  Generally faster than `read_8`.
-    fn read(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
+    fn read(&mut self, address: u64, data: &mut [u8]) -> Result<(), ERR> {
         if self.supports_native_64bit_access() {
             // Avoid heap allocation and copy if we don't need it.
             self.read_8(address, data)?;
@@ -130,58 +171,64 @@ pub trait MemoryInterface {
     ///
     /// The address where the write should be performed at has to be a multiple of 8.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
-    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error>;
+    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), ERR> {
+        self.write_64(address, std::slice::from_ref(&data))
+    }
 
     /// Write a 32bit word at `address`.
     ///
     /// The address where the write should be performed at has to be a multiple of 4.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
-    fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), Error>;
+    fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), ERR> {
+        self.write_32(address, std::slice::from_ref(&data))
+    }
 
     /// Write a 16bit word at `address`.
     ///
     /// The address where the write should be performed at has to be a multiple of 2.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
-    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error>;
+    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), ERR> {
+        self.write_16(address, std::slice::from_ref(&data))
+    }
 
     /// Write an 8bit word at `address`.
-    fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error>;
+    fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), ERR> {
+        self.write_8(address, std::slice::from_ref(&data))
+    }
 
     /// Write a block of 64bit words at `address`.
     ///
     /// The number of words written is `data.len()`.
     /// The address where the write should be performed at has to be a multiple of 8.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
-    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error>;
+    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), ERR>;
 
     /// Write a block of 32bit words at `address`.
     ///
     /// The number of words written is `data.len()`.
     /// The address where the write should be performed at has to be a multiple of 4.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
-    fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error>;
+    fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), ERR>;
 
     /// Write a block of 16bit words at `address`.
     ///
     /// The number of words written is `data.len()`.
     /// The address where the write should be performed at has to be a multiple of 2.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
-    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error>;
+    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), ERR>;
 
     /// Write a block of 8bit words at `address`.
-    fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error>;
+    fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), ERR>;
 
     /// Writes bytes using 64 bit memory access. Address must be 64 bit aligned
     /// and data must be an exact multiple of 8.
-    fn write_mem_64bit(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
+    fn write_mem_64bit(&mut self, address: u64, data: &[u8]) -> Result<(), ERR> {
         // Default implementation uses `write_64`, then converts u64 values back
         // to bytes. Assumes target is little endian. May be overridden to
         // provide an implementation that avoids heap allocation and endian
         // conversions. Must be overridden for big endian targets.
         if data.len() % 8 != 0 {
-            return Err(Error::Other(
-                "Call to read_mem_64bit with data.len() not a multiple of 8".to_string(),
-            ));
+            return Err(InvalidDataLengthError::new("write_mem_64bit", 8).into());
         }
         let mut buffer = vec![0u64; data.len() / 8];
         for (bytes, value) in data.chunks_exact(8).zip(buffer.iter_mut()) {
@@ -196,15 +243,13 @@ pub trait MemoryInterface {
 
     /// Writes bytes using 32 bit memory access. Address must be 32 bit aligned
     /// and data must be an exact multiple of 8.
-    fn write_mem_32bit(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
+    fn write_mem_32bit(&mut self, address: u64, data: &[u8]) -> Result<(), ERR> {
         // Default implementation uses `write_32`, then converts u32 values back
         // to bytes. Assumes target is little endian. May be overridden to
         // provide an implementation that avoids heap allocation and endian
         // conversions. Must be overridden for big endian targets.
         if data.len() % 4 != 0 {
-            return Err(Error::Other(
-                "Call to read_mem_32bit with data.len() not a multiple of 4".to_string(),
-            ));
+            return Err(InvalidDataLengthError::new("write_mem_32bit", 4).into());
         }
         let mut buffer = vec![0u32; data.len() / 4];
         for (bytes, value) in data.chunks_exact(4).zip(buffer.iter_mut()) {
@@ -223,9 +268,9 @@ pub trait MemoryInterface {
     ///
     /// If the target does not support 8-bit aligned access, and `address` is not
     /// aligned on a 32-bit boundary, this function will return a [`Error::MemoryNotAligned`] error.
-    fn write(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
+    fn write(&mut self, mut address: u64, mut data: &[u8]) -> Result<(), ERR> {
         let len = data.len();
-        let start_extra_count = 4 - (address % 4) as usize;
+        let start_extra_count = ((4 - (address % 4) as usize) % 4).min(len);
         let end_extra_count = (len - start_extra_count) % 4;
         let inbetween_count = len - start_extra_count - end_extra_count;
         assert!(start_extra_count < 4);
@@ -238,32 +283,43 @@ pub trait MemoryInterface {
         if address % 4 != 0 || len % 4 != 0 {
             // If we do not support 8 bit transfers we have to bail because we can only do 32 bit word aligned transers.
             if !self.supports_8bit_transfers()? {
-                return Err(Error::MemoryNotAligned {
+                return Err(MemoryNotAlignedError {
                     address,
                     alignment: 4,
-                });
+                }
+                .into());
             }
 
             // We first do an 8 bit write of the first < 4 bytes up until the 4 byte aligned boundary.
             self.write_8(address, &data[..start_extra_count])?;
+
+            address += start_extra_count as u64;
+            data = &data[start_extra_count..];
         }
 
-        let mut buffer = vec![0u32; inbetween_count / 4];
-        for (bytes, value) in data.chunks_exact(4).zip(buffer.iter_mut()) {
-            *value = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-        }
-        self.write_32(address, &buffer)?;
+        // Make sure we don't try to do an empty but potentially unaligned write
+        if inbetween_count > 0 {
+            // We do a 32 bit write of the remaining bytes that are 4 byte aligned.
+            let mut buffer = vec![0u32; inbetween_count / 4];
+            for (bytes, value) in data.chunks_exact(4).zip(buffer.iter_mut()) {
+                *value = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            }
+            self.write_32(address, &buffer)?;
 
-        // We read the remaining bytes that we did not read yet which is always n < 4.
+            address += inbetween_count as u64;
+            data = &data[inbetween_count..];
+        }
+
+        // We write the remaining bytes that we did not write yet which is always n < 4.
         if end_extra_count > 0 {
-            self.write_8(address, &data[..start_extra_count])?;
+            self.write_8(address, &data[..end_extra_count])?;
         }
 
         Ok(())
     }
 
     /// Returns whether the current platform supports native 8bit transfers.
-    fn supports_8bit_transfers(&self) -> Result<bool, Error>;
+    fn supports_8bit_transfers(&self) -> Result<bool, ERR>;
 
     /// Flush any outstanding operations.
     ///
@@ -271,96 +327,7 @@ pub trait MemoryInterface {
     /// to assure that any such batched writes have in fact been issued, `flush`
     /// can be called.  Takes no arguments, but may return failure if a batched
     /// operation fails.
-    fn flush(&mut self) -> Result<(), Error>;
-}
-
-impl<T> MemoryInterface for &mut T
-where
-    T: MemoryInterface,
-{
-    fn supports_native_64bit_access(&mut self) -> bool {
-        (*self).supports_native_64bit_access()
-    }
-
-    fn read_word_64(&mut self, address: u64) -> Result<u64, Error> {
-        (*self).read_word_64(address)
-    }
-
-    fn read_word_32(&mut self, address: u64) -> Result<u32, Error> {
-        (*self).read_word_32(address)
-    }
-
-    fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
-        (*self).read_word_16(address)
-    }
-
-    fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
-        (*self).read_word_8(address)
-    }
-
-    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), Error> {
-        (*self).read_64(address, data)
-    }
-
-    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error> {
-        (*self).read_32(address, data)
-    }
-
-    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error> {
-        (*self).read_16(address, data)
-    }
-
-    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
-        (*self).read_8(address, data)
-    }
-
-    fn read(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
-        (*self).read(address, data)
-    }
-
-    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
-        (*self).write_word_64(address, data)
-    }
-
-    fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), Error> {
-        (*self).write_word_32(address, data)
-    }
-
-    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
-        (*self).write_word_16(address, data)
-    }
-
-    fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
-        (*self).write_word_8(address, data)
-    }
-
-    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error> {
-        (*self).write_64(address, data)
-    }
-
-    fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
-        (*self).write_32(address, data)
-    }
-
-    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
-        (*self).write_16(address, data)
-    }
-
-    fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
-        (*self).write_8(address, data)
-    }
-
-    fn write(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
-        (*self).write(address, data)
-    }
-
-    fn supports_8bit_transfers(&self) -> Result<bool, Error> {
-        MemoryInterface::supports_8bit_transfers(*self)
-    }
-
-    fn flush(&mut self) -> Result<(), Error> {
-        (*self).flush()
-    }
+    fn flush(&mut self) -> Result<(), ERR>;
 }
 
 // Helper functions to validate address space constraints

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -16,7 +16,7 @@ use crate::{
         MemoryApInformation, PortType, RawDapAccess, SwoAccess,
     },
     probe::{DebugProbe, DebugProbeError, Probe, WireProtocol},
-    Error, MemoryMappedRegister,
+    Error, MemoryInterface, MemoryMappedRegister,
 };
 
 /// This is a mock probe which can be used for mocking things in tests or for dry runs.
@@ -74,7 +74,7 @@ impl SwdSequence for &mut MockCore {
     }
 }
 
-impl ArmMemoryInterface for &mut MockCore {
+impl MemoryInterface<ArmError> for &mut MockCore {
     fn read_8(&mut self, _address: u64, _data: &mut [u8]) -> Result<(), ArmError> {
         todo!()
     }
@@ -172,7 +172,9 @@ impl ArmMemoryInterface for &mut MockCore {
     fn supports_8bit_transfers(&self) -> Result<bool, ArmError> {
         todo!()
     }
+}
 
+impl ArmMemoryInterface for &mut MockCore {
     fn ap(&mut self) -> MemoryAp {
         todo!()
     }

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -9,6 +9,7 @@ use super::{DebugProbe, DebugProbeError, ProbeCreationError, WireProtocol};
 use crate::architecture::arm::ap::GenericAp;
 use crate::architecture::arm::memory::adi_v5_memory_interface::ArmMemoryInterface;
 use crate::architecture::arm::{valid_32bit_arm_address, ArmError};
+use crate::MemoryInterface;
 use crate::{
     architecture::arm::{
         ap::{valid_access_ports, AccessPort, ApAccess, ApClass, MemoryAp, IDR},
@@ -1625,7 +1626,7 @@ impl SwdSequence for StLinkMemoryInterface<'_> {
     }
 }
 
-impl ArmMemoryInterface for StLinkMemoryInterface<'_> {
+impl MemoryInterface<ArmError> for StLinkMemoryInterface<'_> {
     fn supports_native_64bit_access(&mut self) -> bool {
         false
     }
@@ -1894,7 +1895,9 @@ impl ArmMemoryInterface for StLinkMemoryInterface<'_> {
     fn supports_8bit_transfers(&self) -> Result<bool, ArmError> {
         Ok(true)
     }
+}
 
+impl ArmMemoryInterface for StLinkMemoryInterface<'_> {
     fn get_arm_communication_interface(
         &mut self,
     ) -> Result<


### PR DESCRIPTION
Probe-rs implements in several locations quasi identical version of `probe_rs::memory::MemoryInterface`.
This factorizes (some of) these ocurrences and reduces code duplication.

While doing this, it was noted that the default implementation of `MemoryInterface::write` didn’t pass all `architecture::arm::memory::adi_v5_memory_interface::test::*`. This fixes the issue by moving the implementation from `AdiMemoryInterface::write` back to `MemoryInterface`.

Follows:
- https://github.com/probe-rs/probe-rs/pull/2704