### PR TITLE
Make progress bars constant width

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/flash.rs
@@ -189,20 +189,33 @@ impl ProgressBarGroup {
         }
     }
 
-    pub fn add(&mut self, bar: ProgressBar) {
-        let msg_template = "{msg:.green.bold} {spinner} [{elapsed_precise}] [{wide_bar}] {bytes:>10}/{total_bytes:>10} @ {bytes_per_sec:>12} (ETA {eta_precise})";
+    fn active() -> ProgressStyle {
+        let msg_template = "{msg:.green.bold} {spinner} {percent:>3}% ({eta_precise}) [{bar:20}] {bytes:>10} @ {bytes_per_sec:>12}";
         let style = ProgressStyle::default_bar()
             .tick_chars("⠁⠁⠉⠙⠚⠒⠂⠂⠒⠲⠴⠤⠄⠄⠤⠠⠠⠤⠦⠖⠒⠐⠐⠒⠓⠋⠉⠈⠈✔")
             .progress_chars("--")
             .template(msg_template)
             .expect("Error in progress bar creation. This is a bug, please report it.");
+        style
+    }
 
+    fn finished() -> ProgressStyle {
+        let msg_template = "{msg:.green.bold} {spinner} {percent:>3}% ({elapsed_precise}) [{bar:20}] {bytes:>10} @ {bytes_per_sec:>12}";
+        let style = ProgressStyle::default_bar()
+            .tick_chars("⠁⠁⠉⠙⠚⠒⠂⠂⠒⠲⠴⠤⠄⠄⠤⠠⠠⠤⠦⠖⠒⠐⠐⠒⠓⠋⠉⠈⠈✔")
+            .progress_chars("##")
+            .template(msg_template)
+            .expect("Error in progress bar creation. This is a bug, please report it.");
+        style
+    }
+
+    pub fn add(&mut self, bar: ProgressBar) {
         if self.append_phase {
             bar.set_message(format!("{} {}", self.message, self.bars.len() + 1));
         } else {
             bar.set_message(self.message.clone());
         }
-        bar.set_style(style);
+        bar.set_style(Self::active());
         bar.enable_steady_tick(Duration::from_millis(100));
         bar.reset_elapsed();
 
@@ -239,6 +252,7 @@ impl ProgressBarGroup {
 
     pub fn finish(&mut self) {
         if let Some(bar) = self.bars.get(self.selected) {
+            bar.set_style(Self::finished());
             bar.finish();
         }
         self.next();

--- a/probe-rs-tools/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/flash.rs
@@ -144,7 +144,7 @@ pub fn run_flash_download(
     logging::clear_progress_bar();
 
     logging::eprintln(format!(
-        "    {} in {}s",
+        "     {} in {:.02}s",
         "Finished".green().bold(),
         flash_timer.elapsed().as_secs_f32(),
     ));
@@ -190,7 +190,7 @@ impl ProgressBarGroup {
     }
 
     pub fn add(&mut self, bar: ProgressBar) {
-        let msg_template = "{msg:.green.bold} {spinner} [{elapsed_precise}] [{wide_bar}] {bytes:>8}/{total_bytes:>8} @ {bytes_per_sec:>10} (eta {eta:3})";
+        let msg_template = "{msg:.green.bold} {spinner} [{elapsed_precise}] [{wide_bar}] {bytes:>10}/{total_bytes:>10} @ {bytes_per_sec:>12} (ETA {eta_precise})";
         let style = ProgressStyle::default_bar()
             .tick_chars("⠁⠁⠉⠙⠚⠒⠂⠂⠒⠲⠴⠤⠄⠄⠤⠠⠠⠤⠦⠖⠒⠐⠐⠒⠓⠋⠉⠈⠈✔")
             .progress_chars("--")

--- a/probe-rs-tools/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/flash.rs
@@ -189,24 +189,25 @@ impl ProgressBarGroup {
         }
     }
 
-    fn active() -> ProgressStyle {
-        let msg_template = "{msg:.green.bold} {spinner} {percent:>3}% ({eta_precise}) [{bar:20}] {bytes:>10} @ {bytes_per_sec:>12}";
-        let style = ProgressStyle::default_bar()
+    fn idle() -> ProgressStyle {
+        ProgressStyle::with_template("{msg:.green.bold} {spinner} {percent:>3}% [{bar:20}]")
+            .expect("Error in progress bar creation. This is a bug, please report it.")
             .tick_chars("⠁⠁⠉⠙⠚⠒⠂⠂⠒⠲⠴⠤⠄⠄⠤⠠⠠⠤⠦⠖⠒⠐⠐⠒⠓⠋⠉⠈⠈✔")
             .progress_chars("--")
-            .template(msg_template)
-            .expect("Error in progress bar creation. This is a bug, please report it.");
-        style
+    }
+
+    fn active() -> ProgressStyle {
+        ProgressStyle::with_template("{msg:.green.bold} {spinner} {percent:>3}% [{bar:20}] {bytes:>10} @ {bytes_per_sec:>12} (ETA {eta})")
+            .expect("Error in progress bar creation. This is a bug, please report it.")
+            .tick_chars("⠁⠁⠉⠙⠚⠒⠂⠂⠒⠲⠴⠤⠄⠄⠤⠠⠠⠤⠦⠖⠒⠐⠐⠒⠓⠋⠉⠈⠈✔")
+            .progress_chars("##-")
     }
 
     fn finished() -> ProgressStyle {
-        let msg_template = "{msg:.green.bold} {spinner} {percent:>3}% ({elapsed_precise}) [{bar:20}] {bytes:>10} @ {bytes_per_sec:>12}";
-        let style = ProgressStyle::default_bar()
+        ProgressStyle::with_template("{msg:.green.bold} {spinner} {percent:>3}% [{bar:20}] {bytes:>10} @ {bytes_per_sec:>12} (took {elapsed})")
+            .expect("Error in progress bar creation. This is a bug, please report it.")
             .tick_chars("⠁⠁⠉⠙⠚⠒⠂⠂⠒⠲⠴⠤⠄⠄⠤⠠⠠⠤⠦⠖⠒⠐⠐⠒⠓⠋⠉⠈⠈✔")
             .progress_chars("##")
-            .template(msg_template)
-            .expect("Error in progress bar creation. This is a bug, please report it.");
-        style
     }
 
     pub fn add(&mut self, bar: ProgressBar) {
@@ -215,7 +216,7 @@ impl ProgressBarGroup {
         } else {
             bar.set_message(self.message.clone());
         }
-        bar.set_style(Self::active());
+        bar.set_style(Self::idle());
         bar.enable_steady_tick(Duration::from_millis(100));
         bar.reset_elapsed();
 
@@ -230,8 +231,7 @@ impl ProgressBarGroup {
 
     pub fn inc(&mut self, size: u64) {
         if let Some(bar) = self.bars.get(self.selected) {
-            let style = bar.style().progress_chars("##-");
-            bar.set_style(style);
+            bar.set_style(Self::active());
             bar.inc(size);
         }
     }


### PR DESCRIPTION
Before:

```
     Running `target\debug\probe-rs.exe run C:\_Hobby\rpi-smoke-tester-setup\embedded-test\esp-hal\output\esp32s2`
      Erasing ✔ [00:00:01] [########################################] 192.00 KiB/192.00 KiB @ 189.88 KiB/s (eta 0s )
  Programming ✔ [00:00:02] [############################################] 27.95 KiB/27.95 KiB @ 9.52 KiB/s (eta 0s )
    Finished in 2.9602304s
```

After:

```
     Running `target\debug\probe-rs.exe run C:\_Hobby\rpi-smoke-tester-setup\embedded-test\esp-hal\output\esp32s2`
      Erasing ✔ [00:00:01] [###################################] 192.00 KiB/192.00 KiB @ 189.35 KiB/s (ETA 00:00:00)
  Programming ✔ [00:00:02] [###################################]  27.95 KiB/ 27.95 KiB @   9.53 KiB/s (ETA 00:00:00)
     Finished in 2.96s
```

- Changed the display format of ETA, and Finished
- Aligned Finished with the other labels
- Widened the current/total bytes and throughput fields

Closes #2736