### PR TITLE
Use flate2 instead of directly using miniz_oxide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,12 +44,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,7 +210,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "object 0.32.2",
  "rustc-demangle",
 ]
@@ -1106,7 +1100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1941,15 +1935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,6 +2290,7 @@ dependencies = [
  "dunce",
  "espflash",
  "fastrand",
+ "flate2",
  "futures-lite",
  "gdbstub",
  "gimli 0.31.0",
@@ -2315,7 +2301,6 @@ dependencies = [
  "itertools 0.13.0",
  "itm",
  "jep106",
- "miniz_oxide 0.8.0",
  "nusb",
  "object 0.36.3",
  "once_cell",

--- a/probe-rs-target/src/flash_algorithm.rs
+++ b/probe-rs-target/src/flash_algorithm.rs
@@ -11,7 +11,7 @@ pub enum TransferEncoding {
     #[default]
     Raw,
 
-    /// Flash data is compressed using the `miniz_oxide` crate.
+    /// Zlib-compressed data, originally using the `miniz_oxide` crate.
     ///
     /// Compressed images are written in page sized chunks, each chunk written to the image's start
     /// address. The length of the compressed image is stored in the first 4 bytes of the first

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -53,7 +53,7 @@ ihex = "3.0"
 itertools = "0.13"
 jep106 = "0.2"
 once_cell = "1"
-miniz_oxide = "0.8"
+flate2 = "1.0"
 object = { version = "0.36", default-features = false, features = [
     "elf",
     "read_core",

--- a/probe-rs/src/flashing/encoder.rs
+++ b/probe-rs/src/flashing/encoder.rs
@@ -1,3 +1,5 @@
+use std::io::Write as _;
+
 use probe_rs_target::TransferEncoding;
 
 use crate::flashing::{FlashLayout, FlashPage, FlashSector};
@@ -40,12 +42,12 @@ impl EncoderAlgorithm for RawEncoder {
 ///
 /// The flash loader that accepts this format must be able to track the offset in the current image.
 /// The end of an image is signaled by the first non-full page. This may include an empty page.
-struct MinizEncoder {
+struct ZlibEncoder {
     flash: FlashLayout,
     compressed_pages: Vec<FlashPage>,
 }
 
-impl MinizEncoder {
+impl ZlibEncoder {
     fn new(flash: FlashLayout) -> Self {
         let mut compressed_pages = vec![];
 
@@ -55,8 +57,15 @@ impl MinizEncoder {
             if image.is_empty() {
                 return;
             }
+
+            use flate2::write::ZlibEncoder;
+            use flate2::Compression;
+
             // This page is not contiguous with the previous one, finish the previous image.
-            let compressed = miniz_oxide::deflate::compress_to_vec_zlib(image, 9);
+            let mut e = ZlibEncoder::new(Vec::new(), Compression::best());
+            // These unwraps are okay because we are writing to a Vec and that is infallible.
+            e.write_all(image).unwrap();
+            let compressed = e.finish().unwrap();
 
             let image_len = compressed.len();
             // We chunk up the image and prepend the compressed image's length to the first chunk.
@@ -114,7 +123,7 @@ impl MinizEncoder {
     }
 }
 
-impl EncoderAlgorithm for MinizEncoder {
+impl EncoderAlgorithm for ZlibEncoder {
     fn pages(&self) -> &[FlashPage] {
         &self.compressed_pages
     }
@@ -137,7 +146,7 @@ impl FlashEncoder {
         Self {
             encoder: match encoding {
                 TransferEncoding::Raw => Box::new(RawEncoder::new(flash)),
-                TransferEncoding::Miniz => Box::new(MinizEncoder::new(flash)),
+                TransferEncoding::Miniz => Box::new(ZlibEncoder::new(flash)),
             },
         }
     }


### PR DESCRIPTION
Renovate has some trouble updating miniz_oxide, and our dependencies all use flate2, so why not do it in probe-rs, too. I'm keeping the transfer encoding as `Miniz` for no good reason, but we can rename it to zlib as well if we want to.