### PR TITLE
Resume cores before parsing elf data

### DIFF
--- a/changelog/fixed-halting.md
+++ b/changelog/fixed-halting.md
@@ -1,0 +1,1 @@
+Fix excessive halting in `probe-rs attach` which may leave devices in a non-functional state

--- a/probe-rs-tools/src/bin/probe-rs/cmd/read.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/read.rs
@@ -34,6 +34,7 @@ pub struct Cmd {
 impl Cmd {
     pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, _probe_options) = self.probe_options.simple_attach(lister)?;
+
         let mut core = session.core(self.shared.core)?;
         let words = self.words as usize;
 
@@ -63,6 +64,9 @@ impl Cmd {
                 println!();
             }
         }
+        std::mem::drop(core);
+
+        session.resume_all_cores()?;
 
         Ok(())
     }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
@@ -97,6 +97,9 @@ impl Cmd {
         let (mut session, probe_options) =
             self.shared_options.probe_options.simple_attach(lister)?;
 
+        // Resume cores now to prevent halting while processing elf
+        session.resume_all_cores()?;
+
         let rtt_scan_regions = match self.shared_options.rtt_scan_memory {
             true => session.target().rtt_scan_regions.clone(),
             false => ScanRegion::Ranges(vec![]),

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -778,6 +778,24 @@ impl Session {
             })
         })
     }
+
+    /// Resume all cores
+    pub fn resume_all_cores(&mut self) -> Result<(), Error> {
+        // Resume cores
+        for core_id in 0..self.cores.len() {
+            match self.core(core_id) {
+                Ok(mut core) => {
+                    if core.core_halted()? {
+                        core.run()?;
+                    }
+                }
+                Err(Error::CoreDisabled(i)) => tracing::debug!("Core {i} is disabled"),
+                Err(error) => return Err(error),
+            }
+        }
+
+        Ok(())
+    }
 }
 
 // This test ensures that [Session] is fully [Send] + [Sync].


### PR DESCRIPTION
Fixes #2799 (at least for me). Processing the elf can take multiple 100ms, and I guess the C6 just doesn't tolerate being halted for so long.

I think maybe we should resume cores before we return from `Session::new` but I was worried about side effects.