### PR TITLE
Add support for Digilent probes

### DIFF
--- a/changelog/added-digilent-probes
+++ b/changelog/added-digilent-probes
@@ -1,0 +1,1 @@
+Added support for Digilent HS1, HS2, and HS3 FTDI probes.

--- a/probe-rs/src/probe/ftdi/ftdaye/mod.rs
+++ b/probe-rs/src/probe/ftdi/ftdaye/mod.rs
@@ -276,6 +276,9 @@ impl Builder {
 pub struct Device {
     context: FtdiContext,
     chip_type: Option<ChipType>,
+    vendor_id: u16,
+    product_id: u16,
+    product_string: Option<String>,
 }
 
 impl std::fmt::Debug for Device {
@@ -430,6 +433,9 @@ impl Device {
                 bitbang: None,
             },
             chip_type,
+            vendor_id: usb_device.vendor_id(),
+            product_id: usb_device.product_id(),
+            product_string: usb_device.product_string().map(|s| s.to_string()),
         })
     }
 
@@ -451,6 +457,18 @@ impl Device {
 
     pub fn chip_type(&self) -> Option<ChipType> {
         self.chip_type
+    }
+
+    pub fn vendor_id(&self) -> u16 {
+        self.vendor_id
+    }
+
+    pub fn product_id(&self) -> u16 {
+        self.product_id
+    }
+
+    pub fn product_string(&self) -> Option<&str> {
+        self.product_string.as_deref()
     }
 
     pub fn set_pins(&mut self, level: u16, direction: u16) -> Result<()> {


### PR DESCRIPTION
## Change
This change sets different FTDI pin layouts depending on which probe is detected, which is required to support Digilent HS* JTAG probes.

The layout is determined by the `vendor_id`, `product_id`, and `product_string`. The product description is required because the USB `vendor_id` and `product_id` are not enough to identify Digilent probes (e.g. Digilent HS2 & HS3 are the same).

## Background
I have several Digilent JTAG probes that are based on FTDI chips, but they did not work as expected when tested with probe-rs. After digging into the FTDI module, I found that probe-rs [defaults the pin configurations](https://github.com/probe-rs/probe-rs/blob/7dfe7ae8f8d5b5f1d3e6a698aad488edac4e92ef/probe-rs/src/probe/ftdi/mod.rs#L78-L83) to `output: 0x0008, direction: 0x000b`. However, the Diligent probes require different values. For example, the Digilent HS3 requires `output: 0x2088, direction: 0x308b`, otherwise it will not function. I found these values in the OpenOCD interface script: [digilent_jtag_hs3.cfg](https://github.com/openocd-org/openocd/blob/e09bb72da50c9a9878565af23ee8d5465c11526d/tcl/interface/ftdi/digilent_jtag_hs3.cfg#L14).

## Question
I've hard-coded values for Digilent probes, just like `ChipType` in `probe/ftdi/ftdaye/mod.rs`. These values are needed to auto-detect the probe, so I don't think they should be run-time configuration or CLI parameters. However, should these be in some YAML that's compiled in like targets? Or, is it ok for now since there are so few?