### PR TITLE
STLink: Add support for V3PWR

### DIFF
--- a/changelog/added-stlink-v3pwr.md
+++ b/changelog/added-stlink-v3pwr.md
@@ -1,0 +1,1 @@
+Added support for STLink-V3PWR

--- a/probe-rs/src/probe/stlink/usb_interface.rs
+++ b/probe-rs/src/probe/stlink/usb_interface.rs
@@ -29,6 +29,7 @@ pub static USB_PID_EP_MAP: Lazy<HashMap<u16, StLinkInfo>> = Lazy::new(|| {
     m.insert(0x374f, StLinkInfo::new("V3", 0x01, 0x81, 0x82)); // Bridge
     m.insert(0x3753, StLinkInfo::new("V3", 0x01, 0x81, 0x82)); // 2VCP
     m.insert(0x3754, StLinkInfo::new("V3", 0x01, 0x81, 0x82)); // Without mass storage
+    m.insert(0x3757, StLinkInfo::new("V3PWR", 0x01, 0x81, 0x82)); // Bridge and power, no MSD
     m
 });
 


### PR DESCRIPTION
This PR adds support for [ST-Link V3PWR](https://www.st.com/en/development-tools/stlink-v3pwr.html).

Simply adding PID 0x3787 to the USB PID map doesn't make the probe work because it reports its version as `V4` instead of `V3`(e.g. `V4J5B1P5`).
This PR makes `hw_version >= 4` probes treated as the same with `hw_version == 3`.
