### PR TITLE
Add support for MIMXRT118x M33 memory access

### DIFF
--- a/changelog/added-rt1189.md
+++ b/changelog/added-rt1189.md
@@ -1,0 +1,1 @@
+Added support for MIIMXRT1189 memory access (`probe-rs read/write`)

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -1,6 +1,6 @@
 use crate::{
     architecture::arm::{
-        ap::valid_access_ports,
+        ap::valid_access_ports_allowlist,
         dp::{
             Abort, Ctrl, DebugPortError, DebugPortId, DebugPortVersion, DpAccess, Select, BASEPTR0,
             BASEPTR1, DPIDR, DPIDR1,
@@ -490,7 +490,8 @@ impl<'interface> ArmCommunicationInterface<Initialized> {
             tracing::trace!("Searching valid APs");
 
             let ap_span = tracing::debug_span!("AP discovery").entered();
-            let access_ports = valid_access_ports(self, dp);
+            let allowed_aps = sequence.allowed_access_ports();
+            let access_ports = valid_access_ports_allowlist(self, dp, allowed_aps);
             let state = self.state.dps.get_mut(&dp).unwrap();
             state.access_ports = access_ports.into_iter().collect();
 

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -975,6 +975,11 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
     fn debug_erase_sequence(&self) -> Option<Arc<dyn DebugEraseSequence>> {
         None
     }
+
+    /// Return the APs that are expected to work.
+    fn allowed_access_ports(&self) -> Vec<u8> {
+        (0..=255).collect()
+    }
 }
 
 /// Chip-Erase Handling via the Device's Debug Interface

--- a/probe-rs/src/vendor/nxp/mod.rs
+++ b/probe-rs/src/vendor/nxp/mod.rs
@@ -8,7 +8,7 @@ use crate::{
         nxp::sequences::{
             nxp_armv7m::{MIMXRT10xx, MIMXRT117x},
             nxp_armv8m::{
-                LPC55Sxx, MIMXRT5xxS,
+                LPC55Sxx, MIMXRT118x, MIMXRT5xxS,
                 MIMXRTFamily::{MIMXRT5, MIMXRT6},
             },
         },
@@ -28,6 +28,8 @@ impl Vendor for Nxp {
             DebugSequence::Arm(MIMXRT10xx::create())
         } else if chip.name.starts_with("MIMXRT117") {
             DebugSequence::Arm(MIMXRT117x::create())
+        } else if chip.name.starts_with("MIMXRT118") {
+            DebugSequence::Arm(MIMXRT118x::create())
         } else if chip.name.starts_with("MIMXRT5") {
             DebugSequence::Arm(MIMXRT5xxS::create(MIMXRT5))
         } else if chip.name.starts_with("MIMXRT6") {

--- a/probe-rs/src/vendor/nxp/mod.rs
+++ b/probe-rs/src/vendor/nxp/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     config::DebugSequence,
     vendor::{
         nxp::sequences::{
-            nxp_armv7m::{MIMXRT10xx, MIMXRT11xx},
+            nxp_armv7m::{MIMXRT10xx, MIMXRT117x},
             nxp_armv8m::{
                 LPC55Sxx, MIMXRT5xxS,
                 MIMXRTFamily::{MIMXRT5, MIMXRT6},
@@ -26,8 +26,8 @@ impl Vendor for Nxp {
     fn try_create_debug_sequence(&self, chip: &Chip) -> Option<DebugSequence> {
         let sequence = if chip.name.starts_with("MIMXRT10") {
             DebugSequence::Arm(MIMXRT10xx::create())
-        } else if chip.name.starts_with("MIMXRT11") {
-            DebugSequence::Arm(MIMXRT11xx::create())
+        } else if chip.name.starts_with("MIMXRT117") {
+            DebugSequence::Arm(MIMXRT117x::create())
         } else if chip.name.starts_with("MIMXRT5") {
             DebugSequence::Arm(MIMXRT5xxS::create(MIMXRT5))
         } else if chip.name.starts_with("MIMXRT6") {

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
@@ -135,20 +135,20 @@ impl ArmDebugSequence for MIMXRT10xx {
     }
 }
 
-/// Debug sequences for MIMXRT11xx MCUs.
+/// Debug sequences for MIMXRT117x MCUs.
 ///
 /// Currently only supports the Cortex M7. In fact, if you try to interact with the Cortex M4,
 /// you'll have a bad time: its access port doesn't appear until it's released from reset!
 /// For the time being, you can only do things through the CM7.
 #[derive(Debug)]
-pub struct MIMXRT11xx {
+pub struct MIMXRT117x {
     /// Given the reset we're performing, we won't be able to perform
     /// a normal vector catch. (The boot ROM doesn't care about us.)
     /// We'll simulate that behavior for the user.
     simulate_reset_catch: AtomicBool,
 }
 
-impl MIMXRT11xx {
+impl MIMXRT117x {
     /// System reset controller base address.
     const SRC: u64 = 0x40C0_4000;
     /// SRC reset mode register.
@@ -160,7 +160,7 @@ impl MIMXRT11xx {
         }
     }
 
-    /// Create a sequence handle for the MIMXRT10xx.
+    /// Create a sequence handle for the MIMXRT117x.
     pub fn create() -> Arc<dyn ArmDebugSequence> {
         Arc::new(Self::new())
     }
@@ -356,7 +356,7 @@ impl MIMXRT11xx {
     }
 }
 
-impl ArmDebugSequence for MIMXRT11xx {
+impl ArmDebugSequence for MIMXRT117x {
     fn reset_catch_set(
         &self,
         _: &mut dyn ArmMemoryInterface,

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
@@ -711,3 +711,29 @@ impl ArmDebugSequence for MIMXRT5xxS {
     // "ResetHardware" intentionally omitted because the default implementation
     // seems equivalent to the one in the CMSIS-Pack.
 }
+
+/// Debug sequences for MIMXRT118x MCUs.
+///
+/// Currently only supports the Cortex M33. In fact, if you try to interact with the Cortex M7,
+/// you'll have a bad time: its access port doesn't appear until it's released from reset!
+/// For the time being, you can only do things through the CM33.
+#[derive(Debug)]
+pub struct MIMXRT118x(());
+
+impl MIMXRT118x {
+    fn new() -> Self {
+        Self(())
+    }
+
+    /// Create a sequence handle for the MIMXRT117x.
+    pub fn create() -> Arc<dyn ArmDebugSequence> {
+        Arc::new(Self::new())
+    }
+}
+
+impl ArmDebugSequence for MIMXRT118x {
+    fn allowed_access_ports(&self) -> Vec<u8> {
+        // AP5 locks the whole DP if you try to read its IDR.
+        vec![0, 1, 3, 4, 6]
+    }
+}

--- a/probe-rs/targets/MIMXRT1180.yaml
+++ b/probe-rs/targets/MIMXRT1180.yaml
@@ -1,0 +1,15 @@
+name: MIMXRT1180
+manufacturer:
+  id: 0x15
+  cc: 0x0
+generated_from_pack: true
+pack_file_release: 19.0.0
+variants:
+- name: MIMXRT1189CVM8B
+  cores:
+  - name: cm33
+    type: armv8m
+    core_access_options: !Arm
+      ap: 3
+      psel: 0x0
+  memory_map:

--- a/probe-rs/targets/MIMXRT1180.yaml
+++ b/probe-rs/targets/MIMXRT1180.yaml
@@ -13,3 +13,34 @@ variants:
       ap: 3
       psel: 0x0
   memory_map:
+  - !Ram
+    name: DTCM
+    range:
+      start: 0x20000000
+      end: 0x20040000
+    cores:
+      - cm33
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x0ffc0000
+      end: 0x10000000
+    cores:
+      - cm33
+  - !Ram
+    name: OCRAM1
+    range:
+      # Note: The reference manual's memory map may start this region at
+      # 0x2848_0000, but there is a note outside the table saying that the first
+      # 16k cannot be safely used.
+      start: 0x20484000
+      end: 0x20500000
+    cores:
+      - cm33
+  - !Ram
+    name: OCRAM2
+    range:
+      start: 0x20500000
+      end: 0x20540000
+    cores:
+      - cm33


### PR DESCRIPTION
The chip requires authentication before the DP can be accessed. This is not implemented here, so unlocking has to be done with external tools for now.

This change allows `probe-rs read` and `probe-rs write` to work on an already unlocked chip, but more work is needed to get e.g. `probe-rs download` working.

The existing strategy for AP discovery (probing every AP until one fails) does not work with this chip. Attempting to read IDR from AP5 causes the whole DP to lock down and require re-authentication. The existing strategy is turned into a default that can be overridden by debug sequences.

The target description is heavily cut down from the target-gen output to avoid hitting currently unsupported features like memory access through the AP for the M7.