### PR TITLE
Fix accidentally ignoring data_load_address

### DIFF
--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -297,15 +297,13 @@ impl FlashAlgorithm {
         let stack_size = raw.stack_size.unwrap_or(Self::FLASH_ALGO_STACK_SIZE) as u64;
         tracing::info!("The flash algorithm will be configured with {stack_size} bytes of stack");
 
-        let data_load_addr = if ram_region == data_ram_region {
-            if let Some(data_load_addr) = raw.data_load_address {
-                data_load_addr
-            } else {
-                // The data is not placed explicitly. We can place it after the code.
-                code_end
-            }
+        let data_load_addr = if let Some(data_load_addr) = raw.data_load_address {
+            data_load_addr
+        } else if ram_region == data_ram_region {
+            // The data is not placed explicitly. We can place it after the code.
+            code_end
         } else {
-            // The data is in a different region. We can place it at the start of the region.
+            // The data is not placed explicitly. We can place it to the start of the memory region.
             data_ram_region.range.start
         };
 

--- a/probe-rs/src/vendor/espressif/mod.rs
+++ b/probe-rs/src/vendor/espressif/mod.rs
@@ -58,6 +58,7 @@ fn try_detect_espressif_chip(
             let Ok(read_magic) = probe.read_word_32(MAGIC_VALUE_ADDRESS) else {
                 continue;
             };
+            tracing::debug!("Read magic value: {read_magic:#010x}");
             if let Some(target) = get_target_by_magic(info, read_magic) {
                 return Ok(Some(target));
             }


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/probe-rs/probe-rs/commit/3e65a72256e76ec3e26b95e8efb4159b2fff4dfd that prevents flashing ESP32 (and maybe others)