### PR TITLE
Probe error related cleanups

### DIFF
--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -786,7 +786,7 @@ impl DebugProbeInfo {
     ///
     /// The exact contents of the string are unstable, this is intended for human consumption only.
     pub fn probe_type(&self) -> String {
-        format!("{}", self.probe_factory)
+        self.probe_factory.to_string()
     }
 }
 

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -22,7 +22,6 @@ use crate::architecture::riscv::communication_interface::{RiscvError, RiscvInter
 use crate::architecture::xtensa::communication_interface::{
     XtensaCommunicationInterface, XtensaDebugInterfaceState, XtensaError,
 };
-use crate::config::RegistryError;
 use crate::config::TargetSelector;
 use crate::probe::common::IdCode;
 use crate::{Error, Permissions, Session};
@@ -106,14 +105,6 @@ pub enum DebugProbeError {
     /// USB Communication Error
     Usb(#[source] std::io::Error),
 
-    /// The firmware on the probe is outdated, and not supported by probe-rs.
-    ///
-    /// This error is especially prominent with ST-Links.
-    /// You can use their official updater utility to update your probe firmware.
-    // TODO: Shouldn't this be probe-specific?
-    #[ignore_extra_doc_attributes]
-    ProbeFirmwareOutdated,
-
     /// An error which is specific to the debug probe in use occurred.
     ProbeSpecific(#[source] Box<dyn std::error::Error + Send + Sync>),
 
@@ -134,9 +125,6 @@ pub enum DebugProbeError {
         /// The name of the unsupported interface.
         interface_name: &'static str,
     },
-
-    /// An error occurred while working with the registry.
-    Registry(#[from] RegistryError),
 
     /// The probe does not support he requested speed setting ({0} kHz).
     UnsupportedSpeed(u32),

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -53,8 +53,8 @@ pub enum WireProtocol {
 impl fmt::Display for WireProtocol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            WireProtocol::Swd => write!(f, "SWD"),
-            WireProtocol::Jtag => write!(f, "JTAG"),
+            WireProtocol::Swd => f.write_str("SWD"),
+            WireProtocol::Jtag => f.write_str("JTAG"),
         }
     }
 }

--- a/probe-rs/src/probe/cmsisdap/commands/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/mod.rs
@@ -7,7 +7,7 @@ pub mod transfer;
 
 use crate::probe::cmsisdap::commands::general::info::PacketSizeCommand;
 use crate::probe::usb_util::InterfaceExt;
-use crate::probe::DebugProbeError;
+use crate::probe::ProbeError;
 use std::io::ErrorKind;
 use std::str::Utf8Error;
 use std::time::Duration;
@@ -50,6 +50,8 @@ pub enum CmsisDapError {
     InvalidIR,
 }
 
+impl ProbeError for CmsisDapError {}
+
 #[derive(Debug, thiserror::Error, docsplay::Display)]
 pub enum SendError {
     /// Error in the USB HID access.
@@ -82,12 +84,6 @@ pub enum SendError {
 
     /// Timeout in USB communication.
     Timeout,
-}
-
-impl From<CmsisDapError> for DebugProbeError {
-    fn from(error: CmsisDapError) -> Self {
-        DebugProbeError::ProbeSpecific(Box::new(error))
-    }
 }
 
 pub enum CmsisDapDevice {
@@ -290,6 +286,7 @@ impl Status {
 /// The command ID is always sent as the first byte for every command,
 /// and also is the first byte of every response.
 #[derive(Debug)]
+#[allow(unused)]
 pub enum CommandId {
     Info = 0x00,
     HostStatus = 0x01,

--- a/probe-rs/src/probe/cmsisdap/commands/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/mod.rs
@@ -14,56 +14,73 @@ use std::time::Duration;
 
 const USB_TIMEOUT: Duration = Duration::from_millis(1000);
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, docsplay::Display)]
 pub enum CmsisDapError {
-    #[error("Error handling CMSIS-DAP command {command_id:?}")]
+    /// Error handling CMSIS-DAP command {command_id:?}.
     Send {
         command_id: CommandId,
         source: SendError,
     },
-    #[error("CMSIS-DAP responded with an error")]
+
+    /// CMSIS-DAP responded with an error.
     ErrorResponse,
-    #[error("Too much data provided for SWJ Sequence command")]
+
+    /// Too much data provided for SWJ Sequence command.
     TooMuchData,
-    #[error("Requested SWO baud rate could not be configured")]
+
+    /// Requested SWO baud rate could not be configured.
     SwoBaudrateNotConfigured,
-    #[error("Probe reported an error while streaming SWO")]
+
+    /// Probe reported an error while streaming SWO.
     SwoTraceStreamError,
-    #[error("Requested SWO mode is not available on this probe")]
+
+    /// Requested SWO mode is not available on this probe.
     SwoModeNotAvailable,
-    #[error("USB Error reading SWO data.")]
+
+    /// USB Error reading SWO data.
     SwoReadError(#[source] std::io::Error),
-    #[error("Could not determine a suitable packet size for this probe")]
+
+    /// Could not determine a suitable packet size for this probe.
     NoPacketSize,
-    #[error("Invalid IDCODE detected")]
+
+    /// Invalid IDCODE detected.
     InvalidIdCode,
-    #[error("Error scanning IR lengths")]
+
+    /// Error scanning IR lengths.
     InvalidIR,
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, docsplay::Display)]
 pub enum SendError {
-    #[error("Error in the USB HID access")]
+    /// Error in the USB HID access.
     HidApi(#[from] hidapi::HidError),
-    #[error("Error in the USB access")]
+
+    /// Error in the USB access.
     UsbError(std::io::Error),
-    #[error("Not enough data in response from probe")]
+
+    /// Not enough data in response from probe.
     NotEnoughData,
-    #[error("Status can only be 0x00 or 0xFF")]
+
+    /// Status can only be 0x00 or 0xFF
     InvalidResponseStatus,
-    #[error("Connecting to target failed, received: {0:x}")]
+
+    /// Connecting to target failed, received: {0:x}
     ConnectResponseError(u8),
-    #[error("Command ID in response (:#02x) does not match sent command ID")]
+
+    /// Command ID in response (:#02x) does not match sent command ID
     CommandIdMismatch(u8),
+
     /// String in response is not valid UTF-8.
     ///
     /// Strings are required to be UTF-8 encoded by the
     /// CMSIS-DAP specification.
-    #[error("String in response is not valid UTF-8.")]
+    #[ignore_extra_doc_attributes]
     InvalidString(#[from] Utf8Error),
-    #[error("Unexpected answer to command")]
+
+    /// Unexpected answer to command.
     UnexpectedAnswer,
-    #[error("Timeout in USB communication.")]
+
+    /// Timeout in USB communication.
     Timeout,
 }
 

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -829,7 +829,7 @@ impl DebugProbe for CmsisDap {
         }
 
         let response = commands::send_command(&mut self.device, DisconnectRequest {})
-            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+            .map_err(DebugProbeError::from)?;
 
         // Tell probe we are disconnected so it can turn off its LED.
         let _: Result<HostStatusResponse, _> =
@@ -1119,16 +1119,10 @@ impl SwoAccess for CmsisDap {
         // Check requested mode is available in probe capabilities
         match config.mode() {
             SwoMode::Uart if !caps.swo_uart_implemented => {
-                return Err(DebugProbeError::ProbeSpecific(
-                    CmsisDapError::SwoModeNotAvailable.into(),
-                )
-                .into())
+                return Err(ArmError::Probe(CmsisDapError::SwoModeNotAvailable.into()));
             }
             SwoMode::Manchester if !caps.swo_manchester_implemented => {
-                return Err(DebugProbeError::ProbeSpecific(
-                    CmsisDapError::SwoModeNotAvailable.into(),
-                )
-                .into())
+                return Err(ArmError::Probe(CmsisDapError::SwoModeNotAvailable.into()));
             }
             _ => (),
         }

--- a/probe-rs/src/probe/ftdi/ftdaye/error.rs
+++ b/probe-rs/src/probe/ftdi/ftdaye/error.rs
@@ -1,6 +1,6 @@
 use nusb::descriptors::ActiveConfigurationError;
 
-use crate::probe::{ftdi::ftdaye::ChipType, DebugProbeError};
+use crate::probe::{ftdi::ftdaye::ChipType, ProbeError};
 
 #[derive(Debug, thiserror::Error)]
 pub enum FtdiError {
@@ -24,8 +24,4 @@ pub enum FtdiError {
     Other(String),
 }
 
-impl From<FtdiError> for DebugProbeError {
-    fn from(e: FtdiError) -> Self {
-        DebugProbeError::ProbeSpecific(Box::new(e))
-    }
-}
+impl ProbeError for FtdiError {}

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -178,8 +178,7 @@ impl JtagAdapter {
     fn flush(&mut self) -> Result<(), DebugProbeError> {
         self.finalize_command()?;
         self.send_buffer()?;
-        self.read_response()
-            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+        self.read_response()?;
 
         Ok(())
     }
@@ -332,9 +331,7 @@ impl DebugProbe for FtdiProbe {
     fn attach(&mut self) -> Result<(), DebugProbeError> {
         tracing::debug!("Attaching...");
 
-        self.adapter
-            .attach()
-            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+        self.adapter.attach()?;
 
         self.scan_chain()?;
         self.select_target(0)

--- a/probe-rs/src/probe/jlink/error.rs
+++ b/probe-rs/src/probe/jlink/error.rs
@@ -1,4 +1,4 @@
-use crate::probe::DebugProbeError;
+use crate::probe::ProbeError;
 
 use super::{capabilities::Capability, interface::Interface};
 
@@ -39,8 +39,4 @@ pub enum JlinkError {
     Other(String),
 }
 
-impl From<JlinkError> for DebugProbeError {
-    fn from(e: JlinkError) -> Self {
-        DebugProbeError::ProbeSpecific(Box::new(e))
-    }
-}
+impl ProbeError for JlinkError {}

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         FullyQualifiedApAddress, Pins, SwoAccess, SwoConfig, SwoMode,
     },
     probe::{
-        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, Probe, ProbeCreationError,
+        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, Probe, ProbeError,
         ProbeFactory, WireProtocol,
     },
     Error as ProbeRsError, MemoryInterface,
@@ -1252,10 +1252,9 @@ impl<D: StLinkUsb> SwoAccess for StLink<D> {
                 self.start_trace_reception(config)?;
                 Ok(())
             }
-            SwoMode::Manchester => Err(DebugProbeError::ProbeSpecific(
+            SwoMode::Manchester => Err(ArmError::Probe(
                 StlinkError::ManchesterSwoNotSupported.into(),
-            )
-            .into()),
+            )),
         }
     }
 
@@ -1316,17 +1315,7 @@ pub enum StlinkError {
     Usb(#[from] std::io::Error),
 }
 
-impl From<StlinkError> for DebugProbeError {
-    fn from(e: StlinkError) -> Self {
-        DebugProbeError::ProbeSpecific(Box::new(e))
-    }
-}
-
-impl From<StlinkError> for ProbeCreationError {
-    fn from(e: StlinkError) -> Self {
-        ProbeCreationError::ProbeSpecific(Box::new(e))
-    }
-}
+impl ProbeError for StlinkError {}
 
 #[derive(Debug)]
 struct UninitializedStLink {

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1277,25 +1277,18 @@ impl<D: StLinkUsb> SwoAccess for StLink<D> {
 }
 
 /// ST-Link specific errors.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, docsplay::Display)]
 pub enum StlinkError {
     /// Invalid voltage values returned by probe.
-    #[error("Invalid voltage values returned by probe.")]
     VoltageDivisionByZero,
 
     /// Probe is in an unknown mode.
-    #[error("Probe is in an unknown mode.")]
     UnknownMode,
 
-    /// Banks not allowed on DP register.
-    #[error(
-        "Current version of the STLink firmware does not support accessing banked DP registers. \
-         Upgrading the firmware to the newest version might fix this."
-    )]
+    /// Current version of the STLink firmware does not support accessing banked DP registers.
     BanksNotAllowedOnDPRegister,
 
-    /// Not enough bytes were written.
-    #[error("Not enough bytes written.")]
+    /// Not enough bytes were written. Expected {should} but only {is} were written.
     NotEnoughBytesWritten {
         /// The number of bytes actually written
         is: usize,
@@ -1304,32 +1297,25 @@ pub enum StlinkError {
     },
 
     /// USB endpoint not found.
-    #[error("Usb endpoint not found.")]
     EndpointNotFound,
 
-    /// Command failed.
-    #[error("Command failed with status {0:?}")]
+    /// Command failed with status {0:?}.
     CommandFailed(Status),
 
     /// The probe does not support JTAG.
-    #[error("JTAG not supported on Probe")]
     JTAGNotSupportedOnProbe,
 
     /// The probe does not support SWO with Manchester encoding.
-    #[error("Manchester-coded SWO mode not supported")]
     ManchesterSwoNotSupported,
 
     /// The probe does not support multidrop SWD.
-    #[error("Multidrop SWD not supported")]
     MultidropNotSupported,
 
     /// Attempted unaligned access.
-    #[error("Unaligned")]
     UnalignedAddress,
 
     /// USB error.
-    #[error("USB")]
-    Usb(Box<dyn std::error::Error + Sync + Send>),
+    Usb(#[source] Box<dyn std::error::Error + Sync + Send>),
 }
 
 impl From<nusb::Error> for StlinkError {

--- a/probe-rs/src/probe/stlink/usb_interface.rs
+++ b/probe-rs/src/probe/stlink/usb_interface.rs
@@ -7,7 +7,7 @@ use crate::probe::{stlink::StlinkError, usb_util::InterfaceExt};
 use std::collections::HashMap;
 
 use super::tools::{is_stlink_device, read_serial_number};
-use crate::probe::{DebugProbeError, DebugProbeSelector, ProbeCreationError};
+use crate::probe::{DebugProbeSelector, ProbeCreationError};
 
 /// The USB Command packet size.
 const CMD_LEN: usize = 16;
@@ -80,14 +80,10 @@ pub trait StLinkUsb: std::fmt::Debug {
 
     /// Reset the USB device. This can be used to recover when the
     /// STLink does not respond to USB requests.
-    fn reset(&mut self) -> Result<(), DebugProbeError>;
+    fn reset(&mut self) -> Result<(), StlinkError>;
 
     /// Reads SWO data from the probe.
-    fn read_swo(
-        &mut self,
-        read_data: &mut [u8],
-        timeout: Duration,
-    ) -> Result<usize, DebugProbeError>;
+    fn read_swo(&mut self, read_data: &mut [u8], timeout: Duration) -> Result<usize, StlinkError>;
 }
 
 // Copy of `Selector::matches` except it uses the stlink-specific read_serial_number
@@ -247,11 +243,7 @@ impl StLinkUsb for StLinkUsbDevice {
         Ok(())
     }
 
-    fn read_swo(
-        &mut self,
-        read_data: &mut [u8],
-        timeout: Duration,
-    ) -> Result<usize, DebugProbeError> {
+    fn read_swo(&mut self, read_data: &mut [u8], timeout: Duration) -> Result<usize, StlinkError> {
         tracing::trace!(
             "Reading {:?} SWO bytes to STLink, timeout: {:?}",
             read_data.len(),
@@ -265,14 +257,14 @@ impl StLinkUsb for StLinkUsbDevice {
         } else {
             self.interface
                 .read_bulk(ep_swo, read_data, timeout)
-                .map_err(DebugProbeError::Usb)
+                .map_err(StlinkError::Usb)
         }
     }
 
     /// Reset the USB device. This can be used to recover when the
     /// STLink does not respond to USB requests.
-    fn reset(&mut self) -> Result<(), DebugProbeError> {
+    fn reset(&mut self) -> Result<(), StlinkError> {
         tracing::debug!("Resetting USB device of STLink");
-        self.device_handle.reset().map_err(DebugProbeError::Usb)
+        self.device_handle.reset().map_err(StlinkError::Usb)
     }
 }

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -558,7 +558,7 @@ pub(crate) enum WchLinkError {
     InvalidPayload,
     /// Protocol error.
     Protocol(u8, Vec<u8>),
-    /// Unknown chip {0:#02x}.
+    /// Unknown chip {0:#04x}.
     UnknownChip(u8),
     /// Unsupported operation.
     UnsupportedOperation,

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -16,8 +16,8 @@ use crate::{
         communication_interface::RiscvInterfaceBuilder, dtm::jtag_dtm::JtagDtmBuilder,
     },
     probe::{
-        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeCreationError,
-        ProbeFactory, WireProtocol,
+        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeError, ProbeFactory,
+        WireProtocol,
     },
 };
 
@@ -438,9 +438,7 @@ impl JTAGAccess for WchLink {
                     self.dmi_op_write(0x10, 0x00000001)?;
                     // dmcontrol.dmactive is checked later
                 } else if val & DTMCS_DMIHARDRESET_MASK != 0 {
-                    return Err(DebugProbeError::ProbeSpecific(Box::new(
-                        WchLinkError::UnsupportedOperation,
-                    )));
+                    return Err(WchLinkError::UnsupportedOperation.into());
                 }
 
                 Ok(0x71_u32.to_le_bytes().to_vec())
@@ -566,14 +564,4 @@ pub(crate) enum WchLinkError {
     UnsupportedOperation,
 }
 
-impl From<WchLinkError> for DebugProbeError {
-    fn from(e: WchLinkError) -> Self {
-        DebugProbeError::ProbeSpecific(Box::new(e))
-    }
-}
-
-impl From<WchLinkError> for ProbeCreationError {
-    fn from(e: WchLinkError) -> Self {
-        ProbeCreationError::ProbeSpecific(Box::new(e))
-    }
-}
+impl ProbeError for WchLinkError {}

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -544,25 +544,25 @@ fn list_wlink_devices() -> Vec<DebugProbeInfo> {
     probes
 }
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, docsplay::Display)]
 pub(crate) enum WchLinkError {
-    #[error("Unknown WCH-Link device(new variant?)")]
+    /// Unknown WCH-Link device.
     UnknownDevice,
-    #[error("Firmware version is not supported.")]
+    /// Firmware version is not supported.
     UnsupportedFirmwareVersion,
-    #[error("Not enough bytes written.")]
+    /// Not enough bytes written.
     NotEnoughBytesWritten { is: usize, should: usize },
-    #[error("Not enough bytes read.")]
+    /// Not enough bytes read.
     NotEnoughBytesRead { is: usize, should: usize },
-    #[error("Usb endpoint not found.")]
+    /// Usb endpoint not found.
     EndpointNotFound,
-    #[error("Invalid payload.")]
+    /// Invalid payload.
     InvalidPayload,
-    #[error("Protocol error.")]
+    /// Protocol error.
     Protocol(u8, Vec<u8>),
-    #[error("Unknown chip 0x{0:02x}")]
+    /// Unknown chip {0:#02x}.
     UnknownChip(u8),
-    #[error("Unsupported operation.")]
+    /// Unsupported operation.
     UnsupportedOperation,
 }
 

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -225,7 +225,7 @@ impl WchLink {
         self.v_minor = probe_info.minor_version;
 
         if self.v_major != 0x02 && self.v_minor < 0x07 {
-            return Err(DebugProbeError::ProbeFirmwareOutdated);
+            return Err(WchLinkError::UnsupportedFirmwareVersion.into());
         }
 
         self.variant = probe_info.variant;
@@ -568,10 +568,7 @@ pub(crate) enum WchLinkError {
 
 impl From<WchLinkError> for DebugProbeError {
     fn from(e: WchLinkError) -> Self {
-        match e {
-            WchLinkError::UnsupportedFirmwareVersion => DebugProbeError::ProbeFirmwareOutdated,
-            _ => DebugProbeError::ProbeSpecific(Box::new(e)),
-        }
+        DebugProbeError::ProbeSpecific(Box::new(e))
     }
 }
 


### PR DESCRIPTION
Use the probe-specific errors internally more, replace the generic probe firmware error with probe-specific variants.

Probe-specific errors can now be downcast to concrete error types, which I hope will make it simpler to inspect ProbeSpecificError variants.

Somewhat experimental and we might reuse the AnyShim idea for other trait-upcasting-at-home tasks (like Probe -> concrete probe impl)