### PR TITLE
Semihosting: print to console

### DIFF
--- a/changelog/added-semihosting-stdout.md
+++ b/changelog/added-semihosting-stdout.md
@@ -1,0 +1,1 @@
+Added support to probe-rs-tools to print messages using `semihosting`.

--- a/changelog/changed-semihosting.md
+++ b/changelog/changed-semihosting.md
@@ -1,0 +1,1 @@
+The `semihosting` module is now public, and the reexports have been removed from `probe_rs`.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
@@ -591,13 +591,17 @@ impl SemihostingPrinter {
             SemihostingCommand::Write(request) => match request.file_handle() {
                 handle if handle == Self::STDOUT => {
                     if self.stdout_open {
-                        std::io::stdout().write_all(&request.read(core)?).unwrap();
+                        let bytes = request.read(core)?;
+                        let str = String::from_utf8_lossy(&bytes);
+                        std::io::stdout().write_all(str.as_bytes()).unwrap();
                         request.write_status(core, 0)?;
                     }
                 }
                 handle if handle == Self::STDERR => {
                     if self.stderr_open {
-                        std::io::stderr().write_all(&request.read(core)?).unwrap();
+                        let bytes = request.read(core)?;
+                        let str = String::from_utf8_lossy(&bytes);
+                        std::io::stderr().write_all(str.as_bytes()).unwrap();
                         request.write_status(core, 0)?;
                     }
                 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
@@ -616,6 +616,6 @@ impl SemihostingPrinter {
             _ => {}
         };
 
-        Ok(()) // Continue running
+        Ok(())
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
@@ -349,11 +349,15 @@ impl RunLoop {
             // this is important so we do one last poll after halt, so we flush all messages
             // the core printed before halting, such as a panic message.
             let mut return_reason = None;
+            let mut was_halted = false;
             match core.status()? {
                 probe_rs::CoreStatus::Halted(reason) => match predicate(reason, core) {
                     Ok(Some(r)) => return_reason = Some(Ok(ReturnReason::Predicate(r))),
                     Err(e) => return_reason = Some(Err(e)),
-                    Ok(None) => core.run()?,
+                    Ok(None) => {
+                        was_halted = true;
+                        core.run()?
+                    }
                 },
                 probe_rs::CoreStatus::Running
                 | probe_rs::CoreStatus::Sleeping
@@ -387,9 +391,12 @@ impl RunLoop {
             // Poll RTT with a frequency of 10 Hz if we do not receive any new data.
             // Once we receive new data, we bump the frequency to 1kHz.
             //
+            // We also poll at 1kHz if the core was halted, to speed up reading strings
+            // from semihosting. The core is not expected to be halted for other reasons.
+            //
             // If the polling frequency is too high, the USB connection to the probe
             // can become unstable. Hence we only pull as little as necessary.
-            if had_rtt_data {
+            if had_rtt_data || was_halted {
                 thread::sleep(Duration::from_millis(1));
             } else {
                 thread::sleep(Duration::from_millis(100));

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/normal_run_mode.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/normal_run_mode.rs
@@ -50,6 +50,10 @@ impl RunMode for NormalRunMode {
                     tracing::warn!("Target wanted to run semihosting operation SYS_GET_CMDLINE, but probe-rs does not support this operation yet. Continuing...");
                     Ok(None) // Continue running
                 }
+                SemihostingCommand::WriteConsole(string) => {
+                    std::io::stdout().write_all(string.as_bytes()).unwrap();
+                    Ok(None) // Continue running
+                }
             }
         };
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/normal_run_mode.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/normal_run_mode.rs
@@ -1,6 +1,4 @@
-use std::{io::Write as _, num::NonZeroU32};
-
-use crate::cmd::run::{OutputStream, RunLoop, RunMode};
+use crate::cmd::run::{OutputStream, RunLoop, RunMode, SemihostingPrinter};
 use anyhow::anyhow;
 use probe_rs::{semihosting::SemihostingCommand, BreakpointCause, Core, HaltReason, Session};
 
@@ -29,6 +27,7 @@ impl RunMode for NormalRunMode {
     fn run(&self, mut session: Session, mut run_loop: RunLoop) -> anyhow::Result<()> {
         let mut core = session.core(run_loop.core_id)?;
 
+        let mut printer = SemihostingPrinter::new();
         let halt_handler = |halt_reason: HaltReason, core: &mut Core| {
             let HaltReason::Breakpoint(BreakpointCause::Semihosting(cmd)) = halt_reason else {
                 anyhow::bail!("CPU halted unexpectedly.");
@@ -52,46 +51,12 @@ impl RunMode for NormalRunMode {
                     tracing::warn!("Target wanted to run semihosting operation SYS_GET_CMDLINE, but probe-rs does not support this operation yet. Continuing...");
                     Ok(None) // Continue running
                 }
-                SemihostingCommand::Open(request) => {
-                    let path = request.path(core)?;
-                    if path == ":tt" {
-                        request.respond_with_handle(core, NonZeroU32::new(1).unwrap())?;
-                    } else {
-                        tracing::warn!(
-                            "Target wanted to open file {path}, but probe-rs does not support this operation yet. Continuing..."
-                        );
-                    }
-                    Ok(None) // Continue running
-                }
-                SemihostingCommand::Close(request) => {
-                    let handle = request.file_handle(core)?;
-                    if handle == 1 {
-                        request.success(core)?;
-                    } else {
-                        tracing::warn!(
-                            "Target wanted to close file handle {handle}, but probe-rs does not support this operation yet. Continuing..."
-                        );
-                    }
-                    Ok(None) // Continue running
-                }
-                SemihostingCommand::Write(request) => {
-                    if request.file_handle() == 1 {
-                        std::io::stdout().write_all(&request.read(core)?).unwrap();
-
-                        request.write_status(core, 0)?;
-                    } else {
-                        tracing::warn!(
-                            "Target wanted to write to file handle {}, but probe-rs does not support this operation yet. Continuing...",
-                            request.file_handle()
-                        );
-                    }
-                    Ok(None) // Continue running
-                }
-                SemihostingCommand::WriteConsole(request) => {
-                    std::io::stdout()
-                        .write_all(request.read(core)?.as_bytes())
-                        .unwrap();
-                    Ok(None) // Continue running
+                other @ (SemihostingCommand::Open(_)
+                | SemihostingCommand::Close(_)
+                | SemihostingCommand::WriteConsole(_)
+                | SemihostingCommand::Write(_)) => {
+                    printer.handle(other, core)?;
+                    Ok(None)
                 }
             }
         };

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/test_run_mode.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/test_run_mode.rs
@@ -223,6 +223,10 @@ impl TestRunMode {
                     Ok(Some(TestOutcome::Panic))
                 }
 
+                SemihostingCommand::WriteConsole(string) => {
+                    std::io::stdout().write_all(string.as_bytes()).unwrap();
+                    Ok(None) // Continue running
+                }
                 other => {
                     // Invalid sequence of semihosting calls => Abort testing altogether
                     anyhow::bail!(

--- a/probe-rs/src/architecture/arm/core/cortex_m.rs
+++ b/probe-rs/src/architecture/arm/core/cortex_m.rs
@@ -221,10 +221,7 @@ pub(crate) fn check_for_semihosting(
     );
 
     let command = if TRAP_INSTRUCTION == actual_instruction {
-        let r0: u32 = core.read_core_reg(RegisterId(0))?.try_into()?;
-        let r1: u32 = core.read_core_reg(RegisterId(1))?.try_into()?;
-        tracing::info!("Semihosting found pc={pc:#x} r0={r0:#x} r1={r1:#x}");
-        Some(decode_semihosting_syscall(core, r0, r1)?)
+        Some(decode_semihosting_syscall(core)?)
     } else {
         None
     };

--- a/probe-rs/src/architecture/arm/core/cortex_m.rs
+++ b/probe-rs/src/architecture/arm/core/cortex_m.rs
@@ -5,7 +5,8 @@ use crate::{
     core::RegisterId,
     memory_mapped_bitfield_register,
     semihosting::decode_semihosting_syscall,
-    CoreInterface, Error, MemoryMappedRegister, SemihostingCommand,
+    semihosting::SemihostingCommand,
+    CoreInterface, Error, MemoryMappedRegister,
 };
 use std::time::{Duration, Instant};
 

--- a/probe-rs/src/architecture/arm/core/cortex_m.rs
+++ b/probe-rs/src/architecture/arm/core/cortex_m.rs
@@ -195,8 +195,6 @@ pub(crate) fn check_for_semihosting(
     cached_command: Option<SemihostingCommand>,
     core: &mut dyn CoreInterface,
 ) -> Result<Option<SemihostingCommand>, Error> {
-    let pc: u32 = core.read_core_reg(core.program_counter().id)?.try_into()?;
-
     // The Arm Semihosting Specification, specificies that the instruction
     // "BKPT 0xAB" (encoded as 0xBEAB) triggers a semihosting call.
     // <https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst#the-semihosting-interface>
@@ -204,6 +202,13 @@ pub(crate) fn check_for_semihosting(
         // instruction encoded as little endian
         0xAB, 0xBE,
     ];
+
+    // We only want to decode the semihosting command once, since answering it might change some of the registers
+    if let Some(command) = cached_command {
+        return Ok(Some(command));
+    }
+
+    let pc: u32 = core.read_core_reg(core.program_counter().id)?.try_into()?;
 
     let mut actual_instruction = [0u8; 2];
     core.read_8(pc as u64, &mut actual_instruction)?;
@@ -215,22 +220,16 @@ pub(crate) fn check_for_semihosting(
         actual_instruction[0]
     );
 
-    if TRAP_INSTRUCTION == actual_instruction {
-        // BKPT 0xAB -> we are semihosting
-
-        Ok(Some(match cached_command {
-            None => {
-                // We only want to decode the semihosting command once, since answering it might change some of the registers
-                let r0: u32 = core.read_core_reg(RegisterId(0))?.try_into()?;
-                let r1: u32 = core.read_core_reg(RegisterId(1))?.try_into()?;
-                tracing::info!("Semihosting found pc={pc:#x} r0={r0:#x} r1={r1:#x}");
-                decode_semihosting_syscall(core, r0, r1)?
-            }
-            Some(cached_command) => cached_command,
-        }))
+    let command = if TRAP_INSTRUCTION == actual_instruction {
+        let r0: u32 = core.read_core_reg(RegisterId(0))?.try_into()?;
+        let r1: u32 = core.read_core_reg(RegisterId(1))?.try_into()?;
+        tracing::info!("Semihosting found pc={pc:#x} r0={r0:#x} r1={r1:#x}");
+        Some(decode_semihosting_syscall(core, r0, r1)?)
     } else {
-        Ok(None)
-    }
+        None
+    };
+
+    Ok(command)
 }
 
 fn wait_for_core_register_transfer(

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     core::{BreakpointCause, RegisterValue},
-    memory_mapped_bitfield_register, CoreStatus, HaltReason, SemihostingCommand,
+    memory_mapped_bitfield_register,
+    semihosting::SemihostingCommand,
+    CoreStatus, HaltReason,
 };
 
 use super::memory::ArmMemoryInterface;

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -75,8 +75,6 @@ impl<'state> Riscv32<'state> {
 
     /// Check if the current breakpoint is a semihosting call
     fn check_for_semihosting(&mut self) -> Result<Option<SemihostingCommand>, Error> {
-        let pc: u32 = self.read_core_reg(self.program_counter().id)?.try_into()?;
-
         // The Riscv Semihosting Specification, specificies the following sequence of instructions,
         // to trigger a semihosting call:
         // <https://github.com/riscv-software-src/riscv-semihosting/blob/main/riscv-semihosting-spec.adoc>
@@ -86,6 +84,13 @@ impl<'state> Riscv32<'state> {
             0x00100073, // ebreak (Break to debugger)
             0x40705013, // srai x0, x0, 7 (NOP encoding the semihosting call number 7)
         ];
+
+        // We only want to decode the semihosting command once, since answering it might change some of the registers
+        if let Some(command) = self.state.semihosting_command {
+            return Ok(Some(command));
+        }
+
+        let pc: u32 = self.read_core_reg(self.program_counter().id)?.try_into()?;
 
         // Read the actual instructions, starting at the instruction before the ebreak (PC-4)
         let mut actual_instructions = [0u32; 3];
@@ -99,28 +104,22 @@ impl<'state> Riscv32<'state> {
             actual_instructions[2]
         );
 
-        if TRAP_INSTRUCTIONS == actual_instructions {
-            // Trap sequence found -> we're semihosting
-            match self.state.semihosting_command {
-                None => {
-                    // We only want to decode the semihosting command once, since answering it might change some of the registers
-                    let a0: u32 = self
-                        .read_core_reg(self.registers().get_argument_register(0).unwrap().id())?
-                        .try_into()?;
-                    let a1: u32 = self
-                        .read_core_reg(self.registers().get_argument_register(1).unwrap().id())?
-                        .try_into()?;
+        let command = if TRAP_INSTRUCTIONS == actual_instructions {
+            let a0: u32 = self
+                .read_core_reg(self.registers().get_argument_register(0).unwrap().id())?
+                .try_into()?;
+            let a1: u32 = self
+                .read_core_reg(self.registers().get_argument_register(1).unwrap().id())?
+                .try_into()?;
 
-                    tracing::info!("Semihosting found pc={pc:#x} a0={a0:#x} a1={a1:#x}");
-                    let cmd = decode_semihosting_syscall(self, a0, a1)?;
-                    self.state.semihosting_command = Some(cmd);
-                    Ok(Some(cmd))
-                }
-                Some(command) => Ok(Some(command)),
-            }
+            tracing::info!("Semihosting found pc={pc:#x} a0={a0:#x} a1={a1:#x}");
+            Some(decode_semihosting_syscall(self, a0, a1)?)
         } else {
-            Ok(None)
-        }
+            None
+        };
+        self.state.semihosting_command = command;
+
+        Ok(command)
     }
 
     fn determine_number_of_hardware_breakpoints(&mut self) -> Result<u32, RiscvError> {

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -9,8 +9,9 @@ use crate::{
     memory_mapped_bitfield_register,
     probe::DebugProbeError,
     semihosting::decode_semihosting_syscall,
+    semihosting::SemihostingCommand,
     CoreInterface, CoreRegister, CoreStatus, CoreType, Error, HaltReason, InstructionSet,
-    MemoryInterface, MemoryMappedRegister, SemihostingCommand,
+    MemoryInterface, MemoryMappedRegister,
 };
 use bitfield::bitfield;
 use communication_interface::{AbstractCommandErrorKind, RiscvCommunicationInterface, RiscvError};

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -105,15 +105,7 @@ impl<'state> Riscv32<'state> {
         );
 
         let command = if TRAP_INSTRUCTIONS == actual_instructions {
-            let a0: u32 = self
-                .read_core_reg(self.registers().get_argument_register(0).unwrap().id())?
-                .try_into()?;
-            let a1: u32 = self
-                .read_core_reg(self.registers().get_argument_register(1).unwrap().id())?
-                .try_into()?;
-
-            tracing::info!("Semihosting found pc={pc:#x} a0={a0:#x} a1={a1:#x}");
-            Some(decode_semihosting_syscall(self, a0, a1)?)
+            Some(decode_semihosting_syscall(self)?)
         } else {
             None
         };

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -184,7 +184,7 @@ impl<'probe> Xtensa<'probe> {
         };
 
         // We only want to decode the semihosting command once, since answering it might change some of the registers
-        if let Some(command) = self.state.semihosting_command.clone() {
+        if let Some(command) = self.state.semihosting_command {
             return Ok(Some(command));
         }
 
@@ -206,7 +206,7 @@ impl<'probe> Xtensa<'probe> {
         } else {
             None
         };
-        self.state.semihosting_command = command.clone();
+        self.state.semihosting_command = command;
 
         Ok(command)
     }

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -184,7 +184,7 @@ impl<'probe> Xtensa<'probe> {
         };
 
         // We only want to decode the semihosting command once, since answering it might change some of the registers
-        if let Some(command) = self.state.semihosting_command {
+        if let Some(command) = self.state.semihosting_command.clone() {
             return Ok(Some(command));
         }
 
@@ -206,7 +206,7 @@ impl<'probe> Xtensa<'probe> {
         } else {
             None
         };
-        self.state.semihosting_command = command;
+        self.state.semihosting_command = command.clone();
 
         Ok(command)
     }

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -20,8 +20,8 @@ use crate::{
     },
     memory::CoreMemoryInterface,
     semihosting::decode_semihosting_syscall,
+    semihosting::SemihostingCommand,
     CoreInformation, CoreInterface, CoreRegister, CoreStatus, Error, HaltReason, MemoryInterface,
-    SemihostingCommand,
 };
 
 pub(crate) mod arch;

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -199,14 +199,10 @@ impl<'probe> Xtensa<'probe> {
             0,
         ]);
 
-        tracing::debug!("Semihosting check pc={pc:#x} instruction={actual_instruction:#010x}, expected={SEMI_BREAK:#010x}");
+        tracing::debug!("Semihosting check pc={pc:#x} instruction={actual_instruction:#010x}");
 
         let command = if actual_instruction == SEMI_BREAK {
-            let a2: u32 = self.read_core_reg(RegisterId::from(2))?.try_into()?;
-            let a3: u32 = self.read_core_reg(RegisterId::from(3))?.try_into()?;
-
-            tracing::debug!("Semihosting found pc={pc:#x} a2={a2:#x} a3={a3:#x}");
-            Some(decode_semihosting_syscall(self, a2, a3)?)
+            Some(decode_semihosting_syscall(self)?)
         } else {
             None
         };

--- a/probe-rs/src/core/core_status.rs
+++ b/probe-rs/src/core/core_status.rs
@@ -1,4 +1,4 @@
-use crate::SemihostingCommand;
+use crate::semihosting::SemihostingCommand;
 
 /// The status of the core.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -85,7 +85,7 @@ pub mod integration;
 mod memory;
 pub mod probe;
 pub mod rtt;
-mod semihosting;
+pub mod semihosting;
 mod session;
 #[cfg(test)]
 mod test;
@@ -98,9 +98,6 @@ pub use crate::core::{
 };
 pub use crate::error::Error;
 pub use crate::memory::MemoryInterface;
-pub use crate::semihosting::{
-    ExitErrorDetails, GetCommandLineRequest, SemihostingCommand, UnknownCommandDetails,
-};
 pub use crate::session::{Permissions, Session};
 
 #[cfg(feature = "debug")]

--- a/probe-rs/src/semihosting.rs
+++ b/probe-rs/src/semihosting.rs
@@ -114,7 +114,7 @@ impl GetCommandLineRequest {
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct OpenRequest {
     path: ZeroTerminatedString,
-    mode: u32,
+    mode: &'static str,
 }
 
 impl OpenRequest {
@@ -124,7 +124,7 @@ impl OpenRequest {
     }
 
     /// Reads the raw mode from the target.
-    pub fn mode_raw(&self) -> u32 {
+    pub fn mode(&self) -> &'static str {
         self.mode
     }
 
@@ -362,7 +362,21 @@ pub fn decode_semihosting_syscall(
                     address: string,
                     length: Some(str_len),
                 },
-                mode,
+                mode: match mode {
+                    0 => "r",
+                    1 => "rb",
+                    2 => "r+",
+                    3 => "r+b",
+                    4 => "w",
+                    5 => "wb",
+                    6 => "w+",
+                    7 => "w+b",
+                    8 => "a",
+                    9 => "ab",
+                    10 => "a+",
+                    11 => "a+b",
+                    _ => "unknown",
+                },
             })
         }
 

--- a/probe-rs/src/semihosting.rs
+++ b/probe-rs/src/semihosting.rs
@@ -149,9 +149,16 @@ impl Buffer {
 /// Only supports SYS_EXIT, SYS_EXIT_EXTENDED and SYS_GET_CMDLINE at the moment
 pub fn decode_semihosting_syscall(
     core: &mut dyn CoreInterface,
-    operation: u32,
-    parameter: u32,
 ) -> Result<SemihostingCommand, Error> {
+    let operation: u32 = core
+        .read_core_reg(core.registers().get_argument_register(0).unwrap().id())?
+        .try_into()?;
+    let parameter: u32 = core
+        .read_core_reg(core.registers().get_argument_register(1).unwrap().id())?
+        .try_into()?;
+
+    tracing::debug!("Semihosting found r0={operation:#x} r1={parameter:#x}");
+
     // This is defined by the ARM Semihosting Specification:
     // <https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst#semihosting-operations>
 

--- a/probe-rs/src/semihosting.rs
+++ b/probe-rs/src/semihosting.rs
@@ -1,7 +1,13 @@
-use crate::{CoreInterface, Error, RegisterValue};
+//! ARM semihosting support.
+//!
+//! Specification: <https://github.com/ARM-software/abi-aa/blob/2024Q3/semihosting/semihosting.rst>
+
+use std::num::NonZeroU32;
+
+use crate::{CoreInterface, Error, MemoryInterface, RegisterValue};
 
 /// Indicates the operation the target would like the debugger to perform.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum SemihostingCommand {
     /// The target indicates that it completed successfully and no-longer wishes
     /// to run.
@@ -14,8 +20,17 @@ pub enum SemihostingCommand {
     /// The target indicates that it would like to read the command line arguments.
     GetCommandLine(GetCommandLineRequest),
 
+    /// The target requests to open a file on the host.
+    Open(OpenRequest),
+
+    /// The target requests to close a file on the host.
+    Close(CloseRequest),
+
     /// The target indicated that it would like to write to the console.
-    WriteConsole(String),
+    WriteConsole(WriteConsoleRequest),
+
+    /// The target indicated that it would like to write to the console.
+    Write(WriteRequest),
 
     /// The target indicated that it would like to run a semihosting operation which we don't support yet.
     Unknown(UnknownCommandDetails),
@@ -93,6 +108,92 @@ impl GetCommandLineRequest {
     }
 }
 
+/// A request to open a file on the host.
+///
+/// Note that this is not implemented by probe-rs yet.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub struct OpenRequest {
+    path: ZeroTerminatedString,
+    mode: u32,
+}
+
+impl OpenRequest {
+    /// Reads the path from the target.
+    pub fn path(&self, core: &mut dyn CoreInterface) -> Result<String, Error> {
+        self.path.read(core)
+    }
+
+    /// Reads the raw mode from the target.
+    pub fn mode_raw(&self) -> u32 {
+        self.mode
+    }
+
+    /// Responds with the opened file handle to the target.
+    pub fn respond_with_handle(
+        &self,
+        core: &mut dyn CoreInterface,
+        handle: NonZeroU32,
+    ) -> Result<(), Error> {
+        write_status(core, handle.get() as i32)
+    }
+}
+
+/// A request to open a file on the host.
+///
+/// Note that this is not implemented by probe-rs yet.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub struct CloseRequest {
+    pointer: u32,
+}
+
+impl CloseRequest {
+    /// Returns the handle of the file to close
+    pub fn file_handle(&self, core: &mut dyn CoreInterface) -> Result<u32, Error> {
+        core.read_word_32(self.pointer as u64)
+    }
+
+    /// Responds with success to the target.
+    pub fn success(&self, core: &mut dyn CoreInterface) -> Result<(), Error> {
+        write_status(core, 0)
+    }
+}
+
+/// A request to write to the console
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub struct WriteConsoleRequest(ZeroTerminatedString);
+impl WriteConsoleRequest {
+    /// Reads the string from the target
+    pub fn read(&self, core: &mut crate::Core<'_>) -> Result<String, Error> {
+        self.0.read(core)
+    }
+}
+
+/// A request to write to the console
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub struct WriteRequest {
+    handle: u32,
+    bytes: u32,
+    len: u32,
+}
+impl WriteRequest {
+    /// Returns the handle of the file to write to
+    pub fn file_handle(&self) -> u32 {
+        self.handle
+    }
+
+    /// Reads the buffer from the target
+    pub fn read(&self, core: &mut crate::Core<'_>) -> Result<Vec<u8>, Error> {
+        let mut buf = vec![0u8; self.len as usize];
+        core.read(self.bytes as u64, &mut buf)?;
+        Ok(buf)
+    }
+
+    /// Writes the status of the semihosting operation to the return register of the target
+    pub fn write_status(&self, core: &mut dyn CoreInterface, status: i32) -> Result<(), Error> {
+        write_status(core, status)
+    }
+}
+
 fn write_status(core: &mut dyn CoreInterface, value: i32) -> Result<(), crate::Error> {
     let reg = core.registers().get_argument_register(0).unwrap();
     core.write_core_reg(reg.into(), RegisterValue::U32(value as u32))?;
@@ -100,9 +201,9 @@ fn write_status(core: &mut dyn CoreInterface, value: i32) -> Result<(), crate::E
     Ok(())
 }
 
-// When using some semihosting commands, the target usually allocates a buffer for the host to read/write to.
-// The targets just gives us an address pointing to two u32 values, the address of the buffer and
-// the length of the buffer.
+/// When using some semihosting commands, the target usually allocates a buffer for the host to read/write to.
+/// The targets just gives us an address pointing to two u32 values, the address of the buffer and
+/// the length of the buffer.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct Buffer {
     buffer_location: u32, // The address where the buffer address and length are stored
@@ -148,6 +249,40 @@ impl Buffer {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+struct ZeroTerminatedString {
+    address: u32,
+    length: Option<u32>,
+}
+
+impl ZeroTerminatedString {
+    /// Reads the buffer contents from the target.
+    pub fn read(&self, core: &mut dyn CoreInterface) -> Result<String, Error> {
+        let mut bytes = Vec::new();
+
+        if let Some(len) = self.length {
+            bytes = vec![0; len as usize];
+            core.read(self.address as u64, &mut bytes)?;
+        } else {
+            let mut buf = [0; 128];
+            let mut from = self.address as u64;
+
+            loop {
+                core.read(from, &mut buf)?;
+                if let Some(end) = buf.iter().position(|&x| x == 0) {
+                    bytes.extend_from_slice(&buf[..end]);
+                    break;
+                }
+
+                bytes.extend_from_slice(&buf);
+                from += buf.len() as u64;
+            }
+        }
+
+        Ok(String::from_utf8_lossy(&bytes).to_string())
+    }
+}
+
 /// Decodes a semihosting syscall without running the requested action.
 /// Only supports SYS_EXIT, SYS_EXIT_EXTENDED and SYS_GET_CMDLINE at the moment
 pub fn decode_semihosting_syscall(
@@ -169,8 +304,11 @@ pub fn decode_semihosting_syscall(
     const SYS_EXIT: u32 = 0x18;
     const SYS_EXIT_EXTENDED: u32 = 0x20;
     const SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT: u32 = 0x20026;
+    const SYS_OPEN: u32 = 0x01;
+    const SYS_CLOSE: u32 = 0x02;
     const SYS_WRITEC: u32 = 0x03;
     const SYS_WRITE0: u32 = 0x04;
+    const SYS_WRITE: u32 = 0x05;
 
     Ok(match (operation, parameter) {
         (SYS_EXIT, SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT) => SemihostingCommand::ExitSuccess,
@@ -213,36 +351,49 @@ pub fn decode_semihosting_syscall(
             )?))
         }
 
-        (SYS_WRITEC, pointer) => {
-            // Parameter points to a byte in memory.
-            let mut buf = 0;
-            core.read_8(pointer as u64, std::slice::from_mut(&mut buf))?;
+        (SYS_OPEN, pointer) => {
+            let [string, mode, str_len] = param3(core, pointer)?;
 
-            let c = buf as u8 as char;
-            SemihostingCommand::WriteConsole(String::from(c))
+            // signal to target: status = failure, in case the application does not answer this request
+            // -1 is the error value for SYS_OPEN
+            write_status(core, -1)?;
+            SemihostingCommand::Open(OpenRequest {
+                path: ZeroTerminatedString {
+                    address: string,
+                    length: Some(str_len),
+                },
+                mode,
+            })
+        }
+
+        (SYS_CLOSE, pointer) => {
+            // signal to target: status = failure, in case the application does not answer this request
+            // -1 is the error value for SYS_CLOSE
+            write_status(core, -1)?;
+            SemihostingCommand::Close(CloseRequest { pointer })
+        }
+
+        (SYS_WRITEC, pointer) => {
+            SemihostingCommand::WriteConsole(WriteConsoleRequest(ZeroTerminatedString {
+                address: pointer,
+                length: Some(1),
+            }))
             // no response is given
         }
 
         (SYS_WRITE0, pointer) => {
+            SemihostingCommand::WriteConsole(WriteConsoleRequest(ZeroTerminatedString {
+                address: pointer,
+                length: None,
+            }))
             // no response is given
-            // Parameter points to a byte in memory.
-            let mut buf = [0; 128];
-            let mut from = pointer;
+        }
 
-            let mut bytes = Vec::new();
-            loop {
-                core.read(from as u64, &mut buf)?;
-                if let Some(end) = buf.iter().position(|&x| x == 0) {
-                    bytes.extend_from_slice(&buf[..end]);
-                    break;
-                }
-
-                bytes.extend_from_slice(&buf);
-                from += buf.len() as u32;
-            }
-
-            SemihostingCommand::WriteConsole(String::from_utf8_lossy(&bytes).to_string())
-            // no response is given
+        (SYS_WRITE, pointer) => {
+            let [handle, bytes, len] = param3(core, pointer)?;
+            // signal to target: status = failure, in case the application does not answer this request
+            write_status(core, -1)?;
+            SemihostingCommand::Write(WriteRequest { handle, bytes, len })
         }
 
         _ => {
@@ -259,4 +410,10 @@ pub fn decode_semihosting_syscall(
             })
         }
     })
+}
+
+fn param3(core: &mut dyn CoreInterface, pointer: u32) -> Result<[u32; 3], crate::Error> {
+    let mut buf = [0; 3];
+    core.read_32(pointer as u64, &mut buf)?;
+    Ok(buf)
 }


### PR DESCRIPTION
If there is already a semihosting command cached, the previous code read PC, read around the PC, and then did nothing. This PR removes these reads, while making additional cleanups.

This PR also implements limited handling of SYS_OPEN, SYS_CLOSE and WRITE to allow the `semihosting` crate to print panic messages.