### PR TITLE
Check if completions folder exists before writing

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
@@ -260,12 +260,20 @@ impl ShellExt for Zsh {
 # Add .zfunc to FPATH for autocompletion
 export FPATH="$HOME/.zfunc:$FPATH"
 "#;
-                std::fs::OpenOptions::new()
+                let result = std::fs::OpenOptions::new()
                     .append(true)
                     .open(&zshrc_path)
                     .and_then(|mut file| writeln!(file, "{}", export_cmd))
-                    .context("Failed to update .zshrc with FPATH")?;
-                eprintln!("Added .zfunc to FPATH in .zshrc. Please reload your zsh.");
+                    .context("Failed to update .zshrc with FPATH");
+
+                match result {
+                    Ok(_) => eprintln!("Added .zfunc to FPATH in .zshrc. Please reload your zsh."),
+                    Err(e) => {
+                        eprintln!("Error: {}", e);
+                        eprintln!("Please add the following line to your .zshrc manually:");
+                        eprintln!("{}", export_cmd);
+                    }
+                }
             }
         }
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
@@ -256,7 +256,10 @@ impl ShellExt for Zsh {
         if let Ok(fpath) = std::env::var("FPATH") {
             if !fpath.split(':').any(|p| p == path.to_str().unwrap()) {
                 let zshrc_path = dir.home_dir().join(".zshrc");
-                let export_cmd = "\n# Add .zfunc to FPATH for autocompletion\nexport FPATH=\"$HOME/.zfunc:$FPATH\"\n";
+                let export_cmd = r#"
+# Add .zfunc to FPATH for autocompletion
+export FPATH="$HOME/.zfunc:$FPATH"
+"#;
                 std::fs::OpenOptions::new()
                     .append(true)
                     .open(&zshrc_path)

--- a/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
@@ -321,7 +321,15 @@ impl ShellExt for PowerShell {
 fn write_script(path: &Path, script: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         if !parent.exists() {
-            std::fs::create_dir_all(parent).context("Failed to create directory")?;
+            if let Err(e) = std::fs::create_dir_all(parent).context("Failed to create directory") {
+                println!("{script}");
+                eprintln!("Creating the parent directories failed: {}", e);
+                eprintln!(
+                    "Please create the parent directories and write the above script to {} manually",
+                    path.display()
+                );
+                return Err(e);
+            }
         }
     }
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
@@ -291,6 +291,12 @@ impl ShellExt for PowerShell {
 }
 
 fn write_script(path: &Path, script: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent).context("Failed to create directory")?;
+        }
+    }
+
     let res = std::fs::write(path, script);
     if res.is_err() {
         println!("{script}");

--- a/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
@@ -301,5 +301,5 @@ fn write_script(path: &Path, script: &str) -> Result<()> {
         );
     }
 
-    res.context("Writing th script failed")
+    res.context("Writing the script failed")
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
@@ -249,7 +249,24 @@ impl ShellExt for Zsh {
         };
 
         let path = dir.home_dir().join(".zfunc/").join(file_name);
-        write_script(&path, script)
+        write_script(&path, script)?;
+        use std::io::Write;
+
+        // Check if .zfunc is in FPATH
+        if let Ok(fpath) = std::env::var("FPATH") {
+            if !fpath.split(':').any(|p| p == path.to_str().unwrap()) {
+                let zshrc_path = dir.home_dir().join(".zshrc");
+                let export_cmd = "\n# Add .zfunc to FPATH for autocompletion\nexport FPATH=\"$HOME/.zfunc:$FPATH\"\n";
+                std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(&zshrc_path)
+                    .and_then(|mut file| writeln!(file, "{}", export_cmd))
+                    .context("Failed to update .zshrc with FPATH")?;
+                eprintln!("Added .zfunc to FPATH in .zshrc. Please reload your zsh.");
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
@@ -328,8 +328,8 @@ fn write_script(path: &Path, script: &str) -> Result<()> {
     let res = std::fs::write(path, script);
     if res.is_err() {
         println!("{script}");
-        println!("Writing the autocompletion script failed");
-        println!(
+        eprintln!("Writing the autocompletion script failed");
+        eprintln!(
             "Please write the above script to {} manually",
             path.display()
         );


### PR DESCRIPTION
This PR checks if the parent folders are missing when creating the completions, and if they are, it creates them.
It also checks if the completions folder is in the `FPATH` variable, and if not, adds it to `.zshrc`.

Not sure if it's necessary to add an entry in the changelog folder for this; I can create one if you'd like.