### PR TITLE
Add manufacturer code to fix filtering on website

### DIFF
--- a/changelog/added-manufacturer-code.md
+++ b/changelog/added-manufacturer-code.md
@@ -1,1 +1,0 @@
-Added target manufacturer code to fix filtering on the website.

--- a/changelog/added-manufacturer-code.md
+++ b/changelog/added-manufacturer-code.md
@@ -1,0 +1,1 @@
+Added target manufacturer code to fix filtering on the website.

--- a/probe-rs/targets/CC13XX_CC26XX_Series.yaml
+++ b/probe-rs/targets/CC13XX_CC26XX_Series.yaml
@@ -1,4 +1,7 @@
 name: CC13xx CC26xx Series
+manufacturer:
+  id: 0x17
+  cc: 0x0
 variants:
 - name: CC2642R
   cores:


### PR DESCRIPTION
This is an attempt to fix the manufacturer filtering on the website https://github.com/probe-rs/webpage/issues/152

If this is how it should be solved, I can add it to more of the files!