### PR TITLE
Add support for tunneled JTAG access to RISC-V targets

### DIFF
--- a/changelog/added-riscv-jtag-tunnel.md
+++ b/changelog/added-riscv-jtag-tunnel.md
@@ -1,0 +1,1 @@
+Added support for tunneled JTAG access to RISC-V targets configured with a `RiscvJtagTunnel` in `Chip::jtag`.

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -16,6 +16,20 @@ pub struct ScanChainElement {
     pub ir_len: Option<u8>,
 }
 
+/// Configuration for JTAG tunneling.
+///
+/// This JTAG tunnel wraps JTAG IR and DR accesses as DR access to a specific instruction. For
+/// example, this can be used to access a Risc-V core in an FPGA using the same JTAG cable that
+/// configures the FPGA.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JtagTunnel {
+    /// JTAG instruction used to tunnel
+    pub ir_id: u32,
+
+    /// Width of tunneled JTAG instruction register
+    pub ir_width: u32,
+}
+
 /// Configuration for JTAG probes.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Jtag {
@@ -24,6 +38,10 @@ pub struct Jtag {
     /// ref: `<https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain>`
     #[serde(default)]
     pub scan_chain: Option<Vec<ScanChainElement>>,
+
+    /// Describes JTAG tunnel
+    #[serde(default)]
+    pub tunnel: Option<JtagTunnel>,
 }
 
 /// A single chip variant.

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -22,7 +22,7 @@ pub struct ScanChainElement {
 /// example, this can be used to access a Risc-V core in an FPGA using the same JTAG cable that
 /// configures the FPGA.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct JtagTunnel {
+pub struct RiscvJtagTunnel {
     /// JTAG instruction used to tunnel
     pub ir_id: u32,
 
@@ -39,9 +39,9 @@ pub struct Jtag {
     #[serde(default)]
     pub scan_chain: Option<Vec<ScanChainElement>>,
 
-    /// Describes JTAG tunnel
+    /// Describes JTAG tunnel for Risc-V
     #[serde(default)]
-    pub tunnel: Option<JtagTunnel>,
+    pub riscv_tunnel: Option<RiscvJtagTunnel>,
 }
 
 /// A single chip variant.

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -19,7 +19,7 @@ mod memory;
 pub(crate) mod serialize;
 
 pub use chip::{
-    ArmCoreAccessOptions, Chip, Core, CoreAccessOptions, Jtag, RiscvCoreAccessOptions,
+    ArmCoreAccessOptions, Chip, Core, CoreAccessOptions, Jtag, JtagTunnel, RiscvCoreAccessOptions,
     ScanChainElement, XtensaCoreAccessOptions,
 };
 pub use chip_family::{

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -19,8 +19,8 @@ mod memory;
 pub(crate) mod serialize;
 
 pub use chip::{
-    ArmCoreAccessOptions, Chip, Core, CoreAccessOptions, Jtag, JtagTunnel, RiscvCoreAccessOptions,
-    ScanChainElement, XtensaCoreAccessOptions,
+    ArmCoreAccessOptions, Chip, Core, CoreAccessOptions, Jtag, RiscvCoreAccessOptions,
+    RiscvJtagTunnel, ScanChainElement, XtensaCoreAccessOptions,
 };
 pub use chip_family::{
     Architecture, ChipFamily, CoreType, InstructionSet, TargetDescriptionSource,

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -6,8 +6,8 @@
 
 use crate::architecture::riscv::dtm::dtm_access::DtmAccess;
 use crate::{
-    architecture::riscv::*, memory_mapped_bitfield_register, probe::DeferredResultIndex,
-    Error as ProbeRsError,
+    architecture::riscv::*, config::Target, memory_mapped_bitfield_register,
+    probe::DeferredResultIndex, Error as ProbeRsError,
 };
 use std::any::Any;
 use std::collections::HashMap;
@@ -369,6 +369,26 @@ pub trait RiscvInterfaceBuilder<'probe> {
         Err(DebugProbeError::InterfaceNotAvailable {
             interface_name: "Tunneled RISC-V",
         })
+    }
+
+    /// Consumes the factory and creates a communication interface
+    /// object initialised with the given state.
+    ///
+    /// Automatically determines whether to use JTAG tunneling or not from the target.
+    fn attach_auto<'state>(
+        self: Box<Self>,
+        target: &Target,
+        state: &'state mut RiscvDebugInterfaceState,
+    ) -> Result<RiscvCommunicationInterface<'state>, DebugProbeError>
+    where
+        'probe: 'state,
+    {
+        let maybe_tunnel = target.jtag.as_ref().map(|j| j.tunnel.as_ref()).flatten();
+        if let Some(tunnel) = maybe_tunnel {
+            self.attach_tunneled(tunnel.ir_id, tunnel.ir_width, state)
+        } else {
+            self.attach(state)
+        }
     }
 }
 

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -383,7 +383,11 @@ pub trait RiscvInterfaceBuilder<'probe> {
     where
         'probe: 'state,
     {
-        let maybe_tunnel = target.jtag.as_ref().map(|j| j.tunnel.as_ref()).flatten();
+        let maybe_tunnel = target
+            .jtag
+            .as_ref()
+            .map(|j| j.riscv_tunnel.as_ref())
+            .flatten();
         if let Some(tunnel) = maybe_tunnel {
             self.attach_tunneled(tunnel.ir_id, tunnel.ir_width, state)
         } else {

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -354,6 +354,22 @@ pub trait RiscvInterfaceBuilder<'probe> {
     ) -> Result<RiscvCommunicationInterface<'state>, DebugProbeError>
     where
         'probe: 'state;
+
+    /// Consumes the factory and creates a communication interface
+    /// object using a JTAG tunnel initialised with the given state.
+    fn attach_tunneled<'state>(
+        self: Box<Self>,
+        _tunnel_ir_id: u32,
+        _tunnel_ir_width: u32,
+        _state: &'state mut RiscvDebugInterfaceState,
+    ) -> Result<RiscvCommunicationInterface<'state>, DebugProbeError>
+    where
+        'probe: 'state,
+    {
+        Err(DebugProbeError::InterfaceNotAvailable {
+            interface_name: "Tunneled RISC-V",
+        })
+    }
 }
 
 /// A interface that implements controls for RISC-V cores.

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -383,11 +383,7 @@ pub trait RiscvInterfaceBuilder<'probe> {
     where
         'probe: 'state,
     {
-        let maybe_tunnel = target
-            .jtag
-            .as_ref()
-            .map(|j| j.riscv_tunnel.as_ref())
-            .flatten();
+        let maybe_tunnel = target.jtag.as_ref().and_then(|j| j.riscv_tunnel.as_ref());
         if let Some(tunnel) = maybe_tunnel {
             self.attach_tunneled(tunnel.ir_id, tunnel.ir_width, state)
         } else {

--- a/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
@@ -69,10 +69,7 @@ impl<'probe> JtagDtm<'probe> {
     }
 
     fn transform_dmi_result(response_bytes: Vec<u8>) -> Result<u32, DmiOperationStatus> {
-        let response_value: u128 = response_bytes.iter().enumerate().fold(0, |acc, elem| {
-            let (byte_offset, value) = elem;
-            acc + ((*value as u128) << (8 * byte_offset))
-        });
+        let response_value = u128_from_data(&response_bytes);
 
         // Verify that the transfer was ok
         let op = (response_value & DMI_OP_MASK) as u8;
@@ -356,6 +353,13 @@ impl DmiOperationStatus {
 
         Some(status)
     }
+}
+
+fn u128_from_data(data: &[u8]) -> u128 {
+    data.iter().enumerate().fold(0, |acc, elem| {
+        let (byte_offset, value) = elem;
+        acc + ((*value as u128) << (8 * byte_offset))
+    })
 }
 
 /// Address of the `dtmcs` JTAG register.

--- a/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
@@ -5,7 +5,6 @@
 
 use bitfield::bitfield;
 use std::time::{Duration, Instant};
-use std::u32;
 
 use crate::architecture::riscv::communication_interface::{
     RiscvCommunicationInterface, RiscvDebugInterfaceState, RiscvError, RiscvInterfaceBuilder,
@@ -366,7 +365,7 @@ impl<'probe> TunneledJtagDtm<'probe> {
 
     fn transform_tunneled_dr_result(response_bytes: Vec<u8>) -> Vec<u8> {
         let raw_response = u128_from_data(&response_bytes);
-        let response = (raw_response >> 4) as u128;
+        let response = raw_response >> 4;
         response.to_le_bytes().into()
     }
 

--- a/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
@@ -5,17 +5,18 @@
 
 use bitfield::bitfield;
 use std::time::{Duration, Instant};
+use std::u32;
 
 use crate::architecture::riscv::communication_interface::{
     RiscvCommunicationInterface, RiscvDebugInterfaceState, RiscvError, RiscvInterfaceBuilder,
 };
 use crate::architecture::riscv::dtm::dtm_access::DtmAccess;
 use crate::error::Error;
-use crate::probe::DebugProbeError;
 use crate::probe::{
     CommandResult, DeferredResultIndex, DeferredResultSet, JTAGAccess, JtagCommandQueue,
     JtagWriteCommand,
 };
+use crate::probe::{DebugProbeError, ShiftDrCommand};
 
 #[derive(Debug, Default)]
 struct DtmState {
@@ -50,6 +51,28 @@ impl<'probe> RiscvInterfaceBuilder<'probe> for JtagDtmBuilder<'probe> {
 
         Ok(RiscvCommunicationInterface::new(
             Box::new(JtagDtm::new(self.0, dtm_state)),
+            &mut state.interface_state,
+        ))
+    }
+
+    fn attach_tunneled<'state>(
+        self: Box<Self>,
+        tunnel_ir_id: u32,
+        tunnel_ir_width: u32,
+        state: &'state mut RiscvDebugInterfaceState,
+    ) -> Result<RiscvCommunicationInterface<'state>, DebugProbeError>
+    where
+        'probe: 'state,
+    {
+        let dtm_state = state.dtm_state.downcast_mut::<DtmState>().unwrap();
+
+        Ok(RiscvCommunicationInterface::new(
+            Box::new(TunneledJtagDtm::new(
+                self.0,
+                tunnel_ir_id,
+                tunnel_ir_width,
+                dtm_state,
+            )),
             &mut state.interface_state,
         ))
     }
@@ -289,6 +312,298 @@ impl DtmAccess for JtagDtm<'_> {
     }
 }
 
+/// Access to the tunneled Debug Transport Module (DTM),
+/// which is used to communicate with the RISC-V debug module.
+///
+/// The protocol was originally created by SiFive for their IP, but many others implement it. For
+/// reference, see the `riscv use_bscan_tunnel` command of riscv-openocd.
+///
+/// Tunneled DR scan:
+/// 1. Select IR (0) or DR (1): 1 bit
+/// 2. Width of tunneled scan: 7 bits
+/// 3. Tunneled scan bits: width + 1 bits
+/// 4. Set tunnel to idle: 3 zero bits
+#[derive(Debug)]
+pub struct TunneledJtagDtm<'probe> {
+    pub probe: &'probe mut dyn JTAGAccess,
+    state: &'probe mut DtmState,
+    select_dtmcs: JtagWriteCommand,
+    select_dmi: JtagWriteCommand,
+}
+
+impl<'probe> TunneledJtagDtm<'probe> {
+    fn new(
+        probe: &'probe mut dyn JTAGAccess,
+        tunnel_ir_id: u32,
+        tunnel_ir_width: u32,
+        state: &'probe mut DtmState,
+    ) -> Self {
+        Self {
+            probe,
+            state,
+            select_dtmcs: tunnel_select_command(tunnel_ir_id, tunnel_ir_width, DTMCS_ADDRESS),
+            select_dmi: tunnel_select_command(tunnel_ir_id, tunnel_ir_width, DMI_ADDRESS),
+        }
+    }
+
+    fn write_dtmcs(&mut self, data: u32) -> Result<u32, RiscvError> {
+        self.probe.write_register(
+            self.select_dtmcs.address,
+            &self.select_dtmcs.data,
+            self.select_dtmcs.len,
+        )?;
+        let cmd = tunnel_dtmcs_command(data);
+        let result = self
+            .probe
+            .write_dr(&cmd.data, cmd.len)
+            .map(|r| (cmd.transform)(&cmd, r))?;
+        match result {
+            Ok(CommandResult::U32(d)) => Ok(d),
+            Err(crate::Error::Probe(e)) => Err(e.into()),
+            _ => Err(RiscvError::DtmOperationFailed),
+        }
+    }
+
+    fn transform_tunneled_dr_result(response_bytes: Vec<u8>) -> Vec<u8> {
+        let raw_response = u128_from_data(&response_bytes);
+        let response = (raw_response >> 4) as u128;
+        response.to_le_bytes().into()
+    }
+
+    fn dmi_register_access(
+        &mut self,
+        op: DmiOperation,
+    ) -> Result<Result<u32, DmiOperationStatus>, DebugProbeError> {
+        self.probe.write_register(
+            self.select_dmi.address,
+            &self.select_dmi.data,
+            self.select_dmi.len,
+        )?;
+
+        let dmi_bits = self.state.abits + DMI_ADDRESS_BIT_OFFSET;
+        let (bit_size, bytes) = op.to_tunneled_byte_batch(dmi_bits);
+        self.probe
+            .write_dr(&bytes, bit_size)
+            .map(Self::transform_tunneled_dr_result)
+            .map(JtagDtm::transform_dmi_result)
+    }
+
+    fn schedule_dmi_register_access(
+        &mut self,
+        op: DmiOperation,
+    ) -> Result<DeferredResultIndex, RiscvError> {
+        self.state.queued_commands.schedule(self.select_dmi.clone());
+
+        let dmi_bits = self.state.abits + DMI_ADDRESS_BIT_OFFSET;
+        let (bit_size, bytes) = op.to_tunneled_byte_batch(dmi_bits);
+
+        Ok(self.state.queued_commands.schedule(ShiftDrCommand {
+            data: bytes.to_vec(),
+            transform: |_, raw_result| {
+                let result = Self::transform_tunneled_dr_result(raw_result);
+                JtagDtm::transform_dmi_result(result)
+                    .map(CommandResult::U32)
+                    .map_err(|e| Error::Riscv(e.map_as_err().unwrap_err()))
+            },
+            len: bit_size,
+        }))
+    }
+
+    fn dmi_register_access_with_timeout(
+        &mut self,
+        op: DmiOperation,
+        timeout: Duration,
+    ) -> Result<u32, RiscvError> {
+        let start_time = Instant::now();
+
+        self.execute()?;
+
+        loop {
+            match self.dmi_register_access(op)? {
+                Ok(result) => return Ok(result),
+                Err(DmiOperationStatus::RequestInProgress) => {
+                    // Operation still in progress, reset dmi status and try again.
+                    self.clear_error_state()?;
+                    self.probe
+                        .set_idle_cycles(self.probe.idle_cycles().saturating_add(1));
+                }
+                Err(e) => return Err(e.map_as_err().unwrap_err()),
+            };
+
+            if start_time.elapsed() > timeout {
+                return Err(RiscvError::Timeout);
+            }
+        }
+    }
+}
+
+impl DtmAccess for TunneledJtagDtm<'_> {
+    fn init(&mut self) -> Result<(), RiscvError> {
+        self.probe.tap_reset()?;
+        let raw_dtmcs = self.write_dtmcs(0)?;
+
+        if raw_dtmcs == 0 {
+            return Err(RiscvError::NoRiscvTarget);
+        }
+
+        let dtmcs = Dtmcs(raw_dtmcs);
+
+        tracing::debug!("{:?}", dtmcs);
+
+        let abits = dtmcs.abits();
+        let idle_cycles = dtmcs.idle();
+
+        if dtmcs.version() != 1 {
+            return Err(RiscvError::UnsupportedDebugTransportModuleVersion(
+                dtmcs.version() as u8,
+            ));
+        }
+
+        // Setup the number of idle cycles between JTAG accesses
+        self.probe.set_idle_cycles(idle_cycles as u8);
+        self.state.abits = abits;
+
+        Ok(())
+    }
+
+    fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
+        self.probe.target_reset_assert()
+    }
+
+    fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {
+        self.probe.target_reset_deassert()
+    }
+
+    fn clear_error_state(&mut self) -> Result<(), RiscvError> {
+        let mut dtmcs = Dtmcs(0);
+
+        dtmcs.set_dmireset(true);
+
+        let Dtmcs(reg_value) = dtmcs;
+
+        self.write_dtmcs(reg_value)?;
+
+        Ok(())
+    }
+
+    fn read_deferred_result(
+        &mut self,
+        index: DeferredResultIndex,
+    ) -> Result<CommandResult, RiscvError> {
+        match self.state.jtag_results.take(index) {
+            Ok(result) => Ok(result),
+            Err(index) => {
+                self.execute()?;
+                // We can lose data if `execute` fails.
+                self.state
+                    .jtag_results
+                    .take(index)
+                    .map_err(|_| RiscvError::BatchedResultNotAvailable)
+            }
+        }
+    }
+
+    fn execute(&mut self) -> Result<(), RiscvError> {
+        let mut cmds = std::mem::take(&mut self.state.queued_commands);
+
+        while !cmds.is_empty() {
+            match self.probe.write_register_batch(&cmds) {
+                Ok(r) => {
+                    self.state.jtag_results.merge_from(r);
+                    return Ok(());
+                }
+                Err(e) => match e.error {
+                    Error::Riscv(RiscvError::DtmOperationInProcess) => {
+                        self.clear_error_state()?;
+
+                        // queue up the remaining commands when we retry
+                        cmds.consume(e.results.len());
+                        self.state.jtag_results.merge_from(e.results);
+
+                        self.probe
+                            .set_idle_cycles(self.probe.idle_cycles().saturating_add(1));
+                    }
+                    Error::Riscv(error) => return Err(error),
+                    Error::Probe(error) => return Err(error.into()),
+                    _other => unreachable!(),
+                },
+            }
+        }
+
+        Ok(())
+    }
+
+    fn schedule_write(
+        &mut self,
+        address: u64,
+        value: u32,
+    ) -> Result<Option<DeferredResultIndex>, RiscvError> {
+        self.schedule_dmi_register_access(DmiOperation::Write { address, value })
+            .map(Some)
+    }
+
+    fn schedule_read(&mut self, address: u64) -> Result<DeferredResultIndex, RiscvError> {
+        // Prepare the read by sending a read request with the register address
+        self.schedule_dmi_register_access(DmiOperation::Read { address })?;
+
+        // Read back the response from the previous request.
+        self.schedule_dmi_register_access(DmiOperation::NoOp)
+    }
+
+    fn read_with_timeout(&mut self, address: u64, timeout: Duration) -> Result<u32, RiscvError> {
+        // Prepare the read by sending a read request with the register address
+        self.schedule_dmi_register_access(DmiOperation::Read { address })?;
+
+        self.dmi_register_access_with_timeout(DmiOperation::NoOp, timeout)
+    }
+
+    fn write_with_timeout(
+        &mut self,
+        address: u64,
+        value: u32,
+        timeout: Duration,
+    ) -> Result<Option<u32>, RiscvError> {
+        self.dmi_register_access_with_timeout(DmiOperation::Write { address, value }, timeout)
+            .map(Some)
+    }
+
+    fn read_idcode(&mut self) -> Result<Option<u32>, DebugProbeError> {
+        let value = self.probe.read_register(0x1, 32)?;
+        Ok(Some(u32::from_le_bytes((&value[..]).try_into().unwrap())))
+    }
+}
+
+fn tunnel_select_command(
+    tunnel_ir_id: u32,
+    tunnel_ir_width: u32,
+    address: u32,
+) -> JtagWriteCommand {
+    let tunneled_ir: u32 = (tunnel_ir_width << (tunnel_ir_width + 3)) | (address << 3);
+    let tunneled_ir_len = 1 + 7 + tunnel_ir_width + 3;
+    JtagWriteCommand {
+        address: tunnel_ir_id,
+        data: tunneled_ir.to_le_bytes().into(),
+        len: tunneled_ir_len,
+        transform: |_, _| Ok(CommandResult::None),
+    }
+}
+
+fn tunnel_dtmcs_command(data: u32) -> ShiftDrCommand {
+    let width_offset = 1 + (DTMCS_WIDTH as u128) + 3;
+    let msb_offset = 7 + width_offset;
+    let tunneled_dr: u128 =
+        (1 << msb_offset) | ((DTMCS_WIDTH as u128) << width_offset) | ((data as u128) << 3);
+    ShiftDrCommand {
+        data: tunneled_dr.to_le_bytes().into(),
+        len: (msb_offset as u32) + 1,
+        transform: |_, result| {
+            let raw_response = u128_from_data(&result);
+            let response = (raw_response >> 4) as u32;
+            Ok(CommandResult::U32(response))
+        },
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 pub enum DmiOperation {
     NoOp,
@@ -305,18 +620,28 @@ impl DmiOperation {
         }
     }
 
-    pub fn to_byte_batch(self) -> [u8; 16] {
+    fn register_value(&self) -> u128 {
         let (opcode, address, value): (u128, u128, u128) = match self {
             Self::NoOp => (self.opcode() as u128, 0, 0),
-            Self::Read { address } => (self.opcode() as u128, address as u128, 0),
+            Self::Read { address } => (self.opcode() as u128, *address as u128, 0),
             Self::Write { address, value } => {
-                (self.opcode() as u128, address as u128, value as u128)
+                (self.opcode() as u128, *address as u128, *value as u128)
             }
         };
-        let register_value: u128 =
-            (address << DMI_ADDRESS_BIT_OFFSET) | (value << DMI_VALUE_BIT_OFFSET) | opcode;
+        (address << DMI_ADDRESS_BIT_OFFSET) | (value << DMI_VALUE_BIT_OFFSET) | opcode
+    }
 
-        register_value.to_le_bytes()
+    pub fn to_byte_batch(self) -> [u8; 16] {
+        self.register_value().to_le_bytes()
+    }
+
+    pub fn to_tunneled_byte_batch(self, dmi_bits: u32) -> (u32, [u8; 16]) {
+        let width_offset = 1 + (dmi_bits) + 3;
+        let msb_offset = 7 + width_offset;
+        let bits = (1 << (msb_offset as u128))
+            | (((dmi_bits + 1) as u128) << (width_offset as u128))
+            | (self.register_value() << 3);
+        (msb_offset + 1, bits.to_le_bytes())
     }
 }
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -112,7 +112,7 @@ impl ArchitectureInterface {
                 match &mut ifaces[idx] {
                     JtagInterface::Riscv(state) => {
                         let factory = probe.try_get_riscv_interface_builder()?;
-                        let iface = factory.attach(state)?;
+                        let iface = factory.attach_auto(target, state)?;
                         combined_state.attach_riscv(target, iface)
                     }
                     JtagInterface::Xtensa(state) => {
@@ -346,7 +346,7 @@ impl Session {
                     let factory = probe.try_get_riscv_interface_builder()?;
                     let mut state = factory.create_state();
                     {
-                        let mut interface = factory.attach(&mut state)?;
+                        let mut interface = factory.attach_auto(&target, &mut state)?;
                         interface.enter_debug_mode()?;
                     }
 
@@ -562,7 +562,7 @@ impl Session {
             probe.select_jtag_tap(tap_idx)?;
             if let JtagInterface::Riscv(state) = &mut ifaces[tap_idx] {
                 let factory = probe.try_get_riscv_interface_builder()?;
-                return Ok(factory.attach(state)?);
+                return Ok(factory.attach_auto(&self.target, state)?);
             }
         }
         Err(RiscvError::NoRiscvTarget.into())


### PR DESCRIPTION
## Change
This change adds `TunneledJtagDtm` in `architecture::riscv::dtm::jtag_dtm` that allows access to a RISC-V target through a JTAG tunnel with a configurable instruction and data register width. Additionally, this change adds `attached_tunneled` and `attach_auto` in `RiscvInterfaceBuilder` to allow `Session` to use a tunnel if configured on the `Target`.

The JTAG tunnel is configurable in YAML for a variant like this:
```yaml
  # config for Xilinx BSCANE2
  jtag:
    riscv_tunnel:
      ir_id: 0x23
      ir_width: 6
```

I've tested it with a VexRiscv soft-core running on a Xilinx XC7A200T using a Digilent HS3 probe.

## Background
It's common to use a JTAG tunnel to access RISC-V soft-cores running on FPGAs. A tunnel allows using the same cable for configuring the FPGA and debug access to the soft-core within. The simple protocol was originally created by SiFive, but is now used by many (including [VexRiscv](https://github.com/SpinalHDL/VexRiscv#tunneled-jtag)).

OpenOCD supports tunneled JTAG access to RISC-V with the `riscv use_bscan_tunnel` command ([docs on this page](https://openocd.org/doc/html/Architecture-and-Core-Commands.html)).

A tunneled scan looks like this:
1. Scan configured instruction (`RiscvJtagTunnel::ir_id`)
2. Scan data register with:
    1. Select IR (0) or DR (1): 1 bit
    2. Width of tunneled scan: 7 bits
    3. Tunneled scan bits: width + 1 bits
    4. Set tunnel to idle: 3 zero bits