### PR TITLE
probe-rs: arm: memory_ap: Default HNONSEC to !SPIDEN

### DIFF
--- a/changelog/fixed-hnonsec.md
+++ b/changelog/fixed-hnonsec.md
@@ -1,0 +1,1 @@
+Fixed connection on TrustZone capable MCUs when HNONSEC is set incorrectly.

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb3.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb3.rs
@@ -31,6 +31,7 @@ impl AmbaAhb3 {
         let me = Self { address, csw, cfg };
         let csw = CSW {
             DbgSwEnable: true,
+            HNONSEC: !csw.SPIDEN,
             MasterType: true,
             Cacheable: true,
             Privileged: true,

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5.rs
@@ -31,6 +31,7 @@ impl AmbaAhb5 {
         let me = Self { address, csw, cfg };
         let csw = CSW {
             DbgSwEnable: true,
+            HNONSEC: !csw.SPIDEN,
             MasterType: true,
             Privileged: true,
             Data: true,

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5_hprot.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5_hprot.rs
@@ -31,6 +31,7 @@ impl AmbaAhb5Hprot {
         let me = Self { address, csw, cfg };
         let csw = CSW {
             DbgSwEnable: true,
+            HNONSEC: !csw.SPIDEN,
             MasterType: true,
             Cacheable: true,
             Privileged: true,


### PR DESCRIPTION
Some MCUs appear to have HNONSEC set to non-privileged mode by default. Because ADIv5 calls for HNONSEC to be privileged (that is, false) by default when the bit is implemented, let's default to that for AHB3 and AHB5 interconnects.

Fixes #2788