### PR TITLE
Introduce RttClient for better RTT error tolerance

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
@@ -29,7 +29,7 @@ verify = false
 
 [default.reset]
 # Whether or not the target should be reset.
-# When flashing is enabled as well, the target will be reset after flashing.
+# When flashing is enabled as well, the target will be reset after flashing regardless of this setting.
 enabled = true
 # Whether or not the target should be halted after reset.
 halt_afterwards = false

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -476,7 +476,7 @@ fn attach_to_rtt_shared(
             Ok(rtta) => return Ok(Some(rtta)),
             Err(error) => {
                 if start.elapsed() > timeout {
-                    return Err(error);
+                    return Err(error.into());
                 }
             }
         }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -435,7 +435,7 @@ fn run_rttui_app(
 
     let logname = format!("{name}_{chip_name}_{timestamp_millis}");
     // TODO: work with the client instead of unwrapping it
-    let mut app = rttui::app::App::new(rtt.into_target(), config, logname)?;
+    let mut app = rttui::app::App::new(rtt, config, logname)?;
     loop {
         app.render();
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -382,7 +382,7 @@ fn run_rttui_app(
 
     let mut client = RttClient::new(Some(&elf), rtt_config.clone(), ScanRegion::Ram)?;
 
-    if config.flashing.enabled {
+    if config.flashing.enabled || config.reset.enabled {
         let mut session_handle = session.lock();
         let mut core = session_handle.core(core_id)?;
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -365,13 +365,17 @@ fn run_rttui_app(
         });
     }
 
+    let elf = fs::read(elf_path)?;
+    let defmt_state = DefmtState::try_from_bytes(&elf)?;
+
     let Some(rtt) = attach_to_rtt_shared(
         session,
         core_id,
         config.rtt.timeout,
-        elf_path,
+        &elf,
         &rtt_config,
         timezone_offset,
+        defmt_state.as_ref(),
     )
     .context("Failed to attach to RTT")?
     else {
@@ -379,7 +383,7 @@ fn run_rttui_app(
         return Ok(());
     };
 
-    if require_defmt && rtt.defmt_state.is_none() {
+    if require_defmt && defmt_state.is_none() {
         tracing::warn!(
             "RTT channels with format = defmt found, but no defmt metadata found in the ELF file."
         );
@@ -413,7 +417,7 @@ fn run_rttui_app(
         / 1_000_000;
 
     let logname = format!("{name}_{chip_name}_{timestamp_millis}");
-    let mut app = rttui::app::App::new(rtt, config, logname)?;
+    let mut app = rttui::app::App::new(rtt, config, logname, defmt_state)?;
     loop {
         app.render();
 
@@ -443,15 +447,15 @@ fn attach_to_rtt_shared(
     session: &FairMutex<Session>,
     core_id: usize,
     timeout: Duration,
-    elf_file: &Path,
+    elf: &[u8],
     rtt_config: &RttConfig,
     timestamp_offset: UtcOffset,
+    defmt_state: Option<&DefmtState>,
 ) -> Result<Option<RttActiveTarget>> {
     // Try to find the RTT control block symbol in the ELF file.
     // If we find it, we can use the exact address to attach to the RTT control block. Otherwise, we
     // fall back to the caller-provided scan regions.
-    let elf = fs::read(elf_file)?;
-    let scan_region = if let Some(address) = RttActiveTarget::get_rtt_symbol_from_bytes(&elf) {
+    let scan_region = if let Some(address) = RttActiveTarget::get_rtt_symbol_from_bytes(elf) {
         ScanRegion::Exact(address)
     } else {
         ScanRegion::Ram
@@ -463,7 +467,6 @@ fn attach_to_rtt_shared(
     // once per poll call.
     let start = Instant::now();
     loop {
-        let defmt_state = DefmtState::try_from_bytes(&elf)?;
         let rtt = match try_attach_to_rtt_shared(session, core_id, timeout, &scan_region) {
             Ok(rtt) => rtt,
             Err(Error::NoControlBlockLocation) => return Ok(None),

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -29,8 +29,8 @@ use crate::util::common_options::{BinaryDownloadOptions, OperationError, ProbeOp
 use crate::util::flash::{build_loader, run_flash_download};
 use crate::util::logging::setup_logging;
 use crate::util::rtt::client::RttClient;
-use crate::util::rtt::{self, DefmtState, RttChannelConfig, RttConfig};
-use crate::util::{cargo::build_artifact, common_options::CargoOptions, logging, rtt::DataFormat};
+use crate::util::rtt::{self, RttChannelConfig, RttConfig};
+use crate::util::{cargo::build_artifact, common_options::CargoOptions, logging};
 use crate::FormatOptions;
 
 #[derive(Debug, clap::Parser)]
@@ -336,10 +336,9 @@ fn run_rttui_app(
     // Make sure our defaults are the same as the ones intended in the config struct.
     let default_channel_config = RttChannelConfig::default();
 
-    let mut require_defmt = false;
     for channel_config in config.rtt.up_channels.iter() {
         // Where `channel_config` is unspecified, apply default from `default_channel_config`.
-        let rtt_channel_config = RttChannelConfig {
+        rtt_config.channels.push(RttChannelConfig {
             channel_number: Some(channel_config.channel),
             data_format: channel_config
                 .format
@@ -355,11 +354,7 @@ fn run_rttui_app(
                 .clone()
                 .or_else(|| default_channel_config.log_format.clone()),
             mode: channel_config.mode.or(default_channel_config.mode),
-        };
-        if rtt_channel_config.data_format == DataFormat::Defmt {
-            require_defmt = true;
-        }
-        rtt_config.channels.push(rtt_channel_config);
+        });
     }
     // In case we have down channels without up channels, add them separately.
     for channel_config in config.rtt.down_channels.iter() {
@@ -378,7 +373,6 @@ fn run_rttui_app(
     }
 
     let elf = fs::read(elf_path)?;
-    let defmt_state = DefmtState::try_from_bytes(&elf)?;
 
     let mut client = RttClient::new(Some(&elf), rtt_config.clone(), ScanRegion::Ram)?;
 
@@ -412,12 +406,6 @@ fn run_rttui_app(
         }
     };
 
-    if require_defmt && !rtt.supports_defmt() {
-        tracing::warn!(
-            "RTT channels with format = defmt found, but no defmt metadata found in the ELF file."
-        );
-    }
-
     tracing::info!("RTT initialized.");
 
     // Check if the terminal supports x
@@ -447,7 +435,7 @@ fn run_rttui_app(
 
     let logname = format!("{name}_{chip_name}_{timestamp_millis}");
     // TODO: work with the client instead of unwrapping it
-    let mut app = rttui::app::App::new(rtt.into_target(), config, logname, defmt_state)?;
+    let mut app = rttui::app::App::new(rtt.into_target(), config, logname)?;
     loop {
         app.render();
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -38,7 +38,7 @@ pub struct App {
 
     current_height: usize,
 
-    pub(crate) up_channels: Vec<Rc<RefCell<UpChannel>>>,
+    up_channels: Vec<Rc<RefCell<UpChannel>>>,
 }
 
 impl App {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -17,7 +17,7 @@ use std::{path::PathBuf, sync::mpsc::TryRecvError};
 
 use crate::{
     cmd::cargo_embed::rttui::{channel::ChannelData, tab::TabConfig},
-    util::rtt::RttActiveTarget,
+    util::rtt::client::RttClient,
 };
 
 use super::super::config;
@@ -42,8 +42,10 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(rtt: RttActiveTarget, config: config::Config, logname: String) -> Result<Self> {
+    pub fn new(rtt: RttClient, config: config::Config, logname: String) -> Result<Self> {
         let mut tab_config = config.rtt.tabs;
+
+        let rtt = rtt.into_target();
 
         // Create channel states
         let mut up_channels = Vec::new();

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -65,7 +65,7 @@ impl App {
                 tab_config.push(TabConfig {
                     up_channel: number,
                     down_channel: None,
-                    name: Some(up.channel_name.clone()),
+                    name: Some(up.channel_name()),
                     hide: false,
                 });
             }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -17,7 +17,7 @@ use std::{path::PathBuf, sync::mpsc::TryRecvError};
 
 use crate::{
     cmd::cargo_embed::rttui::{channel::ChannelData, tab::TabConfig},
-    util::rtt::{DefmtState, RttActiveTarget},
+    util::rtt::RttActiveTarget,
 };
 
 use super::super::config;
@@ -38,18 +38,11 @@ pub struct App {
 
     current_height: usize,
 
-    defmt_state: Option<DefmtState>,
-
     pub(crate) up_channels: Vec<Rc<RefCell<UpChannel>>>,
 }
 
 impl App {
-    pub fn new(
-        rtt: RttActiveTarget,
-        config: config::Config,
-        logname: String,
-        defmt_state: Option<DefmtState>,
-    ) -> Result<Self> {
+    pub fn new(rtt: RttActiveTarget, config: config::Config, logname: String) -> Result<Self> {
         let mut tab_config = config.rtt.tabs;
 
         // Create channel states
@@ -159,7 +152,6 @@ impl App {
             events,
             history_path,
             logname,
-            defmt_state,
             current_height: 0,
 
             up_channels,
@@ -248,9 +240,7 @@ impl App {
     /// Polls the RTT target for new data on all channels.
     pub fn poll_rtt(&mut self, core: &mut Core) -> Result<()> {
         for channel in self.up_channels.iter_mut() {
-            channel
-                .borrow_mut()
-                .poll_rtt(core, self.defmt_state.as_ref())?;
+            channel.borrow_mut().poll_rtt(core)?;
         }
 
         Ok(())

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -44,7 +44,12 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(rtt: RttActiveTarget, config: config::Config, logname: String) -> Result<Self> {
+    pub fn new(
+        rtt: RttActiveTarget,
+        config: config::Config,
+        logname: String,
+        defmt_state: Option<DefmtState>,
+    ) -> Result<Self> {
         let mut tab_config = config.rtt.tabs;
 
         // Create channel states
@@ -154,7 +159,7 @@ impl App {
             events,
             history_path,
             logname,
-            defmt_state: rtt.defmt_state,
+            defmt_state,
             current_height: 0,
 
             up_channels,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -93,7 +93,7 @@ impl App {
                         0
                     },
                     down_channel: Some(number),
-                    name: Some(down.channel_name.clone()),
+                    name: Some(down.channel_name()),
                     hide: false,
                 });
             }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
@@ -4,7 +4,7 @@ use probe_rs::{rtt::Error, Core};
 
 use crate::{
     cmd::cargo_embed::rttui::tcp::TcpPublisher,
-    util::rtt::{ChannelDataCallbacks, DefmtState, RttActiveUpChannel},
+    util::rtt::{ChannelDataCallbacks, RttActiveUpChannel},
 };
 
 pub enum ChannelData {
@@ -61,16 +61,9 @@ impl UpChannel {
         }
     }
 
-    pub fn poll_rtt(
-        &mut self,
-        core: &mut Core<'_>,
-        defmt_state: Option<&DefmtState>,
-    ) -> Result<(), Error> {
-        self.rtt_channel.poll_process_rtt_data(
-            core,
-            defmt_state,
-            &mut (&mut self.tcp_stream, &mut self.data),
-        )
+    pub fn poll_rtt(&mut self, core: &mut Core<'_>) -> Result<(), Error> {
+        self.rtt_channel
+            .poll_process_rtt_data(core, &mut (&mut self.tcp_stream, &mut self.data))
     }
 
     pub(crate) fn clean_up(&mut self, core: &mut Core<'_>) -> Result<(), Error> {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use probe_rs::Core;
+use probe_rs::{rtt::Error, Core};
 
 use crate::{
     cmd::cargo_embed::rttui::tcp::TcpPublisher,
@@ -13,7 +13,7 @@ pub enum ChannelData {
 }
 
 impl ChannelDataCallbacks for (&mut Option<TcpPublisher>, &mut ChannelData) {
-    fn on_string_data(&mut self, _channel: usize, data: String) -> anyhow::Result<()> {
+    fn on_string_data(&mut self, _channel: usize, data: String) -> Result<(), Error> {
         if let Some(ref mut stream) = self.0 {
             stream.send(data.as_bytes());
         }
@@ -26,7 +26,7 @@ impl ChannelDataCallbacks for (&mut Option<TcpPublisher>, &mut ChannelData) {
         Ok(())
     }
 
-    fn on_binary_data(&mut self, _channel: usize, incoming: &[u8]) -> anyhow::Result<()> {
+    fn on_binary_data(&mut self, _channel: usize, incoming: &[u8]) -> Result<(), Error> {
         if let Some(ref mut stream) = self.0 {
             stream.send(incoming);
         }
@@ -65,7 +65,7 @@ impl UpChannel {
         &mut self,
         core: &mut Core<'_>,
         defmt_state: Option<&DefmtState>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Error> {
         self.rtt_channel.poll_process_rtt_data(
             core,
             defmt_state,
@@ -73,7 +73,7 @@ impl UpChannel {
         )
     }
 
-    pub(crate) fn clean_up(&mut self, core: &mut Core<'_>) -> anyhow::Result<()> {
+    pub(crate) fn clean_up(&mut self, core: &mut Core<'_>) -> Result<(), Error> {
         self.rtt_channel.clean_up(core)
     }
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
@@ -77,7 +77,7 @@ impl UpChannel {
         self.rtt_channel.clean_up(core)
     }
 
-    pub(crate) fn channel_name(&self) -> &str {
-        &self.rtt_channel.channel_name
+    pub(crate) fn channel_name(&self) -> String {
+        self.rtt_channel.channel_name()
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/tab.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/tab.rs
@@ -45,7 +45,7 @@ impl Tab {
         name: Option<String>,
     ) -> Self {
         Self {
-            name: name.unwrap_or_else(|| up_channel.borrow().channel_name().to_string()),
+            name: name.unwrap_or_else(|| up_channel.borrow().channel_name()),
             up_channel,
             down_channel: down_channel.map(|down| (down, String::new())),
             scroll_offset: 0,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -444,7 +444,7 @@ fn try_attach_rtt(
     timestamp_offset: UtcOffset,
     defmt_state: Option<&DefmtState>,
 ) -> Result<RttActiveTarget, DebuggerError> {
-    let header_address = RttActiveTarget::get_rtt_symbol_from_bytes(&elf)
+    let header_address = RttActiveTarget::get_rtt_symbol_from_bytes(elf)
         .ok_or_else(|| anyhow!("No RTT control block found in ELF file"))?;
 
     let scan_region = ScanRegion::Exact(header_address);

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -1,30 +1,28 @@
 use std::{ops::Range, path::Path};
 
 use super::session_data::{self, ActiveBreakpoint, BreakpointType, SourceLocationScope};
-use crate::util::rtt::{self, DataFormat, DefmtState, RttActiveTarget};
-use crate::{
-    cmd::dap_server::{
-        debug_adapter::{
-            dap::{
-                adapter::DebugAdapter,
-                core_status::DapStatus,
-                dap_types::{ContinuedEventBody, MessageSeverity, Source, StoppedEventBody},
-            },
-            protocol::ProtocolAdapter,
+use crate::cmd::dap_server::{
+    debug_adapter::{
+        dap::{
+            adapter::DebugAdapter,
+            core_status::DapStatus,
+            dap_types::{ContinuedEventBody, MessageSeverity, Source, StoppedEventBody},
         },
-        peripherals::svd_variables::SvdCache,
-        server::debug_rtt,
-        DebuggerError,
+        protocol::ProtocolAdapter,
     },
-    util::rtt::RttConfig,
+    peripherals::svd_variables::SvdCache,
+    server::debug_rtt,
+    DebuggerError,
 };
+use crate::util::rtt::client::RttClient;
+use crate::util::rtt::{self, DataFormat};
 use anyhow::{anyhow, Result};
 use probe_rs::debug::VerifiedBreakpoint;
 use probe_rs::{
     debug::{
         debug_info::DebugInfo, stack_frame::StackFrameInfo, ColumnType, ObjectRef, VariableCache,
     },
-    rtt::{Rtt, ScanRegion},
+    rtt::ScanRegion,
     Core, CoreStatus, HaltReason,
 };
 use time::UtcOffset;
@@ -49,6 +47,7 @@ pub struct CoreData {
     pub stack_frames: Vec<probe_rs::debug::stack_frame::StackFrame>,
     pub breakpoints: Vec<session_data::ActiveBreakpoint>,
     pub rtt_connection: Option<debug_rtt::RttConnection>,
+    pub rtt_client: Option<RttClient>,
 }
 
 /// [CoreHandle] provides handles to various data structures required to debug a single instance of a core. The actual state is stored in [session_data::SessionData].
@@ -183,26 +182,32 @@ impl<'p> CoreHandle<'p> {
         rtt_config: &rtt::RttConfig,
         timestamp_offset: UtcOffset,
     ) -> Result<()> {
-        let mut debugger_rtt_channels: Vec<debug_rtt::DebuggerRttChannel> = vec![];
+        let client = if let Some(client) = self.core_data.rtt_client.as_mut() {
+            client
+        } else {
+            // Create the RTT client using the RTT control block address from the ELF file.
+            let elf = std::fs::read(program_binary)
+                .map_err(|error| anyhow!("Error attempting to attach to RTT: {error}"))?;
 
-        let elf = std::fs::read(program_binary)
-            .map_err(|error| anyhow!("Error attempting to attach to RTT: {error}"))?;
+            let mut client = RttClient::new(
+                Some(&elf),
+                rtt_config.clone(),
+                // Do not scan the memory for the control block.
+                ScanRegion::Ranges(vec![]),
+            )?;
 
-        let defmt_state = DefmtState::try_from_bytes(&elf)
-            .map_err(|err| anyhow!("Failed to process defmt data: {err}"))?;
+            client.timezone_offset = timestamp_offset;
 
-        // Attach to RTT by using the RTT control block address from the ELF file. Do not scan the memory for the control block.
-        let Ok(target_rtt) = try_attach_rtt(
-            &mut self.core,
-            &elf,
-            rtt_config,
-            timestamp_offset,
-            defmt_state.as_ref(),
-        ) else {
-            tracing::warn!("Failed to initalize RTT. Will try again on the next request... ");
-            return Ok(());
+            self.core_data.rtt_client.insert(client)
         };
 
+        if !client.try_attach(&mut self.core)? {
+            return Ok(());
+        }
+
+        let target_rtt = self.core_data.rtt_client.take().unwrap().into_target();
+
+        let mut debugger_rtt_channels: Vec<debug_rtt::DebuggerRttChannel> = vec![];
         for up_channel in target_rtt.active_up_channels.iter() {
             debugger_rtt_channels.push(debug_rtt::DebuggerRttChannel {
                 channel_number: up_channel.number(),
@@ -219,7 +224,6 @@ impl<'p> CoreHandle<'p> {
         self.core_data.rtt_connection = Some(debug_rtt::RttConnection {
             target_rtt,
             debugger_rtt_channels,
-            defmt_state,
         });
 
         Ok(())
@@ -435,28 +439,6 @@ impl<'p> CoreHandle<'p> {
         // Consolidating all memory ranges that are withing 0x400 bytes of each other.
         consolidate_memory_ranges(all_discrete_memory_ranges, 0x400)
     }
-}
-
-fn try_attach_rtt(
-    core: &mut Core,
-    elf: &[u8],
-    rtt_config: &RttConfig,
-    timestamp_offset: UtcOffset,
-    defmt_state: Option<&DefmtState>,
-) -> Result<RttActiveTarget, DebuggerError> {
-    let header_address = RttActiveTarget::get_rtt_symbol_from_bytes(elf)
-        .ok_or_else(|| anyhow!("No RTT control block found in ELF file"))?;
-
-    let scan_region = ScanRegion::Exact(header_address);
-
-    let rtt = Rtt::attach_region(core, &scan_region)
-        .map_err(|error| anyhow!("Error attempting to attach to RTT: {error}"))?;
-
-    tracing::info!("RTT initialized.");
-    let target = RttActiveTarget::new(core, rtt, defmt_state, rtt_config, timestamp_offset)
-        .map_err(|err| anyhow!("Failed to attach to RTT: {err}"))?;
-
-    Ok(target)
 }
 
 /// Return a Vec of memory ranges that consolidate the adjacent memory ranges of the input ranges.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -205,6 +205,8 @@ impl<'p> CoreHandle<'p> {
             return Ok(());
         }
 
+        // TODO: we should probably use the RttClient all the way, then we can clean up this allow.
+        #[allow(clippy::unwrap_used)] // We know the client is Some() because of the if let above.
         let target_rtt = self.core_data.rtt_client.take().unwrap().into_target();
 
         let mut debugger_rtt_channels: Vec<debug_rtt::DebuggerRttChannel> = vec![];

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -191,6 +191,7 @@ impl<'p> CoreHandle<'p> {
 
             let mut client = RttClient::new(
                 Some(&elf),
+                self.core.target(),
                 rtt_config.clone(),
                 // Do not scan the memory for the control block.
                 ScanRegion::Ranges(vec![]),

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -211,7 +211,7 @@ impl<'p> CoreHandle<'p> {
             });
             debug_adapter.rtt_window(
                 up_channel.number(),
-                up_channel.channel_name.clone(),
+                up_channel.channel_name(),
                 DataFormat::from(&up_channel.data_format),
             );
         }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
@@ -62,17 +62,6 @@ impl DebuggerRttChannel {
             return false;
         }
 
-        struct StringCollector {
-            data: Option<String>,
-        }
-
-        impl ChannelDataCallbacks for StringCollector {
-            fn on_string_data(&mut self, _channel: usize, data: String) -> Result<(), Error> {
-                self.data = Some(data);
-                Ok(())
-            }
-        }
-
         let mut out = StringCollector { data: None };
 
         if let Err(e) = client.poll_channel(core, self.channel_number, &mut out) {
@@ -86,5 +75,16 @@ impl DebuggerRttChannel {
             Some(data) => debug_adapter.rtt_output(self.channel_number, data),
             None => false,
         }
+    }
+}
+
+struct StringCollector {
+    data: Option<String>,
+}
+
+impl ChannelDataCallbacks for StringCollector {
+    fn on_string_data(&mut self, _channel: usize, data: String) -> Result<(), Error> {
+        self.data = Some(data);
+        Ok(())
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
@@ -15,6 +15,9 @@ pub struct RttConnection {
     pub(crate) target_rtt: rtt::RttActiveTarget,
     /// Some status fields and methods to ensure continuity in flow of data from target to debugger to client.
     pub(crate) debugger_rtt_channels: Vec<DebuggerRttChannel>,
+
+    /// defmt decoding and location information
+    pub(crate) defmt_state: Option<rtt::DefmtState>,
 }
 
 impl RttConnection {
@@ -27,8 +30,12 @@ impl RttConnection {
     ) -> bool {
         let mut at_least_one_channel_had_data = false;
         for debugger_rtt_channel in self.debugger_rtt_channels.iter_mut() {
-            at_least_one_channel_had_data |=
-                debugger_rtt_channel.poll_rtt_data(target_core, debug_adapter, &mut self.target_rtt)
+            at_least_one_channel_had_data |= debugger_rtt_channel.poll_rtt_data(
+                target_core,
+                debug_adapter,
+                &mut self.target_rtt,
+                self.defmt_state.as_ref(),
+            )
         }
         at_least_one_channel_had_data
     }
@@ -57,6 +64,7 @@ impl DebuggerRttChannel {
         core: &mut Core,
         debug_adapter: &mut DebugAdapter<P>,
         rtt_target: &mut rtt::RttActiveTarget,
+        defmt_state: Option<&rtt::DefmtState>,
     ) -> bool {
         if !self.has_client_window {
             return false;
@@ -79,9 +87,7 @@ impl DebuggerRttChannel {
 
         let mut out = StringCollector { data: None };
 
-        if let Err(e) =
-            rtt_channel.poll_process_rtt_data(core, rtt_target.defmt_state.as_ref(), &mut out)
-        {
+        if let Err(e) = rtt_channel.poll_process_rtt_data(core, defmt_state, &mut out) {
             debug_adapter
                 .show_error_message(&DebuggerError::Other(anyhow!(e)))
                 .ok();

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
@@ -1,4 +1,4 @@
-use crate::util::rtt;
+use crate::util::rtt::client::RttClient;
 use crate::{
     cmd::dap_server::{
         debug_adapter::{dap::adapter::*, protocol::ProtocolAdapter},
@@ -12,7 +12,7 @@ use probe_rs::{rtt::Error, Core};
 /// Manage the active RTT target for a specific SessionData, as well as provide methods to reliably move RTT from target, through the debug_adapter, to the client.
 pub struct RttConnection {
     /// The connection to RTT on the target
-    pub(crate) target_rtt: rtt::RttActiveTarget,
+    pub(crate) client: RttClient,
     /// Some status fields and methods to ensure continuity in flow of data from target to debugger to client.
     pub(crate) debugger_rtt_channels: Vec<DebuggerRttChannel>,
 }
@@ -28,14 +28,14 @@ impl RttConnection {
         let mut at_least_one_channel_had_data = false;
         for debugger_rtt_channel in self.debugger_rtt_channels.iter_mut() {
             at_least_one_channel_had_data |=
-                debugger_rtt_channel.poll_rtt_data(target_core, debug_adapter, &mut self.target_rtt)
+                debugger_rtt_channel.poll_rtt_data(target_core, debug_adapter, &mut self.client)
         }
         at_least_one_channel_had_data
     }
 
     /// Clean up the RTT connection, restoring the state changes that we made.
     pub fn clean_up(&mut self, target_core: &mut Core) -> Result<(), DebuggerError> {
-        self.target_rtt
+        self.client
             .clean_up(target_core)
             .map_err(|err| DebuggerError::Other(anyhow!(err)))?;
         Ok(())
@@ -56,15 +56,11 @@ impl DebuggerRttChannel {
         &mut self,
         core: &mut Core,
         debug_adapter: &mut DebugAdapter<P>,
-        rtt_target: &mut rtt::RttActiveTarget,
+        client: &mut RttClient,
     ) -> bool {
         if !self.has_client_window {
             return false;
         }
-
-        let Some(rtt_channel) = rtt_target.active_up_channels.get_mut(self.channel_number) else {
-            return false;
-        };
 
         struct StringCollector {
             data: Option<String>,
@@ -79,7 +75,7 @@ impl DebuggerRttChannel {
 
         let mut out = StringCollector { data: None };
 
-        if let Err(e) = rtt_channel.poll_process_rtt_data(core, &mut out) {
+        if let Err(e) = client.poll_channel(core, self.channel_number, &mut out) {
             debug_adapter
                 .show_error_message(&DebuggerError::Other(anyhow!(e)))
                 .ok();

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -142,6 +142,7 @@ impl SessionData {
                 stack_frames: vec![],
                 breakpoints: vec![],
                 rtt_connection: None,
+                rtt_client: None,
             })
         }
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -246,7 +246,7 @@ impl SessionData {
                     }
                 } else if debug_adapter.configuration_is_done() {
                     // We have not yet reached the point in the target application where the RTT buffers are initialized,
-                    // so, provided we have processed the MSDAP request for "configurationDone" , we should check again.
+                    // so, provided we have processed the MSDAP request for "configurationDone", we should check again.
 
                     #[allow(clippy::unwrap_used)]
                     match target_core.attach_to_rtt(

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
@@ -11,13 +11,13 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use probe_rs::debug::{DebugInfo, DebugRegisters};
 use probe_rs::flashing::FileDownloadError;
 use probe_rs::{
     exception_handler_for_core,
     probe::list::Lister,
-    rtt::{try_attach_to_rtt, Error as RttError, ScanRegion},
+    rtt::{Error as RttError, ScanRegion},
     Core, CoreInterface, Error, HaltReason, Session, VectorCatchCondition,
 };
 use signal_hook::consts::signal;
@@ -25,9 +25,8 @@ use time::UtcOffset;
 
 use crate::util::common_options::{BinaryDownloadOptions, ProbeOptions};
 use crate::util::flash::{build_loader, run_flash_download};
-use crate::util::rtt::{
-    self, ChannelDataCallbacks, DefmtState, RttActiveTarget, RttChannelConfig, RttConfig,
-};
+use crate::util::rtt::client::RttClient;
+use crate::util::rtt::{self, ChannelDataCallbacks, RttChannelConfig, RttConfig};
 use crate::FormatOptions;
 
 #[derive(clap::Parser)]
@@ -126,17 +125,29 @@ impl Cmd {
             false => ScanRegion::Ranges(vec![]),
         };
 
+        let mut rtt_config = RttConfig::default();
+        rtt_config.channels.push(RttChannelConfig {
+            channel_number: Some(0),
+            show_location: !self.shared_options.no_location,
+            log_format: self.shared_options.log_format.clone(),
+            ..Default::default()
+        });
+
+        let elf = fs::read(&self.shared_options.path)?;
+
         run_mode.run(
             session,
             RunLoop {
                 core_id,
-                rtt_scan_regions,
-                timestamp_offset,
                 path: self.shared_options.path,
                 always_print_stacktrace: self.shared_options.always_print_stacktrace,
-                no_location: self.shared_options.no_location,
-                log_format: self.shared_options.log_format,
-                defmt_state: None,
+                rtt_client: {
+                    let mut client = RttClient::new(Some(&elf), rtt_config, rtt_scan_regions)?;
+
+                    client.timezone_offset = timestamp_offset;
+
+                    client
+                },
             },
         )?;
 
@@ -195,13 +206,9 @@ fn elf_contains_test(path: &Path) -> anyhow::Result<bool> {
 
 struct RunLoop {
     core_id: usize,
-    rtt_scan_regions: ScanRegion,
     path: PathBuf,
-    timestamp_offset: UtcOffset,
     always_print_stacktrace: bool,
-    no_location: bool,
-    log_format: Option<String>,
-    defmt_state: Option<DefmtState>,
+    rtt_client: RttClient,
 }
 
 #[derive(PartialEq, Debug)]
@@ -265,42 +272,10 @@ impl RunLoop {
         }
         let start = Instant::now();
 
-        let mut rtt_config = RttConfig::default();
-        rtt_config.channels.push(RttChannelConfig {
-            channel_number: Some(0),
-            show_location: !self.no_location,
-            log_format: self.log_format.clone(),
-            ..Default::default()
-        });
-
-        let elf = fs::read(&self.path)?;
-        self.defmt_state = DefmtState::try_from_bytes(&elf)?;
-        let mut rtta = attach_to_rtt(
-            core,
-            Duration::from_secs(1),
-            &self.rtt_scan_regions,
-            &elf,
-            &rtt_config,
-            self.timestamp_offset,
-            self.defmt_state.as_ref(),
-        )
-        .context("Failed to attach to RTT")?;
-
-        let result = self.do_run_until(
-            core,
-            &mut rtta,
-            output_stream,
-            timeout,
-            start,
-            &mut predicate,
-        );
+        let result = self.do_run_until(core, output_stream, timeout, start, &mut predicate);
 
         // Always clean up after RTT but don't overwrite the original result.
-        let cleanup_result = if let Some(mut rtta) = rtta {
-            rtta.clean_up(core)
-        } else {
-            Ok(())
-        };
+        let cleanup_result = self.rtt_client.clean_up(core);
 
         if result.is_ok() {
             // If the result is Ok, we return the potential error during cleanup.
@@ -311,9 +286,8 @@ impl RunLoop {
     }
 
     fn do_run_until<F, R>(
-        &self,
+        &mut self,
         core: &mut Core,
-        rtta: &mut Option<RttActiveTarget>,
         output_stream: OutputStream,
         timeout: Option<Duration>,
         start: Instant,
@@ -360,7 +334,7 @@ impl RunLoop {
                 }
             }
 
-            let had_rtt_data = poll_rtt(rtta, core, output_stream, self.defmt_state.as_ref())?;
+            let had_rtt_data = poll_rtt(&mut self.rtt_client, core, output_stream)?;
 
             if return_reason.is_none() {
                 if exit.load(Ordering::Relaxed) {
@@ -477,81 +451,34 @@ fn print_stacktrace<S: Write + ?Sized>(
 
 /// Poll RTT and print the received buffer.
 fn poll_rtt<S: Write + ?Sized>(
-    rtta: &mut Option<RttActiveTarget>,
+    rtt_client: &mut RttClient,
     core: &mut Core<'_>,
     out_stream: &mut S,
-    defmt_state: Option<&DefmtState>,
 ) -> Result<bool, anyhow::Error> {
-    let mut had_data = false;
-    if let Some(rtta) = rtta {
-        struct OutCollector<'a, O: Write + ?Sized> {
-            out_stream: &'a mut O,
-            had_data: bool,
-        }
-
-        impl<O: Write + ?Sized> ChannelDataCallbacks for OutCollector<'_, O> {
-            fn on_string_data(&mut self, _channel: usize, data: String) -> Result<(), RttError> {
-                if data.is_empty() {
-                    return Ok(());
-                }
-                self.had_data = true;
-                self.out_stream
-                    .write_all(data.as_bytes())
-                    .map_err(|err| anyhow!(err))?;
-                Ok(())
-            }
-        }
-
-        let mut out = OutCollector {
-            out_stream,
-            had_data: false,
-        };
-
-        rtta.poll_rtt_fallible(core, &mut out, defmt_state)?;
-        had_data = out.had_data;
+    struct OutCollector<'a, O: Write + ?Sized> {
+        out_stream: &'a mut O,
+        had_data: bool,
     }
 
-    Ok(had_data)
-}
+    impl<O: Write + ?Sized> ChannelDataCallbacks for OutCollector<'_, O> {
+        fn on_string_data(&mut self, _channel: usize, data: String) -> Result<(), RttError> {
+            if data.is_empty() {
+                return Ok(());
+            }
+            self.had_data = true;
+            self.out_stream
+                .write_all(data.as_bytes())
+                .map_err(|err| anyhow!(err))?;
+            Ok(())
+        }
+    }
 
-fn attach_to_rtt(
-    core: &mut Core<'_>,
-    timeout: Duration,
-    rtt_region: &ScanRegion,
-    elf: &[u8],
-    rtt_config: &RttConfig,
-    timestamp_offset: UtcOffset,
-    defmt_state: Option<&DefmtState>,
-) -> Result<Option<RttActiveTarget>> {
-    // Try to find the RTT control block symbol in the ELF file.
-    // If we find it, we can use the exact address to attach to the RTT control block. Otherwise, we
-    // fall back to the caller-provided scan regions.
-    let exact_region;
-    let scan_region = if let Some(address) = RttActiveTarget::get_rtt_symbol_from_bytes(&elf) {
-        exact_region = ScanRegion::Exact(address);
-        &exact_region
-    } else {
-        rtt_region
+    let mut out = OutCollector {
+        out_stream,
+        had_data: false,
     };
 
-    // FIXME: this is a terrible way to do this. While it works (for a particular error), it's not
-    // a general solution and it's also wasting a lot of time on re-parsing ELF and looking for the
-    // control block. We should refactor this to only try a single iteration of the attaching
-    // once per poll call.
-    let start = Instant::now();
-    loop {
-        let rtt = match try_attach_to_rtt(core, timeout, scan_region) {
-            Ok(rtt) => rtt,
-            Err(RttError::NoControlBlockLocation) => return Ok(None),
-            Err(err) => return Err(anyhow!("Error attempting to attach to RTT: {err}")),
-        };
-        match RttActiveTarget::new(core, rtt, defmt_state, rtt_config, timestamp_offset) {
-            Ok(rtta) => return Ok(Some(rtta)),
-            Err(error) => {
-                if start.elapsed() > timeout {
-                    return Err(error.into());
-                }
-            }
-        }
-    }
+    rtt_client.poll(core, &mut out)?;
+
+    Ok(out.had_data)
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
@@ -484,16 +484,14 @@ fn poll_rtt<S: Write + ?Sized>(
         }
 
         impl<O: Write + ?Sized> ChannelDataCallbacks for OutCollector<'_, O> {
-            fn on_string_data(
-                &mut self,
-                _channel: usize,
-                data: String,
-            ) -> Result<(), anyhow::Error> {
+            fn on_string_data(&mut self, _channel: usize, data: String) -> Result<(), RttError> {
                 if data.is_empty() {
                     return Ok(());
                 }
                 self.had_data = true;
-                self.out_stream.write_all(data.as_bytes())?;
+                self.out_stream
+                    .write_all(data.as_bytes())
+                    .map_err(|err| anyhow!(err))?;
                 Ok(())
             }
         }
@@ -546,7 +544,7 @@ fn attach_to_rtt(
             Ok(rtta) => return Ok(Some(rtta)),
             Err(error) => {
                 if start.elapsed() > timeout {
-                    return Err(error);
+                    return Err(error.into());
                 }
             }
         }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/normal_run_mode.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/normal_run_mode.rs
@@ -24,7 +24,7 @@ impl NormalRunMode {
     }
 }
 impl RunMode for NormalRunMode {
-    fn run(&self, mut session: Session, run_loop: RunLoop) -> anyhow::Result<()> {
+    fn run(&self, mut session: Session, mut run_loop: RunLoop) -> anyhow::Result<()> {
         let mut core = session.core(run_loop.core_id)?;
 
         let halt_handler = |halt_reason: HaltReason, _core: &mut Core| {

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -407,8 +407,8 @@ impl RttActiveUpChannel {
     /// returns the number of bytes that was read.
     pub fn poll_rtt(&mut self, core: &mut Core) -> Result<Option<usize>, Error> {
         match self.up_channel.read(core, self.rtt_buffer.0.as_mut())? {
-            0 => return Ok(None),
-            count => return Ok(Some(count)),
+            0 => Ok(None),
+            count => Ok(Some(count)),
         }
     }
 

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -592,6 +592,22 @@ impl RttActiveTarget {
         Ok(())
     }
 
+    /// Polls the RTT target on all channels and returns available data.
+    /// An error on any channel will return an error instead of incomplete data.
+    pub fn poll_channel_fallible(
+        &mut self,
+        core: &mut Core,
+        channel: usize,
+        collector: &mut impl ChannelDataCallbacks,
+    ) -> Result<(), Error> {
+        if let Some(channel) = self.active_up_channels.get_mut(channel) {
+            channel.poll_process_rtt_data(core, collector)?;
+            Ok(())
+        } else {
+            Err(Error::MissingChannel(channel))
+        }
+    }
+
     /// Clean up temporary changes made to the channels.
     pub fn clean_up(&mut self, core: &mut Core) -> Result<(), Error> {
         for channel in self.active_up_channels.iter_mut() {

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -412,7 +412,7 @@ impl RttActiveUpChannel {
                 Ok(0) => return None,
                 Ok(count) => return Some(count),
                 Err(error) if loop_count == RETRY_COUNT => {
-                    tracing::error!("\nError reading from RTT: {:?}", anyhow::anyhow!(error));
+                    tracing::error!("Error reading from RTT: {:?}", anyhow::anyhow!(error));
                     return None;
                 }
                 _ => thread::sleep(Duration::from_millis(50)),

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -308,7 +308,6 @@ pub trait ChannelDataCallbacks {
 #[derive(Debug)]
 pub struct RttActiveUpChannel {
     pub up_channel: UpChannel,
-    pub channel_name: String,
     pub data_format: ChannelDataFormat,
     rtt_buffer: Box<[u8]>,
 
@@ -365,17 +364,6 @@ impl RttActiveUpChannel {
             }
         };
 
-        let channel_name = up_channel
-            .name()
-            .map(ToString::to_string)
-            .unwrap_or_else(|| {
-                format!(
-                    "Unnamed {} RTT up channel - {}",
-                    channel_config.data_format,
-                    up_channel.number()
-                )
-            });
-
         let mut original_mode = None;
         if let Some(mode) = channel_config.mode.or(
             // Try not to corrupt the byte stream if using defmt
@@ -392,10 +380,22 @@ impl RttActiveUpChannel {
         Ok(Self {
             rtt_buffer: vec![0; up_channel.buffer_size().max(1)].into_boxed_slice(),
             up_channel,
-            channel_name,
             data_format,
             original_mode,
         })
+    }
+
+    pub fn channel_name(&self) -> String {
+        self.up_channel
+            .name()
+            .map(ToString::to_string)
+            .unwrap_or_else(|| {
+                format!(
+                    "Unnamed {} RTT up channel - {}",
+                    DataFormat::from(&self.data_format),
+                    self.up_channel.number()
+                )
+            })
     }
 
     pub fn number(&self) -> usize {

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -484,7 +484,6 @@ impl RttActiveDownChannel {
 pub struct RttActiveTarget {
     pub active_up_channels: Vec<RttActiveUpChannel>,
     pub active_down_channels: Vec<RttActiveDownChannel>,
-    pub defmt_state: Option<DefmtState>,
 }
 
 /// defmt information common to all defmt channels.
@@ -524,7 +523,7 @@ impl RttActiveTarget {
     pub fn new(
         core: &mut Core,
         rtt: probe_rs::rtt::Rtt,
-        defmt_state: Option<DefmtState>,
+        defmt_state: Option<&DefmtState>,
         rtt_config: &RttConfig,
         timestamp_offset: UtcOffset,
     ) -> Result<Self, Error> {
@@ -542,7 +541,7 @@ impl RttActiveTarget {
                 channel,
                 &channel_config,
                 timestamp_offset,
-                defmt_state.as_ref(),
+                defmt_state,
             )?);
         }
 
@@ -555,7 +554,6 @@ impl RttActiveTarget {
         Ok(Self {
             active_up_channels,
             active_down_channels,
-            defmt_state,
         })
     }
 
@@ -591,8 +589,8 @@ impl RttActiveTarget {
         &mut self,
         core: &mut Core,
         collector: &mut impl ChannelDataCallbacks,
+        defmt_state: Option<&DefmtState>,
     ) -> Result<(), Error> {
-        let defmt_state = self.defmt_state.as_ref();
         for channel in self.active_up_channels.iter_mut() {
             channel.poll_process_rtt_data(core, defmt_state, collector)?;
         }

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -443,20 +443,18 @@ impl RttActiveUpChannel {
 #[derive(Debug)]
 pub struct RttActiveDownChannel {
     pub down_channel: DownChannel,
-    pub channel_name: String,
 }
 
 impl RttActiveDownChannel {
     pub fn new(down_channel: DownChannel) -> Self {
-        let channel_name = down_channel
+        Self { down_channel }
+    }
+
+    pub fn channel_name(&self) -> String {
+        self.down_channel
             .name()
             .map(ToString::to_string)
-            .unwrap_or_else(|| format!("Unnamed RTT down channel - {}", down_channel.number()));
-
-        Self {
-            down_channel,
-            channel_name,
-        }
+            .unwrap_or_else(|| format!("Unnamed RTT down channel - {}", self.down_channel.number()))
     }
 
     pub fn number(&self) -> usize {

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
@@ -32,10 +32,10 @@ impl RttClient {
         };
 
         if let Some(elf) = elf {
-            if let Some(address) = RttActiveTarget::get_rtt_symbol_from_bytes(&elf) {
-                this.scan_region = ScanRegion::Exact(address)
+            if let Some(address) = RttActiveTarget::get_rtt_symbol_from_bytes(elf) {
+                this.scan_region = ScanRegion::Exact(address);
             }
-            this.defmt_data = DefmtState::try_from_bytes(&elf)?;
+            this.defmt_data = DefmtState::try_from_bytes(elf)?;
         }
 
         Ok(this)

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
@@ -13,11 +13,20 @@ use time::UtcOffset;
 pub struct RttClient {
     pub defmt_data: Option<Arc<DefmtState>>,
     pub scan_region: ScanRegion,
-    rtt_config: RttConfig,
-    target: Option<RttActiveTarget>,
-    try_attaching: bool,
     pub timezone_offset: UtcOffset,
+    rtt_config: RttConfig,
+
+    /// The internal RTT handle, if we have successfully attached to the target.
+    target: Option<RttActiveTarget>,
+
+    /// If false, don't try to attach to the target.
+    try_attaching: bool,
+
+    /// Whether we have polled data since the last time the control block was corrupted. Used to
+    /// prevent spamming the log with messages about corrupted control blocks.
     polled_data: bool,
+
+    /// The core used to poll the target.
     core_id: usize,
 }
 

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
@@ -114,4 +114,22 @@ impl RttClient {
 
         Ok(())
     }
+
+    pub(crate) fn clear_control_block(&mut self, core: &mut Core) -> Result<(), Error> {
+        if self.target.is_none() {
+            self.try_attach(core)?;
+        }
+
+        let Some(target) = self.target.as_mut() else {
+            // If we can't attach, we don't have a valid
+            // control block and don't have to do anything.
+            return Ok(());
+        };
+
+        target.clear_control_block(core)?;
+
+        self.target = None;
+
+        Ok(())
+    }
 }

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
@@ -1,0 +1,117 @@
+use crate::util::rtt::{ChannelDataCallbacks, DefmtState, RttActiveTarget, RttConfig};
+use probe_rs::{
+    rtt::{Error, Rtt, ScanRegion},
+    Core,
+};
+use time::UtcOffset;
+
+pub struct RttClient {
+    pub defmt_data: Option<DefmtState>,
+    pub scan_region: ScanRegion,
+    rtt_config: RttConfig,
+    target: Option<RttActiveTarget>,
+    try_attaching: bool,
+    pub timezone_offset: UtcOffset,
+    polled_data: bool,
+}
+
+impl RttClient {
+    pub fn new(
+        elf: Option<&[u8]>,
+        rtt_config: RttConfig,
+        scan_region: ScanRegion,
+    ) -> Result<Self, Error> {
+        let mut this = Self {
+            defmt_data: None,
+            scan_region,
+            rtt_config,
+            target: None,
+            try_attaching: true,
+            timezone_offset: UtcOffset::UTC,
+            polled_data: false,
+        };
+
+        if let Some(elf) = elf {
+            if let Some(address) = RttActiveTarget::get_rtt_symbol_from_bytes(&elf) {
+                this.scan_region = ScanRegion::Exact(address)
+            }
+            this.defmt_data = DefmtState::try_from_bytes(&elf)?;
+        }
+
+        Ok(this)
+    }
+
+    fn try_attach(&mut self, core: &mut Core) -> Result<(), Error> {
+        if !self.try_attaching {
+            return Ok(());
+        }
+
+        match Rtt::attach_region(core, &self.scan_region).and_then(|rtt| {
+            RttActiveTarget::new(
+                core,
+                rtt,
+                self.defmt_data.as_ref(),
+                &self.rtt_config,
+                self.timezone_offset,
+            )
+            .map(Some)
+        }) {
+            Ok(rtt) => self.target = rtt,
+            Err(Error::ControlBlockNotFound) => {}
+            Err(Error::ControlBlockCorrupted(error)) => {
+                tracing::debug!("RTT control block corrupted ({error})");
+            }
+            Err(Error::NoControlBlockLocation) => self.try_attaching = false,
+            Err(error) => return Err(error),
+        };
+
+        Ok(())
+    }
+
+    pub fn poll(
+        &mut self,
+        core: &mut Core,
+        collector: &mut impl ChannelDataCallbacks,
+    ) -> Result<(), Error> {
+        if self.target.is_none() {
+            self.try_attach(core)?;
+        }
+
+        let Some(target) = self.target.as_mut() else {
+            return Ok(());
+        };
+
+        let result = target.poll_rtt_fallible(core, collector, self.defmt_data.as_ref());
+        self.handle_poll_result(result)
+    }
+
+    fn handle_poll_result(&mut self, result: Result<(), Error>) -> Result<(), Error> {
+        match result {
+            Ok(()) => self.polled_data = true,
+            Err(Error::ControlBlockCorrupted(error)) => {
+                if self.polled_data {
+                    tracing::warn!("RTT control block corrupted ({error}), re-attaching");
+                }
+                self.target = None;
+                self.polled_data = false;
+            }
+            Err(Error::ReadPointerChanged) => {
+                if self.polled_data {
+                    tracing::warn!("RTT read pointer changed, re-attaching");
+                }
+                self.target = None;
+                self.polled_data = false;
+            }
+            other => return other,
+        }
+        Ok(())
+    }
+
+    pub fn clean_up(&mut self, core: &mut Core) -> Result<(), Error> {
+        if let Some(target) = self.target.as_mut() {
+            target.clean_up(core)?;
+        }
+
+        Ok(())
+    }
+}

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["tests/"]
 
 [features]
 default = ["builtin-targets", "debug"]
-gdb-server = ["dep:gdbstub", "dep:anyhow"]
+gdb-server = ["dep:gdbstub"]
 
 # Enable all built in targets.
 builtin-targets = ["dep:bincode", "dep:serde_yaml", "dep:probe-rs-target"]
@@ -38,6 +38,7 @@ debug = [
 test = []
 
 [dependencies]
+anyhow.workspace = true
 docsplay.workspace = true
 thiserror.workspace = true
 probe-rs-target.workspace = true
@@ -77,7 +78,6 @@ hexdump = { version = "0.1", optional = true }
 
 # gdb server
 gdbstub = { version = "0.7", optional = true }
-anyhow = { workspace = true, optional = true }
 
 # debug
 gimli = { version = "0.31", default-features = false, features = [
@@ -97,7 +97,6 @@ bincode = { version = "1", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 
 [dev-dependencies]
-anyhow.workspace = true
 pretty_env_logger = "0.5"
 fastrand = "2.1"
 serde_json = "1"

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -153,13 +153,20 @@ impl Target {
         self.flash_algorithms.iter().find(|a| a.name == name)
     }
 
-    /// Gets the core index from the core name
-    pub(crate) fn core_index_by_name(&self, name: &str) -> Option<usize> {
+    /// Returns the core index from the core name
+    pub fn core_index_by_name(&self, name: &str) -> Option<usize> {
         self.cores.iter().position(|c| c.name == name)
     }
 
-    /// Gets the first found [MemoryRegion] that contains the given address
-    pub(crate) fn get_memory_region_by_address(&self, address: u64) -> Option<&MemoryRegion> {
+    /// Returns the core index from the core name
+    pub fn core_index_by_address(&self, address: u64) -> Option<usize> {
+        let target_memory = self.memory_region_by_address(address)?;
+        let core_name = target_memory.cores().first()?;
+        self.core_index_by_name(core_name)
+    }
+
+    /// Returns the first found [MemoryRegion] that contains the given address
+    pub fn memory_region_by_address(&self, address: u64) -> Option<&MemoryRegion> {
         self.memory_map
             .iter()
             .find(|region| region.contains(address))

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -214,7 +214,7 @@ where
 pub struct Core<'probe> {
     id: usize,
     name: &'probe str,
-    memory_regions: &'probe [MemoryRegion],
+    target: &'probe Target,
 
     inner: Box<dyn CoreInterface + 'probe>,
 }
@@ -241,22 +241,28 @@ impl<'probe> Core<'probe> {
     pub(crate) fn new(
         id: usize,
         name: &'probe str,
-        memory_regions: &'probe [MemoryRegion],
+        target: &'probe Target,
         core: impl CoreInterface + 'probe,
     ) -> Core<'probe> {
         Self {
             id,
             name,
-            memory_regions,
+            target,
             inner: Box::new(core),
         }
     }
 
-    /// Return the memory regions associated with this core.
+    /// Returns the memory regions associated with this core.
     pub fn memory_regions(&self) -> impl Iterator<Item = &MemoryRegion> {
-        self.memory_regions
+        self.target
+            .memory_map
             .iter()
             .filter(|r| r.cores().iter().any(|m| m == self.name))
+    }
+
+    /// Returns the target descriptor of the current `Session`.
+    pub fn target(&self) -> &Target {
+        self.target
     }
 
     /// Creates a new [`CoreState`]

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -42,8 +42,6 @@ impl CombinedCoreState {
         target: &'probe Target,
         arm_interface: &'probe mut Box<dyn ArmProbeInterface>,
     ) -> Result<Core<'probe>, Error> {
-        let memory_regions = &target.memory_map;
-
         let name = &target.cores[self.id].name;
 
         let memory = arm_interface.memory_interface(&self.arm_memory_ap())?;
@@ -61,13 +59,13 @@ impl CombinedCoreState {
             SpecificCoreState::Armv6m(s) => Core::new(
                 self.id,
                 name,
-                memory_regions,
+                target,
                 crate::architecture::arm::armv6m::Armv6m::new(memory, s, debug_sequence)?,
             ),
             SpecificCoreState::Armv7a(s) => Core::new(
                 self.id,
                 name,
-                memory_regions,
+                target,
                 crate::architecture::arm::armv7a::Armv7a::new(
                     memory,
                     s,
@@ -78,13 +76,13 @@ impl CombinedCoreState {
             SpecificCoreState::Armv7m(s) | SpecificCoreState::Armv7em(s) => Core::new(
                 self.id,
                 name,
-                memory_regions,
+                target,
                 crate::architecture::arm::armv7m::Armv7m::new(memory, s, debug_sequence)?,
             ),
             SpecificCoreState::Armv8a(s) => Core::new(
                 self.id,
                 name,
-                memory_regions,
+                target,
                 crate::architecture::arm::armv8a::Armv8a::new(
                     memory,
                     s,
@@ -96,7 +94,7 @@ impl CombinedCoreState {
             SpecificCoreState::Armv8m(s) => Core::new(
                 self.id,
                 name,
-                memory_regions,
+                target,
                 crate::architecture::arm::armv8m::Armv8m::new(memory, s, debug_sequence)?,
             ),
             _ => {
@@ -161,7 +159,6 @@ impl CombinedCoreState {
         target: &'probe Target,
         mut interface: RiscvCommunicationInterface<'probe>,
     ) -> Result<Core<'probe>, Error> {
-        let memory_regions = &target.memory_map;
         let name = &target.cores[self.id].name;
 
         let ResolvedCoreOptions::Riscv { options, sequence } = &self.core_state.core_access_options
@@ -190,7 +187,7 @@ impl CombinedCoreState {
         Ok(Core::new(
             self.id,
             name,
-            memory_regions,
+            target,
             crate::architecture::riscv::Riscv32::new(interface, s, debug_sequence)?,
         ))
     }
@@ -200,7 +197,6 @@ impl CombinedCoreState {
         target: &'probe Target,
         interface: XtensaCommunicationInterface<'probe>,
     ) -> Result<Core<'probe>, Error> {
-        let memory_regions = &target.memory_map;
         let name = &target.cores[self.id].name;
 
         let ResolvedCoreOptions::Xtensa { sequence, .. } = &self.core_state.core_access_options
@@ -222,7 +218,7 @@ impl CombinedCoreState {
         Ok(Core::new(
             self.id,
             name,
-            memory_regions,
+            target,
             crate::architecture::xtensa::Xtensa::new(interface, s, debug_sequence)?,
         ))
     }

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -797,7 +797,7 @@ impl<O: Operation> ActiveFlasher<'_, O> {
             return Ok(());
         };
 
-        for channel in rtt.up_channels().iter() {
+        for channel in rtt.up_channels().iter_mut() {
             let mut buffer = vec![0; channel.buffer_size()];
             match channel.read(&mut self.core, &mut buffer) {
                 Ok(read) if read > 0 => {

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -720,10 +720,7 @@ impl FlashLoader {
                 data.len()
             );
 
-            let associated_region = session
-                .target()
-                .get_memory_region_by_address(address)
-                .unwrap();
+            let associated_region = session.target().memory_region_by_address(address).unwrap();
 
             // We verified NVM regions before, in flasher.program().
             if !associated_region.is_ram() {

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -478,6 +478,12 @@ pub enum Error {
 
     /// Unexpected error while reading {0} from target memory. Please report this as a bug.
     MemoryRead(String),
+
+    /// Defmt-related error.
+    Defmt(#[source] anyhow::Error),
+
+    /// Some uncategorized error occurred.
+    Other(#[from] anyhow::Error),
 }
 
 fn display_list(list: &[Rtt]) -> String {

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -479,9 +479,6 @@ pub enum Error {
     /// Unexpected error while reading {0} from target memory. Please report this as a bug.
     MemoryRead(String),
 
-    /// Defmt-related error.
-    Defmt(#[source] anyhow::Error),
-
     /// Some uncategorized error occurred.
     Other(#[from] anyhow::Error),
 

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -467,7 +467,7 @@ pub enum Error {
     /// Multiple control blocks found in target memory: {display_list(_0)}.
     MultipleControlBlocksFound(Vec<Rtt>),
 
-    /// The control block has been corrupted. {0}
+    /// The control block has been corrupted: {0}
     ControlBlockCorrupted(String),
 
     /// Attempted an RTT operation against a Core number that is different from the Core number against which RTT was initialized. Expected {0}, found {1}

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -101,6 +101,7 @@ use zerocopy::{FromBytes, FromZeroes};
 ///         RTT, because the buffer sizes are incorrect.
 #[derive(Debug)]
 pub struct Rtt {
+    /// The location of the control block in target memory.
     ptr: u64,
 
     /// The detected up (target to host) channels.
@@ -420,6 +421,12 @@ impl Rtt {
     /// Returns a particular down channel.
     pub fn down_channel(&mut self, channel: usize) -> Option<&mut DownChannel> {
         self.down_channels.get_mut(channel)
+    }
+
+    /// Returns the size of the RTT control block.
+    pub fn control_block_size(core: &Core) -> usize {
+        let is_64_bit = core.is_64_bit();
+        RttControlBlockHeader::minimal_header_size(is_64_bit)
     }
 }
 

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -491,6 +491,9 @@ pub enum Error {
 
     /// The read pointer changed unexpectedly.
     ReadPointerChanged,
+
+    /// Channel {0} does not exist.
+    MissingChannel(usize),
 }
 
 fn display_list(list: &[Rtt]) -> String {

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -480,7 +480,7 @@ pub enum Error {
     /// Attempted an RTT operation against a Core number that is different from the Core number against which RTT was initialized. Expected {0}, found {1}
     IncorrectCoreSpecified(usize, usize),
 
-    /// Error communicating with probe: {0}
+    /// Error communicating with the probe.
     Probe(#[from] crate::Error),
 
     /// Unexpected error while reading {0} from target memory. Please report this as a bug.

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -403,23 +403,23 @@ impl Rtt {
     }
 
     /// Returns a reference to the detected up channels.
-    pub fn up_channels(&mut self) -> &[UpChannel] {
+    pub fn up_channels(&mut self) -> &mut [UpChannel] {
         &mut self.up_channels
     }
 
     /// Returns a reference to the detected down channels.
-    pub fn down_channels(&mut self) -> &[DownChannel] {
+    pub fn down_channels(&mut self) -> &mut [DownChannel] {
         &mut self.down_channels
     }
 
     /// Returns a particular up channel.
-    pub fn up_channel(&self, channel: usize) -> Option<&UpChannel> {
-        self.up_channels.get(channel)
+    pub fn up_channel(&mut self, channel: usize) -> Option<&mut UpChannel> {
+        self.up_channels.get_mut(channel)
     }
 
     /// Returns a particular down channel.
-    pub fn down_channel(&self, channel: usize) -> Option<&DownChannel> {
-        self.down_channels.get(channel)
+    pub fn down_channel(&mut self, channel: usize) -> Option<&mut DownChannel> {
+        self.down_channels.get_mut(channel)
     }
 }
 
@@ -484,6 +484,9 @@ pub enum Error {
 
     /// Some uncategorized error occurred.
     Other(#[from] anyhow::Error),
+
+    /// The read pointer changed unexpectedly.
+    ReadPointerChanged,
 }
 
 fn display_list(list: &[Rtt]) -> String {

--- a/probe-rs/src/rtt/channel.rs
+++ b/probe-rs/src/rtt/channel.rs
@@ -211,17 +211,11 @@ impl Channel {
             return Ok(None);
         };
 
-        let name = if info.standard_name_pointer() == 0 {
-            None
-        } else {
-            read_c_string(core, info.standard_name_pointer())?
-        };
-
         let this = Channel {
             number,
             core_id: core.id(),
             metadata_ptr,
-            name,
+            name: read_c_string(core, info.standard_name_pointer())?,
             info,
             last_read_ptr: None,
         };
@@ -513,6 +507,10 @@ impl RttChannel for DownChannel {
 /// Reads a null-terminated string from target memory. Lossy UTF-8 decoding is used.
 fn read_c_string(core: &mut Core, ptr: u64) -> Result<Option<String>, Error> {
     // Find out which memory range contains the pointer
+    if ptr == 0 {
+        // If the pointer is null, return None.
+        return Ok(None);
+    }
 
     let Some(range) = core
         .memory_regions()

--- a/probe-rs/src/rtt/channel.rs
+++ b/probe-rs/src/rtt/channel.rs
@@ -461,7 +461,7 @@ impl DownChannel {
                 break;
             }
 
-            core.write_8(self.0.info.buffer_start_pointer() + write, &buf[..count])?;
+            core.write(self.0.info.buffer_start_pointer() + write, &buf[..count])?;
 
             total += count;
             write += count as u64;


### PR DESCRIPTION
Initial implementation of `RttClient` that is able to reconnect, as well as allows handling semihosting calls that happen before attaching.

We also only process the firmware .elf once, instead of multiple times to get the RTT poller core, defmt location information and control block symbol address. This was especially prominent in the debugger, which re-processed everything in case it wasn't able to attach immediately.

RttClient is used for the run loops, cargo-embed and dap-server, but not in flasher/rtt-host at this point. This is because the client currently lives in probe-rs-tools, not the probe-rs library. This may be changed but I am not sure if we want defmt decoding tied to the library at this point, or if we have some better solution to separate data processing from the polling.

We no longer print RTT messages from a previous "session" (i.e. from before the reset)
We should no longer have control block corruption errors, at least not as often as before

Improvement opportunities:
- React to configuration changes - channels appearing and going away
- Route stdin to channel 0 in the run loop
- Multiplex all up channel data in the run loop
- Move RttClient to the library, use it in rtt-host

cc #2444
cc #2185
cc #1939