### PR TITLE
Assign cores to NvmRegions created from flash algorithms

### DIFF
--- a/changelog/added-cores-to-conjured-regions.md
+++ b/changelog/added-cores-to-conjured-regions.md
@@ -1,0 +1,1 @@
+Assign cores to NvmRegions created from flash algorithms

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -88,9 +88,13 @@ impl Target {
                 // EEPROM regions. We probably don't want to erase these regions, so we set
                 // `is_alias`, which then causes "erase all" to skip the region.
                 memory_map.push(MemoryRegion::Nvm(NvmRegion {
-                    name: None,
+                    name: Some(format!("synthesized for {algo_name}")),
                     range: algo_range.clone(),
-                    cores: algo.cores.clone(),
+                    cores: if algo.cores.is_empty() {
+                        chip.cores.iter().map(|core| core.name.clone()).collect()
+                    } else {
+                        algo.cores.clone()
+                    },
                     is_alias: true,
                     access: Some(MemoryAccess {
                         read: false,

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -758,7 +758,7 @@ impl FlashLoader {
         let algorithms = target
             .flash_algorithms
             .iter()
-            // filter for algorithims that contiain adress range
+            // filter for algorithms that contain address range
             .filter(|&fa| {
                 fa.flash_properties
                     .address_range


### PR DESCRIPTION
I found this was necessary to execute a flash algorithm for an external memory lacking an explicit NvmRegion in the YAML.