### PR TITLE
arm: Use FullyQualifiedApAddresses rather than GenericAp or MemoryAp

### DIFF
--- a/changelog/changed-use-FullyQualifiedApAddress-instead-of-MemoryAp-and-GenericAp.md
+++ b/changelog/changed-use-FullyQualifiedApAddress-instead-of-MemoryAp-and-GenericAp.md
@@ -1,0 +1,1 @@
+arm: Use FullyQualifiedApAddress instead of MemoryAp and GenericAp in method

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -8,7 +8,6 @@ mod tmc;
 mod tpiu;
 mod trace_funnel;
 
-use super::ap::{GenericAp, MemoryAp};
 use super::memory::romtable::{CoresightComponent, PeripheralType, RomTableError};
 use super::memory::Component;
 use super::ArmError;
@@ -111,9 +110,7 @@ pub fn get_arm_components(
 
     for ap_index in 0..(interface.num_access_ports(dp)? as u8) {
         let ap_information = interface
-            .ap_information(&GenericAp::new(FullyQualifiedApAddress::v1_with_dp(
-                dp, ap_index,
-            )))?
+            .ap_information(&FullyQualifiedApAddress::v1_with_dp(dp, ap_index))?
             .clone();
 
         let component = match ap_information {
@@ -126,10 +123,9 @@ pub fn get_arm_components(
                 debug_base_address,
                 ..
             }) => {
-                let ap = MemoryAp::new(address);
-                let mut memory = interface.memory_interface(&ap)?;
+                let mut memory = interface.memory_interface(&address)?;
                 let component = Component::try_parse(&mut *memory, debug_base_address)?;
-                Ok(CoresightComponent::new(component, ap))
+                Ok(CoresightComponent::new(component, address))
             }
             ApInformation::Other { address, .. } => {
                 // Return an error, only possible to get Component from MemoryAP

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -2,6 +2,7 @@ use super::super::ap::{
     AccessPortError, AddressIncrement, ApAccess, ApRegister, DataSize, MemoryAp, CSW, DRW, TAR,
     TAR2,
 };
+use crate::architecture::arm::ap::AccessPort;
 use crate::architecture::arm::communication_interface::{FlushableArmAccess, SwdSequence};
 use crate::architecture::arm::{
     communication_interface::Initialized, dp::DpAccess, memory::ArmMemoryInterface,
@@ -135,7 +136,7 @@ where
         self.interface
             .read_ap_register(&self.memory_ap)
             .map_err(AccessPortError::register_read_error::<R, _>)
-            .map_err(|error| ArmError::from_access_port(error, &self.memory_ap))
+            .map_err(|error| ArmError::from_access_port(error, self.memory_ap.ap_address()))
     }
 
     /// Read multiple 32 bit values from the DRW register on the given AP.
@@ -152,7 +153,7 @@ where
             self.interface
                 .read_ap_register_repeated(&self.memory_ap, DRW { data: 0 }, values)
                 .map_err(AccessPortError::register_read_error::<DRW, _>)
-                .map_err(|err| ArmError::from_access_port(err, &self.memory_ap))
+                .map_err(|err| ArmError::from_access_port(err, self.memory_ap.ap_address()))
         }
     }
 
@@ -165,7 +166,7 @@ where
         self.interface
             .write_ap_register(&self.memory_ap, register)
             .map_err(AccessPortError::register_write_error::<R, _>)
-            .map_err(|e| ArmError::from_access_port(e, &self.memory_ap))
+            .map_err(|e| ArmError::from_access_port(e, self.memory_ap.ap_address()))
     }
 
     /// Write multiple 32 bit values to the DRW register on the given AP.
@@ -180,7 +181,7 @@ where
             self.interface
                 .write_ap_register_repeated(&self.memory_ap, DRW { data: 0 }, values)
                 .map_err(AccessPortError::register_write_error::<DRW, _>)
-                .map_err(|e| ArmError::from_access_port(e, &self.memory_ap))
+                .map_err(|e| ArmError::from_access_port(e, self.memory_ap.ap_address()))
         }
     }
 }

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -12,7 +12,7 @@ mod traits;
 
 pub use self::core::{armv6m, armv7a, armv7m, armv8a, armv8m, Dump};
 use self::{
-    ap::{AccessPort, AccessPortError},
+    ap::AccessPortError,
     communication_interface::RegisterParseError,
     dp::DebugPortError,
     memory::romtable::RomTableError,
@@ -140,9 +140,9 @@ pub enum ArmError {
 
 impl ArmError {
     /// Constructs [`ArmError::MemoryNotAligned`] from the address and the required alignment.
-    pub fn from_access_port(err: AccessPortError, ap: &impl AccessPort) -> Self {
+    pub fn from_access_port(err: AccessPortError, ap_address: &FullyQualifiedApAddress) -> Self {
         ArmError::AccessPort {
-            address: ap.ap_address().clone(),
+            address: ap_address.clone(),
             source: err,
         }
     }

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 use super::{
-    ap::{AccessPortError, MemoryAp},
+    ap::AccessPortError,
     armv6m::Demcr,
     communication_interface::{DapProbe, Initialized},
     component::{TraceFunnel, TraceSink},
@@ -30,7 +30,8 @@ use super::{
         romtable::{CoresightComponent, PeripheralType},
         ArmMemoryInterface,
     },
-    ArmCommunicationInterface, ArmError, DpAddress, Pins, PortType, Register,
+    ArmCommunicationInterface, ArmError, DpAddress, FullyQualifiedApAddress, Pins, PortType,
+    Register,
 };
 
 /// An error occurred when executing an ARM debug sequence
@@ -643,12 +644,12 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
     fn debug_core_start(
         &self,
         interface: &mut dyn ArmProbeInterface,
-        core_ap: MemoryAp,
+        core_ap: &FullyQualifiedApAddress,
         core_type: CoreType,
         debug_base: Option<u64>,
         cti_base: Option<u64>,
     ) -> Result<(), ArmError> {
-        let mut core = interface.memory_interface(&core_ap)?;
+        let mut core = interface.memory_interface(core_ap)?;
 
         // Dispatch based on core type (Cortex-A vs M)
         match core_type {
@@ -770,7 +771,7 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
     fn debug_device_unlock(
         &self,
         _interface: &mut dyn ArmProbeInterface,
-        _default_ap: &MemoryAp,
+        _default_ap: &FullyQualifiedApAddress,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
         tracing::debug!("debug_device_unlock - empty by default");

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -3,7 +3,6 @@ use crate::flashing::FlashLoader;
 use crate::{
     architecture::{
         arm::{
-            ap::MemoryAp,
             sequences::{ArmDebugSequence, DefaultArmSequence},
             DpAddress, FullyQualifiedApAddress,
         },
@@ -236,20 +235,20 @@ pub enum DebugSequence {
 pub(crate) trait CoreExt {
     // Retrieve the Coresight MemoryAP which should be used to
     // access the core, if available.
-    fn memory_ap(&self) -> Option<MemoryAp>;
+    fn memory_ap(&self) -> Option<FullyQualifiedApAddress>;
 }
 
 impl CoreExt for Core {
-    fn memory_ap(&self) -> Option<MemoryAp> {
+    fn memory_ap(&self) -> Option<FullyQualifiedApAddress> {
         match &self.core_access_options {
             probe_rs_target::CoreAccessOptions::Arm(options) => {
-                Some(MemoryAp::new(FullyQualifiedApAddress::v1_with_dp(
+                Some(FullyQualifiedApAddress::v1_with_dp(
                     match options.psel {
                         0 => DpAddress::Default,
                         x => DpAddress::Multidrop(x),
                     },
                     options.ap,
-                )))
+                ))
             }
             probe_rs_target::CoreAccessOptions::Riscv(_) => None,
             probe_rs_target::CoreAccessOptions::Xtensa(_) => None,

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -1,7 +1,6 @@
 use crate::{
     architecture::{
         arm::{
-            ap::MemoryAp,
             core::{CortexAState, CortexMState},
             ArmProbeInterface, DpAddress, FullyQualifiedApAddress,
         },
@@ -125,7 +124,7 @@ impl CombinedCoreState {
             // Enable debug mode
             sequence.debug_core_start(
                 interface,
-                self.arm_memory_ap(),
+                &self.arm_memory_ap(),
                 self.core_type(),
                 options.debug_base,
                 options.cti_base,
@@ -233,7 +232,7 @@ impl CombinedCoreState {
     /// ## Panic
     ///
     /// This function will panic if the core is not an ARM core and doesn't have a memory AP
-    pub(crate) fn arm_memory_ap(&self) -> MemoryAp {
+    pub(crate) fn arm_memory_ap(&self) -> FullyQualifiedApAddress {
         self.core_state.memory_ap()
     }
 }
@@ -253,7 +252,7 @@ impl CoreState {
         }
     }
 
-    pub(crate) fn memory_ap(&self) -> MemoryAp {
+    pub(crate) fn memory_ap(&self) -> FullyQualifiedApAddress {
         let ResolvedCoreOptions::Arm { options, .. } = &self.core_access_options else {
             unreachable!(
                 "The stored core state is not compatible with the ARM architecture. \
@@ -266,9 +265,7 @@ impl CoreState {
             x => DpAddress::Multidrop(x),
         };
 
-        let ap = FullyQualifiedApAddress::v1_with_dp(dp, options.ap);
-
-        MemoryAp::new(ap)
+        FullyQualifiedApAddress::v1_with_dp(dp, options.ap)
     }
 }
 

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -5,7 +5,7 @@ use probe_rs_target::ScanChainElement;
 
 use crate::{
     architecture::arm::{
-        ap::{memory_ap::mock::MockMemoryAp, AccessPort, MemoryAp},
+        ap::{memory_ap::mock::MockMemoryAp, MemoryAp},
         armv8m::Dhcsr,
         communication_interface::{
             ArmDebugState, Initialized, SwdSequence, Uninitialized, UninitializedArmProbe,
@@ -485,10 +485,10 @@ impl UninitializedArmProbe for FakeArmInterface<Uninitialized> {
 impl ArmProbeInterface for FakeArmInterface<Initialized> {
     fn memory_interface(
         &mut self,
-        access_port: &MemoryAp,
+        access_port_address: &FullyQualifiedApAddress,
     ) -> Result<Box<dyn ArmMemoryInterface + '_>, ArmError> {
         let ap_information = MemoryApInformation {
-            address: access_port.ap_address().clone(),
+            address: access_port_address.clone(),
             supports_only_32bit_data_size: false,
             debug_base_address: 0xf000_0000,
             supports_hnonsec: false,
@@ -500,7 +500,7 @@ impl ArmProbeInterface for FakeArmInterface<Initialized> {
         match self.probe.memory_ap {
             MockedAp::MemoryAp(ref mut memory_ap) => {
                 let memory = ADIMemoryInterface::new(memory_ap, ap_information)
-                    .map_err(|e| ArmError::from_access_port(e, access_port))?;
+                    .map_err(|e| ArmError::from_access_port(e, access_port_address))?;
 
                 Ok(Box::new(memory) as _)
             }
@@ -510,7 +510,7 @@ impl ArmProbeInterface for FakeArmInterface<Initialized> {
 
     fn ap_information(
         &mut self,
-        _access_port: &crate::architecture::arm::ap::GenericAp,
+        _access_port: &FullyQualifiedApAddress,
     ) -> Result<&crate::architecture::arm::ApInformation, ArmError> {
         todo!()
     }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -1,27 +1,25 @@
-use crate::architecture::arm::ap::AccessPort;
-use crate::architecture::arm::component::get_arm_components;
-use crate::architecture::arm::sequences::{ArmDebugSequence, DefaultArmSequence};
-use crate::architecture::arm::{ArmError, DpAddress};
-use crate::architecture::riscv::communication_interface::{RiscvDebugInterfaceState, RiscvError};
-use crate::architecture::xtensa::communication_interface::{
-    XtensaCommunicationInterface, XtensaDebugInterfaceState, XtensaError,
-};
-use crate::config::{CoreExt, RegistryError, Target, TargetSelector};
-use crate::core::{Architecture, CombinedCoreState};
-use crate::probe::fake_probe::FakeProbe;
-use crate::probe::ProbeCreationError;
 use crate::{
     architecture::{
         arm::{
-            communication_interface::ArmProbeInterface, component::TraceSink,
-            memory::CoresightComponent, SwoReader,
+            communication_interface::ArmProbeInterface,
+            component::{get_arm_components, TraceSink},
+            memory::CoresightComponent,
+            sequences::{ArmDebugSequence, DefaultArmSequence},
+            ArmError, DpAddress, SwoReader,
         },
-        riscv::communication_interface::RiscvCommunicationInterface,
+        riscv::communication_interface::{
+            RiscvCommunicationInterface, RiscvDebugInterfaceState, RiscvError,
+        },
+        xtensa::communication_interface::{
+            XtensaCommunicationInterface, XtensaDebugInterfaceState, XtensaError,
+        },
     },
-    config::DebugSequence,
-};
-use crate::{
-    probe::{list::Lister, AttachMethod, DebugProbeError, Probe},
+    config::{CoreExt, DebugSequence, RegistryError, Target, TargetSelector},
+    core::{Architecture, CombinedCoreState},
+    probe::{
+        fake_probe::FakeProbe, list::Lister, AttachMethod, DebugProbeError, Probe,
+        ProbeCreationError,
+    },
     Core, CoreType, Error,
 };
 use std::ops::DerefMut;
@@ -181,7 +179,7 @@ impl Session {
             ))
         })?;
 
-        let default_dp = default_memory_ap.ap_address().dp();
+        let default_dp = default_memory_ap.dp();
 
         let sequence_handle = match &target.debug_sequence {
             DebugSequence::Arm(sequence) => sequence.clone(),

--- a/probe-rs/src/vendor/infineon/mod.rs
+++ b/probe-rs/src/vendor/infineon/mod.rs
@@ -5,7 +5,7 @@ use probe_rs_target::{chip_detection::ChipDetectionMethod, Chip};
 
 use crate::{
     architecture::arm::{
-        ap::MemoryAp, memory::ArmMemoryInterface, ArmChipInfo, ArmError, ArmProbeInterface,
+        memory::ArmMemoryInterface, ArmChipInfo, ArmError, ArmProbeInterface,
         FullyQualifiedApAddress,
     },
     config::{registry, DebugSequence},
@@ -59,7 +59,7 @@ fn try_detect_xmc4xxx(
     }
 
     // FIXME: This is a bit shaky but good enough for now.
-    let access_port = &MemoryAp::new(FullyQualifiedApAddress::v1_with_default_dp(0));
+    let access_port = &FullyQualifiedApAddress::v1_with_default_dp(0);
     let mut memory_interface = interface.memory_interface(access_port)?;
 
     // First, read the SCU peripheral ID register to verify that this is an XMC4000.

--- a/probe-rs/src/vendor/microchip/mod.rs
+++ b/probe-rs/src/vendor/microchip/mod.rs
@@ -3,7 +3,7 @@
 use probe_rs_target::{chip_detection::ChipDetectionMethod, Chip};
 
 use crate::{
-    architecture::arm::{ap::MemoryAp, ArmChipInfo, ArmProbeInterface, FullyQualifiedApAddress},
+    architecture::arm::{ArmChipInfo, ArmProbeInterface, FullyQualifiedApAddress},
     config::{registry, DebugSequence},
     vendor::{
         microchip::sequences::atsam::{AtSAM, DsuDid},
@@ -44,11 +44,11 @@ impl Vendor for Microchip {
         }
 
         // FIXME: This is a bit shaky but good enough for now.
-        let access_port = MemoryAp::new(FullyQualifiedApAddress::v1_with_default_dp(0));
+        let access_port = &FullyQualifiedApAddress::v1_with_default_dp(0);
         // This device has an Atmel DSU - Read and parse the DSU DID register
         let did = DsuDid(
             interface
-                .memory_interface(&access_port)?
+                .memory_interface(access_port)?
                 .read_word_32(DsuDid::ADDRESS)?,
         );
 

--- a/probe-rs/src/vendor/microchip/sequences/atsam.rs
+++ b/probe-rs/src/vendor/microchip/sequences/atsam.rs
@@ -1,16 +1,12 @@
 //! Sequences for ATSAM D1x/D2x/DAx/D5x/E5x target families
 
 use crate::{
-    architecture::{
-        self,
-        arm::{
-            ap::MemoryAp,
-            armv7m::Dhcsr,
-            communication_interface::{DapProbe, SwdSequence},
-            memory::ArmMemoryInterface,
-            sequences::{ArmDebugSequence, ArmDebugSequenceError, DebugEraseSequence},
-            ArmError, ArmProbeInterface, FullyQualifiedApAddress, Pins,
-        },
+    architecture::arm::{
+        armv7m::Dhcsr,
+        communication_interface::{DapProbe, SwdSequence},
+        memory::ArmMemoryInterface,
+        sequences::{ArmDebugSequence, ArmDebugSequenceError, DebugEraseSequence},
+        ArmError, ArmProbeInterface, FullyQualifiedApAddress, Pins,
     },
     probe::DebugProbeError,
     session::MissingPermissions,
@@ -465,12 +461,12 @@ impl ArmDebugSequence for AtSAM {
     fn debug_core_start(
         &self,
         interface: &mut dyn ArmProbeInterface,
-        core_ap: MemoryAp,
+        core_ap: &FullyQualifiedApAddress,
         _core_type: CoreType,
         _debug_base: Option<u64>,
         _cti_base: Option<u64>,
     ) -> Result<(), ArmError> {
-        let mut core = interface.memory_interface(&core_ap)?;
+        let mut core = interface.memory_interface(core_ap)?;
 
         self.release_reset_extension(&mut *core)
     }
@@ -518,7 +514,7 @@ impl ArmDebugSequence for AtSAM {
     fn debug_device_unlock(
         &self,
         interface: &mut dyn ArmProbeInterface,
-        default_ap: &architecture::arm::ap::MemoryAp,
+        default_ap: &FullyQualifiedApAddress,
         permissions: &Permissions,
     ) -> Result<(), ArmError> {
         // First check if the device is locked
@@ -540,7 +536,7 @@ impl ArmDebugSequence for AtSAM {
 
 impl DebugEraseSequence for AtSAM {
     fn erase_all(&self, interface: &mut dyn ArmProbeInterface) -> Result<(), ArmError> {
-        let mem_ap = &MemoryAp::new(FullyQualifiedApAddress::v1_with_default_dp(0));
+        let mem_ap = &FullyQualifiedApAddress::v1_with_default_dp(0);
 
         let mut memory = interface.memory_interface(mem_ap)?;
 

--- a/probe-rs/src/vendor/nordicsemi/mod.rs
+++ b/probe-rs/src/vendor/nordicsemi/mod.rs
@@ -9,8 +9,7 @@ use probe_rs_target::{
 
 use crate::{
     architecture::arm::{
-        ap::MemoryAp, memory::ArmMemoryInterface, ArmChipInfo, ArmProbeInterface,
-        FullyQualifiedApAddress,
+        memory::ArmMemoryInterface, ArmChipInfo, ArmProbeInterface, FullyQualifiedApAddress,
     },
     config::{registry, DebugSequence},
     vendor::{
@@ -51,8 +50,8 @@ impl Vendor for NordicSemi {
         }
 
         // FIXME: This is a bit shaky but good enough for now.
-        let access_port = MemoryAp::new(FullyQualifiedApAddress::v1_with_default_dp(0));
-        let mut memory_interface = probe.memory_interface(&access_port)?;
+        let access_port = &FullyQualifiedApAddress::v1_with_default_dp(0);
+        let mut memory_interface = probe.memory_interface(access_port)?;
 
         // Cache to avoid reading the same register multiple times
         let mut register_values: HashMap<u32, u32> = HashMap::new();

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
@@ -2,7 +2,6 @@
 
 use crate::{
     architecture::arm::{
-        ap::MemoryAp,
         communication_interface::Initialized,
         memory::ArmMemoryInterface,
         sequences::{ArmDebugSequence, ArmDebugSequenceError},
@@ -82,7 +81,7 @@ impl<T: Nrf> ArmDebugSequence for T {
     fn debug_device_unlock(
         &self,
         interface: &mut dyn ArmProbeInterface,
-        default_ap: &MemoryAp,
+        default_ap: &FullyQualifiedApAddress,
         permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
         let mut interface = interface.memory_interface(default_ap)?;

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf52.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf52.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 
 use crate::architecture::arm::{
-    ap::MemoryAp,
     component::TraceSink,
     memory::CoresightComponent,
     sequences::{ArmDebugSequence, ArmDebugSequenceError},
@@ -87,7 +86,7 @@ impl ArmDebugSequence for Nrf52 {
     fn debug_device_unlock(
         &self,
         iface: &mut dyn ArmProbeInterface,
-        _default_ap: &MemoryAp,
+        _default_ap: &FullyQualifiedApAddress,
         permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
         let ctrl_ap = &FullyQualifiedApAddress::v1_with_default_dp(1);
@@ -152,7 +151,7 @@ impl ArmDebugSequence for Nrf52 {
             }
         };
 
-        let mut memory = interface.memory_interface(&components[0].ap)?;
+        let mut memory = interface.memory_interface(&components[0].ap_address)?;
         let mut config = clock::TraceConfig::read(&mut *memory)?;
         config.set_traceportspeed(portspeed);
         if matches!(sink, TraceSink::Tpiu(_)) {

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf91.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf91.rs
@@ -3,12 +3,9 @@
 use std::sync::Arc;
 
 use super::nrf::Nrf;
-use crate::architecture::arm::ap::AccessPort;
-use crate::architecture::arm::memory::ArmMemoryInterface;
-use crate::architecture::arm::sequences::ArmDebugSequence;
-use crate::architecture::arm::ArmError;
 use crate::architecture::arm::{
-    communication_interface::Initialized, ArmCommunicationInterface, DapAccess,
+    ap::AccessPort, communication_interface::Initialized, memory::ArmMemoryInterface,
+    sequences::ArmDebugSequence, ArmCommunicationInterface, ArmError, DapAccess,
     FullyQualifiedApAddress,
 };
 
@@ -28,8 +25,7 @@ impl Nrf for Nrf9160 {
         &self,
         memory: &mut dyn ArmMemoryInterface,
     ) -> Vec<(FullyQualifiedApAddress, FullyQualifiedApAddress)> {
-        let memory_ap = memory.ap();
-        let ap_address = memory_ap.ap_address();
+        let dp = memory.ap().ap_address().dp();
 
         let core_aps = [(0, 4)];
 
@@ -37,8 +33,8 @@ impl Nrf for Nrf9160 {
             .into_iter()
             .map(|(core_ahb_ap, core_ctrl_ap)| {
                 (
-                    FullyQualifiedApAddress::v1_with_dp(ap_address.dp(), core_ahb_ap),
-                    FullyQualifiedApAddress::v1_with_dp(ap_address.dp(), core_ctrl_ap),
+                    FullyQualifiedApAddress::v1_with_dp(dp, core_ahb_ap),
+                    FullyQualifiedApAddress::v1_with_dp(dp, core_ctrl_ap),
                 )
             })
             .collect()

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
@@ -11,7 +11,7 @@ use std::{
 
 use crate::{
     architecture::arm::{
-        ap::{AccessPortError, ApAccess, CSW},
+        ap::{AccessPort, AccessPortError, ApAccess, CSW},
         armv7m::{FpCtrl, FpRev2CompX},
         core::{
             armv7m::{Aircr, Dhcsr},
@@ -425,12 +425,12 @@ impl ArmDebugSequence for MIMXRT11xx {
         //
         // The ARM communication interface knows how to re-initialize the debug port.
         // Re-initializing the core(s) is on us.
-        let ap = probe.ap();
+        let ap = probe.ap().ap_address().clone();
         let interface = probe.get_arm_communication_interface()?;
         interface.reinitialize()?;
 
         assert!(debug_base.is_none());
-        self.debug_core_start(interface, ap, core_type, None, None)?;
+        self.debug_core_start(interface, &ap, core_type, None, None)?;
 
         // Are we back?
         self.wait_for_enable(probe, Duration::from_millis(300))?;

--- a/probe-rs/src/vendor/st/sequences/stm32_armv6.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32_armv6.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use probe_rs_target::CoreType;
 
 use crate::architecture::arm::{
-    ap::MemoryAp, memory::ArmMemoryInterface, sequences::ArmDebugSequence, ArmError,
-    ArmProbeInterface,
+    memory::ArmMemoryInterface, sequences::ArmDebugSequence, ArmError, ArmProbeInterface,
+    FullyQualifiedApAddress,
 };
 
 /// Supported families for custom sequences on ARMv6 STM32 devices.
@@ -115,7 +115,7 @@ impl ArmDebugSequence for Stm32Armv6 {
     fn debug_device_unlock(
         &self,
         interface: &mut dyn ArmProbeInterface,
-        default_ap: &MemoryAp,
+        default_ap: &FullyQualifiedApAddress,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
         let mut memory = interface.memory_interface(default_ap)?;

--- a/probe-rs/src/vendor/st/sequences/stm32_armv7.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32_armv7.rs
@@ -13,11 +13,10 @@ use std::sync::Arc;
 use probe_rs_target::CoreType;
 
 use crate::architecture::arm::{
-    ap::MemoryAp,
     component::TraceSink,
     memory::{ArmMemoryInterface, CoresightComponent},
     sequences::ArmDebugSequence,
-    ArmError, ArmProbeInterface,
+    ArmError, ArmProbeInterface, FullyQualifiedApAddress,
 };
 
 /// Marker structure for most ARMv7 STM32 devices.
@@ -72,7 +71,7 @@ impl ArmDebugSequence for Stm32Armv7 {
     fn debug_device_unlock(
         &self,
         interface: &mut dyn ArmProbeInterface,
-        default_ap: &MemoryAp,
+        default_ap: &FullyQualifiedApAddress,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
         let mut memory = interface.memory_interface(default_ap)?;
@@ -106,7 +105,7 @@ impl ArmDebugSequence for Stm32Armv7 {
         components: &[CoresightComponent],
         sink: &TraceSink,
     ) -> Result<(), ArmError> {
-        let mut memory = interface.memory_interface(&components[0].ap)?;
+        let mut memory = interface.memory_interface(&components[0].ap_address)?;
         let mut cr = dbgmcu::Control::read(&mut *memory)?;
 
         if matches!(sink, TraceSink::Tpiu(_) | TraceSink::Swo(_)) {

--- a/probe-rs/src/vendor/st/sequences/stm32_armv8.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32_armv8.rs
@@ -9,11 +9,10 @@ use std::sync::Arc;
 use probe_rs_target::CoreType;
 
 use crate::architecture::arm::{
-    ap::MemoryAp,
     component::TraceSink,
     memory::{ArmMemoryInterface, CoresightComponent},
     sequences::ArmDebugSequence,
-    ArmError, ArmProbeInterface,
+    ArmError, ArmProbeInterface, FullyQualifiedApAddress,
 };
 
 /// Marker structure for ARMv8 STM32 devices.
@@ -68,7 +67,7 @@ impl ArmDebugSequence for Stm32Armv8 {
     fn debug_device_unlock(
         &self,
         interface: &mut dyn ArmProbeInterface,
-        default_ap: &MemoryAp,
+        default_ap: &FullyQualifiedApAddress,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
         let mut memory = interface.memory_interface(default_ap)?;
@@ -99,7 +98,7 @@ impl ArmDebugSequence for Stm32Armv8 {
         components: &[CoresightComponent],
         sink: &TraceSink,
     ) -> Result<(), ArmError> {
-        let mut memory = interface.memory_interface(&components[0].ap)?;
+        let mut memory = interface.memory_interface(&components[0].ap_address)?;
         let mut cr = dbgmcu::Control::read(&mut *memory)?;
 
         if matches!(sink, TraceSink::Tpiu(_) | TraceSink::Swo(_)) {

--- a/probe-rs/src/vendor/st/sequences/stm32h7.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32h7.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use probe_rs_target::CoreType;
 
 use crate::architecture::arm::{
-    ap::MemoryAp,
     component::{TraceFunnel, TraceSink},
     memory::{romtable::RomTableError, ArmMemoryInterface, CoresightComponent, PeripheralType},
     sequences::ArmDebugSequence,
@@ -149,13 +148,13 @@ impl ArmDebugSequence for Stm32h7 {
     fn debug_device_unlock(
         &self,
         interface: &mut dyn ArmProbeInterface,
-        _default_ap: &MemoryAp,
+        _default_ap: &FullyQualifiedApAddress,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
         // Power up the debug components through AP2, which is the default AP debug port.
-        let ap = MemoryAp::new(FullyQualifiedApAddress::v1_with_default_dp(2));
+        let ap = &FullyQualifiedApAddress::v1_with_default_dp(2);
 
-        let mut memory = interface.memory_interface(&ap)?;
+        let mut memory = interface.memory_interface(ap)?;
         self.enable_debug_components(&mut *memory, true)?;
 
         Ok(())

--- a/probe-rs/src/vendor/ti/sequences/cc13xx_cc26xx.rs
+++ b/probe-rs/src/vendor/ti/sequences/cc13xx_cc26xx.rs
@@ -2,6 +2,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::architecture::arm::ap::AccessPort;
 use crate::architecture::arm::armv7m::{Demcr, Dhcsr};
 use crate::architecture::arm::communication_interface::DapProbe;
 use crate::architecture::arm::memory::ArmMemoryInterface;
@@ -361,12 +362,12 @@ impl ArmDebugSequence for CC13xxCC26xx {
         std::thread::sleep(Duration::from_millis(1));
 
         // Re-initializing the core(s) is on us.
-        let ap = probe.ap();
+        let ap = probe.ap().ap_address().clone();
         let interface = probe.get_arm_communication_interface()?;
         interface.reinitialize()?;
 
         assert!(debug_base.is_none());
-        self.debug_core_start(interface, ap, core_type, None, None)?;
+        self.debug_core_start(interface, &ap, core_type, None, None)?;
 
         if demcr.vc_corereset() {
             // TODO! Find a way to call the armv7m::halt function instead


### PR DESCRIPTION
- Those two type do not provide much value beyond being attached to a set
  of registers.
- GenericAp can be converted to MemoryAp without checks.

Follows:
- https://github.com/probe-rs/probe-rs/pull/2708