### PR TITLE
Make gdb-server compatible with lldb

### DIFF
--- a/changelog/changed-register-names-lowercase.md
+++ b/changelog/changed-register-names-lowercase.md
@@ -1,0 +1,1 @@
+* Register names are now lower-case when gdb-debugging through gdbstub. This makes probe-rs compatible with lldb. 

--- a/probe-rs/src/gdb_server/target/desc/data.rs
+++ b/probe-rs/src/gdb_server/target/desc/data.rs
@@ -114,7 +114,9 @@ impl TargetDescription {
                 let _ = write!(
                     target_description,
                     "<reg name='{}' bitsize='{}' type='{}'/>",
-                    reg.name.to_lowercase(), reg.size, reg._type
+                    reg.name.to_lowercase(),
+                    reg.size,
+                    reg._type
                 );
             }
 

--- a/probe-rs/src/gdb_server/target/desc/data.rs
+++ b/probe-rs/src/gdb_server/target/desc/data.rs
@@ -114,7 +114,7 @@ impl TargetDescription {
                 let _ = write!(
                     target_description,
                     "<reg name='{}' bitsize='{}' type='{}'/>",
-                    reg.name, reg.size, reg._type
+                    reg.name.to_lowercase(), reg.size, reg._type
                 );
             }
 


### PR DESCRIPTION
lldb requires the "pc" register to be lower-case. A capital "PC" confuses it to a point where it thinks it is not debugging at all.

This was already the case for RISC-V. For consistency, I feel it's better to simply lower-case every register.

Confirmed that armv6-m and risc-v debugging now works just fine with lldb (tested on Raspberry Pi Pico and esp32c6).

Also confirmed that gdb debugging still works fine - register names are now lower-case of course.