### PR TITLE
Some improvements for better multicore ESP32 support

### DIFF
--- a/changelog/added-core-disabled.md
+++ b/changelog/added-core-disabled.md
@@ -1,0 +1,1 @@
+Added new `Error::CoreDisabled` variant.

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -165,8 +165,10 @@ impl<'probe> XtensaCommunicationInterface<'probe> {
     }
 
     pub(crate) fn leave_debug_mode(&mut self) -> Result<(), XtensaError> {
-        self.restore_registers()?;
-        self.resume()?;
+        if self.xdm.status()?.stopped() {
+            self.restore_registers()?;
+            self.resume()?;
+        }
         self.xdm.leave_ocd_mode()?;
 
         tracing::debug!("Left OCD mode");

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -19,13 +19,16 @@ use super::xdm::{Error as XdmError, Xdm};
 /// Possible Xtensa errors
 #[derive(thiserror::Error, Debug, docsplay::Display)]
 pub enum XtensaError {
-    /// An error originating from the DebugProbe occurred
+    /// An error originating from the DebugProbe occurred.
     DebugProbe(#[from] DebugProbeError),
 
-    /// Xtensa debug module error
+    /// Xtensa debug module error.
     XdmError(#[from] XdmError),
 
-    /// The operation has timed out
+    /// The core is not enabled.
+    CoreDisabled,
+
+    /// The operation has timed out.
     // TODO: maybe we could be a bit more specific
     Timeout,
 

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -682,10 +682,15 @@ impl<'probe> XtensaCommunicationInterface<'probe> {
     }
 
     pub(crate) fn reset_and_halt(&mut self, timeout: Duration) -> Result<(), XtensaError> {
+        self.clear_register_cache();
         self.xdm.reset_and_halt()?;
         self.wait_for_core_halted(timeout)?;
 
         Ok(())
+    }
+
+    pub(crate) fn clear_register_cache(&mut self) {
+        self.state.saved_registers.clear();
     }
 }
 

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -164,6 +164,16 @@ impl<'probe> XtensaCommunicationInterface<'probe> {
         Ok(())
     }
 
+    pub(crate) fn leave_debug_mode(&mut self) -> Result<(), XtensaError> {
+        self.restore_registers()?;
+        self.resume()?;
+        self.xdm.leave_ocd_mode()?;
+
+        tracing::debug!("Left OCD mode");
+
+        Ok(())
+    }
+
     /// Returns the number of hardware breakpoints the target supports.
     ///
     /// On the Xtensa architecture this is the `NIBREAK` configuration parameter.

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -228,6 +228,9 @@ impl<'probe> CoreInterface for Xtensa<'probe> {
 
     fn run(&mut self) -> Result<(), Error> {
         self.skip_breakpoint_instruction()?;
+        if self.state.pc_written {
+            self.interface.clear_register_cache();
+        }
         Ok(self.interface.resume()?)
     }
 

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -31,6 +31,9 @@ pub(crate) mod sequences;
 #[derive(Debug)]
 /// Xtensa core state.
 pub struct XtensaCoreState {
+    /// Whether the core is enabled.
+    enabled: bool,
+
     /// Whether hardware breakpoints are enabled.
     breakpoints_enabled: bool,
 
@@ -51,6 +54,7 @@ impl XtensaCoreState {
     /// Creates a new [`XtensaCoreState`].
     pub(crate) fn new() -> Self {
         Self {
+            enabled: false,
             breakpoints_enabled: false,
             breakpoint_set: [false; 2],
             pc_written: false,
@@ -80,10 +84,15 @@ impl<'probe> Xtensa<'probe> {
 
     /// Create a new Xtensa interface for a particular core.
     pub fn new(
-        interface: XtensaCommunicationInterface<'probe>,
+        mut interface: XtensaCommunicationInterface<'probe>,
         state: &'probe mut XtensaCoreState,
         sequence: Arc<dyn XtensaDebugSequence>,
     ) -> Result<Self, Error> {
+        if !state.enabled {
+            interface.enter_debug_mode()?;
+            state.enabled = true;
+        }
+
         Ok(Self {
             interface,
             state,

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -83,12 +83,12 @@ impl<'probe> Xtensa<'probe> {
         interface: XtensaCommunicationInterface<'probe>,
         state: &'probe mut XtensaCoreState,
         sequence: Arc<dyn XtensaDebugSequence>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, Error> {
+        Ok(Self {
             interface,
             state,
             sequence,
-        }
+        })
     }
 
     fn core_info(&mut self) -> Result<CoreInformation, Error> {

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -407,10 +407,7 @@ impl<'probe> CoreInterface for Xtensa<'probe> {
     }
 
     fn debug_core_stop(&mut self) -> Result<(), Error> {
-        self.interface.restore_registers()?;
-        self.interface.resume()?;
-        self.interface.xdm.leave_ocd_mode()?;
-        tracing::info!("Left OCD mode");
+        self.interface.leave_debug_mode()?;
         Ok(())
     }
 }

--- a/probe-rs/src/architecture/xtensa/sequences.rs
+++ b/probe-rs/src/architecture/xtensa/sequences.rs
@@ -10,10 +10,7 @@ use crate::Session;
 /// Should be implemented on a custom handle for chips that require special sequence code.
 pub trait XtensaDebugSequence: Send + Sync + Debug {
     /// Executed when the probe establishes a connection to the target.
-    fn on_connect(
-        &self,
-        _interface: &mut XtensaCommunicationInterface,
-    ) -> Result<(), crate::Error> {
+    fn on_connect(&self, _session: &mut Session) -> Result<(), crate::Error> {
         Ok(())
     }
 

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -1,4 +1,7 @@
-use std::{fmt::Debug, time::Duration};
+use std::{
+    fmt::Debug,
+    time::{Duration, Instant},
+};
 
 use crate::{
     architecture::xtensa::arch::instruction::{Instruction, InstructionEncoding},
@@ -186,9 +189,10 @@ impl<'probe> Xdm<'probe> {
         self.pwr_write(PowerDevice::PowerControl, pwr_control.0)?;
 
         tracing::trace!("Waiting for power domain to turn on");
-        let now = std::time::Instant::now();
+        let now = Instant::now();
         loop {
             let bits = self.pwr_write(PowerDevice::PowerStat, 0)?;
+            tracing::debug!("PowerStatus: {:?}", PowerStatus(bits));
             if PowerStatus(bits).debug_domain_on() {
                 break;
             }
@@ -681,6 +685,7 @@ bitfield::bitfield! {
 bitfield::bitfield! {
     #[derive(Copy, Clone)]
     pub struct PowerStatus(u8);
+    impl Debug;
 
     pub core_domain_on,    _: 0;
     pub mem_domain_on,     _: 1;

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -240,6 +240,7 @@ impl<'probe> Xdm<'probe> {
             status.set_exec_overrun(true);
             status.set_debug_pend_break(true);
             status.set_debug_pend_host(true);
+            status.set_debug_int_break(true);
 
             status
         })?;

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -207,6 +207,8 @@ impl<'probe> Xdm<'probe> {
         self.write_nexus_register(DebugControlSet({
             let mut reg = DebugControlBits(0);
             reg.set_enable_ocd(true);
+            reg.set_break_in_en(true);
+            reg.set_break_out_en(true);
             reg
         }))?;
 
@@ -446,6 +448,8 @@ impl<'probe> Xdm<'probe> {
 
             control.set_enable_ocd(true);
             control.set_debug_interrupt(true);
+            control.set_break_in_en(true);
+            control.set_break_out_en(true);
 
             control
         }));
@@ -488,6 +492,8 @@ impl<'probe> Xdm<'probe> {
             let mut control = DebugControlBits(0);
 
             control.set_enable_ocd(true);
+            control.set_break_in_en(true);
+            control.set_break_out_en(true);
 
             control
         }))?;

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -214,11 +214,12 @@ impl<'probe> Xdm<'probe> {
 
         // read the device_id
         let device_id = self.read_nexus_register::<OcdId>()?.0;
+        tracing::debug!("Read OCDID: {:#010X}", device_id);
 
         if device_id == 0 || device_id == !0 {
             return Err(DebugProbeError::TargetNotFound.into());
         }
-        tracing::info!("Found Xtensa device with OCDID: 0x{:08X}", device_id);
+        tracing::info!("Found Xtensa device with OCDID: {:#010X}", device_id);
 
         let status = self.status()?;
         tracing::debug!("{:?}", status);

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -203,6 +203,9 @@ impl<'probe> Xdm<'probe> {
         pwr_control.set_jtag_debug_use(true);
         self.pwr_write(PowerDevice::PowerControl, pwr_control.0)?;
 
+        let idcode = self.read_idcode()?;
+        tracing::debug!("Read IDCODE: {:#010X}", idcode);
+
         // read the device_id
         let device_id = self.read_nexus_register::<OcdId>()?.0;
         tracing::debug!("Read OCDID: {:#010X}", device_id);

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -256,6 +256,8 @@ impl<'probe> Xdm<'probe> {
         tracing::debug!("Read OCDID: {:#010X}", device_id);
 
         if device_id == 0 || device_id == u32::MAX {
+            // Disable the debug module if we can't work with it.
+            self.pwr_write(PowerDevice::PowerControl, 0)?;
             return Err(XtensaError::CoreDisabled);
         }
         tracing::info!("Found Xtensa device with OCDID: {:#010X}", device_id);

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -223,7 +223,7 @@ impl CombinedCoreState {
             self.id,
             name,
             memory_regions,
-            crate::architecture::xtensa::Xtensa::new(interface, s, debug_sequence),
+            crate::architecture::xtensa::Xtensa::new(interface, s, debug_sequence)?,
         ))
     }
 

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -17,7 +17,9 @@ pub enum Error {
     Riscv(#[source] RiscvError),
     /// An Xtensa specific error occurred.
     Xtensa(#[source] XtensaError),
-    /// Core {0} does not exist
+    /// Core {0} is not enabled.
+    CoreDisabled(usize),
+    /// Core {0} does not exist.
     CoreNotFound(usize),
     /// Unable to load specification for chip
     ChipNotFound(#[from] RegistryError),

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -1087,7 +1087,6 @@ impl ChainParams {
 
         let mut found = false;
         for (index, tap) in chain.iter().enumerate() {
-            tracing::info!("{:?}", tap);
             if index == selected {
                 params.irlen = tap.irlen;
                 found = true;

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -439,7 +439,7 @@ pub(crate) trait RawJtagIo {
         self.shift_bits(tms, tdi, iter::repeat(false))?;
         let response = self.read_captured_bits()?;
 
-        tracing::debug!("Response to reset: {}", response);
+        tracing::debug!("Response to reset: {response}");
 
         Ok(())
     }
@@ -454,8 +454,9 @@ pub(crate) trait RawJtagIo {
 
         let max_ir_address = (1 << params.irlen) - 1;
 
-        tracing::debug!("Setting chain params: {:?}", params);
-        tracing::debug!("Setting max_ir_address to {}", max_ir_address);
+        tracing::debug!("Selecting JTAG TAP: {target}");
+        tracing::debug!("Setting chain params: {params:?}");
+        tracing::debug!("Setting max_ir_address to {max_ir_address}");
 
         let state = self.state_mut();
         state.max_ir_address = max_ir_address;

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -108,6 +108,7 @@ impl ArchitectureInterface {
             ArchitectureInterface::Arm(interface) => combined_state.attach_arm(target, interface),
             ArchitectureInterface::Jtag(probe, ifaces) => {
                 let idx = combined_state.interface_idx();
+                probe.select_jtag_tap(idx)?;
                 match &mut ifaces[idx] {
                     JtagInterface::Riscv(state) => {
                         let factory = probe.try_get_riscv_interface_builder()?;
@@ -552,6 +553,7 @@ impl Session {
     ) -> Result<RiscvCommunicationInterface, Error> {
         let tap_idx = self.interface_idx(core_id)?;
         if let ArchitectureInterface::Jtag(probe, ifaces) = &mut self.interfaces {
+            probe.select_jtag_tap(tap_idx)?;
             if let JtagInterface::Riscv(state) = &mut ifaces[tap_idx] {
                 let factory = probe.try_get_riscv_interface_builder()?;
                 return Ok(factory.attach(state)?);
@@ -567,6 +569,7 @@ impl Session {
     ) -> Result<XtensaCommunicationInterface, Error> {
         let tap_idx = self.interface_idx(core_id)?;
         if let ArchitectureInterface::Jtag(probe, ifaces) = &mut self.interfaces {
+            probe.select_jtag_tap(tap_idx)?;
             if let JtagInterface::Xtensa(state) = &mut ifaces[tap_idx] {
                 return Ok(probe.try_get_xtensa_interface(state)?);
             }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -387,11 +387,7 @@ impl Session {
 
         // Connect to the cores
         match session.target.debug_sequence.clone() {
-            DebugSequence::Xtensa(sequence) => {
-                for core_id in 0..session.cores.len() {
-                    sequence.on_connect(&mut session.get_xtensa_interface(core_id)?)?;
-                }
-            }
+            DebugSequence::Xtensa(sequence) => sequence.on_connect(&mut session)?,
 
             DebugSequence::Riscv(sequence) => {
                 for core_id in 0..session.cores.len() {

--- a/probe-rs/src/vendor/espressif/sequences/esp32.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32.rs
@@ -5,12 +5,7 @@ use std::sync::Arc;
 use probe_rs_target::Chip;
 
 use super::esp::EspFlashSizeDetector;
-use crate::{
-    architecture::xtensa::{
-        communication_interface::XtensaCommunicationInterface, sequences::XtensaDebugSequence,
-    },
-    MemoryInterface, Session,
-};
+use crate::{architecture::xtensa::sequences::XtensaDebugSequence, MemoryInterface, Session};
 
 /// The debug sequence implementation for the ESP32.
 #[derive(Debug)]
@@ -33,32 +28,34 @@ impl ESP32 {
 }
 
 impl XtensaDebugSequence for ESP32 {
-    fn on_connect(&self, interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
+    fn on_connect(&self, session: &mut Session) -> Result<(), crate::Error> {
+        let mut core = session.core(0)?;
+
         tracing::info!("Disabling ESP32 watchdogs...");
 
         // tg0 wdg
         const TIMG0_BASE: u64 = 0x3ff5f000;
         const TIMG0_WRITE_PROT: u64 = TIMG0_BASE | 0x64;
         const TIMG0_WDTCONFIG0: u64 = TIMG0_BASE | 0x48;
-        interface.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
+        core.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
 
         // tg1 wdg
         const TIMG1_BASE: u64 = 0x3ff60000;
         const TIMG1_WRITE_PROT: u64 = TIMG1_BASE | 0x64;
         const TIMG1_WDTCONFIG0: u64 = TIMG1_BASE | 0x48;
-        interface.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
+        core.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
 
         // rtc wdg
         const RTC_CNTL_BASE: u64 = 0x3ff48000;
         const RTC_WRITE_PROT: u64 = RTC_CNTL_BASE | 0xa4;
         const RTC_WDTCONFIG0: u64 = RTC_CNTL_BASE | 0x8c;
-        interface.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(RTC_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(RTC_WDTCONFIG0, 0x0)?;
+        core.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
 
         tracing::warn!("Be careful not to reset your ESP32 while connected to the debugger! Depending on the specific device, this may render it temporarily inoperable or permanently damage it.");
 

--- a/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
@@ -5,12 +5,7 @@ use std::sync::Arc;
 use probe_rs_target::Chip;
 
 use super::esp::EspFlashSizeDetector;
-use crate::{
-    architecture::xtensa::{
-        communication_interface::XtensaCommunicationInterface, sequences::XtensaDebugSequence,
-    },
-    MemoryInterface, Session,
-};
+use crate::{architecture::xtensa::sequences::XtensaDebugSequence, MemoryInterface, Session};
 
 /// The debug sequence implementation for the ESP32-S2.
 #[derive(Debug)]
@@ -33,32 +28,34 @@ impl ESP32S2 {
 }
 
 impl XtensaDebugSequence for ESP32S2 {
-    fn on_connect(&self, interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
+    fn on_connect(&self, session: &mut Session) -> Result<(), crate::Error> {
+        let mut core = session.core(0)?;
+
         tracing::info!("Disabling ESP32-S2 watchdogs...");
 
         // tg0 wdg
         const TIMG0_BASE: u64 = 0x3f41f000;
         const TIMG0_WRITE_PROT: u64 = TIMG0_BASE | 0x64;
         const TIMG0_WDTCONFIG0: u64 = TIMG0_BASE | 0x48;
-        interface.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
+        core.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
 
         // tg1 wdg
         const TIMG1_BASE: u64 = 0x3f420000;
         const TIMG1_WRITE_PROT: u64 = TIMG1_BASE | 0x64;
         const TIMG1_WDTCONFIG0: u64 = TIMG1_BASE | 0x48;
-        interface.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
+        core.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
 
         // rtc wdg
         const RTC_CNTL_BASE: u64 = 0x3f408000;
         const RTC_WRITE_PROT: u64 = RTC_CNTL_BASE | 0xac;
         const RTC_WDTCONFIG0: u64 = RTC_CNTL_BASE | 0x94;
-        interface.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(RTC_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(RTC_WDTCONFIG0, 0x0)?;
+        core.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
 
         Ok(())
     }

--- a/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
@@ -5,12 +5,7 @@ use std::sync::Arc;
 use probe_rs_target::Chip;
 
 use super::esp::EspFlashSizeDetector;
-use crate::{
-    architecture::xtensa::{
-        communication_interface::XtensaCommunicationInterface, sequences::XtensaDebugSequence,
-    },
-    MemoryInterface, Session,
-};
+use crate::{architecture::xtensa::sequences::XtensaDebugSequence, MemoryInterface, Session};
 
 /// The debug sequence implementation for the ESP32-S3.
 #[derive(Debug)]
@@ -33,32 +28,34 @@ impl ESP32S3 {
 }
 
 impl XtensaDebugSequence for ESP32S3 {
-    fn on_connect(&self, interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
+    fn on_connect(&self, session: &mut Session) -> Result<(), crate::Error> {
+        let mut core = session.core(0)?;
+
         tracing::info!("Disabling ESP32-S3 watchdogs...");
 
         // tg0 wdg
         const TIMG0_BASE: u64 = 0x6001f000;
         const TIMG0_WRITE_PROT: u64 = TIMG0_BASE | 0x64;
         const TIMG0_WDTCONFIG0: u64 = TIMG0_BASE | 0x48;
-        interface.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
+        core.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
 
         // tg1 wdg
         const TIMG1_BASE: u64 = 0x60020000;
         const TIMG1_WRITE_PROT: u64 = TIMG1_BASE | 0x64;
         const TIMG1_WDTCONFIG0: u64 = TIMG1_BASE | 0x48;
-        interface.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
+        core.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
 
         // rtc wdg
         const RTC_CNTL_BASE: u64 = 0x60008000;
         const RTC_WRITE_PROT: u64 = RTC_CNTL_BASE | 0xa4;
         const RTC_WDTCONFIG0: u64 = RTC_CNTL_BASE | 0x98;
-        interface.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        interface.write_word_32(RTC_WDTCONFIG0, 0x0)?;
-        interface.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
+        core.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        core.write_word_32(RTC_WDTCONFIG0, 0x0)?;
+        core.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
 
         Ok(())
     }

--- a/probe-rs/src/vendor/mod.rs
+++ b/probe-rs/src/vendor/mod.rs
@@ -172,6 +172,8 @@ fn try_detect_arm_chip(mut probe: Probe) -> Result<(Probe, Option<Target>), Erro
 fn try_detect_riscv_chip(probe: &mut Probe) -> Result<Option<Target>, Error> {
     let mut found_target = None;
 
+    probe.select_jtag_tap(0)?;
+
     match probe.try_get_riscv_interface_builder() {
         Ok(factory) => {
             let mut state = factory.create_state();
@@ -217,6 +219,8 @@ fn try_detect_riscv_chip(probe: &mut Probe) -> Result<Option<Target>, Error> {
 
 fn try_detect_xtensa_chip(probe: &mut Probe) -> Result<Option<Target>, Error> {
     let mut found_target = None;
+
+    probe.select_jtag_tap(0)?;
 
     let mut state = XtensaDebugInterfaceState::default();
     match probe.try_get_xtensa_interface(&mut state) {

--- a/probe-rs/src/vendor/mod.rs
+++ b/probe-rs/src/vendor/mod.rs
@@ -243,7 +243,7 @@ fn try_detect_xtensa_chip(probe: &mut Probe) -> Result<Option<Target>, Error> {
                 Err(error) => tracing::debug!("Error during Xtensa chip detection: {error}"),
             }
 
-            // TODO: disable debug module
+            interface.leave_debug_mode()?;
         }
 
         Err(DebugProbeError::InterfaceNotAvailable { .. }) => {

--- a/probe-rs/targets/esp32.yaml
+++ b/probe-rs/targets/esp32.yaml
@@ -9,6 +9,10 @@ variants:
     type: xtensa
     core_access_options: !Xtensa
       jtag_tap: 0
+  - name: app
+    type: xtensa
+    core_access_options: !Xtensa
+      jtag_tap: 1
   memory_map:
   - !Nvm
     range:
@@ -16,6 +20,7 @@ variants:
       end: 0x1000000
     cores:
     - main
+    - app
     access:
       boot: true
   - !Nvm
@@ -25,6 +30,7 @@ variants:
       end: 0x3fc00000
     cores:
     - main
+    - app
     is_alias: true
   - !Ram
     name: SRAM2, Data bus
@@ -33,6 +39,7 @@ variants:
       end: 0x3ffe0000
     cores:
     - main
+    - app
   - !Ram
     name: SRAM1, Data bus
     range:
@@ -40,6 +47,7 @@ variants:
       end: 0x40000000
     cores:
     - main
+    - app
   - !Ram
     name: SRAM0, Instruction bus, non-cache
     range:
@@ -47,6 +55,7 @@ variants:
       end: 0x400a0000
     cores:
     - main
+    - app
   - !Nvm
     name: External instruction bus
     range:
@@ -54,6 +63,7 @@ variants:
       end: 0x40c00000
     cores:
     - main
+    - app
     is_alias: true
   flash_algorithms:
   - esp32-flashloader
@@ -84,5 +94,6 @@ flash_algorithms:
       address: 0x0
   cores:
   - main
+  - app
   stack_overflow_check: false
   transfer_encoding: miniz

--- a/probe-rs/targets/esp32s3.yaml
+++ b/probe-rs/targets/esp32s3.yaml
@@ -14,6 +14,10 @@ variants:
     type: xtensa
     core_access_options: !Xtensa
       jtag_tap: 0
+  - name: cpu1
+    type: xtensa
+    core_access_options: !Xtensa
+      jtag_tap: 1
   memory_map:
   - !Nvm
     range:
@@ -21,6 +25,7 @@ variants:
       end: 0x4000000
     cores:
     - cpu0
+    - cpu1
     access:
       boot: true
   - !Nvm
@@ -30,6 +35,7 @@ variants:
       end: 0x3e000000
     cores:
     - cpu0
+    - cpu1
     is_alias: true
   - !Ram
     name: SRAM1 Data bus
@@ -38,6 +44,7 @@ variants:
       end: 0x3fcf0000
     cores:
     - cpu0
+    - cpu1
   - !Ram
     name: SRAM2 Data bus
     range:
@@ -45,6 +52,7 @@ variants:
       end: 0x3fd00000
     cores:
     - cpu0
+    - cpu1
   - !Ram
     name: SRAM1 Instruction bus
     range:
@@ -52,6 +60,7 @@ variants:
       end: 0x40378000
     cores:
     - cpu0
+    - cpu1
   - !Ram
     name: SRAM2 Instruction bus
     range:
@@ -59,6 +68,7 @@ variants:
       end: 0x403e0000
     cores:
     - cpu0
+    - cpu1
   - !Nvm
     name: External instruction bus
     range:
@@ -66,6 +76,7 @@ variants:
       end: 0x44000000
     cores:
     - cpu0
+    - cpu1
     is_alias: true
   flash_algorithms:
   - esp32s3-flashloader
@@ -102,5 +113,6 @@ flash_algorithms:
       address: 0x0
   cores:
   - cpu0
+  - cpu1
   stack_overflow_check: false
   transfer_encoding: miniz


### PR DESCRIPTION
- In some places, we forgot to switch jtag taps, so we probably missed initializing some things or worked with the wrong core in places. (Or would have, if the second cores were defined)
- If the debugger writes the PC or resets the core, do not restore cached registers. (We might need to do this for all cores, but let's cross that bridge when we get to it)
- Make sure that the BreakIn/BreakOut interfaces are enabled on Xtensa
- Fiddle with logs a bit
- Use Session in the connect sequence
- Do not immediately die if a core is not enabled
- re-add the second core definitions