### PR TITLE
probe-rs: add initial support for black magic probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,10 +601,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
+name = "core-foundation"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
@@ -2072,7 +2082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d8beeee5c0ad012e1eaca540f5610d09a3af58ec435537d511b67e0be36ea66"
 dependencies = [
  "atomic-waker",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-foundation-sys",
  "io-kit-sys",
  "log",
@@ -2990,7 +3000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3119,12 +3129,13 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241ebb629ed9bf598b2b392ba42aa429f9ef2a0099001246a36ac4c084ee183f"
+checksum = "7331eefcaafaa382c0df95bcd84068f0b3e3c215c300750dde2316e9b8806ed5"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "io-kit-sys",
  "mach2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,16 +1758,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libudev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
-dependencies = [
- "libc",
- "libudev-sys",
-]
-
-[[package]]
 name = "libudev-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3137,7 +3127,6 @@ dependencies = [
  "cfg-if",
  "core-foundation-sys",
  "io-kit-sys",
- "libudev",
  "mach2",
  "nix 0.26.4",
  "scopeguard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,6 +1758,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libudev"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
+dependencies = [
+ "libc",
+ "libudev-sys",
+]
+
+[[package]]
 name = "libudev-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +1989,17 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2337,6 +2358,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serialport",
  "svg",
  "termtree",
  "test-case",
@@ -3106,6 +3128,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serialport"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241ebb629ed9bf598b2b392ba42aa429f9ef2a0099001246a36ac4c084ee183f"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "core-foundation-sys",
+ "io-kit-sys",
+ "libudev",
+ "mach2",
+ "nix 0.26.4",
+ "scopeguard",
+ "unescaper",
+ "winapi",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3837,6 +3877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "unescaper"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c878a167baa8afd137494101a688ef8c67125089ff2249284bd2b5f9bfedb815"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]

--- a/changelog/added-black-magic-probe-support.md
+++ b/changelog/added-black-magic-probe-support.md
@@ -1,0 +1,1 @@
+Added initial support for the Black Magic Probe in bit-bang mode.

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -62,8 +62,8 @@ nusb = "0.1.9"
 futures-lite = { version = "2", default-features = false }
 async-io = "2"
 scroll = "0.12"
+serialport = { version = "4.5.0", default-features = false, features = ["usbportinfo-interface"] }
 svg = "0.18"
-serialport = { version = "4.5.0", features = ["usbportinfo-interface"] }
 tracing = "0.1"
 uf2-decode = "0.2"
 espflash = { version = "3", default-features = false }

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -63,6 +63,7 @@ futures-lite = { version = "2", default-features = false }
 async-io = "2"
 scroll = "0.12"
 svg = "0.18"
+serialport = { version = "4.5.0", features = ["usbportinfo-interface"] }
 tracing = "0.1"
 uf2-decode = "0.2"
 espflash = { version = "3", default-features = false }

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -62,7 +62,7 @@ nusb = "0.1.9"
 futures-lite = { version = "2", default-features = false }
 async-io = "2"
 scroll = "0.12"
-serialport = { version = "4.5.0", default-features = false, features = ["usbportinfo-interface"] }
+serialport = { version = "4.6.0", default-features = false, features = ["usbportinfo-interface"] }
 svg = "0.18"
 tracing = "0.1"
 uf2-decode = "0.2"

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -3,6 +3,7 @@ pub(crate) mod arm_debug_interface;
 pub(crate) mod common;
 pub(crate) mod usb_util;
 
+pub mod blackmagic;
 pub mod cmsisdap;
 pub mod espusbjtag;
 pub mod fake_probe;

--- a/probe-rs/src/probe/blackmagic/arm.rs
+++ b/probe-rs/src/probe/blackmagic/arm.rs
@@ -353,19 +353,19 @@ impl ArmProbeInterface for BlackMagicProbeArmDebug {
 }
 
 impl SwoAccess for BlackMagicProbeArmDebug {
-    fn enable_swo(&mut self, config: &crate::architecture::arm::SwoConfig) -> Result<(), ArmError> {
-        println!("Enabling SWO: {:?}", config);
-        unimplemented!()
+    fn enable_swo(
+        &mut self,
+        _config: &crate::architecture::arm::SwoConfig,
+    ) -> Result<(), ArmError> {
+        Err(ArmError::NotImplemented("swo not implemented"))
     }
 
     fn disable_swo(&mut self) -> Result<(), ArmError> {
-        println!("Disabling SWO");
-        unimplemented!()
+        Err(ArmError::NotImplemented("swo not implemented"))
     }
 
-    fn read_swo_timeout(&mut self, timeout: std::time::Duration) -> Result<Vec<u8>, ArmError> {
-        println!("Setting read swo timeout: {:?}", timeout);
-        unimplemented!()
+    fn read_swo_timeout(&mut self, _timeout: std::time::Duration) -> Result<Vec<u8>, ArmError> {
+        Err(ArmError::NotImplemented("swo not implemented"))
     }
 }
 

--- a/probe-rs/src/probe/blackmagic/arm.rs
+++ b/probe-rs/src/probe/blackmagic/arm.rs
@@ -16,7 +16,7 @@ use crate::{Error as ProbeRsError, MemoryInterface};
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[derive(Debug)]
 pub(crate) struct UninitializedBlackMagicArmProbe {
@@ -774,19 +774,19 @@ impl MemoryInterface<ArmError> for BlackMagicProbeMemoryInterface<'_> {
     }
 
     fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), ArmError> {
-        self.read(address, data.as_bytes_mut())
+        self.read(address, data.as_mut_bytes())
     }
 
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), ArmError> {
-        self.read(address, data.as_bytes_mut())
+        self.read(address, data.as_mut_bytes())
     }
 
     fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), ArmError> {
-        self.read(address, data.as_bytes_mut())
+        self.read(address, data.as_mut_bytes())
     }
 
     fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), ArmError> {
-        self.read(address, data.as_bytes_mut())
+        self.read(address, data.as_mut_bytes())
     }
 
     fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), ArmError> {

--- a/probe-rs/src/probe/blackmagic/arm.rs
+++ b/probe-rs/src/probe/blackmagic/arm.rs
@@ -1,0 +1,840 @@
+use crate::architecture::arm::ap::memory_ap::registers::{AddressIncrement, CSW};
+use crate::architecture::arm::ap::memory_ap::{DataSize, MemoryAp, MemoryApType};
+use crate::architecture::arm::ap::valid_access_ports;
+use crate::architecture::arm::communication_interface::SwdSequence;
+use crate::architecture::arm::dp::{Abort, Ctrl, DebugPortError, DpAccess, Select};
+use crate::architecture::arm::memory::{ArmMemoryInterface, Component};
+use crate::architecture::arm::{
+    communication_interface::UninitializedArmProbe, sequences::ArmDebugSequence, ArmProbeInterface,
+};
+use crate::architecture::arm::{
+    ArmChipInfo, ArmError, DapAccess, DpAddress, FullyQualifiedApAddress, RawDapAccess, SwoAccess,
+};
+use crate::probe::blackmagic::{BlackMagicProbe, ProtocolVersion, RemoteCommand};
+use crate::probe::{DebugProbeError, Probe};
+use crate::{Error as ProbeRsError, MemoryInterface};
+use std::collections::BTreeSet;
+use std::io::{Read, Write};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use zerocopy::AsBytes;
+
+#[derive(Debug)]
+pub(crate) struct UninitializedBlackMagicArmProbe<R: Read, W: Write> {
+    probe: Box<BlackMagicProbe<R, W>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct BlackMagicProbeArmDebug<R: Read, W: Write> {
+    probe: Box<BlackMagicProbe<R, W>>,
+
+    /// Information about the APs of the target.
+    /// APs are identified by a number, starting from zero.
+    pub access_ports: BTreeSet<FullyQualifiedApAddress>,
+}
+
+#[derive(Debug)]
+pub(crate) struct BlackMagicProbeMemoryInterface<'probe, R: Read, W: Write> {
+    probe: &'probe mut BlackMagicProbeArmDebug<R, W>,
+    current_ap: MemoryAp,
+    index: u8,
+    apsel: u8,
+    csw: u32,
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    UninitializedBlackMagicArmProbe<R, W>
+{
+    pub fn new(probe: Box<BlackMagicProbe<R, W>>) -> Self {
+        Self { probe }
+    }
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    UninitializedArmProbe for UninitializedBlackMagicArmProbe<R, W>
+{
+    #[tracing::instrument(level = "trace", skip(self, sequence))]
+    fn initialize(
+        mut self: Box<Self>,
+        sequence: Arc<dyn ArmDebugSequence>,
+        dp: DpAddress,
+    ) -> Result<Box<dyn ArmProbeInterface>, (Box<dyn UninitializedArmProbe>, ProbeRsError)> {
+        // Switch to the correct mode
+        if let Err(e) = sequence.debug_port_setup(&mut *self.probe, dp) {
+            return Err((self, e.into()));
+        }
+
+        if let Err(e) = sequence.debug_port_connect(&mut *self.probe, dp) {
+            tracing::warn!("failed to switch to DP {:x?}: {}", dp, e);
+
+            // Try the more involved debug_port_setup sequence, which also handles dormant mode.
+            if let Err(e) = sequence.debug_port_setup(&mut *self.probe, dp) {
+                return Err((self, ProbeRsError::Arm(e)));
+            }
+        }
+
+        let interface = BlackMagicProbeArmDebug::new(self.probe, dp)
+            .map_err(|(s, e)| (s as Box<_>, ProbeRsError::from(e)))?;
+
+        Ok(Box::new(interface))
+    }
+
+    fn close(self: Box<Self>) -> Probe {
+        Probe::from_attached_probe(self.probe)
+    }
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    SwdSequence for UninitializedBlackMagicArmProbe<R, W>
+{
+    fn swj_sequence(
+        &mut self,
+        bit_len: u8,
+        bits: u64,
+    ) -> Result<(), crate::probe::DebugProbeError> {
+        self.probe.swj_sequence(bit_len, bits)
+    }
+
+    fn swj_pins(
+        &mut self,
+        pin_out: u32,
+        pin_select: u32,
+        pin_wait: u32,
+    ) -> Result<u32, crate::probe::DebugProbeError> {
+        self.probe.swj_pins(pin_out, pin_select, pin_wait)
+    }
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    BlackMagicProbeArmDebug<R, W>
+{
+    fn new(
+        probe: Box<BlackMagicProbe<R, W>>,
+        dp: DpAddress,
+    ) -> Result<Self, (Box<UninitializedBlackMagicArmProbe<R, W>>, ArmError)> {
+        let mut interface = Self {
+            probe,
+            access_ports: BTreeSet::new(),
+        };
+
+        interface.debug_port_start(dp).unwrap();
+
+        interface.access_ports = valid_access_ports(&mut interface, DpAddress::Default)
+            .into_iter()
+            .collect();
+        interface.access_ports.iter().for_each(|addr| {
+            tracing::debug!("AP {:#x?}", addr);
+        });
+        Ok(interface)
+    }
+
+    /// Connect to the target debug port and power it up. This is based on the
+    /// `DebugPortStart` function from the [ARM SVD Debug Description].
+    ///
+    /// [ARM SVD Debug Description]: https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/debug_description.html#debugPortStart
+    fn debug_port_start(&mut self, dp: DpAddress) -> Result<(), ArmError> {
+        // Clear all errors.
+        // CMSIS says this is only necessary to do inside the `if powered_down`, but
+        // without it here, nRF52840 faults in the next access.
+        let mut abort = Abort(0);
+        abort.set_dapabort(true);
+        abort.set_orunerrclr(true);
+        abort.set_wderrclr(true);
+        abort.set_stkerrclr(true);
+        abort.set_stkcmpclr(true);
+        self.write_dp_register(dp, abort)?;
+
+        self.write_dp_register(dp, Select(0))?;
+
+        let ctrl = self.read_dp_register::<Ctrl>(dp)?;
+
+        let powered_down = !(ctrl.csyspwrupack() && ctrl.cdbgpwrupack());
+
+        if powered_down {
+            let mut ctrl = Ctrl(0);
+            ctrl.set_cdbgpwrupreq(true);
+            ctrl.set_csyspwrupreq(true);
+            self.write_dp_register(dp, ctrl.clone())?;
+
+            let start = Instant::now();
+            loop {
+                let ctrl = self.read_dp_register::<Ctrl>(dp)?;
+                if ctrl.csyspwrupack() && ctrl.cdbgpwrupack() {
+                    break;
+                }
+                if start.elapsed() >= Duration::from_secs(1) {
+                    return Err(ArmError::Timeout);
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+
+            // TODO: Handle JTAG Specific part
+
+            // TODO: Only run the following code when the SWD protocol is used
+
+            // Init AP Transfer Mode, Transaction Counter, and Lane Mask (Normal Transfer Mode, Include all Byte Lanes)
+            let mut ctrl = Ctrl(0);
+            ctrl.set_cdbgpwrupreq(true);
+            ctrl.set_csyspwrupreq(true);
+            ctrl.set_mask_lane(0b1111);
+            self.write_dp_register(dp, ctrl)?;
+
+            let ctrl_reg: Ctrl = self.read_dp_register(dp)?;
+            if !(ctrl_reg.csyspwrupack() && ctrl_reg.cdbgpwrupack()) {
+                tracing::error!("debug power-up request failed");
+                return Err(DebugPortError::TargetPowerUpFailed.into());
+            }
+
+            // According to CMSIS docs, here's where we would clear errors
+            // in ABORT, but we do that above instead.
+        }
+        Ok(())
+    }
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    ArmProbeInterface for BlackMagicProbeArmDebug<R, W>
+{
+    fn access_ports(
+        &mut self,
+        dp: DpAddress,
+    ) -> Result<BTreeSet<FullyQualifiedApAddress>, ArmError> {
+        if dp != DpAddress::Default {
+            return Err(ArmError::NotImplemented("multidrop not yet implemented"));
+        }
+
+        Ok(self.access_ports.clone())
+    }
+
+    fn close(self: Box<Self>) -> Probe {
+        Probe::from_attached_probe(self.probe)
+    }
+
+    fn current_debug_port(&self) -> DpAddress {
+        todo!()
+    }
+
+    fn memory_interface(
+        &mut self,
+        access_port: &FullyQualifiedApAddress,
+    ) -> Result<Box<dyn crate::architecture::arm::memory::ArmMemoryInterface + '_>, ArmError> {
+        let mut current_ap = MemoryAp::new(self, access_port)?;
+
+        // Construct a CSW to pass to the AP when accessing memory.
+        let csw: CSW = match &mut current_ap {
+            MemoryAp::AmbaAhb3(ap) => {
+                let mut csw = ap.status(self)?;
+
+                csw.DbgSwEnable = true;
+                csw.AddrInc = AddressIncrement::Off;
+                csw.Size = DataSize::U8;
+
+                csw.MasterType = true;
+                csw.Privileged = true;
+                csw.Data = true;
+
+                csw.Allocate = false;
+                csw.Cacheable = false;
+                csw.Bufferable = false;
+
+                // Enable secure access if it's allowed
+                csw.HNONSEC = !csw.SPIDEN;
+
+                CSW::try_from(Into::<u32>::into(csw))?
+            }
+            MemoryAp::AmbaAhb5(ap) => {
+                let mut csw = ap.status(self)?;
+
+                csw.DbgSwEnable = true;
+                csw.AddrInc = AddressIncrement::Off;
+                csw.Size = DataSize::U8;
+
+                csw.MasterType = true;
+                csw.Data = true;
+                csw.Privileged = true;
+
+                // Enable secure access if it's allowed
+                csw.HNONSEC = !csw.SPIDEN;
+
+                CSW::try_from(Into::<u32>::into(csw))?
+            }
+            MemoryAp::AmbaAhb5Hprot(ap) => {
+                let mut csw = ap.status(self)?;
+
+                csw.DbgSwEnable = true;
+                csw.AddrInc = AddressIncrement::Off;
+                csw.Size = DataSize::U8;
+
+                csw.MasterType = true;
+                csw.Data = true;
+                csw.Privileged = true;
+
+                // Enable secure access if it's allowed
+                csw.HNONSEC = !csw.SPIDEN;
+
+                CSW::try_from(Into::<u32>::into(csw))?
+            }
+            MemoryAp::AmbaApb2Apb3(ap) => {
+                let mut csw = ap.status(self)?;
+
+                csw.DbgSwEnable = true;
+                csw.AddrInc = AddressIncrement::Off;
+                csw.Size = DataSize::U8;
+
+                CSW::try_from(Into::<u32>::into(csw))?
+            }
+            MemoryAp::AmbaApb4Apb5(ap) => {
+                let mut csw = ap.status(self)?;
+
+                csw.DbgSwEnable = true;
+                csw.AddrInc = AddressIncrement::Off;
+                csw.Size = DataSize::U8;
+
+                // Enable secure access if it's allowed
+                csw.NonSecure = !csw.SPIDEN;
+                csw.Privileged = true;
+
+                CSW::try_from(Into::<u32>::into(csw))?
+            }
+            MemoryAp::AmbaAxi3Axi4(ap) => {
+                let mut csw = ap.status(self)?;
+
+                csw.DbgSwEnable = true;
+                csw.AddrInc = AddressIncrement::Off;
+                csw.Size = DataSize::U8;
+
+                csw.Instruction = false;
+                // Enable secure access if it's allowed
+                csw.NonSecure = !csw.SPIDEN;
+                csw.Privileged = true;
+                csw.CACHE = 0;
+
+                CSW::try_from(Into::<u32>::into(csw))?
+            }
+            MemoryAp::AmbaAxi5(ap) => {
+                let mut csw = ap.status(self)?;
+
+                csw.DbgSwEnable = true;
+                csw.AddrInc = AddressIncrement::Off;
+                csw.Size = DataSize::U8;
+
+                csw.Instruction = false;
+                // Enable secure access if it's allowed
+                csw.NonSecure = !csw.SPIDEN;
+                csw.Privileged = true;
+                csw.CACHE = 0;
+                csw.MTE = false;
+
+                CSW::try_from(Into::<u32>::into(csw))?
+            }
+        };
+
+        Ok(Box::new(BlackMagicProbeMemoryInterface {
+            probe: self,
+            current_ap,
+            index: 0,
+            apsel: 0,
+            csw: csw.into(),
+        }) as _)
+    }
+
+    fn read_chip_info_from_rom_table(
+        &mut self,
+        dp: DpAddress,
+    ) -> Result<Option<crate::architecture::arm::ArmChipInfo>, ArmError> {
+        if dp != DpAddress::Default {
+            return Err(ArmError::NotImplemented("multidrop not yet implemented"));
+        }
+
+        for ap in self.access_ports.clone() {
+            if let Ok(mut memory) = self.memory_interface(&ap) {
+                let base_address = memory.base_address()?;
+                let component = Component::try_parse(&mut *memory, base_address)?;
+
+                if let Component::Class1RomTable(component_id, _) = component {
+                    if let Some(jep106) = component_id.peripheral_id().jep106() {
+                        return Ok(Some(ArmChipInfo {
+                            manufacturer: jep106,
+                            part: component_id.peripheral_id().part(),
+                        }));
+                    }
+                }
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    SwoAccess for BlackMagicProbeArmDebug<R, W>
+{
+    fn enable_swo(&mut self, config: &crate::architecture::arm::SwoConfig) -> Result<(), ArmError> {
+        println!("Enabling SWO: {:?}", config);
+        unimplemented!()
+    }
+
+    fn disable_swo(&mut self) -> Result<(), ArmError> {
+        println!("Disabling SWO");
+        unimplemented!()
+    }
+
+    fn read_swo_timeout(&mut self, timeout: std::time::Duration) -> Result<Vec<u8>, ArmError> {
+        println!("Setting read swo timeout: {:?}", timeout);
+        unimplemented!()
+    }
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    SwdSequence for BlackMagicProbeArmDebug<R, W>
+{
+    fn swj_sequence(
+        &mut self,
+        bit_len: u8,
+        bits: u64,
+    ) -> Result<(), crate::probe::DebugProbeError> {
+        self.probe.swj_sequence(bit_len, bits)
+    }
+
+    fn swj_pins(
+        &mut self,
+        pin_out: u32,
+        pin_select: u32,
+        pin_wait: u32,
+    ) -> Result<u32, crate::probe::DebugProbeError> {
+        self.probe.swj_pins(pin_out, pin_select, pin_wait)
+    }
+}
+
+fn dp_to_bmp(dp: DpAddress) -> Result<u8, ArmError> {
+    match dp {
+        DpAddress::Default => Ok(0),
+        DpAddress::Multidrop(val) => val
+            .try_into()
+            .map_err(|_| ArmError::NotImplemented("multidrop value is out of range")),
+    }
+}
+
+fn ap_to_bmp(ap: &FullyQualifiedApAddress) -> Result<(u8, u8), ArmError> {
+    let apsel = match ap.ap() {
+        crate::architecture::arm::ApAddress::V1(val) => *val,
+        crate::architecture::arm::ApAddress::V2(_) => {
+            return Err(ArmError::NotImplemented(
+                "AP address v2 currently unsupported",
+            ))
+        }
+    };
+    Ok((dp_to_bmp(ap.dp())?, apsel))
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    DapAccess for BlackMagicProbeArmDebug<R, W>
+{
+    fn read_raw_dp_register(&mut self, dp: DpAddress, addr: u8) -> Result<u32, ArmError> {
+        let index = dp_to_bmp(dp)?;
+        let command = match self.probe.remote_protocol {
+            ProtocolVersion::V0 => {
+                return Err(ArmError::Probe(
+                    DebugProbeError::CommandNotSupportedByProbe {
+                        command_name: "adiv5 raw dp read",
+                    },
+                ));
+            }
+            ProtocolVersion::V0P => RemoteCommand::ReadDpV0P { addr },
+            ProtocolVersion::V1 | ProtocolVersion::V2 => RemoteCommand::ReadDpV1 { index, addr },
+            ProtocolVersion::V3 | ProtocolVersion::V4 => RemoteCommand::ReadDpV3 { index, addr },
+        };
+        Ok(u32::from_be(
+            TryInto::<u32>::try_into(
+                self.probe
+                    .command(command)
+                    .map_err(|e| ArmError::Probe(e.into()))?
+                    .0,
+            )
+            .unwrap(),
+        ))
+    }
+
+    fn write_raw_dp_register(
+        &mut self,
+        dp: DpAddress,
+        addr: u8,
+        value: u32,
+    ) -> Result<(), ArmError> {
+        let index = dp_to_bmp(dp)?;
+        let command = match self.probe.remote_protocol {
+            ProtocolVersion::V0 => {
+                return Err(ArmError::Probe(
+                    DebugProbeError::CommandNotSupportedByProbe {
+                        command_name: "adiv5 raw dp write",
+                    },
+                ));
+            }
+            ProtocolVersion::V0P => RemoteCommand::RawAccessV0P {
+                rnw: 0,
+                addr,
+                value,
+            },
+            ProtocolVersion::V1 | ProtocolVersion::V2 => RemoteCommand::RawAccessV1 {
+                index,
+                rnw: 0,
+                addr,
+                value,
+            },
+            ProtocolVersion::V3 | ProtocolVersion::V4 => RemoteCommand::RawAccessV3 {
+                index,
+                rnw: 0,
+                addr,
+                value,
+            },
+        };
+        let result = self
+            .probe
+            .command(command)
+            .map_err(|e| ArmError::Probe(e.into()))?
+            .0;
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(ArmError::Probe(DebugProbeError::Other(format!(
+                "probe returned unexpected result: {}",
+                result
+            ))))
+        }
+    }
+
+    fn read_raw_ap_register(
+        &mut self,
+        ap: &FullyQualifiedApAddress,
+        addr: u8,
+    ) -> Result<u32, ArmError> {
+        let (index, apsel) = ap_to_bmp(ap)?;
+
+        let command = match self.probe.remote_protocol {
+            ProtocolVersion::V0 => {
+                return Err(ArmError::Probe(
+                    DebugProbeError::CommandNotSupportedByProbe {
+                        command_name: "adiv5 raw ap read",
+                    },
+                ));
+            }
+            ProtocolVersion::V0P => RemoteCommand::ReadApV0P { apsel, addr },
+            ProtocolVersion::V1 | ProtocolVersion::V2 => {
+                RemoteCommand::ReadApV1 { index, apsel, addr }
+            }
+            ProtocolVersion::V3 | ProtocolVersion::V4 => {
+                RemoteCommand::ReadApV3 { index, apsel, addr }
+            }
+        };
+        let result = u32::from_be(
+            TryInto::<u32>::try_into(
+                self.probe
+                    .command(command)
+                    .map_err(|e| ArmError::Probe(e.into()))?
+                    .0,
+            )
+            .unwrap(),
+        );
+        Ok(result)
+    }
+
+    fn write_raw_ap_register(
+        &mut self,
+        ap: &FullyQualifiedApAddress,
+        addr: u8,
+        value: u32,
+    ) -> Result<(), ArmError> {
+        let (index, apsel) = ap_to_bmp(ap)?;
+        let command = match self.probe.remote_protocol {
+            ProtocolVersion::V0 => {
+                return Err(ArmError::Probe(
+                    DebugProbeError::CommandNotSupportedByProbe {
+                        command_name: "adiv5 raw ap write",
+                    },
+                ));
+            }
+            ProtocolVersion::V0P => RemoteCommand::WriteApV0P { apsel, addr, value },
+            ProtocolVersion::V1 | ProtocolVersion::V2 => RemoteCommand::WriteApV1 {
+                index,
+                apsel,
+                addr,
+                value,
+            },
+            ProtocolVersion::V3 | ProtocolVersion::V4 => RemoteCommand::WriteApV3 {
+                index,
+                apsel,
+                addr,
+                value,
+            },
+        };
+
+        let result = self
+            .probe
+            .command(command)
+            .map_err(|e| ArmError::Probe(e.into()))?
+            .0;
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(ArmError::Probe(DebugProbeError::Other(format!(
+                "probe returned unexpected result: {}",
+                result
+            ))))
+        }
+    }
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    ArmMemoryInterface for BlackMagicProbeMemoryInterface<'_, R, W>
+{
+    fn ap(&mut self) -> &mut MemoryAp {
+        &mut self.current_ap
+    }
+
+    fn base_address(&mut self) -> Result<u64, ArmError> {
+        self.current_ap.base_address(self.probe)
+    }
+
+    fn get_arm_communication_interface(
+        &mut self,
+    ) -> Result<
+        &mut crate::architecture::arm::ArmCommunicationInterface<
+            crate::architecture::arm::communication_interface::Initialized,
+        >,
+        crate::probe::DebugProbeError,
+    > {
+        Err(DebugProbeError::InterfaceNotAvailable {
+            interface_name: "ARM",
+        })
+    }
+
+    fn try_as_parts(
+        &mut self,
+    ) -> Result<
+        (
+            &mut crate::architecture::arm::ArmCommunicationInterface<
+                crate::architecture::arm::communication_interface::Initialized,
+            >,
+            &mut MemoryAp,
+        ),
+        crate::probe::DebugProbeError,
+    > {
+        Err(DebugProbeError::InterfaceNotAvailable {
+            interface_name: "ARM",
+        })
+    }
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    SwdSequence for BlackMagicProbeMemoryInterface<'_, R, W>
+{
+    fn swj_sequence(
+        &mut self,
+        bit_len: u8,
+        bits: u64,
+    ) -> Result<(), crate::probe::DebugProbeError> {
+        self.probe.swj_sequence(bit_len, bits)
+    }
+
+    fn swj_pins(
+        &mut self,
+        pin_out: u32,
+        pin_select: u32,
+        pin_wait: u32,
+    ) -> Result<u32, crate::probe::DebugProbeError> {
+        self.probe.swj_pins(pin_out, pin_select, pin_wait)
+    }
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    BlackMagicProbeMemoryInterface<'_, R, W>
+{
+    fn read_slice(&mut self, offset: u64, data: &mut [u8]) -> Result<(), ArmError> {
+        // Leave enough room for '&K' plus '#' plus an optional NULL.
+        if data.len() * 2 + 4 >= super::BLACK_MAGIC_REMOTE_SIZE_MAX {
+            return Err(ArmError::OutOfBounds);
+        }
+        let command = match self.probe.probe.remote_protocol {
+            ProtocolVersion::V0 => {
+                return Err(ArmError::Probe(
+                    DebugProbeError::CommandNotSupportedByProbe {
+                        command_name: "adiv5 memory read",
+                    },
+                ));
+            }
+            ProtocolVersion::V0P => RemoteCommand::MemReadV0P {
+                apsel: self.apsel,
+                csw: self.csw,
+                offset: offset
+                    .try_into()
+                    .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
+                data,
+            },
+            ProtocolVersion::V1 | ProtocolVersion::V2 => RemoteCommand::MemReadV1 {
+                index: self.index,
+                apsel: self.apsel,
+                csw: self.csw,
+                offset: offset
+                    .try_into()
+                    .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
+                data,
+            },
+            ProtocolVersion::V3 => RemoteCommand::MemReadV3 {
+                index: self.index,
+                apsel: self.apsel,
+                csw: self.csw,
+                offset: offset
+                    .try_into()
+                    .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
+                data,
+            },
+            ProtocolVersion::V4 => RemoteCommand::MemReadV4 {
+                index: self.index,
+                apsel: self.apsel,
+                csw: self.csw,
+                offset,
+                data,
+            },
+        };
+        self.probe
+            .probe
+            .command(command)
+            .map_err(|e| ArmError::Probe(e.into()))?;
+        Ok(())
+    }
+
+    fn read(&mut self, offset: u64, data: &mut [u8]) -> Result<(), ArmError> {
+        let chunk_size = super::BLACK_MAGIC_REMOTE_SIZE_MAX / 2 - 8;
+        for (chunk_index, chunk) in data.chunks_mut(chunk_size).enumerate() {
+            self.read_slice(chunk_index as u64 * chunk_size as u64 + offset, chunk)?;
+        }
+        Ok(())
+    }
+
+    fn write_slice(&mut self, align: u8, offset: u64, data: &[u8]) -> Result<(), ArmError> {
+        // Leave enough room for the memory message overhead
+        if data.len() * 2 + 40 >= super::BLACK_MAGIC_REMOTE_SIZE_MAX {
+            return Err(ArmError::OutOfBounds);
+        }
+        let command = match self.probe.probe.remote_protocol {
+            ProtocolVersion::V0 => {
+                return Err(ArmError::Probe(
+                    DebugProbeError::CommandNotSupportedByProbe {
+                        command_name: "adiv5 memory write",
+                    },
+                ));
+            }
+            ProtocolVersion::V0P => RemoteCommand::MemWriteV0P {
+                apsel: self.apsel,
+                csw: self.csw,
+                align,
+                offset: offset
+                    .try_into()
+                    .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
+                data,
+            },
+            ProtocolVersion::V1 | ProtocolVersion::V2 => RemoteCommand::MemWriteV1 {
+                index: self.index,
+                apsel: self.apsel,
+                csw: self.csw,
+                align,
+                offset: offset
+                    .try_into()
+                    .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
+                data,
+            },
+            ProtocolVersion::V3 => RemoteCommand::MemWriteV3 {
+                index: self.index,
+                apsel: self.apsel,
+                csw: self.csw,
+                align,
+                offset: offset
+                    .try_into()
+                    .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
+                data,
+            },
+            ProtocolVersion::V4 => RemoteCommand::MemWriteV4 {
+                index: self.index,
+                apsel: self.apsel,
+                csw: self.csw,
+                align,
+                offset,
+                data,
+            },
+        };
+        let result = self
+            .probe
+            .probe
+            .command(command)
+            .map_err(|e| ArmError::Probe(e.into()))?
+            .0;
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(ArmError::Probe(DebugProbeError::Other(format!(
+                "probe returned unexpected result: {}",
+                result
+            ))))
+        }
+    }
+
+    fn write(&mut self, align: u8, offset: u64, data: &[u8]) -> Result<(), ArmError> {
+        let chunk_size = super::BLACK_MAGIC_REMOTE_SIZE_MAX / 2 - 40;
+        for (chunk_index, chunk) in data.chunks(chunk_size).enumerate() {
+            self.write_slice(
+                align,
+                chunk_index as u64 * chunk_size as u64 + offset,
+                chunk,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    MemoryInterface<ArmError> for BlackMagicProbeMemoryInterface<'_, R, W>
+{
+    fn supports_native_64bit_access(&mut self) -> bool {
+        self.probe.probe.remote_protocol == ProtocolVersion::V4
+    }
+
+    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), ArmError> {
+        self.read(address, data.as_bytes_mut())
+    }
+
+    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), ArmError> {
+        self.read(address, data.as_bytes_mut())
+    }
+
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), ArmError> {
+        self.read(address, data.as_bytes_mut())
+    }
+
+    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), ArmError> {
+        self.read(address, data.as_bytes_mut())
+    }
+
+    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), ArmError> {
+        self.write(3, address, data.as_bytes())
+    }
+
+    fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), ArmError> {
+        self.write(2, address, data.as_bytes())
+    }
+
+    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), ArmError> {
+        self.write(1, address, data.as_bytes())
+    }
+
+    fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), ArmError> {
+        self.write(0, address, data.as_bytes())
+    }
+
+    fn supports_8bit_transfers(&self) -> Result<bool, ArmError> {
+        Ok(true)
+    }
+
+    fn flush(&mut self) -> Result<(), ArmError> {
+        Ok(())
+    }
+}

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -276,22 +276,25 @@ impl<'a> RemoteCommand<'a> {
     }
 }
 
+// Implement `ToString` instead of `Display` as this is for generating
+// strings to send over the network, and is not meant for human consumption.
+#[allow(clippy::to_string_trait_impl)]
 impl<'a> std::string::ToString for RemoteCommand<'a> {
     fn to_string(&self) -> String {
         match self {
-            RemoteCommand::Handshake(_) => format!("+#!GA#"),
-            RemoteCommand::GetVoltage => format!(" !GV#"),
-            RemoteCommand::GetSpeedKhz => format!("!Gf#"),
+            RemoteCommand::Handshake(_) => "+#!GA#".to_string(),
+            RemoteCommand::GetVoltage => " !GV#".to_string(),
+            RemoteCommand::GetSpeedKhz => "!Gf#".to_string(),
             RemoteCommand::SetSpeedKhz(speed) => {
                 format!("!GF{:08x}#", speed)
             }
-            RemoteCommand::HighLevelCheck => format!("!HC#"),
+            RemoteCommand::HighLevelCheck => "!HC#".to_string(),
             RemoteCommand::SetNrst(set) => format!("!GZ{}#", if *set { '1' } else { '0' }),
             RemoteCommand::SetPower(set) => format!("!GP{}#", if *set { '1' } else { '0' }),
             RemoteCommand::TargetClockOutput { enable } => {
                 format!("!GE{}#", if *enable { '1' } else { '0' })
             }
-            RemoteCommand::SpeedKhz => format!("!Gf#"),
+            RemoteCommand::SpeedKhz => "!Gf#".to_string(),
             RemoteCommand::RawAccessV0P { rnw, addr, value } => {
                 format!("!HL{:02x}{:04x}{:08x}#", rnw, addr, value)
             }
@@ -509,8 +512,8 @@ impl<'a> std::string::ToString for RemoteCommand<'a> {
                 if *tms { '1' } else { '0' },
                 if *tdi { '1' } else { '0' }
             ),
-            RemoteCommand::JtagInit => format!("+#!JS#"),
-            RemoteCommand::JtagReset => format!("+#!JR#"),
+            RemoteCommand::JtagInit => "+#!JS#".to_string(),
+            RemoteCommand::JtagReset => "+#!JR#".to_string(),
             RemoteCommand::JtagTms { bits, length } => {
                 format!("!JT{:02x}{:x}#", *length, *bits)
             }
@@ -532,7 +535,7 @@ impl<'a> std::string::ToString for RemoteCommand<'a> {
                 "!HJ{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:08x}#",
                 *index, *dr_prescan, *dr_postscan, *ir_len, *ir_prescan, *ir_postscan, *current_ir
             ),
-            RemoteCommand::SwdInit => format!("!SS#"),
+            RemoteCommand::SwdInit => "!SS#".to_string(),
             RemoteCommand::SwdIn { length: bits } => {
                 format!("!Si{:02x}#", *bits)
             }
@@ -548,9 +551,7 @@ impl<'a> std::string::ToString for RemoteCommand<'a> {
             RemoteCommand::TargetReset(reset) => {
                 format!("!GZ{}#", if *reset { '1' } else { '0' })
             }
-            RemoteCommand::GetAccelerators => {
-                format!("!HA#")
-            }
+            RemoteCommand::GetAccelerators => "!HA#".to_string(),
         }
     }
 }
@@ -1441,11 +1442,11 @@ fn black_magic_debug_port_info(
                 u8::from_str_radix(&read_file_to_string(dir, file)?, 16).ok()
             }
 
-            let vid = read_file_to_u16(&usb_device_path, &"idVendor")?;
-            let pid = read_file_to_u16(&usb_device_path, &"idProduct")?;
-            let interface_number = read_file_to_u8(&usb_interface_path, &"bInterfaceNumber");
-            let serial_number = read_file_to_string(&usb_device_path, &"serial");
-            let product_name = read_file_to_string(&usb_device_path, &"product")
+            let vid = read_file_to_u16(usb_device_path, "idVendor")?;
+            let pid = read_file_to_u16(usb_device_path, "idProduct")?;
+            let interface_number = read_file_to_u8(usb_interface_path, "bInterfaceNumber");
+            let serial_number = read_file_to_string(usb_device_path, "serial");
+            let product_name = read_file_to_string(usb_device_path, "product")
                 .unwrap_or_else(|| "Black Magic Probe".to_string());
             (vid, pid, serial_number, interface_number, product_name)
         }

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -275,47 +275,40 @@ impl<'a> RemoteCommand<'a> {
     }
 }
 
-impl<'a> core::fmt::Display for RemoteCommand<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<'a> std::string::ToString for RemoteCommand<'a> {
+    fn to_string(&self) -> String {
         match self {
-            RemoteCommand::Handshake(_) => write!(f, "+#!GA#"),
-            RemoteCommand::GetVoltage => write!(f, " !GV#"),
-            RemoteCommand::GetSpeedKhz => write!(f, "!Gf#"),
+            RemoteCommand::Handshake(_) => format!("+#!GA#"),
+            RemoteCommand::GetVoltage => format!(" !GV#"),
+            RemoteCommand::GetSpeedKhz => format!("!Gf#"),
             RemoteCommand::SetSpeedKhz(speed) => {
-                write!(f, "!GF{:08x}#", speed)
+                format!("!GF{:08x}#", speed)
             }
-            RemoteCommand::HighLevelCheck => write!(f, "!HC#"),
-            RemoteCommand::SetNrst(set) => write!(f, "!GZ{}#", if *set { '1' } else { '0' }),
-            RemoteCommand::SetPower(set) => write!(f, "!GP{}#", if *set { '1' } else { '0' }),
+            RemoteCommand::HighLevelCheck => format!("!HC#"),
+            RemoteCommand::SetNrst(set) => format!("!GZ{}#", if *set { '1' } else { '0' }),
+            RemoteCommand::SetPower(set) => format!("!GP{}#", if *set { '1' } else { '0' }),
             RemoteCommand::TargetClockOutput { enable } => {
-                write!(f, "!GE{}#", if *enable { '1' } else { '0' })
+                format!("!GE{}#", if *enable { '1' } else { '0' })
             }
-            RemoteCommand::SpeedKhz => write!(f, "!Gf#"),
+            RemoteCommand::SpeedKhz => format!("!Gf#"),
             RemoteCommand::RawAccessV0P { rnw, addr, value } => {
-                write!(f, "!HL{:02x}{:04x}{:08x}#", rnw, addr, value)
+                format!("!HL{:02x}{:04x}{:08x}#", rnw, addr, value)
             }
             RemoteCommand::ReadDpV0P { addr } => {
-                write!(f, "!Hdff{:04x}#", addr)
+                format!("!Hdff{:04x}#", addr)
             }
             RemoteCommand::ReadApV0P { apsel, addr } => {
-                write!(f, "!Ha{:02x}{:04x}#", apsel, 0x100 | *addr as u16)
+                format!("!Ha{:02x}{:04x}#", apsel, 0x100 | *addr as u16)
             }
             RemoteCommand::WriteApV0P { apsel, addr, value } => {
-                write!(
-                    f,
-                    "!HA{:02x}{:04x}{:08x}#",
-                    apsel,
-                    0x100 | *addr as u16,
-                    value
-                )
+                format!("!HA{:02x}{:04x}{:08x}#", apsel, 0x100 | *addr as u16, value)
             }
             RemoteCommand::MemReadV0P {
                 apsel,
                 csw,
                 offset,
                 data,
-            } => write!(
-                f,
+            } => format!(
                 "!HM{:02x}{:08x}{:08x}{:08x}#",
                 apsel,
                 csw,
@@ -329,19 +322,19 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                 offset,
                 data,
             } => {
-                write!(
-                    f,
+                let mut s = format!(
                     "!Hm{:02x}{:08x}{:02x}{:08x}{:08x}",
                     apsel,
                     csw,
                     *align as u8,
                     offset,
-                    data.len()
-                )?;
+                    data.len(),
+                );
                 for b in data.iter() {
-                    write!(f, "{:02x}", b)?;
+                    s.push_str(&format!("{:02x}", b));
                 }
-                write!(f, "#")
+                s.push('#');
+                s
             }
 
             RemoteCommand::RawAccessV1 {
@@ -350,27 +343,20 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                 addr,
                 value,
             } => {
-                write!(f, "!HL{:02x}{:02x}{:04x}{:08x}#", index, rnw, addr, value)
+                format!("!HL{:02x}{:02x}{:04x}{:08x}#", index, rnw, addr, value)
             }
             RemoteCommand::ReadDpV1 { index, addr } => {
-                write!(f, "!Hd{:02x}ff{:04x}#", index, addr)
+                format!("!Hd{:02x}ff{:04x}#", index, addr)
             }
             RemoteCommand::ReadApV1 { index, apsel, addr } => {
-                write!(
-                    f,
-                    "!Ha{:02x}{:02x}{:04x}#",
-                    index,
-                    apsel,
-                    0x100 | *addr as u16
-                )
+                format!("!Ha{:02x}{:02x}{:04x}#", index, apsel, 0x100 | *addr as u16)
             }
             RemoteCommand::WriteApV1 {
                 index,
                 apsel,
                 addr,
                 value,
-            } => write!(
-                f,
+            } => format!(
                 "!HA{:02x}{:02x}{:04x}{:08x}#",
                 index,
                 apsel,
@@ -383,8 +369,7 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                 csw,
                 offset,
                 data,
-            } => write!(
-                f,
+            } => format!(
                 "!HM{:02x}{:02x}{:08x}{:08x}{:08x}#",
                 index,
                 apsel,
@@ -400,8 +385,7 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                 offset,
                 data,
             } => {
-                write!(
-                    f,
+                let mut s = format!(
                     "!Hm{:02x}{:02x}{:08x}{:02x}{:08x}{:08x}",
                     index,
                     apsel,
@@ -409,11 +393,12 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                     *align as u8,
                     offset,
                     data.len()
-                )?;
+                );
                 for b in data.iter() {
-                    write!(f, "{:02x}", b)?;
+                    s.push_str(&format!("{:02x}", b));
                 }
-                write!(f, "#")
+                s.push('#');
+                s
             }
 
             RemoteCommand::RawAccessV3 {
@@ -422,27 +407,20 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                 addr,
                 value,
             } => {
-                write!(f, "!AR{:02x}{:02x}{:04x}{:08x}#", index, rnw, addr, value)
+                format!("!AR{:02x}{:02x}{:04x}{:08x}#", index, rnw, addr, value)
             }
             RemoteCommand::ReadDpV3 { index, addr } => {
-                write!(f, "!Ad{:02x}ff{:04x}#", index, addr)
+                format!("!Ad{:02x}ff{:04x}#", index, addr)
             }
             RemoteCommand::ReadApV3 { index, apsel, addr } => {
-                write!(
-                    f,
-                    "!Aa{:02x}{:02x}{:04x}#",
-                    index,
-                    apsel,
-                    0x100 | *addr as u16
-                )
+                format!("!Aa{:02x}{:02x}{:04x}#", index, apsel, 0x100 | *addr as u16)
             }
             RemoteCommand::WriteApV3 {
                 index,
                 apsel,
                 addr,
                 value,
-            } => write!(
-                f,
+            } => format!(
                 "!AA{:02x}{:02x}{:04x}{:08x}#",
                 index,
                 apsel,
@@ -455,8 +433,7 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                 csw,
                 offset,
                 data,
-            } => write!(
-                f,
+            } => format!(
                 "!Am{:02x}{:02x}{:08x}{:08x}{:08x}#",
                 index,
                 apsel,
@@ -472,8 +449,7 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                 offset,
                 data,
             } => {
-                write!(
-                    f,
+                let mut s = format!(
                     "!AM{:02x}{:02x}{:08x}{:02x}{:08x}{:08x}",
                     index,
                     apsel,
@@ -481,11 +457,12 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                     *align as u8,
                     offset,
                     data.len()
-                )?;
+                );
                 for b in data.iter() {
-                    write!(f, "{:02x}", b)?;
+                    s.push_str(&format!("{:02x}", b));
                 }
-                write!(f, "#")
+                s.push('#');
+                s
             }
 
             RemoteCommand::MemReadV4 {
@@ -494,8 +471,7 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                 csw,
                 offset,
                 data,
-            } => write!(
-                f,
+            } => format!(
                 "!Am{:02x}{:02x}{:08x}{:016x}{:08x}#",
                 index,
                 apsel,
@@ -511,8 +487,7 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                 offset,
                 data,
             } => {
-                write!(
-                    f,
+                let mut s = format!(
                     "!AM{:02x}{:02x}{:08x}{:02x}{:016x}{:08x}",
                     index,
                     apsel,
@@ -520,26 +495,25 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                     *align as u8,
                     offset,
                     data.len()
-                )?;
+                );
                 for b in data.iter() {
-                    write!(f, "{:02x}", b)?;
+                    s.push_str(&format!("{:02x}", b));
                 }
-                write!(f, "#")
+                s.push('#');
+                s
             }
 
-            RemoteCommand::JtagNext { tms, tdi } => write!(
-                f,
+            RemoteCommand::JtagNext { tms, tdi } => format!(
                 "!JN{}{}#",
                 if *tms { '1' } else { '0' },
                 if *tdi { '1' } else { '0' }
             ),
-            RemoteCommand::JtagInit => write!(f, "+#!JS#"),
-            RemoteCommand::JtagReset => write!(f, "+#!JR#"),
+            RemoteCommand::JtagInit => format!("+#!JS#"),
+            RemoteCommand::JtagReset => format!("+#!JR#"),
             RemoteCommand::JtagTms { bits, length } => {
-                write!(f, "!JT{:02x}{:x}#", *length, *bits)
+                format!("!JT{:02x}{:x}#", *length, *bits)
             }
-            RemoteCommand::JtagTdi { bits, length, tms } => write!(
-                f,
+            RemoteCommand::JtagTdi { bits, length, tms } => format!(
                 "!J{}{:02x}{:x}#",
                 if *tms { 'D' } else { 'd' },
                 *length,
@@ -553,29 +527,28 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                 ir_prescan,
                 ir_postscan,
                 current_ir,
-            } => write!(
-                f,
+            } => format!(
                 "!HJ{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:08x}#",
                 *index, *dr_prescan, *dr_postscan, *ir_len, *ir_prescan, *ir_postscan, *current_ir
             ),
-            RemoteCommand::SwdInit => write!(f, "!SS#"),
+            RemoteCommand::SwdInit => format!("!SS#"),
             RemoteCommand::SwdIn { length: bits } => {
-                write!(f, "!Si{:02x}#", *bits)
+                format!("!Si{:02x}#", *bits)
             }
             RemoteCommand::SwdInParity { length } => {
-                write!(f, "!SI{:02x}#", *length)
+                format!("!SI{:02x}#", *length)
             }
             RemoteCommand::SwdOut { value, length } => {
-                write!(f, "!So{:02x}{:x}#", *length, *value)
+                format!("!So{:02x}{:x}#", *length, *value)
             }
             RemoteCommand::SwdOutParity { value, length } => {
-                write!(f, "!SO{:02x}{:x}#", *length, *value)
+                format!("!SO{:02x}{:x}#", *length, *value)
             }
             RemoteCommand::TargetReset(reset) => {
-                write!(f, "!GZ{}#", if *reset { '1' } else { '0' })
+                format!("!GZ{}#", if *reset { '1' } else { '0' })
             }
             RemoteCommand::GetAccelerators => {
-                write!(f, "!HA#")
+                format!("!HA#")
             }
         }
     }
@@ -621,9 +594,9 @@ impl From<bool> for SwdDirection {
 }
 
 /// A Black Magic Probe.
-pub struct BlackMagicProbe<R: Read, W: Write> {
-    reader: BufReader<R>,
-    writer: BufWriter<W>,
+pub struct BlackMagicProbe {
+    reader: BufReader<Box<dyn Read + Send>>,
+    writer: BufWriter<Box<dyn Write + Send>>,
     protocol: Option<WireProtocol>,
     version: String,
     remote_protocol: ProtocolVersion,
@@ -635,7 +608,7 @@ pub struct BlackMagicProbe<R: Read, W: Write> {
     swd_direction: SwdDirection,
 }
 
-impl<R: Read, W: Write> core::fmt::Debug for BlackMagicProbe<R, W> {
+impl core::fmt::Debug for BlackMagicProbe {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(
             f,
@@ -657,8 +630,11 @@ impl core::fmt::Debug for BlackMagicProbeFactory {
     }
 }
 
-impl<R: Read, W: Write> BlackMagicProbe<R, W> {
-    fn new(reader: R, writer: W) -> Result<Self, DebugProbeError> {
+impl BlackMagicProbe {
+    fn new(
+        reader: Box<dyn Read + Send>,
+        writer: Box<dyn Write + Send>,
+    ) -> Result<Self, DebugProbeError> {
         let mut reader = BufReader::new(reader);
         let mut writer = BufWriter::new(writer);
 
@@ -731,9 +707,13 @@ impl<R: Read, W: Write> BlackMagicProbe<R, W> {
         Self::recv(&mut self.reader, command.response_buffer(), should_decode)
     }
 
-    fn send(writer: &mut BufWriter<W>, command: &RemoteCommand) -> Result<(), RemoteError> {
-        tracing::debug!(" > {}", command);
-        write!(writer, "{}", command).map_err(RemoteError::ProbeError)?;
+    fn send(
+        writer: &mut BufWriter<Box<dyn Write + Send>>,
+        command: &RemoteCommand,
+    ) -> Result<(), RemoteError> {
+        let s = command.to_string();
+        tracing::debug!(" > {}", s);
+        write!(writer, "{}", s).map_err(RemoteError::ProbeError)?;
         writer.flush().map_err(RemoteError::ProbeError)
     }
 
@@ -765,7 +745,7 @@ impl<R: Read, W: Write> BlackMagicProbe<R, W> {
         Ok(val)
     }
 
-    fn recv_u64(reader: &mut BufReader<R>) -> Result<u64, RemoteError> {
+    fn recv_u64(reader: &mut BufReader<Box<dyn Read + Send>>) -> Result<u64, RemoteError> {
         let mut response_buffer = [0u8; 16];
         let mut response_len = 0;
         for dest in response_buffer.iter_mut() {
@@ -785,7 +765,7 @@ impl<R: Read, W: Write> BlackMagicProbe<R, W> {
     }
 
     fn recv(
-        reader: &mut BufReader<R>,
+        reader: &mut BufReader<Box<dyn Read + Send>>,
         buffer: Option<&mut [u8]>,
         decode_hex: bool,
     ) -> Result<RemoteResponse, RemoteError> {
@@ -1040,9 +1020,7 @@ impl<R: Read, W: Write> BlackMagicProbe<R, W> {
     }
 }
 
-impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
-    DebugProbe for BlackMagicProbe<R, W>
-{
+impl DebugProbe for BlackMagicProbe {
     fn get_name(&self) -> &str {
         "Black Magic probe"
     }
@@ -1219,14 +1197,9 @@ impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::D
     }
 }
 
-impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
-    DapProbe for BlackMagicProbe<R, W>
-{
-}
+impl DapProbe for BlackMagicProbe {}
 
-impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
-    RawProtocolIo for BlackMagicProbe<R, W>
-{
+impl RawProtocolIo for BlackMagicProbe {
     fn jtag_shift_tms<M>(&mut self, tms: M, _tdi: bool) -> Result<(), DebugProbeError>
     where
         M: IntoIterator<Item = bool>,
@@ -1324,9 +1297,7 @@ impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::D
     }
 }
 
-impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
-    RawJtagIo for BlackMagicProbe<R, W>
-{
+impl RawJtagIo for BlackMagicProbe {
     fn shift_bit(
         &mut self,
         tms: bool,
@@ -1450,7 +1421,7 @@ impl ProbeFactory for BlackMagicProbeFactory {
                 let writer = reader.try_clone().map_err(|e| {
                     DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::Usb(e))
                 })?;
-                return BlackMagicProbe::new(reader, writer)
+                return BlackMagicProbe::new(Box::new(reader), Box::new(writer))
                     .map(|p| Box::new(p) as Box<dyn DebugProbe>);
             }
         }
@@ -1494,7 +1465,7 @@ impl ProbeFactory for BlackMagicProbeFactory {
             let writer = reader.try_clone().map_err(|_| {
                 DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::CouldNotOpen)
             })?;
-            return BlackMagicProbe::new(reader, writer)
+            return BlackMagicProbe::new(Box::new(reader), Box::new(writer))
                 .map(|p| Box::new(p) as Box<dyn DebugProbe>);
         }
 

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -562,6 +562,7 @@ enum RemoteError {
     Error(u64),
     Unsupported(u64),
     ProbeError(std::io::Error),
+    UnsupportedVersion(u64),
 }
 
 impl core::fmt::Display for RemoteError {
@@ -571,6 +572,7 @@ impl core::fmt::Display for RemoteError {
             Self::Error(e) => write!(f, "Remote error with result {:016x}", *e),
             Self::Unsupported(e) => write!(f, "Remote command unsupported with result {:016x}", *e),
             Self::ProbeError(e) => write!(f, "Probe error {}", e),
+            Self::UnsupportedVersion(e) => write!(f, "Only versions 0-4 are supported, not {}", e),
         }
     }
 }
@@ -657,9 +659,11 @@ impl BlackMagicProbe {
                 2 => ProtocolVersion::V2,
                 3 => ProtocolVersion::V3,
                 4 => ProtocolVersion::V4,
-                _ => {
+                version => {
                     return Err(DebugProbeError::ProbeCouldNotBeCreated(
-                        ProbeCreationError::Other("Unrecognized probe version response"),
+                        ProbeCreationError::ProbeSpecific(
+                            RemoteError::UnsupportedVersion(version).into(),
+                        ),
                     ))
                 }
             }

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -1113,10 +1113,6 @@ impl DebugProbe for BlackMagicProbe {
     }
 
     fn select_protocol(&mut self, protocol: WireProtocol) -> Result<(), DebugProbeError> {
-        // if self.protocol == Some(protocol) {
-        //     return Ok(());
-        // }
-
         self.protocol = Some(protocol);
 
         tracing::debug!("Switching to protocol {}", protocol);

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -50,6 +50,14 @@ enum ProtocolVersion {
     V4,
 }
 
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum Align {
+    U8 = 0,
+    U16 = 1,
+    U32 = 2,
+    U64 = 3,
+}
+
 impl core::fmt::Display for ProtocolVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -109,7 +117,7 @@ enum RemoteCommand<'a> {
     MemWriteV0P {
         apsel: u8,
         csw: u32,
-        align: u8,
+        align: Align,
         offset: u32,
         data: &'a [u8],
     },
@@ -145,7 +153,7 @@ enum RemoteCommand<'a> {
         index: u8,
         apsel: u8,
         csw: u32,
-        align: u8,
+        align: Align,
         offset: u32,
         data: &'a [u8],
     },
@@ -181,7 +189,7 @@ enum RemoteCommand<'a> {
         index: u8,
         apsel: u8,
         csw: u32,
-        align: u8,
+        align: Align,
         offset: u32,
         data: &'a [u8],
     },
@@ -196,7 +204,7 @@ enum RemoteCommand<'a> {
         index: u8,
         apsel: u8,
         csw: u32,
-        align: u8,
+        align: Align,
         offset: u64,
         data: &'a [u8],
     },
@@ -326,7 +334,7 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                     "!Hm{:02x}{:08x}{:02x}{:08x}{:08x}",
                     apsel,
                     csw,
-                    align,
+                    *align as u8,
                     offset,
                     data.len()
                 )?;
@@ -398,7 +406,7 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                     index,
                     apsel,
                     csw,
-                    align,
+                    *align as u8,
                     offset,
                     data.len()
                 )?;
@@ -470,7 +478,7 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                     index,
                     apsel,
                     csw,
-                    align,
+                    *align as u8,
                     offset,
                     data.len()
                 )?;
@@ -509,7 +517,7 @@ impl<'a> core::fmt::Display for RemoteCommand<'a> {
                     index,
                     apsel,
                     csw,
-                    align,
+                    *align as u8,
                     offset,
                     data.len()
                 )?;

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -1,0 +1,1523 @@
+//! Black Magic Probe implementation.
+use std::{
+    char,
+    io::{BufReader, BufWriter, Read, Write},
+    time::Duration,
+};
+
+use crate::{
+    architecture::{
+        arm::{
+            communication_interface::{DapProbe, UninitializedArmProbe},
+            ArmCommunicationInterface,
+        },
+        riscv::{communication_interface::RiscvInterfaceBuilder, dtm::jtag_dtm::JtagDtmBuilder},
+        xtensa::communication_interface::{
+            XtensaCommunicationInterface, XtensaDebugInterfaceState,
+        },
+    },
+    probe::{DebugProbe, DebugProbeInfo, JTAGAccess, ProbeFactory},
+};
+use bitvec::{order::Lsb0, vec::BitVec};
+use probe_rs_target::ScanChainElement;
+use serialport::{available_ports, SerialPortType, UsbPortInfo};
+
+use super::{
+    arm_debug_interface::{ProbeStatistics, RawProtocolIo, SwdSettings},
+    common::{JtagDriverState, RawJtagIo},
+    DebugProbeError, ProbeCreationError, ProbeError, WireProtocol,
+};
+
+const BLACK_MAGIC_PROBE_VID: u16 = 0x1d50;
+const BLACK_MAGIC_PROBE_PID: u16 = 0x6018;
+const BLACK_MAGIC_PROTOCOL_RESPONSE_START: u8 = b'&';
+const BLACK_MAGIC_PROTOCOL_RESPONSE_END: u8 = b'#';
+pub(crate) const BLACK_MAGIC_REMOTE_SIZE_MAX: usize = 1024;
+
+mod arm;
+use arm::UninitializedBlackMagicArmProbe;
+
+/// A factory for creating [`BlackMagicProbe`] instances.
+pub struct BlackMagicProbeFactory;
+
+#[derive(PartialEq)]
+enum ProtocolVersion {
+    V0,
+    V0P,
+    V1,
+    V2,
+    V3,
+    V4,
+}
+
+impl core::fmt::Display for ProtocolVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::V0 => "V0",
+                Self::V0P => "V0P",
+                Self::V1 => "V1",
+                Self::V2 => "V2",
+                Self::V3 => "V3",
+                Self::V4 => "V4",
+            }
+        )
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+enum RemoteCommand<'a> {
+    Handshake(&'a mut [u8]),
+    GetAccelerators,
+    HighLevelCheck,
+    GetVoltage,
+    GetSpeedKhz,
+    SetNrst(bool),
+    SetPower(bool),
+    TargetClockOutput {
+        enable: bool,
+    },
+    SetSpeedKhz(u32),
+    SpeedKhz,
+    TargetReset(bool),
+    RawAccessV0P {
+        rnw: u8,
+        addr: u8,
+        value: u32,
+    },
+    ReadDpV0P {
+        addr: u8,
+    },
+    ReadApV0P {
+        apsel: u8,
+        addr: u8,
+    },
+    WriteApV0P {
+        apsel: u8,
+        addr: u8,
+        value: u32,
+    },
+    MemReadV0P {
+        apsel: u8,
+        csw: u32,
+        offset: u32,
+        data: &'a mut [u8],
+    },
+    MemWriteV0P {
+        apsel: u8,
+        csw: u32,
+        align: u8,
+        offset: u32,
+        data: &'a [u8],
+    },
+    RawAccessV1 {
+        index: u8,
+        rnw: u8,
+        addr: u8,
+        value: u32,
+    },
+    ReadDpV1 {
+        index: u8,
+        addr: u8,
+    },
+    ReadApV1 {
+        index: u8,
+        apsel: u8,
+        addr: u8,
+    },
+    WriteApV1 {
+        index: u8,
+        apsel: u8,
+        addr: u8,
+        value: u32,
+    },
+    MemReadV1 {
+        index: u8,
+        apsel: u8,
+        csw: u32,
+        offset: u32,
+        data: &'a mut [u8],
+    },
+    MemWriteV1 {
+        index: u8,
+        apsel: u8,
+        csw: u32,
+        align: u8,
+        offset: u32,
+        data: &'a [u8],
+    },
+    RawAccessV3 {
+        index: u8,
+        rnw: u8,
+        addr: u8,
+        value: u32,
+    },
+    ReadDpV3 {
+        index: u8,
+        addr: u8,
+    },
+    ReadApV3 {
+        index: u8,
+        apsel: u8,
+        addr: u8,
+    },
+    WriteApV3 {
+        index: u8,
+        apsel: u8,
+        addr: u8,
+        value: u32,
+    },
+    MemReadV3 {
+        index: u8,
+        apsel: u8,
+        csw: u32,
+        offset: u32,
+        data: &'a mut [u8],
+    },
+    MemWriteV3 {
+        index: u8,
+        apsel: u8,
+        csw: u32,
+        align: u8,
+        offset: u32,
+        data: &'a [u8],
+    },
+    MemReadV4 {
+        index: u8,
+        apsel: u8,
+        csw: u32,
+        offset: u64,
+        data: &'a mut [u8],
+    },
+    MemWriteV4 {
+        index: u8,
+        apsel: u8,
+        csw: u32,
+        align: u8,
+        offset: u64,
+        data: &'a [u8],
+    },
+    JtagNext {
+        tms: bool,
+        tdi: bool,
+    },
+    JtagTms {
+        bits: u32,
+        length: usize,
+    },
+    JtagTdi {
+        bits: u32,
+        length: usize,
+        tms: bool,
+    },
+    JtagInit,
+    JtagReset,
+    JtagAddDevice {
+        index: u8,
+        dr_prescan: u8,
+        dr_postscan: u8,
+        ir_len: u8,
+        ir_prescan: u8,
+        ir_postscan: u8,
+        current_ir: u32,
+    },
+    SwdInit,
+    SwdIn {
+        length: usize,
+    },
+    SwdInParity {
+        length: usize,
+    },
+    SwdOut {
+        value: u32,
+        length: usize,
+    },
+    SwdOutParity {
+        value: u32,
+        length: usize,
+    },
+}
+
+impl<'a> RemoteCommand<'a> {
+    /// Return the buffer from the payload of the specified value where the
+    /// response should be written.
+    fn response_buffer(&mut self) -> Option<&mut [u8]> {
+        match self {
+            RemoteCommand::Handshake(data) => Some(data),
+            RemoteCommand::MemReadV0P { data, .. } => Some(data),
+            RemoteCommand::MemReadV1 { data, .. } => Some(data),
+            RemoteCommand::MemReadV3 { data, .. } => Some(data),
+            RemoteCommand::MemReadV4 { data, .. } => Some(data),
+            _ => None,
+        }
+    }
+
+    /// Return `true` if the resulting buffer should have hex decoded.
+    fn decode_hex(&self) -> bool {
+        matches!(
+            self,
+            RemoteCommand::MemReadV0P { .. }
+                | RemoteCommand::MemReadV1 { .. }
+                | RemoteCommand::MemReadV3 { .. }
+                | RemoteCommand::MemReadV4 { .. }
+        )
+    }
+}
+
+impl<'a> core::fmt::Display for RemoteCommand<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RemoteCommand::Handshake(_) => write!(f, "+#!GA#"),
+            RemoteCommand::GetVoltage => write!(f, " !GV#"),
+            RemoteCommand::GetSpeedKhz => write!(f, "!Gf#"),
+            RemoteCommand::SetSpeedKhz(speed) => {
+                write!(f, "!GF{:08x}#", speed)
+            }
+            RemoteCommand::HighLevelCheck => write!(f, "!HC#"),
+            RemoteCommand::SetNrst(set) => write!(f, "!GZ{}#", if *set { '1' } else { '0' }),
+            RemoteCommand::SetPower(set) => write!(f, "!GP{}#", if *set { '1' } else { '0' }),
+            RemoteCommand::TargetClockOutput { enable } => {
+                write!(f, "!GE{}#", if *enable { '1' } else { '0' })
+            }
+            RemoteCommand::SpeedKhz => write!(f, "!Gf#"),
+            RemoteCommand::RawAccessV0P { rnw, addr, value } => {
+                write!(f, "!HL{:02x}{:04x}{:08x}#", rnw, addr, value)
+            }
+            RemoteCommand::ReadDpV0P { addr } => {
+                write!(f, "!Hdff{:04x}#", addr)
+            }
+            RemoteCommand::ReadApV0P { apsel, addr } => {
+                write!(f, "!Ha{:02x}{:04x}#", apsel, 0x100 | *addr as u16)
+            }
+            RemoteCommand::WriteApV0P { apsel, addr, value } => {
+                write!(
+                    f,
+                    "!HA{:02x}{:04x}{:08x}#",
+                    apsel,
+                    0x100 | *addr as u16,
+                    value
+                )
+            }
+            RemoteCommand::MemReadV0P {
+                apsel,
+                csw,
+                offset,
+                data,
+            } => write!(
+                f,
+                "!HM{:02x}{:08x}{:08x}{:08x}#",
+                apsel,
+                csw,
+                offset,
+                data.len()
+            ),
+            RemoteCommand::MemWriteV0P {
+                apsel,
+                csw,
+                align,
+                offset,
+                data,
+            } => {
+                write!(
+                    f,
+                    "!Hm{:02x}{:08x}{:02x}{:08x}{:08x}",
+                    apsel,
+                    csw,
+                    align,
+                    offset,
+                    data.len()
+                )?;
+                for b in data.iter() {
+                    write!(f, "{:02x}", b)?;
+                }
+                write!(f, "#")
+            }
+
+            RemoteCommand::RawAccessV1 {
+                index,
+                rnw,
+                addr,
+                value,
+            } => {
+                write!(f, "!HL{:02x}{:02x}{:04x}{:08x}#", index, rnw, addr, value)
+            }
+            RemoteCommand::ReadDpV1 { index, addr } => {
+                write!(f, "!Hd{:02x}ff{:04x}#", index, addr)
+            }
+            RemoteCommand::ReadApV1 { index, apsel, addr } => {
+                write!(
+                    f,
+                    "!Ha{:02x}{:02x}{:04x}#",
+                    index,
+                    apsel,
+                    0x100 | *addr as u16
+                )
+            }
+            RemoteCommand::WriteApV1 {
+                index,
+                apsel,
+                addr,
+                value,
+            } => write!(
+                f,
+                "!HA{:02x}{:02x}{:04x}{:08x}#",
+                index,
+                apsel,
+                0x100 | *addr as u16,
+                value
+            ),
+            RemoteCommand::MemReadV1 {
+                index,
+                apsel,
+                csw,
+                offset,
+                data,
+            } => write!(
+                f,
+                "!HM{:02x}{:02x}{:08x}{:08x}{:08x}#",
+                index,
+                apsel,
+                csw,
+                offset,
+                data.len()
+            ),
+            RemoteCommand::MemWriteV1 {
+                index,
+                apsel,
+                csw,
+                align,
+                offset,
+                data,
+            } => {
+                write!(
+                    f,
+                    "!Hm{:02x}{:02x}{:08x}{:02x}{:08x}{:08x}",
+                    index,
+                    apsel,
+                    csw,
+                    align,
+                    offset,
+                    data.len()
+                )?;
+                for b in data.iter() {
+                    write!(f, "{:02x}", b)?;
+                }
+                write!(f, "#")
+            }
+
+            RemoteCommand::RawAccessV3 {
+                index,
+                rnw,
+                addr,
+                value,
+            } => {
+                write!(f, "!AR{:02x}{:02x}{:04x}{:08x}#", index, rnw, addr, value)
+            }
+            RemoteCommand::ReadDpV3 { index, addr } => {
+                write!(f, "!Ad{:02x}ff{:04x}#", index, addr)
+            }
+            RemoteCommand::ReadApV3 { index, apsel, addr } => {
+                write!(
+                    f,
+                    "!Aa{:02x}{:02x}{:04x}#",
+                    index,
+                    apsel,
+                    0x100 | *addr as u16
+                )
+            }
+            RemoteCommand::WriteApV3 {
+                index,
+                apsel,
+                addr,
+                value,
+            } => write!(
+                f,
+                "!AA{:02x}{:02x}{:04x}{:08x}#",
+                index,
+                apsel,
+                0x100 | *addr as u16,
+                value.to_be()
+            ),
+            RemoteCommand::MemReadV3 {
+                index,
+                apsel,
+                csw,
+                offset,
+                data,
+            } => write!(
+                f,
+                "!Am{:02x}{:02x}{:08x}{:08x}{:08x}#",
+                index,
+                apsel,
+                csw,
+                offset,
+                data.len()
+            ),
+            RemoteCommand::MemWriteV3 {
+                index,
+                apsel,
+                csw,
+                align,
+                offset,
+                data,
+            } => {
+                write!(
+                    f,
+                    "!AM{:02x}{:02x}{:08x}{:02x}{:08x}{:08x}",
+                    index,
+                    apsel,
+                    csw,
+                    align,
+                    offset,
+                    data.len()
+                )?;
+                for b in data.iter() {
+                    write!(f, "{:02x}", b)?;
+                }
+                write!(f, "#")
+            }
+
+            RemoteCommand::MemReadV4 {
+                index,
+                apsel,
+                csw,
+                offset,
+                data,
+            } => write!(
+                f,
+                "!Am{:02x}{:02x}{:08x}{:016x}{:08x}#",
+                index,
+                apsel,
+                csw,
+                offset,
+                data.len()
+            ),
+            RemoteCommand::MemWriteV4 {
+                index,
+                apsel,
+                csw,
+                align,
+                offset,
+                data,
+            } => {
+                write!(
+                    f,
+                    "!AM{:02x}{:02x}{:08x}{:02x}{:016x}{:08x}",
+                    index,
+                    apsel,
+                    csw,
+                    align,
+                    offset,
+                    data.len()
+                )?;
+                for b in data.iter() {
+                    write!(f, "{:02x}", b)?;
+                }
+                write!(f, "#")
+            }
+
+            RemoteCommand::JtagNext { tms, tdi } => write!(
+                f,
+                "!JN{}{}#",
+                if *tms { '1' } else { '0' },
+                if *tdi { '1' } else { '0' }
+            ),
+            RemoteCommand::JtagInit => write!(f, "+#!JS#"),
+            RemoteCommand::JtagReset => write!(f, "+#!JR#"),
+            RemoteCommand::JtagTms { bits, length } => {
+                write!(f, "!JT{:02x}{:x}#", *length, *bits)
+            }
+            RemoteCommand::JtagTdi { bits, length, tms } => write!(
+                f,
+                "!J{}{:02x}{:x}#",
+                if *tms { 'D' } else { 'd' },
+                *length,
+                *bits
+            ),
+            RemoteCommand::JtagAddDevice {
+                index,
+                dr_prescan,
+                dr_postscan,
+                ir_len,
+                ir_prescan,
+                ir_postscan,
+                current_ir,
+            } => write!(
+                f,
+                "!HJ{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:08x}#",
+                *index, *dr_prescan, *dr_postscan, *ir_len, *ir_prescan, *ir_postscan, *current_ir
+            ),
+            RemoteCommand::SwdInit => write!(f, "!SS#"),
+            RemoteCommand::SwdIn { length: bits } => {
+                write!(f, "!Si{:02x}#", *bits)
+            }
+            RemoteCommand::SwdInParity { length } => {
+                write!(f, "!SI{:02x}#", *length)
+            }
+            RemoteCommand::SwdOut { value, length } => {
+                write!(f, "!So{:02x}{:x}#", *length, *value)
+            }
+            RemoteCommand::SwdOutParity { value, length } => {
+                write!(f, "!SO{:02x}{:x}#", *length, *value)
+            }
+            RemoteCommand::TargetReset(reset) => {
+                write!(f, "!GZ{}#", if *reset { '1' } else { '0' })
+            }
+            RemoteCommand::GetAccelerators => {
+                write!(f, "!HA#")
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum RemoteError {
+    ParameterError(u64),
+    Error(u64),
+    Unsupported(u64),
+    ProbeError(std::io::Error),
+}
+
+impl core::fmt::Display for RemoteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ParameterError(e) => write!(f, "Remote paramater error with result {:016x}", *e),
+            Self::Error(e) => write!(f, "Remote error with result {:016x}", *e),
+            Self::Unsupported(e) => write!(f, "Remote command unsupported with result {:016x}", *e),
+            Self::ProbeError(e) => write!(f, "Probe error {}", e),
+        }
+    }
+}
+
+impl ProbeError for RemoteError {}
+
+struct RemoteResponse(u64);
+
+#[derive(PartialEq, Copy, Clone)]
+enum SwdDirection {
+    Input,
+    Output,
+}
+
+impl From<bool> for SwdDirection {
+    fn from(value: bool) -> Self {
+        if value {
+            SwdDirection::Output
+        } else {
+            SwdDirection::Input
+        }
+    }
+}
+
+/// A Black Magic Probe.
+pub struct BlackMagicProbe<R: Read, W: Write> {
+    reader: BufReader<R>,
+    writer: BufWriter<W>,
+    protocol: Option<WireProtocol>,
+    version: String,
+    remote_protocol: ProtocolVersion,
+    speed_khz: u32,
+    jtag_state: JtagDriverState,
+    probe_statistics: ProbeStatistics,
+    swd_settings: SwdSettings,
+    in_bits: BitVec<u8, Lsb0>,
+    swd_direction: SwdDirection,
+}
+
+impl<R: Read, W: Write> core::fmt::Debug for BlackMagicProbe<R, W> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(
+            f,
+            "Black Magic Probe {} with remote protocol {}",
+            self.version, self.remote_protocol
+        )
+    }
+}
+
+impl core::fmt::Display for BlackMagicProbeFactory {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "Black Magic Probe Factory")
+    }
+}
+
+impl core::fmt::Debug for BlackMagicProbeFactory {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "Black Magic Probe Factory")
+    }
+}
+
+impl<R: Read, W: Write> BlackMagicProbe<R, W> {
+    fn new(reader: R, writer: W) -> Result<Self, DebugProbeError> {
+        let mut reader = BufReader::new(reader);
+        let mut writer = BufWriter::new(writer);
+
+        let mut handshake_response = [0u8; 1024];
+        Self::send(
+            &mut writer,
+            &RemoteCommand::Handshake(&mut handshake_response),
+        )?;
+        let response_len = Self::recv(&mut reader, Some(&mut handshake_response), false)
+            .map_err(|e| {
+                tracing::error!("Unable to receive command: {:?}", e);
+                DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::CouldNotOpen)
+            })?
+            .0;
+        let version =
+            String::from_utf8_lossy(&handshake_response[0..response_len as usize]).to_string();
+        tracing::info!("Probe version {}", version);
+
+        Self::send(&mut writer, &RemoteCommand::HighLevelCheck)?;
+        let remote_protocol = if let Ok(response) = Self::recv(&mut reader, None, false) {
+            match response.0 {
+                0 => ProtocolVersion::V0P,
+                1 => ProtocolVersion::V1,
+                2 => ProtocolVersion::V2,
+                3 => ProtocolVersion::V3,
+                4 => ProtocolVersion::V4,
+                _ => {
+                    return Err(DebugProbeError::ProbeCouldNotBeCreated(
+                        ProbeCreationError::Other("Unrecognized probe version response"),
+                    ))
+                }
+            }
+        } else {
+            ProtocolVersion::V0
+        };
+
+        tracing::info!("Using BMP protocol {}", remote_protocol);
+
+        let mut probe = Self {
+            reader,
+            writer,
+            protocol: None,
+            version,
+            speed_khz: 0,
+            remote_protocol,
+            jtag_state: JtagDriverState::default(),
+            swd_settings: SwdSettings::default(),
+            probe_statistics: ProbeStatistics::default(),
+            in_bits: BitVec::new(),
+            swd_direction: SwdDirection::Output,
+        };
+
+        probe.command(RemoteCommand::SetPower(false)).ok();
+        probe.command(RemoteCommand::SetNrst(false)).ok();
+        probe.command(RemoteCommand::GetVoltage).ok();
+        probe.command(RemoteCommand::SetSpeedKhz(400_0000)).ok();
+        probe.command(RemoteCommand::GetSpeedKhz).ok();
+
+        Ok(probe)
+    }
+
+    fn command(&mut self, mut command: RemoteCommand) -> Result<RemoteResponse, RemoteError> {
+        let result = Self::send(&mut self.writer, &command);
+        if let Err(e) = result {
+            tracing::error!("Error sending command: {:?}", e);
+            return Err(e);
+        }
+        let should_decode = command.decode_hex();
+
+        Self::recv(&mut self.reader, command.response_buffer(), should_decode)
+    }
+
+    fn send(writer: &mut BufWriter<W>, command: &RemoteCommand) -> Result<(), RemoteError> {
+        tracing::debug!(" > {}", command);
+        write!(writer, "{}", command).map_err(RemoteError::ProbeError)?;
+        writer.flush().map_err(RemoteError::ProbeError)
+    }
+
+    fn hex_val(c: u8) -> Result<u8, char> {
+        match c {
+            b'A'..=b'F' => Ok(c - b'A' + 10),
+            b'a'..=b'f' => Ok(c - b'a' + 10),
+            b'0'..=b'9' => Ok(c - b'0'),
+            _ => Err(c as char),
+        }
+    }
+
+    fn from_hex_u64(hex: &[u8]) -> Result<u64, ()> {
+        // Strip off leading `0x` if present
+        let hex = if hex.first() == Some(&b'0')
+            && (hex.get(1) == Some(&b'x') || hex.get(1) == Some(&b'X'))
+        {
+            &hex[2..]
+        } else {
+            hex
+        };
+
+        let mut val = 0u64;
+
+        for (index, c) in hex.iter().rev().enumerate() {
+            let decoded_val: u64 = Self::hex_val(*c).or(Err(()))?.into();
+            val += decoded_val << (index * 4);
+        }
+        Ok(val)
+    }
+
+    fn recv_u64(reader: &mut BufReader<R>) -> Result<u64, RemoteError> {
+        let mut response_buffer = [0u8; 16];
+        let mut response_len = 0;
+        for dest in response_buffer.iter_mut() {
+            let mut byte = [0u8; 1];
+            reader
+                .read_exact(&mut byte)
+                .map_err(RemoteError::ProbeError)?;
+            if byte[0] == BLACK_MAGIC_PROTOCOL_RESPONSE_END {
+                break;
+            }
+            *dest = byte[0];
+            response_len += 1;
+        }
+        // Convert the hex in the buffer to a u64.
+        Self::from_hex_u64(&response_buffer[0..response_len])
+            .or(Err(RemoteError::ParameterError(0)))
+    }
+
+    fn recv(
+        reader: &mut BufReader<R>,
+        buffer: Option<&mut [u8]>,
+        decode_hex: bool,
+    ) -> Result<RemoteResponse, RemoteError> {
+        // Responses begin with `&`
+        loop {
+            let mut byte = [0u8; 1];
+            reader
+                .read_exact(&mut byte)
+                .map_err(RemoteError::ProbeError)?;
+            if byte[0] == BLACK_MAGIC_PROTOCOL_RESPONSE_START {
+                break;
+            }
+        }
+        let mut response_code = [0u8; 1];
+        reader
+            .read_exact(&mut response_code)
+            .map_err(RemoteError::ProbeError)?;
+        let response_code = response_code[0];
+
+        // If there was no incoming buffer, then we will read up to 64 bits of data and
+        // return a response based on that.
+
+        if response_code == b'K' {
+            let Some(buffer) = buffer else {
+                let response = Self::recv_u64(reader)?;
+                tracing::trace!(" < K{:x}", response);
+                return Ok(RemoteResponse(response));
+            };
+            let mut output_count = 0;
+            for dest in buffer.iter_mut() {
+                let mut byte = [0u8; 1];
+
+                // Read the first nibble
+                reader
+                    .read_exact(&mut byte)
+                    .map_err(RemoteError::ProbeError)?;
+                if byte[0] == BLACK_MAGIC_PROTOCOL_RESPONSE_END {
+                    break;
+                }
+
+                // Add one byte to the resulting output value. This is the case whether we
+                // get one or two nibbles.
+                output_count += 1;
+
+                if decode_hex {
+                    *dest = Self::hex_val(byte[0])
+                        .or(Err(RemoteError::ParameterError(byte[0] as _)))?;
+
+                    // Read the second nibble, if present.
+                    reader
+                        .read_exact(&mut byte)
+                        .map_err(RemoteError::ProbeError)?;
+                    if byte[0] == BLACK_MAGIC_PROTOCOL_RESPONSE_END {
+                        break;
+                    }
+
+                    *dest = *dest << 4
+                        | Self::hex_val(byte[0])
+                            .or(Err(RemoteError::ParameterError(byte[0] as _)))?;
+                } else {
+                    *dest = byte[0];
+                }
+            }
+            tracing::trace!(" < K{:x?}", &buffer[0..output_count as usize]);
+            Ok(RemoteResponse(output_count))
+        } else {
+            let response = Self::recv_u64(reader)?;
+            tracing::trace!(" < {}{:x}", char::from(response_code), response);
+            if response_code == b'E' {
+                Err(RemoteError::Error(response))
+            } else if response_code == b'P' {
+                Err(RemoteError::ParameterError(response))
+            } else {
+                Err(RemoteError::Unsupported(response))
+            }
+        }
+    }
+
+    fn get_speed(&mut self) -> Result<u32, DebugProbeError> {
+        let speed = self.command(RemoteCommand::SpeedKhz)?.0.try_into().unwrap();
+        Ok(speed)
+    }
+
+    fn drain_swd_accumulator(
+        &mut self,
+        output: &mut Vec<bool>,
+        accumulator: u32,
+        accumulator_length: usize,
+    ) -> Result<(), DebugProbeError> {
+        if self.swd_direction == SwdDirection::Output {
+            match self.command(RemoteCommand::SwdOut {
+                value: accumulator,
+                length: accumulator_length,
+            }) {
+                Ok(response) => tracing::debug!(
+                    "Doing SWD out of {} bits: {:x} -- {}",
+                    accumulator_length,
+                    accumulator,
+                    response.0
+                ),
+                Err(e) => tracing::error!(
+                    "Error doing SWD OUT of {} bits ({:x}) -- {}",
+                    accumulator_length,
+                    accumulator,
+                    e
+                ),
+            }
+            for bit in 0..accumulator_length {
+                output.push(accumulator & (1 << bit) != 0);
+            }
+        } else {
+            let result = self.command(RemoteCommand::SwdIn {
+                length: accumulator_length,
+            });
+            match &result {
+                Ok(response) => {
+                    let response = response.0;
+                    tracing::debug!(
+                        "Doing SWD in of {} bits: {:x}",
+                        accumulator_length,
+                        response
+                    );
+                    for bit in 0..accumulator_length {
+                        output.push(response & (1 << bit) != 0);
+                    }
+                }
+                Err(e) => tracing::error!(
+                    "Error doing SWD IN operation of {} bits: {}",
+                    accumulator_length,
+                    e
+                ),
+            }
+        }
+        Ok(())
+    }
+
+    /// Perform a single SWDIO command
+    ///
+    /// The caller needs to ensure that the given iterators are not longer than the maximum transfer size
+    /// allowed. It seems that the maximum transfer size is determined by [`self.max_mem_block_size`].
+    fn perform_swdio_transfer<D, S>(
+        &mut self,
+        dir: D,
+        swdio: S,
+    ) -> Result<Vec<bool>, DebugProbeError>
+    where
+        D: IntoIterator<Item = bool>,
+        S: IntoIterator<Item = bool>,
+    {
+        let dir = dir.into_iter();
+        let swdio = swdio.into_iter();
+        let mut output = vec![];
+
+        let mut accumulator = 0u32;
+        let mut accumulator_length = 0;
+
+        for (dir, swdio) in dir.zip(swdio) {
+            let dir = SwdDirection::from(dir);
+            if dir != self.swd_direction
+                || accumulator_length >= core::mem::size_of_val(&accumulator) * 8
+            {
+                // Inputs are off-by-one due to how J-Link is built. Remove one bit
+                // from the accumulator and store the turnaround bit at the end of
+                // the transaction.
+                if self.swd_direction == SwdDirection::Input && dir == SwdDirection::Output {
+                    accumulator_length -= 2;
+                }
+
+                // Drain the accumulator to the BMP, either writing bits to the device
+                // or reading bits from the device.
+                self.drain_swd_accumulator(&mut output, accumulator, accumulator_length)?;
+
+                // Input -> Output transition
+                if self.swd_direction == SwdDirection::Input && dir == SwdDirection::Output {
+                    output.push(false);
+                    output.push(false);
+                }
+
+                accumulator = 0;
+                accumulator_length = 0;
+            }
+            self.swd_direction = dir;
+            accumulator |= if swdio { 1 << accumulator_length } else { 0 };
+            accumulator_length += 1;
+        }
+
+        if accumulator_length > 0 {
+            self.drain_swd_accumulator(&mut output, accumulator, accumulator_length)?;
+        }
+
+        Ok(output)
+    }
+
+    fn drain_jtag_accumulator(
+        &mut self,
+        accumulator: u32,
+        mut accumulator_length: usize,
+        final_tms: bool,
+        capture: bool,
+        final_transaction: bool,
+    ) -> Result<(), DebugProbeError> {
+        let response = self.command(RemoteCommand::JtagTdi {
+            bits: accumulator,
+            length: accumulator_length,
+            tms: final_tms && final_transaction,
+        })?;
+
+        if capture {
+            // If this is the last bit, then `cap` may be false.
+            if capture && final_transaction {
+                accumulator_length -= 1;
+            }
+            let value = response.0;
+            for bit in 0..accumulator_length {
+                self.in_bits.push(value & (1 << bit) != 0);
+            }
+        }
+        Ok(())
+    }
+
+    fn perform_jtag_transfer(
+        &mut self,
+        transaction: Vec<(bool, bool, bool)>,
+        final_tms: bool,
+        capture: bool,
+    ) -> Result<(), DebugProbeError> {
+        let mut accumulator = 0;
+        let mut accumulator_length = 0;
+        let bit_count = transaction.len();
+
+        for (index, (_, tdi, _)) in transaction.into_iter().enumerate() {
+            accumulator |= if tdi { 1 << accumulator_length } else { 0 };
+            accumulator_length += 1;
+            if accumulator_length >= core::mem::size_of_val(&accumulator) * 8 {
+                let is_final = index + 1 >= bit_count;
+                self.drain_jtag_accumulator(
+                    accumulator,
+                    accumulator_length,
+                    final_tms,
+                    capture,
+                    is_final,
+                )?;
+                accumulator = 0;
+                accumulator_length = 0;
+            }
+        }
+
+        if accumulator_length > 0 {
+            self.drain_jtag_accumulator(accumulator, accumulator_length, final_tms, capture, true)?;
+        }
+        Ok(())
+    }
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    DebugProbe for BlackMagicProbe<R, W>
+{
+    fn get_name(&self) -> &str {
+        "Black Magic probe"
+    }
+
+    fn speed_khz(&self) -> u32 {
+        self.speed_khz
+    }
+
+    fn set_speed(&mut self, speed_khz: u32) -> Result<u32, DebugProbeError> {
+        Self::send(&mut self.writer, &RemoteCommand::SetSpeedKhz(speed_khz))?;
+        self.speed_khz = self.get_speed()?;
+        Ok(self.speed_khz)
+    }
+
+    fn set_scan_chain(&mut self, scan_chain: Vec<ScanChainElement>) -> Result<(), DebugProbeError> {
+        tracing::info!("Setting scan chain to {:?}", scan_chain);
+        self.jtag_state.expected_scan_chain = Some(scan_chain);
+        Ok(())
+    }
+
+    fn scan_chain(&self) -> Result<&[ScanChainElement], DebugProbeError> {
+        if let Some(scan_chain) = &self.jtag_state.expected_scan_chain {
+            Ok(scan_chain)
+        } else {
+            Ok(&[])
+        }
+    }
+
+    fn attach(&mut self) -> Result<(), DebugProbeError> {
+        tracing::debug!("Attaching with protocol '{:?}'", self.protocol);
+
+        // Enable output on the clock pin (if supported)
+        if let ProtocolVersion::V2 | ProtocolVersion::V3 | ProtocolVersion::V4 =
+            self.remote_protocol
+        {
+            self.command(RemoteCommand::TargetClockOutput { enable: true })
+                .ok();
+        }
+
+        match self.protocol {
+            Some(WireProtocol::Jtag) => {
+                self.scan_chain()?;
+                self.select_target(0)?;
+
+                if let ProtocolVersion::V1
+                | ProtocolVersion::V2
+                | ProtocolVersion::V3
+                | ProtocolVersion::V4 = self.remote_protocol
+                {
+                    let sc = &self.jtag_state.chain_params;
+                    self.command(RemoteCommand::JtagAddDevice {
+                        index: 0,
+                        dr_prescan: sc.drpre.try_into().unwrap(),
+                        dr_postscan: sc.drpost.try_into().unwrap(),
+                        ir_len: sc.irlen.try_into().unwrap(),
+                        ir_prescan: sc.irpre.try_into().unwrap(),
+                        ir_postscan: sc.irpost.try_into().unwrap(),
+                        current_ir: u32::MAX,
+                    })?;
+                }
+                Ok(())
+            }
+            Some(WireProtocol::Swd) => Ok(()),
+            _ => Err(DebugProbeError::InterfaceNotAvailable {
+                interface_name: "no protocol specified",
+            }),
+        }
+    }
+
+    fn select_jtag_tap(&mut self, index: usize) -> Result<(), DebugProbeError> {
+        self.select_target(index)
+    }
+
+    fn detach(&mut self) -> Result<(), crate::Error> {
+        Ok(())
+    }
+
+    fn target_reset(&mut self) -> Result<(), DebugProbeError> {
+        // TODO we could add this by using a GPIO. However, different probes may connect
+        // different pins (if any) to the reset line, so we would need to make this configurable.
+        Err(DebugProbeError::NotImplemented {
+            function_name: "target_reset",
+        })
+    }
+
+    fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
+        self.command(RemoteCommand::TargetReset(true))?;
+        Ok(())
+    }
+
+    fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {
+        self.command(RemoteCommand::TargetReset(false))?;
+        Ok(())
+    }
+
+    fn select_protocol(&mut self, protocol: WireProtocol) -> Result<(), DebugProbeError> {
+        // if self.protocol == Some(protocol) {
+        //     return Ok(());
+        // }
+
+        self.protocol = Some(protocol);
+
+        tracing::debug!("Switching to protocol {}", protocol);
+        match protocol {
+            WireProtocol::Jtag => {
+                self.command(RemoteCommand::JtagInit)?;
+                self.command(RemoteCommand::JtagReset)?;
+            }
+            WireProtocol::Swd => {
+                self.command(RemoteCommand::SwdInit)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn active_protocol(&self) -> Option<WireProtocol> {
+        self.protocol
+    }
+
+    fn try_get_riscv_interface_builder<'probe>(
+        &'probe mut self,
+    ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, DebugProbeError> {
+        Ok(Box::new(JtagDtmBuilder::new(self)))
+    }
+
+    fn has_riscv_interface(&self) -> bool {
+        true
+    }
+
+    fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
+    }
+
+    /// Turn this probe into an ARM probe
+    fn try_get_arm_interface<'probe>(
+        mut self: Box<Self>,
+    ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, DebugProbeError)>
+    {
+        let has_adiv5 = match self.remote_protocol {
+            ProtocolVersion::V0 => false,
+            ProtocolVersion::V0P
+            | ProtocolVersion::V1
+            | ProtocolVersion::V2
+            | ProtocolVersion::V3 => true,
+            ProtocolVersion::V4 => {
+                if let Ok(accelerators) = self.command(RemoteCommand::GetAccelerators) {
+                    accelerators.0 & 1 != 0
+                } else {
+                    false
+                }
+            }
+        };
+
+        if has_adiv5 {
+            Ok(Box::new(UninitializedBlackMagicArmProbe::new(self)))
+        } else {
+            Ok(Box::new(ArmCommunicationInterface::new(self, true)))
+        }
+    }
+
+    fn has_arm_interface(&self) -> bool {
+        true
+    }
+
+    fn try_get_xtensa_interface<'probe>(
+        &'probe mut self,
+        state: &'probe mut XtensaDebugInterfaceState,
+    ) -> Result<XtensaCommunicationInterface<'probe>, DebugProbeError> {
+        Ok(XtensaCommunicationInterface::new(self, state))
+    }
+
+    fn has_xtensa_interface(&self) -> bool {
+        true
+    }
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    DapProbe for BlackMagicProbe<R, W>
+{
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    RawProtocolIo for BlackMagicProbe<R, W>
+{
+    fn jtag_shift_tms<M>(&mut self, tms: M, _tdi: bool) -> Result<(), DebugProbeError>
+    where
+        M: IntoIterator<Item = bool>,
+    {
+        self.probe_statistics.report_io();
+
+        let tms = tms.into_iter().collect::<Vec<bool>>();
+        let mut accumulator = 0;
+        let mut accumulator_length = 0;
+        for tms in tms.into_iter() {
+            accumulator |= if tms { 1 << accumulator_length } else { 0 };
+            accumulator_length += 1;
+
+            if accumulator_length >= core::mem::size_of_val(&accumulator) * 8 {
+                self.command(RemoteCommand::JtagTms {
+                    bits: accumulator,
+                    length: accumulator_length,
+                })?;
+                accumulator_length = 0;
+                accumulator = 0;
+            }
+        }
+
+        if accumulator_length > 0 {
+            self.command(RemoteCommand::JtagTms {
+                bits: accumulator,
+                length: accumulator_length,
+            })?;
+        }
+
+        Ok(())
+    }
+
+    fn jtag_shift_tdi<I>(&mut self, _tms: bool, tdi: I) -> Result<(), DebugProbeError>
+    where
+        I: IntoIterator<Item = bool>,
+    {
+        self.probe_statistics.report_io();
+
+        let tdi = tdi.into_iter().collect::<Vec<bool>>();
+        let mut accumulator = 0;
+        let mut accumulator_length = 0;
+        for tms in tdi.into_iter() {
+            accumulator |= if tms { 1 << accumulator_length } else { 0 };
+            accumulator_length += 1;
+
+            if accumulator_length >= core::mem::size_of_val(&accumulator) * 8 {
+                self.command(RemoteCommand::JtagTdi {
+                    bits: accumulator,
+                    length: accumulator_length,
+                    tms: false,
+                })?;
+                accumulator_length = 0;
+                accumulator = 0;
+            }
+        }
+
+        if accumulator_length > 0 {
+            self.command(RemoteCommand::JtagTdi {
+                bits: accumulator,
+                length: accumulator_length,
+                tms: false,
+            })?;
+        }
+
+        Ok(())
+    }
+
+    fn swd_io<D, S>(&mut self, dir: D, swdio: S) -> Result<Vec<bool>, DebugProbeError>
+    where
+        D: IntoIterator<Item = bool>,
+        S: IntoIterator<Item = bool>,
+    {
+        self.probe_statistics.report_io();
+        self.perform_swdio_transfer(dir, swdio)
+    }
+
+    fn swj_pins(
+        &mut self,
+        _pin_out: u32,
+        _pin_select: u32,
+        _pin_wait: u32,
+    ) -> Result<u32, DebugProbeError> {
+        Err(DebugProbeError::CommandNotSupportedByProbe {
+            command_name: "swj_pins",
+        })
+    }
+
+    fn swd_settings(&self) -> &SwdSettings {
+        &self.swd_settings
+    }
+
+    fn probe_statistics(&mut self) -> &mut ProbeStatistics {
+        &mut self.probe_statistics
+    }
+}
+
+impl<R: Read + Send + core::fmt::Debug + 'static, W: Write + Send + core::fmt::Debug + 'static>
+    RawJtagIo for BlackMagicProbe<R, W>
+{
+    fn shift_bit(
+        &mut self,
+        tms: bool,
+        tdi: bool,
+        capture_tdo: bool,
+    ) -> Result<(), DebugProbeError> {
+        self.jtag_state.state.update(tms);
+        let response = self.command(RemoteCommand::JtagNext { tms, tdi }).unwrap();
+        if capture_tdo {
+            self.in_bits.push(response.0 != 0);
+        }
+        Ok(())
+    }
+
+    fn shift_bits(
+        &mut self,
+        tms: impl IntoIterator<Item = bool>,
+        tdi: impl IntoIterator<Item = bool>,
+        cap: impl IntoIterator<Item = bool>,
+    ) -> Result<(), DebugProbeError> {
+        let mut transaction = vec![];
+        let mut last_tms = false;
+        let mut last_cap = false;
+
+        let mut special_transaction = false;
+        let mut tms_true_count = 0;
+        let mut cap_count = 0;
+        for (tms, (tdi, cap)) in tms.into_iter().zip(tdi.into_iter().zip(cap)) {
+            if tms {
+                tms_true_count += 1;
+            }
+            if cap {
+                cap_count += 1;
+            }
+            last_tms = tms;
+            last_cap = cap;
+            transaction.push((tms, tdi, cap));
+        }
+
+        // A strange number of bits are captured, such as including the last bit or
+        // including a smattering of bits in the middle of the transaction.
+        if (cap_count != 0 && (cap_count + 1 != transaction.len())) || last_cap {
+            special_transaction = true;
+        }
+
+        // The TMS value is `true` for a field other than the last bit
+        if tms_true_count > 1 || (tms_true_count == 1 && !last_tms) {
+            special_transaction = true;
+        }
+
+        if special_transaction {
+            for (tms, tdi, cap) in transaction {
+                self.shift_bit(tms, tdi, cap)?;
+            }
+        } else {
+            self.jtag_state.state.update(tms_true_count > 0);
+            self.perform_jtag_transfer(transaction, tms_true_count > 0, cap_count > 0)?;
+        }
+
+        Ok(())
+    }
+
+    fn read_captured_bits(&mut self) -> Result<BitVec<u8, Lsb0>, DebugProbeError> {
+        tracing::trace!("reading captured bits");
+        Ok(std::mem::take(&mut self.in_bits))
+    }
+
+    fn state_mut(&mut self) -> &mut JtagDriverState {
+        &mut self.jtag_state
+    }
+
+    fn state(&self) -> &JtagDriverState {
+        &self.jtag_state
+    }
+}
+
+/// Determine if a given serial port is a Black Magic Probe GDB interface.
+/// The BMP has at least two serial ports, and we want to make sure we get
+/// the correct one.
+fn is_blac_kmagic_probe_hardware(info: &UsbPortInfo, port_name: &str) -> bool {
+    if info.vid != BLACK_MAGIC_PROBE_VID {
+        return false;
+    }
+    if info.pid != BLACK_MAGIC_PROBE_PID {
+        return false;
+    }
+
+    // Mac specifies the interface as the CDC Data interface, whereas Linux and
+    // Windows use the CDC Communications interface. Accept either one here.
+    if info.interface != Some(0) && info.interface != Some(1) {
+        return false;
+    }
+
+    // Only accept /dev/cu.* values on macos, to avoid having two
+    // copies of the port (both /dev/tty.* and /dev/cu.*)
+    if cfg!(target_os = "macos") && !port_name.contains("/cu.") {
+        return false;
+    }
+    true
+}
+
+impl ProbeFactory for BlackMagicProbeFactory {
+    fn open(
+        &self,
+        selector: &super::DebugProbeSelector,
+    ) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
+        // Ensure the VID and PID match Black Magic Probes
+        if selector.vendor_id != BLACK_MAGIC_PROBE_VID
+            || selector.product_id != BLACK_MAGIC_PROBE_PID
+        {
+            return Err(DebugProbeError::ProbeCouldNotBeCreated(
+                ProbeCreationError::NotFound,
+            ));
+        }
+
+        // If the serial number is a valid "address:port" string, attempt to
+        // connect to it via TCP.
+        if let Some(serial_number) = &selector.serial_number {
+            if let Ok(connection) = std::net::TcpStream::connect(serial_number) {
+                let reader = connection;
+                let writer = reader.try_clone().map_err(|e| {
+                    DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::Usb(e))
+                })?;
+                return BlackMagicProbe::new(reader, writer)
+                    .map(|p| Box::new(p) as Box<dyn DebugProbe>);
+            }
+        }
+
+        // Otherwise, treat it as a serial port and iterate through all ports.
+        let Ok(ports) = available_ports() else {
+            return Err(DebugProbeError::ProbeCouldNotBeCreated(
+                ProbeCreationError::CouldNotOpen,
+            ));
+        };
+
+        for port_description in ports {
+            let SerialPortType::UsbPort(info) = port_description.port_type else {
+                continue;
+            };
+
+            if !is_blac_kmagic_probe_hardware(&info, &port_description.port_name) {
+                continue;
+            }
+
+            if selector.serial_number != info.serial_number {
+                continue;
+            }
+
+            // Open with the baud rate 115200. This baud rate is arbitrary, since it's
+            // a soft USB device and will run at the same speed regardless of the baud rate.
+            let mut port = serialport::new(port_description.port_name, 115200)
+                .timeout(std::time::Duration::from_secs(1))
+                .open()
+                .map_err(|_| {
+                    DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::CouldNotOpen)
+                })?;
+
+            // Set DTR, indicating we're ready to communicate.
+            port.write_data_terminal_ready(true).map_err(|_| {
+                DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::CouldNotOpen)
+            })?;
+            // A delay appears necessary to allow the BMP to recognize the DTR signal.
+            std::thread::sleep(Duration::from_millis(250));
+            let reader = port;
+            let writer = reader.try_clone().map_err(|_| {
+                DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::CouldNotOpen)
+            })?;
+            return BlackMagicProbe::new(reader, writer)
+                .map(|p| Box::new(p) as Box<dyn DebugProbe>);
+        }
+
+        Err(DebugProbeError::ProbeCouldNotBeCreated(
+            ProbeCreationError::NotFound,
+        ))
+    }
+
+    fn list_probes(&self) -> Vec<super::DebugProbeInfo> {
+        let mut probes = vec![];
+        let Ok(ports) = available_ports() else {
+            return probes;
+        };
+        for port in ports {
+            let SerialPortType::UsbPort(info) = port.port_type else {
+                continue;
+            };
+            if !is_blac_kmagic_probe_hardware(&info, &port.port_name) {
+                continue;
+            }
+            probes.push(DebugProbeInfo {
+                identifier: info
+                    .product
+                    .unwrap_or_else(|| "Black Magic Probe".to_string()),
+                vendor_id: info.vid,
+                product_id: info.pid,
+                serial_number: info.serial_number.map(|s| s.to_string()),
+                probe_factory: &BlackMagicProbeFactory,
+                hid_interface: info.interface,
+            });
+        }
+        probes
+    }
+}

--- a/probe-rs/src/probe/list.rs
+++ b/probe-rs/src/probe/list.rs
@@ -4,7 +4,7 @@ use crate::probe::{
     DebugProbeError, DebugProbeInfo, DebugProbeSelector, Probe, ProbeCreationError, ProbeFactory,
 };
 
-use super::{cmsisdap, espusbjtag, ftdi, jlink, stlink, wlink};
+use super::{blackmagic, cmsisdap, espusbjtag, ftdi, jlink, stlink, wlink};
 
 /// Struct to list all attached debug probes
 #[derive(Debug)]
@@ -75,6 +75,7 @@ impl Default for AllProbesLister {
 
 impl AllProbesLister {
     const DRIVERS: &'static [&'static dyn ProbeFactory] = &[
+        &blackmagic::BlackMagicProbeFactory,
         &cmsisdap::CmsisDapFactory,
         &ftdi::FtdiProbeFactory,
         &stlink::StLinkFactory,


### PR DESCRIPTION
This adds initial support for using a Black Magic Probe with probe-rs.

This initial commit adds basic support for JTAG and SWD. The probe is operated using bit-bang commands, so it is very slow right now. JTAG in particular is operating bit-by-bit.

Future patches will increase performance.

```
$ cargo run -- info --probe 1d50:6018:97B6DC14
   Compiling probe-rs-tools v0.24.0 (/Users/seancross/Code/probe-rs/probe-rs-tools)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.55s
     Running `target/debug/probe-rs info --probe '1d50:6018:97B6DC14'`
Probing target via JTAG

ARM Chip with debug port Default:
Debug Port: DPv0, DP Designer: <unknown>
└── 0 MemoryAP (AmbaAhb3)
    └── ROM Table (Class 1), Designer: STMicroelectronics
        ├── Cortex-M4 SCS   (Generic IP component)
        │   └── CPUID
        │       ├── IMPLEMENTER: ARM Ltd
        │       ├── VARIANT: 0
        │       ├── PARTNO: Cortex-M4
        │       └── REVISION: 1
        ├── Cortex-M3 DWT   (Generic IP component)
        ├── Cortex-M3 FBP   (Generic IP component)
        ├── Cortex-M3 ITM   (Generic IP component)
        ├── Cortex-M4 TPIU  (Coresight Component)
        └── Cortex-M4 ETM   (Coresight Component)


RISC-V Chip:
  IDCODE: 0000000000
    Version:      0
    Part:         0
    Manufacturer: 0 (Unknown Manufacturer Code)
Error showing Xtensa chip information: An error originating from the DebugProbe occurred.

Caused by:
    Invalid instruction register access: 30

Probing target via SWD

ARM Chip with debug port Default:
Debug Port: DPv1, DP Designer: ARM Ltd
└── 0 MemoryAP (AmbaAhb3)
    └── ROM Table (Class 1), Designer: STMicroelectronics
        ├── Cortex-M4 SCS   (Generic IP component)
        │   └── CPUID
        │       ├── IMPLEMENTER: ARM Ltd
        │       ├── VARIANT: 0
        │       ├── PARTNO: Cortex-M4
        │       └── REVISION: 1
        ├── Cortex-M3 DWT   (Generic IP component)
        ├── Cortex-M3 FBP   (Generic IP component)
        ├── Cortex-M3 ITM   (Generic IP component)
        ├── Cortex-M4 TPIU  (Coresight Component)
        └── Cortex-M4 ETM   (Coresight Component)


Debugging RISC-V targets over SWD is not supported. For these targets, JTAG is the only supported protocol. RISC-V specific information cannot be printed.
Debugging Xtensa targets over SWD is not supported. For these targets, JTAG is the only supported protocol. Xtensa specific information cannot be printed.

$
```