### PR TITLE
embed: Add --config-file parameter

### DIFF
--- a/changelog/added-embed-config-file.md
+++ b/changelog/added-embed-config-file.md
@@ -1,0 +1,1 @@
+`cargo embed` now takes an optional --config-file parameter


### PR DESCRIPTION
Closes: https://github.com/probe-rs/probe-rs/issues/2845

I went with --config-file because the profile selected is called `config` in the code, and having a different option called "config" would be quite confusing; config-file is expected to be rarely used, so let's just be explicit.

<del>Keeping this as a draft while waiting for CI to confirm tests (locally, many failed).</del>