### PR TITLE
flash algorithm: drop unnecessary ARM instructions

### DIFF
--- a/changelog/removed-arm-flash-header.md
+++ b/changelog/removed-arm-flash-header.md
@@ -1,0 +1,1 @@
+Removed the majority of `ARM_FLASH_BLOB_HEADER`, replaced with two arm thumb `brkpt` instructions

--- a/probe-rs/src/architecture/arm/assembly.rs
+++ b/probe-rs/src/architecture/arm/assembly.rs
@@ -1,0 +1,2 @@
+/// ARM breakpoint instruction (x2)
+pub const BRKPT: u32 = 0xBE00_BE00;

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -1,6 +1,7 @@
 //! All the interface bits for ARM.
 
 pub mod ap;
+pub(crate) mod assembly;
 pub(crate) mod communication_interface;
 pub mod component;
 pub(crate) mod core;

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -1,5 +1,9 @@
 use super::FlashError;
-use crate::{architecture::riscv, core::Architecture, Target};
+use crate::{
+    architecture::{arm, riscv},
+    core::Architecture,
+    Target,
+};
 use probe_rs_target::{
     FlashProperties, MemoryRegion, PageInfo, RamRegion, RawFlashAlgorithm, RegionMergeIterator,
     SectorInfo, TransferEncoding,
@@ -174,16 +178,7 @@ impl FlashAlgorithm {
     // Header for RISC-V Flash Algorithms
     const RISCV_FLASH_BLOB_HEADER: [u32; 2] = [riscv::assembly::EBREAK, riscv::assembly::EBREAK];
 
-    const ARM_FLASH_BLOB_HEADER: [u32; 8] = [
-        0xE00A_BE00,
-        0x062D_780D,
-        0x2408_4068,
-        0xD300_0040,
-        0x1E64_4058,
-        0x1C49_D1FA,
-        0x2A00_1E52,
-        0x0477_0D1F,
-    ];
+    const ARM_FLASH_BLOB_HEADER: [u32; 1] = [arm::assembly::BRKPT];
 
     const XTENSA_FLASH_BLOB_HEADER: [u32; 0] = [];
 


### PR DESCRIPTION
This drops the ARM flash header down to a simple breakpoint.

The original flash algo header was introduced [at the start of the project (`FLASH_BLOB_HEADER`)](https://github.com/bobrippling/probe-rs/commit/ac2676604ab8d9c838995413334a0b3d88f95188), likely taken from elsewhere, similarly to `pyocd`.

Going off [the discussion at pyocd], all but the first instruction are unnecessary. They were originally part of a checksum, but now the flash algorithms just jump to the start of the header to trigger a breakpoint, to halt the core when they're done.

This change preserves the 32-bit wide instructions by using two breakpoints.

The only mention of CRCs (which is the dropped algo code) is in 4e4c1675f, which was removed in 26c9b07a3 and 4dda1fc14, so I'm confident this is dead code.

[the discussion at pyocd]: https://github.com/pyocd/pyOCD/discussions/1252