### PR TITLE
Refactor handling of debug information for C-style enums

### DIFF
--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -205,9 +205,11 @@ impl DebugInfo {
         None
     }
 
-    /// We do not actually resolve the children of `[VariableName::StaticScope]` automatically, and only create the necessary header in the `VariableCache`.
+    /// We do not actually resolve the children of `[VariableName::StaticScope]` automatically,
+    /// and only create the necessary header in the `VariableCache`.
     /// This allows us to resolve the `[VariableName::StaticScope]` on demand/lazily, when a user requests it from the debug client.
-    /// This saves a lot of overhead when a user only wants to see the `[VariableName::LocalScope]` or `[VariableName::Registers]` while stepping through code (the most common use cases)
+    /// This saves a lot of overhead when a user only wants to see the `[VariableName::LocalScope]` or `
+    /// [VariableName::Registers]` while stepping through code (the most common use cases)
     pub fn create_static_scope_cache(&self) -> VariableCache {
         VariableCache::new_static_cache()
     }


### PR DESCRIPTION
C-style enums were handled recursively, and mixed with the handling of structs and variables. To simplify this, the enum variants are now handled separately, to make the code easier to follow.

The larger goal is to try and reduce the use of the variable cache for things where we only create temporary entries.