### PR TITLE
Rename ESP32 and add chip detection info

### DIFF
--- a/changelog/changed-esp32.md
+++ b/changelog/changed-esp32.md
@@ -1,0 +1,1 @@
+Renamed the `esp32-3.3v` target to `esp32`

--- a/probe-rs/targets/esp32.yaml
+++ b/probe-rs/targets/esp32.yaml
@@ -2,8 +2,13 @@ name: esp32
 manufacturer:
   id: 0x12
   cc: 0xc
+chip_detection:
+- !Espressif
+  idcode: 0x120034e5
+  variants:
+    0x00f01d83: esp32
 variants:
-- name: esp32-3.3v
+- name: esp32
   cores:
   - name: main
     type: xtensa


### PR DESCRIPTION
cc @MabezDev @SergioGasquez

I'm still mildly uncomfortable here but maybe fearing an invisible monster hurts more than it helps right now. Keeping the target's name aligned with the actual HAL feature name has some benefits that I want to build on.

cc #2756