### PR TITLE
Ensure that we can't queue more bits than the buffer can hold

### DIFF
--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -353,12 +353,11 @@ impl ProtocolHandler {
 
     /// Adds a single command to the output buffer and writes it to the USB EP if the buffer reaches a limit of `OUT_BUFFER_SIZE`.
     fn add_raw_command(&mut self, command: Command) -> Result<(), DebugProbeError> {
-        self.output_buffer.push(command);
-
         // If we reach a maximal size of the output buffer, we flush.
         if self.output_buffer.len() == OUT_BUFFER_SIZE {
             self.send_buffer()?;
         }
+        self.output_buffer.push(command);
 
         Ok(())
     }


### PR DESCRIPTION
This won't change anything, really, just avoids panics like the following:

```
thread 'main' panicked at probe-rs\src\probe\espusbjtag\protocol.rs:374:9:
Output buffer too large: 153 elements, max 128
```

These happen if we return a USB error, so the device has most likely restarted unexpectedly, but at least we'll properly display a USB error instead.