### PR TITLE
Add warning when refusing to read RTT channel name

### DIFF
--- a/changelog/added-warn-rtt-channel-name.md
+++ b/changelog/added-warn-rtt-channel-name.md
@@ -1,0 +1,1 @@
+Added a warning when refusing to read an RTT channel name because of the target description.

--- a/probe-rs/src/rtt/channel.rs
+++ b/probe-rs/src/rtt/channel.rs
@@ -518,6 +518,7 @@ fn read_c_string(core: &mut Core, ptr: u64) -> Result<Option<String>, Error> {
         .find_map(|r| r.contains(ptr).then_some(r.address_range()))
     else {
         // If the pointer is not within any valid range, return None.
+        tracing::warn!("RTT channel name points to unrecognized memory. Bad target description?");
         return Ok(None);
     };
 


### PR DESCRIPTION
When using probe-rs to access a target's RTT stream with an incomplete target description (missing memory map), channel names will not be read, resulting in all content being presented as raw strings instead of interpreting e.g. defmt.

If this happens, it is almost certainly by mistake, so issue a warning.