### PR TITLE
Add API to disable PC sample in ARM

### DIFF
--- a/changelog/added-api-to-disable-pc-sample-in-arm.md
+++ b/changelog/added-api-to-disable-pc-sample-in-arm.md
@@ -1,0 +1,1 @@
+Added API to disable PC sample in ARM

--- a/probe-rs/src/architecture/arm/component/dwt.rs
+++ b/probe-rs/src/architecture/arm/component/dwt.rs
@@ -100,6 +100,15 @@ impl<'a> Dwt<'a> {
         ctrl.set_postpreset(0x3);
         ctrl.store(self.component, self.interface)
     }
+
+    /// Disable PC sample trace output
+    pub fn disable_pc_sampling(&mut self) -> Result<(), ArmError> {
+        let mut ctrl = Ctrl::load(self.component, self.interface)?;
+        ctrl.set_pcsamplena(false);
+        ctrl.set_cyctap(false);
+        ctrl.set_postpreset(0x0);
+        ctrl.store(self.component, self.interface)
+    }
 }
 
 memory_mapped_bitfield_register! {


### PR DESCRIPTION
This PR adds an API to disable pc sampling in ARM, as it is done with data trace and exception trace