### PR TITLE
`extract_ir_lengths`: handle 101x IR scans

### DIFF
--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -232,6 +232,10 @@ pub(crate) fn extract_ir_lengths(
                 Ok(starts_to_lengths(&exp_starts, ir.len()))
             }
         }
+    } else if n_taps == 1 {
+        // If there's only one TAP, this is easy.
+        tracing::info!("Only one TAP detected, IR length {}", ir.len());
+        Ok(vec![ir.len()])
     } else if n_taps == starts.len() {
         // If the number of possible starts matches the number of TAPs,
         // we can unambiguously find all lengths.

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -885,6 +885,19 @@ mod tests {
     }
 
     #[test]
+    fn extract_ir_lengths_with_two_taps_101() {
+        // Slightly contrived example where the IR scan starts with 101xx. In known real devices
+        // the 101 TAP is 5 bits long, but this is an edge case that the algorithm should handle.
+        let ir = &bitvec![u8, Lsb0; 1,0,1,0,1,0,0,0,0];
+        let n_taps = 2;
+        let expected = None;
+
+        let ir_lengths = extract_ir_lengths(ir, n_taps, expected).unwrap();
+
+        assert_eq!(ir_lengths, vec![4, 5]);
+    }
+
+    #[test]
     fn extract_id_codes_one_tap() {
         let mut dr = bitvec![u8, Lsb0; 0; 32];
         dr[0..32].store_le(ARM_TAP.0);


### PR DESCRIPTION
Some devices return `10100` during JTAG IR scan. Previously, the `n_taps == 1` case was supposed to handle these, but the ESP32-P4 will have two JTAG TAPs, and the IR scan is `1010010000`. This PR essentially special-cases the 101 prefix to support such devices.