### PR TITLE
Unwind: Xtensa: follow frame pointer

### DIFF
--- a/changelog/fixed-xtensa-unwind.md
+++ b/changelog/fixed-xtensa-unwind.md
@@ -1,0 +1,1 @@
+Improved unwinding Xtensa stack traces

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -683,8 +683,14 @@ impl DebugInfo {
             // and then the unwind info associated with this row.
             let unwind_info =
                 match get_unwind_info(&mut unwind_context, &self.frame_section, frame_pc) {
-                    Ok(unwind_info) => unwind_info,
-                    Err(_) => {
+                    Ok(unwind_info) => {
+                        tracing::trace!("UNWIND: Found unwind info for address {frame_pc:#010x}");
+                        unwind_info
+                    }
+                    Err(err) => {
+                        tracing::trace!(
+                            "UNWIND: Unable to find unwind info for address {frame_pc:#010x}: {err}"
+                        );
                         // For non exception frames, we cannot do stack unwinding if we do not have debug info.
                         // However, there is one case where we can continue. When the frame registers have a valid
                         // return address/LR value, we can use the LR value to calculate the PC for the calling frame.

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -172,7 +172,7 @@ impl DebugInfo {
                                 if let Some((file, directory)) =
                                     self.find_file_and_directory(unit, previous_row.file_index())
                                 {
-                                    tracing::debug!("{} - {:?}", address, previous_row.isa());
+                                    tracing::debug!("{:#010x} - {:?}", address, previous_row.isa());
                                     return Some(SourceLocation {
                                         line: previous_row.line().map(NonZeroU64::get),
                                         column: Some(previous_row.column().into()),
@@ -187,7 +187,7 @@ impl DebugInfo {
                             if let Some((file, directory)) =
                                 self.find_file_and_directory(unit, row.file_index())
                             {
-                                tracing::debug!("{} - {:?}", address, row.isa());
+                                tracing::debug!("{:#010x} - {:?}", address, row.isa());
 
                                 return Some(SourceLocation {
                                     line: row.line().map(NonZeroU64::get),

--- a/probe-rs/src/debug/exception_handling.rs
+++ b/probe-rs/src/debug/exception_handling.rs
@@ -18,6 +18,8 @@ pub(crate) mod armv7m;
 
 pub(crate) mod armv8m;
 
+pub(crate) mod xtensa;
+
 /// Creates a new exception interface for the [`CoreType`] at hand.
 pub fn exception_handler_for_core(core_type: CoreType) -> Box<dyn ExceptionInterface> {
     use self::{armv6m, armv7m, armv8m};
@@ -25,7 +27,8 @@ pub fn exception_handler_for_core(core_type: CoreType) -> Box<dyn ExceptionInter
         CoreType::Armv6m => Box::new(armv6m::ArmV6MExceptionHandler),
         CoreType::Armv7m | CoreType::Armv7em => Box::new(armv7m::ArmV7MExceptionHandler),
         CoreType::Armv8m => Box::new(armv8m::ArmV8MExceptionHandler),
-        CoreType::Armv7a | CoreType::Armv8a | CoreType::Riscv | CoreType::Xtensa => {
+        CoreType::Xtensa => Box::new(xtensa::XtensaExceptionHandler),
+        CoreType::Armv7a | CoreType::Armv8a | CoreType::Riscv => {
             Box::new(UnimplementedExceptionHandler)
         }
     }

--- a/probe-rs/src/debug/exception_handling.rs
+++ b/probe-rs/src/debug/exception_handling.rs
@@ -5,7 +5,7 @@ use std::ops::ControlFlow;
 
 use probe_rs_target::CoreType;
 
-use crate::{debug::unwind_register, MemoryInterface, RegisterValue};
+use crate::{debug::unwind_pc_without_debuginfo, MemoryInterface};
 
 use super::{DebugError, DebugInfo, DebugRegisters, StackFrame};
 
@@ -127,6 +127,8 @@ pub trait ExceptionInterface {
     ) -> Result<String, DebugError>;
 
     /// Unwind the stack without debug info.
+    ///
+    /// This method can be implemented to provide a stack trace using frame pointers, for example.
     fn unwind_without_debuginfo(
         &self,
         unwind_registers: &mut DebugRegisters,
@@ -135,45 +137,12 @@ pub trait ExceptionInterface {
         instruction_set: Option<crate::InstructionSet>,
         memory: &mut dyn MemoryInterface,
     ) -> ControlFlow<Option<DebugError>> {
-        // For non exception frames, we cannot do stack unwinding if we do not have debug info.
-        // However, there is one case where we can continue. When the frame registers have a valid
-        // return address/LR value, we can use the LR value to calculate the PC for the calling frame.
-        // The current logic will then use that PC to get the next frame's unwind info, and if that exists,
-        // we will be able to continue unwinding.
-        // If the calling frame has no debug info, then the unwinding will end with that frame.
-        let callee_frame_registers = unwind_registers.clone();
-        let mut unwound_return_address: Option<RegisterValue> = unwind_registers
-            .get_return_address()
-            .and_then(|lr| lr.value);
-
-        // This will update the program counter in the `unwind_registers` with the PC value calculated from the LR value.
-        if let Some(calling_pc) = unwind_registers.get_program_counter_mut() {
-            if let ControlFlow::Break(error) = unwind_register(
-                calling_pc,
-                &callee_frame_registers,
-                None,
-                stack_frames
-                    .last()
-                    .and_then(|first_frame| first_frame.canonical_frame_address),
-                &mut unwound_return_address,
-                memory,
-                instruction_set,
-            ) {
-                return ControlFlow::Break(Some(error.into()));
-            };
-
-            if calling_pc
-                .value
-                .map(|calling_pc_value| calling_pc_value == RegisterValue::from(frame_pc))
-                .unwrap_or(false)
-            {
-                // Typically if we have to infer the PC value, it might happen that we are in
-                // a function that has no debug info, and the code is in a tight loop (typical of exception handlers).
-                // In such cases, we will not be able to unwind the stack beyond this frame.
-                return ControlFlow::Break(None);
-            }
-        }
-
-        ControlFlow::Continue(())
+        unwind_pc_without_debuginfo(
+            unwind_registers,
+            frame_pc,
+            stack_frames,
+            instruction_set,
+            memory,
+        )
     }
 }

--- a/probe-rs/src/debug/exception_handling/xtensa.rs
+++ b/probe-rs/src/debug/exception_handling/xtensa.rs
@@ -1,9 +1,11 @@
+use std::ops::ControlFlow;
+
 use crate::{
     debug::{
         exception_handling::{ExceptionInfo, ExceptionInterface},
-        DebugError, DebugInfo, DebugRegisters,
+        unwind_pc_without_debuginfo, DebugError, DebugInfo, DebugRegisters, StackFrame,
     },
-    MemoryInterface,
+    MemoryInterface, RegisterRole, RegisterValue,
 };
 
 pub struct XtensaExceptionHandler;
@@ -43,5 +45,62 @@ impl ExceptionInterface for XtensaExceptionHandler {
         _memory: &mut dyn MemoryInterface,
     ) -> Result<String, DebugError> {
         Err(DebugError::NotImplemented("exception description"))
+    }
+
+    fn unwind_without_debuginfo(
+        &self,
+        unwind_registers: &mut DebugRegisters,
+        frame_pc: u64,
+        stack_frames: &[StackFrame],
+        instruction_set: Option<crate::InstructionSet>,
+        memory: &mut dyn MemoryInterface,
+    ) -> ControlFlow<Option<DebugError>> {
+        // Use the default method to unwind PC.
+        unwind_pc_without_debuginfo(
+            unwind_registers,
+            frame_pc,
+            stack_frames,
+            instruction_set,
+            memory,
+        )?;
+
+        // We can try and use FP to unwind SP and RA that allows us to continue unwinding.
+
+        // Current register values
+        let Ok(fp) = unwind_registers.get_register_value_by_role(&RegisterRole::FramePointer)
+        else {
+            // We can't unwind without FP.
+            return ControlFlow::Break(None);
+        };
+
+        let sp = unwind_registers
+            .get_register_value_by_role(&RegisterRole::StackPointer)
+            .unwrap();
+
+        if sp.abs_diff(fp) >= 1024 * 1024 {
+            // Heuristic: the stack frame is probably smaller than 1MB.
+            return ControlFlow::Continue(());
+        }
+
+        // Read PC and FP from previous stack frame's Register-Spill Area.
+        let mut stack_frame = [0; 2];
+        if let Err(e) = memory.read_32(fp - 16, &mut stack_frame) {
+            // FP points at something we can't read.
+            return ControlFlow::Break(Some(e.into()));
+        }
+
+        let [caller_ra, caller_sp] = stack_frame;
+
+        let unwound_fp = unwind_registers
+            .get_register_mut_by_role(&RegisterRole::FramePointer)
+            .unwrap();
+        unwound_fp.value = Some(RegisterValue::from(caller_sp));
+
+        let unwound_ra = unwind_registers
+            .get_register_mut_by_role(&RegisterRole::ReturnAddress)
+            .unwrap();
+        unwound_ra.value = Some(RegisterValue::from(caller_ra));
+
+        ControlFlow::Continue(())
     }
 }

--- a/probe-rs/src/debug/exception_handling/xtensa.rs
+++ b/probe-rs/src/debug/exception_handling/xtensa.rs
@@ -1,0 +1,47 @@
+use crate::{
+    debug::{
+        exception_handling::{ExceptionInfo, ExceptionInterface},
+        DebugError, DebugInfo, DebugRegisters,
+    },
+    MemoryInterface,
+};
+
+pub struct XtensaExceptionHandler;
+
+impl ExceptionInterface for XtensaExceptionHandler {
+    fn exception_details(
+        &self,
+        _memory: &mut dyn MemoryInterface,
+        _stackframe_registers: &DebugRegisters,
+        _debug_info: &DebugInfo,
+    ) -> Result<Option<ExceptionInfo>, DebugError> {
+        // For architectures where the exception handling has not been implemented in probe-rs,
+        // this will result in maintaining the current `unwind` behavior, i.e. unwinding will include up
+        // to the first frame that was called from an exception handler.
+        Ok(None)
+    }
+
+    fn calling_frame_registers(
+        &self,
+        _memory: &mut dyn MemoryInterface,
+        _stackframe_registers: &crate::debug::DebugRegisters,
+        _raw_exception: u32,
+    ) -> Result<crate::debug::DebugRegisters, DebugError> {
+        Err(DebugError::NotImplemented("calling frame registers"))
+    }
+
+    fn raw_exception(
+        &self,
+        _stackframe_registers: &crate::debug::DebugRegisters,
+    ) -> Result<u32, DebugError> {
+        Err(DebugError::NotImplemented("raw exception"))
+    }
+
+    fn exception_description(
+        &self,
+        _raw_exception: u32,
+        _memory: &mut dyn MemoryInterface,
+    ) -> Result<String, DebugError> {
+        Err(DebugError::NotImplemented("exception description"))
+    }
+}

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -67,7 +67,7 @@ impl UnitInfo {
         debug_info: &'debug_info super::DebugInfo,
         address: u64,
     ) -> Result<Vec<FunctionDie>, DebugError> {
-        tracing::trace!("Searching Function DIE for address {:#x}", address);
+        tracing::trace!("Searching Function DIE for address {:#010x}", address);
 
         let mut entries_cursor = self.unit.entries();
         while let Ok(Some((_depth, current))) = entries_cursor.next_dfs() {
@@ -85,7 +85,7 @@ impl UnitInfo {
             let inlined_functions =
                 self.find_inlined_functions(debug_info, address, current.offset())?;
             tracing::debug!(
-                "{} inlined functions for address {}",
+                "{} inlined functions for address {:#010x}",
                 inlined_functions.len(),
                 address
             );


### PR DESCRIPTION
The Xtensa enabled rustc doesn't seem to emit the debuginfo necessary for unwinding. However, we can implement an architecture-specific frame-pointer chasing to at least get a full backtrace without any more details.

This PR allows other architectures to implement similar schemes by moving the fallback unwinding method into `ExceptionInterface`.