### PR TITLE
Use `bool::is_some_and()` rather than `bool::map_or(false, …)`

### DIFF
--- a/changelog/fixed-is-some-and.md
+++ b/changelog/fixed-is-some-and.md
@@ -1,0 +1,1 @@
+Use `bool::is_some_and()` rather than an hand-crafted version with `bool::map_or(false, …)`.

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -213,7 +213,7 @@ fn prune_logs(directory: &Path) -> Result<(), anyhow::Error> {
         .filter_map(|entry| {
             let entry = entry.ok()?;
             let path = entry.path();
-            if path.extension().map_or(false, |e| e == "log") {
+            if path.extension().is_some_and(|e| e == "log") {
                 let metadata = fs::metadata(&path).ok()?;
                 let last_modified = metadata.created().ok()?;
                 Some((path, last_modified))

--- a/probe-rs/src/debug/source_instructions.rs
+++ b/probe-rs/src/debug/source_instructions.rs
@@ -215,7 +215,7 @@ fn match_file_line_column(
                     && NonZeroU64::new(line) == instruction_location.line
                     && column
                         .map(ColumnType::Column)
-                        .map_or(false, |col| col == instruction_location.column)
+                        .is_some_and(|col| col == instruction_location.column)
             })?;
 
     let source_location =

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -690,7 +690,7 @@ impl Variable {
                 name.starts_with("__")
                     && name
                         .find(char::is_numeric)
-                        .map_or(false, |zero_based_position| zero_based_position == 2)
+                        .is_some_and(|zero_based_position| zero_based_position == 2)
             }
             // Other kind of variables are never indexed
             _ => false,

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -266,7 +266,7 @@ fn walk_files(path: &Path, callback: &mut impl FnMut(&Path) -> Result<()>) -> Re
 }
 
 fn has_extension(path: &Path, ext: &str) -> bool {
-    path.extension().map_or(false, |e| e == ext)
+    path.extension().is_some_and(|e| e == ext)
 }
 
 pub fn visit_file(path: &Path, families: &mut Vec<ChipFamily>) -> Result<()> {

--- a/target-gen/src/main.rs
+++ b/target-gen/src/main.rs
@@ -176,7 +176,7 @@ async fn main() -> Result<()> {
                 for entry in entries {
                     let entry = entry.context("Failed to read directory entry.")?;
                     let path = entry.path();
-                    if path.extension().map_or(false, |ext| ext == "yaml") {
+                    if path.extension().is_some_and(|ext| ext == "yaml") {
                         refresh_yaml(&path)?;
                     }
                 }


### PR DESCRIPTION
`bool::is_some_and()` better carries the meaning of the operation being done, and is stable since Rust 1.70.0.