### PR TITLE
Extract initialize_dp_state, remove repeated debug_port_start

### DIFF
--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -242,16 +242,14 @@ impl AccessPortType for AccessPort {
 pub(crate) fn valid_access_ports<AP>(
     debug_port: &mut AP,
     dp: DpAddress,
-) -> Vec<FullyQualifiedApAddress>
+) -> impl Iterator<Item = FullyQualifiedApAddress> + '_
 where
     AP: DapAccess,
 {
-    (0..=255)
-        .map_while(|ap| {
-            let ap = FullyQualifiedApAddress::v1_with_dp(dp, ap);
-            access_port_is_valid(debug_port, &ap).map(|_| ap)
-        })
-        .collect()
+    (0..=255).map_while(move |ap| {
+        let ap = FullyQualifiedApAddress::v1_with_dp(dp, ap);
+        access_port_is_valid(debug_port, &ap).map(|_| ap)
+    })
 }
 
 /// Tries to find the first AP with the given idr value, returns `None` if there isn't any

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -349,23 +349,17 @@ impl UninitializedArmProbe for ArmCommunicationInterface<Uninitialized> {
 impl<'interface> ArmCommunicationInterface<Initialized> {
     /// Set up and start the debug port with brand-new state.
     fn try_setup(
-        mut probe: Box<dyn DapProbe>,
+        probe: Box<dyn DapProbe>,
         sequence: Arc<dyn ArmDebugSequence>,
         dp: DpAddress,
         use_overrun_detect: bool,
     ) -> Result<Self, (Box<dyn DapProbe>, ArmError)> {
-        if let Err(err) = tracing::debug_span!("debug_port_setup")
-            .in_scope(|| sequence.debug_port_setup(&mut *probe, dp))
-        {
-            return Err((probe, err));
-        }
-
         let mut initializing = Self {
             probe: Some(probe),
             state: Initialized::new(sequence, dp, use_overrun_detect),
         };
 
-        if let Err(err) = initializing.select_dp(dp) {
+        if let Err(err) = initializing.do_select_dp(dp) {
             return Err((initializing.probe.take().unwrap(), err));
         }
 

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1413,11 +1413,8 @@ impl StlinkArmDebug {
         };
 
         interface.access_ports = valid_access_ports(&mut interface, DpAddress::Default)
-            .into_iter()
+            .inspect(|addr| tracing::debug!("AP {addr:#x?}"))
             .collect();
-        interface.access_ports.iter().for_each(|addr| {
-            tracing::debug!("AP {:#x?}", addr);
-        });
 
         Ok(interface)
     }


### PR DESCRIPTION
This PR removes repeatedly turning on a DP on DP switch. Since we no longer disable DPs after switching, we can assume they don't get disabled unexpectedly.