### PR TITLE
Shell completion: Use correct install method for Bash completions.

### DIFF
--- a/changelog/fixed-bash-completion-install.md
+++ b/changelog/fixed-bash-completion-install.md
@@ -1,0 +1,1 @@
+Shell completions: Use correct install method for Bash completions.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
@@ -67,7 +67,7 @@ impl Cmd {
                 Zsh.install(&file_name, &script)?;
             }
             Shell::Bash => {
-                Zsh.install(&file_name, &script)?;
+                Bash.install(&file_name, &script)?;
             }
             Shell::PowerShell => {
                 PowerShell.install(&file_name, &script)?;


### PR DESCRIPTION
The completion installation for Bash was calling the ZSH install method. Use the correct Bash install method.

Tested by running`probe-rs complete install` and confirming the expected file is created.