### PR TITLE
Speed up halting RISC-V cores

### DIFF
--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -955,7 +955,7 @@ impl<'state> RiscvCommunicationInterface<'state> {
 
         let data_len = data.len();
 
-        let mut read_results: Vec<DeferredResultIndex> = vec![];
+        let mut read_results = Vec::with_capacity(data_len);
         for _ in data[..data_len - 1].iter() {
             let idx = self.schedule_read_large_dtm_register::<V, Sbdata>()?;
             read_results.push(idx);


### PR DESCRIPTION
The Xtensa changes have no effect, they are there mostly for consistency and general "looks right"-ness.

This PR is meant to reduce the intrusiveness of probe-rs but it also increases flashing speed of ESP32-C2 by a bit less than 10% (tested locally). C3 is surprisingly less affected, while C6 is less affected too, but in that case it is expected - we don't halt the C6 to read memory from it.