### PR TITLE
Xtensa: slight efficiency improvements

### DIFF
--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -460,7 +460,7 @@ impl<'probe> XtensaCommunicationInterface<'probe> {
             let reader = value.unwrap();
             let value = self.xdm.read_deferred_result(reader)?.into_u32();
 
-            self.write_register_untyped(key, value)?;
+            self.schedule_write_register_untyped(key, value)?;
         }
 
         Ok(())
@@ -653,7 +653,7 @@ impl<'probe> XtensaCommunicationInterface<'probe> {
             .schedule_execute_instruction(Instruction::Sddr32P(CpuRegister::A3));
         self.restore_register(key)?;
 
-        self.xdm.execute()
+        Ok(())
     }
 
     pub(crate) fn write_memory(&mut self, address: u64, data: &[u8]) -> Result<(), XtensaError> {
@@ -707,8 +707,6 @@ impl<'probe> XtensaCommunicationInterface<'probe> {
 
             this.restore_register(key)?;
 
-            this.xdm.execute()?;
-
             // TODO: implement cache flushing on CPUs that need it.
 
             Ok(())
@@ -716,6 +714,7 @@ impl<'probe> XtensaCommunicationInterface<'probe> {
     }
 
     pub(crate) fn reset_and_halt(&mut self, timeout: Duration) -> Result<(), XtensaError> {
+        self.xdm.execute()?;
         self.clear_register_cache();
         self.xdm.reset_and_halt()?;
         self.wait_for_core_halted(timeout)?;

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -126,14 +126,13 @@ impl<'probe> Xtensa<'probe> {
 
             if core_reset {
                 // Run the connection sequence while halted.
-                let was_halted = self.core_halted()?;
-                if !was_halted {
-                    self.halt(Duration::from_millis(500))?;
-                }
+                let was_running = self
+                    .interface
+                    .halt_with_previous(Duration::from_millis(500))?;
 
                 self.sequence.on_connect(&mut self.interface)?;
 
-                if !was_halted {
+                if was_running {
                     self.run()?;
                 }
             }
@@ -290,7 +289,7 @@ impl<'probe> CoreInterface for Xtensa<'probe> {
         if self.state.pc_written {
             self.interface.clear_register_cache();
         }
-        Ok(self.interface.resume()?)
+        Ok(self.interface.resume_core()?)
     }
 
     fn reset(&mut self) -> Result<(), Error> {

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -472,7 +472,7 @@ impl<'probe> Xdm<'probe> {
         Ok(res)
     }
 
-    fn schedule_read_nexus_register<R: NexusRegister>(&mut self) -> DeferredResultIndex {
+    pub(super) fn schedule_read_nexus_register<R: NexusRegister>(&mut self) -> DeferredResultIndex {
         tracing::debug!("Reading from {}", R::NAME);
         self.schedule_dbg_read(R::ADDRESS)
     }

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -659,6 +659,7 @@ impl<'probe> Xdm<'probe> {
     }
 
     pub fn reset_and_halt(&mut self) -> Result<(), XtensaError> {
+        self.execute()?;
         self.pwr_write(PowerDevice::PowerControl, {
             let mut pwr_control = PowerControl(0);
 

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -269,7 +269,10 @@ impl<'probe> Xdm<'probe> {
     }
 
     fn check_enabled(&mut self) -> Result<(), XtensaError> {
-        let device_id = self.read_nexus_register::<OcdId>()?.0;
+        let Ok(device_id) = self.read_nexus_register::<OcdId>() else {
+            return Err(XtensaError::CoreDisabled);
+        };
+        let device_id = device_id.0;
         tracing::debug!("Read OCDID: {:#010X}", device_id);
 
         if device_id == 0 || device_id == u32::MAX {

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -791,7 +791,10 @@ impl Drop for Session {
     #[tracing::instrument(name = "session_drop", skip(self))]
     fn drop(&mut self) {
         if let Err(err) = self.clear_all_hw_breakpoints() {
-            tracing::warn!("Could not clear all hardware breakpoints: {:?}", err);
+            tracing::warn!(
+                "Could not clear all hardware breakpoints: {:?}",
+                anyhow::anyhow!(err)
+            );
         }
 
         // Call any necessary deconfiguration/shutdown hooks.

--- a/probe-rs/src/vendor/espressif/sequences/esp32.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32.rs
@@ -133,7 +133,7 @@ impl XtensaDebugSequence for ESP32 {
             core.write_word_32(RTC_CNTL_RESET_STATE_REG, new_state)?;
         }
 
-        match core.resume() {
+        match core.resume_core() {
             err @ Err(XtensaError::XdmError(
                 xdm::Error::ExecOverrun | xdm::Error::InstructionIgnored,
             )) => {

--- a/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
@@ -164,15 +164,19 @@ impl XtensaDebugSequence for ESP32S2 {
         })?;
 
         // Reset CPU
-        match self.set_peri_reg_mask(core, Self::OPTIONS0, SYS_RESET, SYS_RESET) {
-            err @ Err(crate::Error::Xtensa(XtensaError::XdmError(
+        self.set_peri_reg_mask(core, Self::OPTIONS0, SYS_RESET, SYS_RESET)?;
+
+        // Need to manually execute here, because a yet-to-be-flushed write will start the
+        // reset process.
+        match core.xdm.execute() {
+            err @ Err(XtensaError::XdmError(
                 xdm::Error::ExecOverrun
                 | xdm::Error::InstructionIgnored
                 | xdm::Error::Xdm {
                     source: DebugRegisterError::Unexpected(_),
                     ..
                 },
-            ))) => {
+            )) => {
                 // ignore error
                 tracing::debug!("Error ignored: {err:?}");
             }

--- a/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
@@ -134,7 +134,7 @@ impl XtensaDebugSequence for ESP32S3 {
             core.write_word_32(RTC_CNTL_RESET_STATE_REG, new_state)?;
         }
 
-        core.resume()?;
+        core.resume_core()?;
 
         std::thread::sleep(Duration::from_millis(100));
 


### PR DESCRIPTION
This PR should allow batching up more JTAG commands, although it doesn't really have any visible effect for e.g. flashing speed.

Queue utilisation for RTT polling:

```
before

core status
Executing 2 commands
read pointers
Executing 8 commands
Executing 14 commands
Executing 10 commands
core status
Executing 2 commands
read pointers
Executing 8 commands
Executing 14 commands
Executing 10 commands
read buffer
Executing 8 commands
Executing 12 commands
Executing 10 commands
write pointer
Executing 8 commands
Executing 12 commands
Executing 10 commands

after

core status
Executing 2 commands
read pointers
Executing 22 commands
Executing 10 commands
core status
Executing 2 commands
read pointers
Executing 22 commands
Executing 10 commands
read buffer
Executing 22 commands
Executing 10 commands
write pointer
Executing 20 commands
Executing 10 commands
```