### PR TITLE
Add missing manufacturer codes

### DIFF
--- a/probe-rs/targets/ADuCM302x_Series.yaml
+++ b/probe-rs/targets/ADuCM302x_Series.yaml
@@ -1,4 +1,7 @@
 name: ADuCM302x Series
+manufacturer:
+  id: 0x65
+  cc: 0x0
 generated_from_pack: true
 pack_file_release: 3.2.1
 variants:

--- a/probe-rs/targets/EFM32PG1B_Series.yaml
+++ b/probe-rs/targets/EFM32PG1B_Series.yaml
@@ -1,4 +1,7 @@
 name: EFM32PG1B Series
+manufacturer:
+  id: 0x21
+  cc: 0x2
 generated_from_pack: true
 pack_file_release: 4.3.0
 variants:

--- a/probe-rs/targets/EFM32PG22_Series.yaml
+++ b/probe-rs/targets/EFM32PG22_Series.yaml
@@ -1,4 +1,7 @@
 name: EFM32PG22 Series
+manufacturer:
+  id: 0x21
+  cc: 0x2
 generated_from_pack: true
 pack_file_release: 4.4.0
 variants:

--- a/probe-rs/targets/FM3_Series.yaml
+++ b/probe-rs/targets/FM3_Series.yaml
@@ -1,4 +1,7 @@
 name: FM3 High Performance Series
+manufacturer:
+  id: 0x41
+  cc: 0x0
 generated_from_pack: true
 pack_file_release: 1.2.1
 variants:

--- a/probe-rs/targets/GD32C1x3_Series.yaml
+++ b/probe-rs/targets/GD32C1x3_Series.yaml
@@ -1,4 +1,7 @@
 name: GD32c1x3 Series
+manufacturer:
+  id: 0x48
+  cc: 0x6
 generated_from_pack: true
 pack_file_release: 1.0.1
 variants:

--- a/probe-rs/targets/GD32F10x_Series.yaml
+++ b/probe-rs/targets/GD32F10x_Series.yaml
@@ -1,4 +1,7 @@
 name: GD32F10x Series
+manufacturer:
+  id: 0x48
+  cc: 0x6
 generated_from_pack: true
 pack_file_release: 2.0.3
 variants:

--- a/probe-rs/targets/HK32F030xMxx_Series.yaml
+++ b/probe-rs/targets/HK32F030xMxx_Series.yaml
@@ -1,4 +1,7 @@
 name: HK32F030xMxx Series
+manufacturer:
+  id: 0x68
+  cc: 0xB
 generated_from_pack: true
 pack_file_release: 1.0.17
 variants:

--- a/probe-rs/targets/LM3S_Series.yaml
+++ b/probe-rs/targets/LM3S_Series.yaml
@@ -1,4 +1,7 @@
 name: LM3S Series
+manufacturer:
+  id: 0x17
+  cc: 0x0
 generated_from_pack: true
 pack_file_release: 1.1.0
 variants:

--- a/probe-rs/targets/LPC54102.yaml
+++ b/probe-rs/targets/LPC54102.yaml
@@ -1,4 +1,7 @@
 name: LPC54102
+manufacturer:
+  id: 0x15
+  cc: 0x0
 generated_from_pack: true
 pack_file_release: 12.0.1
 variants:

--- a/probe-rs/targets/LPC55S69.yaml
+++ b/probe-rs/targets/LPC55S69.yaml
@@ -1,4 +1,7 @@
 name: LPC55S69
+manufacturer:
+  id: 0x15
+  cc: 0x0
 generated_from_pack: true
 pack_file_release: 17.0.0
 variants:

--- a/probe-rs/targets/MSPM0C_Series.yaml
+++ b/probe-rs/targets/MSPM0C_Series.yaml
@@ -1,4 +1,7 @@
 name: MSPM0C Series
+manufacturer:
+  id: 0x17
+  cc: 0x0
 generated_from_pack: true
 pack_file_release: 1.1.1
 variants:

--- a/probe-rs/targets/MSPM0G1X0X_G3X0X_Series.yaml
+++ b/probe-rs/targets/MSPM0G1X0X_G3X0X_Series.yaml
@@ -1,4 +1,7 @@
 name: MSPM0G1X0X_G3X0X Series
+manufacturer:
+  id: 0x17
+  cc: 0x0
 generated_from_pack: true
 pack_file_release: 1.3.1
 variants:

--- a/probe-rs/targets/MSPM0L_Series.yaml
+++ b/probe-rs/targets/MSPM0L_Series.yaml
@@ -1,4 +1,7 @@
 name: MSPM0L Series
+manufacturer:
+  id: 0x17
+  cc: 0x0
 generated_from_pack: true
 pack_file_release: 1.1.0
 variants:

--- a/probe-rs/targets/OpenTitan.yaml
+++ b/probe-rs/targets/OpenTitan.yaml
@@ -1,4 +1,7 @@
 name: OpenTitan
+manufacturer:
+  id: 0x6F
+  cc: 0xC
 variants:
 - name: earlgrey
   cores:

--- a/probe-rs/targets/RA0E1_Series.yaml
+++ b/probe-rs/targets/RA0E1_Series.yaml
@@ -1,4 +1,7 @@
 name: RA0E1 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA2A1_Series.yaml
+++ b/probe-rs/targets/RA2A1_Series.yaml
@@ -1,4 +1,7 @@
 name: RA2A1 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA2A2_Series.yaml
+++ b/probe-rs/targets/RA2A2_Series.yaml
@@ -1,4 +1,7 @@
 name: RA2A2 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA2E1_Series.yaml
+++ b/probe-rs/targets/RA2E1_Series.yaml
@@ -1,4 +1,7 @@
 name: RA2E1 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA2E2_Series.yaml
+++ b/probe-rs/targets/RA2E2_Series.yaml
@@ -1,4 +1,7 @@
 name: RA2E2 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA2E3_Series.yaml
+++ b/probe-rs/targets/RA2E3_Series.yaml
@@ -1,4 +1,7 @@
 name: RA2E3 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA2L1_Series.yaml
+++ b/probe-rs/targets/RA2L1_Series.yaml
@@ -1,4 +1,7 @@
 name: RA2L1 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA4E1_Series.yaml
+++ b/probe-rs/targets/RA4E1_Series.yaml
@@ -1,4 +1,7 @@
 name: RA4E1 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA4E2_Series.yaml
+++ b/probe-rs/targets/RA4E2_Series.yaml
@@ -1,4 +1,7 @@
 name: RA4E2 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA4M2_Series.yaml
+++ b/probe-rs/targets/RA4M2_Series.yaml
@@ -1,4 +1,7 @@
 name: RA4M2 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA4M3_Series.yaml
+++ b/probe-rs/targets/RA4M3_Series.yaml
@@ -1,4 +1,7 @@
 name: RA4M3 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA4T1_Series.yaml
+++ b/probe-rs/targets/RA4T1_Series.yaml
@@ -1,4 +1,7 @@
 name: RA4T1 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA4W1_Series.yaml
+++ b/probe-rs/targets/RA4W1_Series.yaml
@@ -1,4 +1,7 @@
 name: RA4W1 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA6E1_Series.yaml
+++ b/probe-rs/targets/RA6E1_Series.yaml
@@ -1,4 +1,7 @@
 name: RA6E1 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA6E2_Series.yaml
+++ b/probe-rs/targets/RA6E2_Series.yaml
@@ -1,4 +1,7 @@
 name: RA6E2 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA6M1_Series.yaml
+++ b/probe-rs/targets/RA6M1_Series.yaml
@@ -1,4 +1,7 @@
 name: RA6M1 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA6M2_Series.yaml
+++ b/probe-rs/targets/RA6M2_Series.yaml
@@ -1,4 +1,7 @@
 name: RA6M2 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA6M3_Series.yaml
+++ b/probe-rs/targets/RA6M3_Series.yaml
@@ -1,4 +1,7 @@
 name: RA6M3 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA6M4_Series.yaml
+++ b/probe-rs/targets/RA6M4_Series.yaml
@@ -1,4 +1,7 @@
 name: RA6M4 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA6M5_Series.yaml
+++ b/probe-rs/targets/RA6M5_Series.yaml
@@ -1,4 +1,7 @@
 name: RA6M5 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA6T1_Series.yaml
+++ b/probe-rs/targets/RA6T1_Series.yaml
@@ -1,4 +1,7 @@
 name: RA6T1 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA6T2_Series.yaml
+++ b/probe-rs/targets/RA6T2_Series.yaml
@@ -1,4 +1,7 @@
 name: RA6T2 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA6T3_Series.yaml
+++ b/probe-rs/targets/RA6T3_Series.yaml
@@ -1,4 +1,7 @@
 name: RA6T3 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA8D1_Series.yaml
+++ b/probe-rs/targets/RA8D1_Series.yaml
@@ -1,4 +1,7 @@
 name: RA8D1 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA8M1_Series.yaml
+++ b/probe-rs/targets/RA8M1_Series.yaml
@@ -1,4 +1,7 @@
 name: RA8M1 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/RA8T1_Series.yaml
+++ b/probe-rs/targets/RA8T1_Series.yaml
@@ -1,4 +1,7 @@
 name: RA8T1 Series
+manufacturer:
+  id: 0x23
+  cc: 0x4
 generated_from_pack: true
 pack_file_release: 5.3.0
 variants:

--- a/probe-rs/targets/SAM3X.yaml
+++ b/probe-rs/targets/SAM3X.yaml
@@ -1,4 +1,7 @@
 name: SAM3X
+manufacturer:
+  id: 0x1f
+  cc: 0x0
 generated_from_pack: true
 pack_file_release: 1.0.50
 variants:

--- a/probe-rs/targets/Tiva_C_Series.yaml
+++ b/probe-rs/targets/Tiva_C_Series.yaml
@@ -1,4 +1,7 @@
 name: Tiva C Series
+manufacturer:
+  id: 0x17
+  cc: 0x0
 generated_from_pack: true
 pack_file_release: 1.1.0
 variants:

--- a/probe-rs/targets/VA416xx_Series.yaml
+++ b/probe-rs/targets/VA416xx_Series.yaml
@@ -1,4 +1,7 @@
 name: VA416xx Series
+manufacturer:
+  id: 0x71
+  cc: 0x7
 generated_from_pack: true
 pack_file_release: 1.0.5
 variants:


### PR DESCRIPTION
This should fix most of the problem with targets not listing under their manufacturer on the website (https://github.com/probe-rs/webpage/issues/152). I have tried to the best of my ability to research what manufacturers should be added and cross checked the codes with the jep106 crate.

Some manufacturers do not appear to have a number in JEP106. Not sure what to do about those?

A couple of manufacturers have been added to the list but are not in the latest release of the jep106 crate. Those targets are **not** in this PR. 

I asked if they can make a new release. https://github.com/Yatekii/jep106/issues/12 