### PR TITLE
Undo the halting hack for ESP32-C2/C3

### DIFF
--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -250,10 +250,6 @@ pub struct RiscvCommunicationInterfaceState {
     /// Store the value of the `hasresethaltreq` bit of the `dmstatus` register.
     hasresethaltreq: Option<bool>,
 
-    /// Workaround for certain MCUs. If set, the target will be halted for a sysbus access, even
-    /// though the spec says it should not be necessary.
-    sysbus_requires_halting: bool,
-
     /// Whether the core is currently halted.
     is_halted: bool,
 
@@ -305,7 +301,6 @@ impl RiscvCommunicationInterfaceState {
             enabled_harts: 0,
             last_selected_hart: 0,
             hasresethaltreq: None,
-            sysbus_requires_halting: false,
             is_halted: false,
 
             current_dmcontrol: Dmcontrol(0),
@@ -1511,9 +1506,6 @@ impl<'state> RiscvCommunicationInterface<'state> {
     fn read_word<V: RiscvValue32>(&mut self, address: u32) -> Result<V, crate::Error> {
         let result = match self.state.memory_access_method(V::WIDTH) {
             MemoryAccessMethod::ProgramBuffer => self.perform_memory_read_progbuf(address)?,
-            MemoryAccessMethod::SystemBus if self.state.sysbus_requires_halting => {
-                self.halted_access(|this| this.perform_memory_read_sysbus(address))?
-            }
             MemoryAccessMethod::SystemBus => self.perform_memory_read_sysbus(address)?,
             MemoryAccessMethod::AbstractCommand => {
                 unimplemented!("Memory access using abstract commands is not implemted")
@@ -1534,9 +1526,6 @@ impl<'state> RiscvCommunicationInterface<'state> {
             MemoryAccessMethod::ProgramBuffer => {
                 self.perform_memory_read_multiple_progbuf(address, data)?;
             }
-            MemoryAccessMethod::SystemBus if self.state.sysbus_requires_halting => {
-                self.halted_access(|this| this.perform_memory_read_multiple_sysbus(address, data))?
-            }
             MemoryAccessMethod::SystemBus => {
                 self.perform_memory_read_multiple_sysbus(address, data)?;
             }
@@ -1553,9 +1542,6 @@ impl<'state> RiscvCommunicationInterface<'state> {
             MemoryAccessMethod::ProgramBuffer => {
                 self.perform_memory_write_progbuf(address, data)?
             }
-            MemoryAccessMethod::SystemBus if self.state.sysbus_requires_halting => {
-                self.halted_access(|this| this.perform_memory_write_sysbus(address, &[data]))?
-            }
             MemoryAccessMethod::SystemBus => self.perform_memory_write_sysbus(address, &[data])?,
             MemoryAccessMethod::AbstractCommand => {
                 unimplemented!("Memory access using abstract commands is not implemted")
@@ -1571,9 +1557,6 @@ impl<'state> RiscvCommunicationInterface<'state> {
         data: &[V],
     ) -> Result<(), crate::Error> {
         match self.state.memory_access_method(V::WIDTH) {
-            MemoryAccessMethod::SystemBus if self.state.sysbus_requires_halting => {
-                self.halted_access(|this| this.perform_memory_write_sysbus(address, data))?
-            }
             MemoryAccessMethod::SystemBus => self.perform_memory_write_sysbus(address, data)?,
             MemoryAccessMethod::ProgramBuffer => {
                 self.perform_memory_write_multiple_progbuf(address, data)?
@@ -1784,10 +1767,6 @@ impl<'state> RiscvCommunicationInterface<'state> {
             }
             other => other,
         }
-    }
-
-    pub(crate) fn sysbus_requires_halting(&mut self, en: bool) {
-        self.state.sysbus_requires_halting = en;
     }
 }
 

--- a/probe-rs/src/vendor/espressif/mod.rs
+++ b/probe-rs/src/vendor/espressif/mod.rs
@@ -97,9 +97,7 @@ impl Vendor for Espressif {
         probe: &mut RiscvCommunicationInterface,
         idcode: u32,
     ) -> Result<Option<String>, Error> {
-        let result = probe.halted_access(|probe| Ok(try_detect_espressif_chip(probe, idcode)))?;
-
-        Ok(result)
+        Ok(try_detect_espressif_chip(probe, idcode))
     }
 
     fn try_detect_xtensa_chip(

--- a/probe-rs/src/vendor/espressif/sequences/esp32c2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c2.rs
@@ -37,9 +37,6 @@ impl RiscvDebugSequence for ESP32C2 {
     fn on_connect(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
         tracing::info!("Disabling esp32c2 watchdogs...");
 
-        // FIXME: this is a terrible hack because we should not need to halt to read memory.
-        interface.sysbus_requires_halting(true);
-
         // disable super wdt
         interface.write_word_32(0x600080A4, 0x8F1D312A)?; // write protection off
         let current = interface.read_word_32(0x600080A0)?;

--- a/probe-rs/src/vendor/espressif/sequences/esp32c3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c3.rs
@@ -37,9 +37,6 @@ impl RiscvDebugSequence for ESP32C3 {
     fn on_connect(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
         tracing::info!("Disabling esp32c3 watchdogs...");
 
-        // FIXME: this is a terrible hack because we should not need to halt to read memory.
-        interface.sysbus_requires_halting(true);
-
         // disable super wdt
         interface.write_word_32(0x600080B0, 0x8F1D312A)?; // write protection off
         let current = interface.read_word_32(0x600080AC)?;


### PR DESCRIPTION
Reverts the halting parts of #2748. I can't seem to be able to reproduce the weird memory reading errors that I had with these devices, and we've fixed the RTT attaching issues since then.