### PR TITLE
Fix RTT when downloading to RAM

### DIFF
--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -352,6 +352,11 @@ impl FlashLoader {
         memory_map.iter().find(|region| region.contains(address))
     }
 
+    /// Returns whether an address will be flashed with data
+    pub fn has_data_for_address(&self, address: u64) -> bool {
+        self.builder.has_data_in_range(&(address..address + 1))
+    }
+
     /// Reads the image according to the file format and adds it to the loader.
     pub fn load_image<T: Read + Seek>(
         &mut self,


### PR DESCRIPTION
## Change
Without this change, probe-rs clears the RTT header after downloading and resetting a target. When downloading to and running from flash memory, this is fine since the startup code in flash will put the RTT header back into RAM. However, when downloading to RAM, the RTT header stays cleared and prevents RTT from working.

This change detects whether any flash memory was written during the download. If so, then it clears the RTT header like before. Otherwise if only RAM was written, then it does not clear the header.

## Background
I was trying to get defmt_rtt to work with a VexRiscv soft-core on a FPGA, but no data was showing up. Debug logs showed that probe-rs was repeatedly looking for the Segger RTT header, but only finding zeros at the expected address.

When I tried rtt_target (without defmt), it worked fine. This made me realize what's happening since rtt_target has an init function that you call from main that creates the header in memory. Looking closer at defmt_rtt, it creates the header statically and relies on the startup code to move it to RAM. In my case I have no flash and no startup code though. So when probe-rs clears the header, it stays clear and probe-rs can't initialize RTT.