### PR TITLE
Simplify ESP flash attach and handle SPI config where needed

### DIFF
--- a/probe-rs/src/architecture/riscv/assembly.rs
+++ b/probe-rs/src/architecture/riscv/assembly.rs
@@ -34,21 +34,6 @@ pub fn addi(source: u8, destination: u8, immediate: i16) -> u32 {
     )
 }
 
-/// Assemble a `lui` instruction.
-pub fn lui(dest: u8, imm: i32) -> u32 {
-    let opcode = 0b0110111;
-
-    u_type_instruction(opcode, dest, imm as u32)
-}
-
-/// Assemble a `jarl` instruction.
-pub fn jarl(base: u8, return_addr: u8, dst: i32) -> u32 {
-    let opcode = 0b1100111;
-    let function = 0b000;
-
-    i_type_instruction(opcode, base, function, return_addr, (dst as u16) & 0xfff)
-}
-
 // We need to perform the csrr instruction, which reads a CSR.
 // This is a pseudo instruction, which actually is encoded as a
 // csrrs instruction, with the rs1 register being x0,
@@ -94,17 +79,6 @@ fn i_type_instruction(opcode: u8, rs1: u8, funct3: u8, rd: u8, imm: u16) -> u32 
         | (funct3 as u32) << 12
         | (rd as u32) << 7
         | opcode as u32
-}
-
-/// Assemble a U-type instruction, as specified in the RISC-V ISA
-///
-/// This function panics if any of the values would have to be truncated.
-fn u_type_instruction(opcode: u8, rd: u8, imm: u32) -> u32 {
-    assert!(opcode <= 0x7f); // [06:00]
-    assert!(rd <= 0x1f); // [11:07]
-    assert!(imm <= 0xf_ffff); // [31:12]
-
-    imm << 12 | (rd as u32) << 7 | opcode as u32
 }
 
 #[cfg(test)]

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -1622,10 +1622,6 @@ impl<'state> RiscvCommunicationInterface<'state> {
         Ok(())
     }
 
-    pub(crate) fn execute(&mut self) -> Result<(), RiscvError> {
-        self.dtm.execute()
-    }
-
     pub(crate) fn schedule_write_dm_register<R: MemoryMappedRegister<u32>>(
         &mut self,
         register: R,

--- a/probe-rs/src/vendor/espressif/mod.rs
+++ b/probe-rs/src/vendor/espressif/mod.rs
@@ -72,19 +72,19 @@ pub struct Espressif;
 impl Vendor for Espressif {
     fn try_create_debug_sequence(&self, chip: &Chip) -> Option<DebugSequence> {
         let sequence = if chip.name.eq_ignore_ascii_case("esp32s2") {
-            DebugSequence::Xtensa(ESP32S2::create(chip))
+            DebugSequence::Xtensa(ESP32S2::create())
         } else if chip.name.eq_ignore_ascii_case("esp32s3") {
-            DebugSequence::Xtensa(ESP32S3::create(chip))
+            DebugSequence::Xtensa(ESP32S3::create())
         } else if chip.name.eq_ignore_ascii_case("esp32c2") {
-            DebugSequence::Riscv(ESP32C2::create(chip))
+            DebugSequence::Riscv(ESP32C2::create())
         } else if chip.name.eq_ignore_ascii_case("esp32c3") {
-            DebugSequence::Riscv(ESP32C3::create(chip))
+            DebugSequence::Riscv(ESP32C3::create())
         } else if chip.name.eq_ignore_ascii_case("esp32c6") {
-            DebugSequence::Riscv(ESP32C6::create(chip))
+            DebugSequence::Riscv(ESP32C6::create())
         } else if chip.name.eq_ignore_ascii_case("esp32h2") {
-            DebugSequence::Riscv(ESP32H2::create(chip))
+            DebugSequence::Riscv(ESP32H2::create())
         } else if chip.name.starts_with("esp32") {
-            DebugSequence::Xtensa(ESP32::create(chip))
+            DebugSequence::Xtensa(ESP32::create())
         } else {
             return None;
         };

--- a/probe-rs/src/vendor/espressif/sequences/esp.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp.rs
@@ -18,6 +18,9 @@ pub(super) struct EspFlashSizeDetector {
     /// The address of the SPI flash peripheral (`SPIMEM1`).
     pub spiflash_peripheral: u32,
 
+    /// The address of the `ets_efuse_get_spiconfig` ROM function, if needed.
+    pub efuse_get_spiconfig_fn: Option<u32>,
+
     /// The address of the `esp_rom_spiflash_attach` ROM function.
     pub attach_fn: u32,
 

--- a/probe-rs/src/vendor/espressif/sequences/esp.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use probe_rs_target::{Architecture, Chip, MemoryRegion};
+use probe_rs_target::Architecture;
 
 use crate::{
     architecture::xtensa::arch::{
@@ -26,14 +26,6 @@ pub(super) struct EspFlashSizeDetector {
 }
 
 impl EspFlashSizeDetector {
-    pub fn stack_pointer(chip: &Chip) -> u32 {
-        chip.memory_map
-            .iter()
-            .find_map(MemoryRegion::as_ram_region)
-            .map(|ram| ram.range.start as u32 + 0x1_0000)
-            .unwrap()
-    }
-
     pub fn detect_flash_size_esp32(
         &self,
         session: &mut Session,

--- a/probe-rs/src/vendor/espressif/sequences/esp.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp.rs
@@ -27,7 +27,6 @@ impl EspFlashSizeDetector {
         let mut core = session.core(0)?;
         core.reset_and_halt(Duration::from_millis(500))?;
 
-        // call esp_rom_spiflash_attach(0, false)
         let regs = core.registers();
         let spi_config = match self.efuse_get_spiconfig_fn {
             Some(get_spiconfig_fn) => {
@@ -43,6 +42,8 @@ impl EspFlashSizeDetector {
             }
             None => 0,
         };
+
+        // call esp_rom_spiflash_attach(spi_config, false)
         core.write_core_reg(regs.argument_register(0), spi_config as u64)?;
         core.write_core_reg(regs.argument_register(1), 0_u64)?;
 

--- a/probe-rs/src/vendor/espressif/sequences/esp32.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32.rs
@@ -5,8 +5,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use probe_rs_target::Chip;
-
 use super::esp::EspFlashSizeDetector;
 use crate::{
     architecture::xtensa::{
@@ -25,7 +23,7 @@ pub struct ESP32 {
 
 impl ESP32 {
     /// Creates a new debug sequence handle for the ESP32.
-    pub fn create(_chip: &Chip) -> Arc<dyn XtensaDebugSequence> {
+    pub fn create() -> Arc<dyn XtensaDebugSequence> {
         tracing::warn!("Be careful not to reset your ESP32 while connected to the debugger! Depending on the specific device, this may render it temporarily inoperable or permanently damage it.");
         Arc::new(Self {
             inner: EspFlashSizeDetector {

--- a/probe-rs/src/vendor/espressif/sequences/esp32.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32.rs
@@ -27,9 +27,10 @@ impl ESP32 {
         tracing::warn!("Be careful not to reset your ESP32 while connected to the debugger! Depending on the specific device, this may render it temporarily inoperable or permanently damage it.");
         Arc::new(Self {
             inner: EspFlashSizeDetector {
-                stack_pointer: 0x3FFE_0000,
-                load_address: 0x400A_0000,
+                stack_pointer: 0x3ffd0000,
+                load_address: 0x4009_0000,
                 spiflash_peripheral: 0x3ff4_2000,
+                efuse_get_spiconfig_fn: Some(0x40008658),
                 attach_fn: 0x4006_2a6c,
             },
         })

--- a/probe-rs/src/vendor/espressif/sequences/esp32c2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c2.rs
@@ -23,8 +23,9 @@ impl ESP32C2 {
         Arc::new(Self {
             inner: EspFlashSizeDetector {
                 stack_pointer: 0x403a0000,
-                load_address: 0, // Unused for RISC-V
+                load_address: 0x4038c000,
                 spiflash_peripheral: 0x6000_2000,
+                efuse_get_spiconfig_fn: None,
                 attach_fn: 0x4000_0178,
             },
         })

--- a/probe-rs/src/vendor/espressif/sequences/esp32c2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c2.rs
@@ -2,8 +2,6 @@
 
 use std::{sync::Arc, time::Duration};
 
-use probe_rs_target::Chip;
-
 use super::esp::EspFlashSizeDetector;
 use crate::{
     architecture::riscv::{
@@ -21,10 +19,10 @@ pub struct ESP32C2 {
 
 impl ESP32C2 {
     /// Creates a new debug sequence handle for the ESP32C2.
-    pub fn create(chip: &Chip) -> Arc<dyn RiscvDebugSequence> {
+    pub fn create() -> Arc<dyn RiscvDebugSequence> {
         Arc::new(Self {
             inner: EspFlashSizeDetector {
-                stack_pointer: EspFlashSizeDetector::stack_pointer(chip),
+                stack_pointer: 0x403a0000,
                 load_address: 0, // Unused for RISC-V
                 spiflash_peripheral: 0x6000_2000,
                 attach_fn: 0x4000_0178,

--- a/probe-rs/src/vendor/espressif/sequences/esp32c3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c3.rs
@@ -2,8 +2,6 @@
 
 use std::{sync::Arc, time::Duration};
 
-use probe_rs_target::Chip;
-
 use super::esp::EspFlashSizeDetector;
 use crate::{
     architecture::riscv::{
@@ -21,10 +19,10 @@ pub struct ESP32C3 {
 
 impl ESP32C3 {
     /// Creates a new debug sequence handle for the ESP32C3.
-    pub fn create(chip: &Chip) -> Arc<dyn RiscvDebugSequence> {
+    pub fn create() -> Arc<dyn RiscvDebugSequence> {
         Arc::new(Self {
             inner: EspFlashSizeDetector {
-                stack_pointer: EspFlashSizeDetector::stack_pointer(chip),
+                stack_pointer: 0x403c0000,
                 load_address: 0, // Unused for RISC-V
                 spiflash_peripheral: 0x6000_2000,
                 attach_fn: 0x4000_0164,

--- a/probe-rs/src/vendor/espressif/sequences/esp32c3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c3.rs
@@ -23,8 +23,9 @@ impl ESP32C3 {
         Arc::new(Self {
             inner: EspFlashSizeDetector {
                 stack_pointer: 0x403c0000,
-                load_address: 0, // Unused for RISC-V
+                load_address: 0x40390000,
                 spiflash_peripheral: 0x6000_2000,
+                efuse_get_spiconfig_fn: Some(0x4000071c),
                 attach_fn: 0x4000_0164,
             },
         })

--- a/probe-rs/src/vendor/espressif/sequences/esp32c6.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c6.rs
@@ -24,8 +24,9 @@ impl ESP32C6 {
         Arc::new(Self {
             inner: EspFlashSizeDetector {
                 stack_pointer: 0x40850000,
-                load_address: 0, // Unused for RISC-V
+                load_address: 0x40810000,
                 spiflash_peripheral: 0x6000_3000,
+                efuse_get_spiconfig_fn: None,
                 attach_fn: 0x4000_01DC,
             },
         })

--- a/probe-rs/src/vendor/espressif/sequences/esp32c6.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c6.rs
@@ -2,8 +2,6 @@
 
 use std::{sync::Arc, time::Duration};
 
-use probe_rs_target::Chip;
-
 use super::esp::EspFlashSizeDetector;
 use crate::{
     architecture::riscv::{
@@ -22,10 +20,10 @@ pub struct ESP32C6 {
 
 impl ESP32C6 {
     /// Creates a new debug sequence handle for the ESP32C6.
-    pub fn create(chip: &Chip) -> Arc<dyn RiscvDebugSequence> {
+    pub fn create() -> Arc<dyn RiscvDebugSequence> {
         Arc::new(Self {
             inner: EspFlashSizeDetector {
-                stack_pointer: EspFlashSizeDetector::stack_pointer(chip),
+                stack_pointer: 0x40850000,
                 load_address: 0, // Unused for RISC-V
                 spiflash_peripheral: 0x6000_3000,
                 attach_fn: 0x4000_01DC,

--- a/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
@@ -24,8 +24,9 @@ impl ESP32H2 {
         Arc::new(Self {
             inner: EspFlashSizeDetector {
                 stack_pointer: 0x40830000,
-                load_address: 0, // Unused for RISC-V
+                load_address: 0x40810000,
                 spiflash_peripheral: 0x6000_3000,
+                efuse_get_spiconfig_fn: None,
                 attach_fn: 0x4000_01D4,
             },
         })

--- a/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
@@ -2,8 +2,6 @@
 
 use std::{sync::Arc, time::Duration};
 
-use probe_rs_target::Chip;
-
 use super::esp::EspFlashSizeDetector;
 use crate::{
     architecture::riscv::{
@@ -22,10 +20,10 @@ pub struct ESP32H2 {
 
 impl ESP32H2 {
     /// Creates a new debug sequence handle for the ESP32H2.
-    pub fn create(chip: &Chip) -> Arc<dyn RiscvDebugSequence> {
+    pub fn create() -> Arc<dyn RiscvDebugSequence> {
         Arc::new(Self {
             inner: EspFlashSizeDetector {
-                stack_pointer: EspFlashSizeDetector::stack_pointer(chip),
+                stack_pointer: 0x40830000,
                 load_address: 0, // Unused for RISC-V
                 spiflash_peripheral: 0x6000_3000,
                 attach_fn: 0x4000_01D4,

--- a/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
@@ -5,8 +5,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use probe_rs_target::Chip;
-
 use super::esp::EspFlashSizeDetector;
 use crate::{
     architecture::xtensa::{
@@ -43,7 +41,7 @@ impl ESP32S2 {
     const TIMG1_WDTCONFIG0: u64 = Self::TIMG1_BASE | 0x48;
 
     /// Creates a new debug sequence handle for the ESP32-S2.
-    pub fn create(_chip: &Chip) -> Arc<dyn XtensaDebugSequence> {
+    pub fn create() -> Arc<dyn XtensaDebugSequence> {
         Arc::new(Self {
             inner: EspFlashSizeDetector {
                 stack_pointer: 0x4000_0000,

--- a/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
@@ -44,9 +44,10 @@ impl ESP32S2 {
     pub fn create() -> Arc<dyn XtensaDebugSequence> {
         Arc::new(Self {
             inner: EspFlashSizeDetector {
-                stack_pointer: 0x4000_0000,
-                load_address: 0x4002C000,
+                stack_pointer: 0x3ffce000,
+                load_address: 0x4002c400,
                 spiflash_peripheral: 0x3f40_2000,
+                efuse_get_spiconfig_fn: Some(0x4000e4a0),
                 attach_fn: 0x4001_7004,
             },
         })

--- a/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
@@ -29,6 +29,7 @@ impl ESP32S3 {
                 stack_pointer: 0x3FCF_0000,
                 load_address: 0x4037_8000,
                 spiflash_peripheral: 0x6000_2000,
+                efuse_get_spiconfig_fn: Some(0x40001f74),
                 attach_fn: 0x4000_0aec,
             },
         })

--- a/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
@@ -5,8 +5,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use probe_rs_target::Chip;
-
 use super::esp::EspFlashSizeDetector;
 use crate::{
     architecture::xtensa::{
@@ -25,7 +23,7 @@ pub struct ESP32S3 {
 
 impl ESP32S3 {
     /// Creates a new debug sequence handle for the ESP32-S3.
-    pub fn create(_chip: &Chip) -> Arc<dyn XtensaDebugSequence> {
+    pub fn create() -> Arc<dyn XtensaDebugSequence> {
         Arc::new(Self {
             inner: EspFlashSizeDetector {
                 stack_pointer: 0x3FCF_0000,


### PR DESCRIPTION
Call `spi_attach_flash` like how the flasher calls functions, instead of progbuf.