### PR TITLE
Add more manufacturer codes

### DIFF
--- a/probe-rs/targets/HC32F005-Series.yaml
+++ b/probe-rs/targets/HC32F005-Series.yaml
@@ -1,4 +1,7 @@
 name: HC32F005-Series
+manufacturer:
+  id: 0x78
+  cc: 0xD
 variants:
 - name: HC32F005C6PA
   cores:

--- a/probe-rs/targets/PAC52XX_Series.yaml
+++ b/probe-rs/targets/PAC52XX_Series.yaml
@@ -1,4 +1,7 @@
 name: PAC52XX Series
+manufacturer:
+  id: 0x6F
+  cc: 0xD
 generated_from_pack: true
 pack_file_release: 2.1.0
 variants:

--- a/probe-rs/targets/PAC55XX_Series.yaml
+++ b/probe-rs/targets/PAC55XX_Series.yaml
@@ -1,4 +1,7 @@
 name: PAC55XX Series
+manufacturer:
+  id: 0x6F
+  cc: 0xD
 generated_from_pack: true
 pack_file_release: 1.1.0
 variants:


### PR DESCRIPTION
This adds a few more manufacturer codes that were just added to jep106.

This improves website filtering issue: https://github.com/probe-rs/webpage/issues/152

Previous PR: https://github.com/probe-rs/probe-rs/pull/2892


Still some manufacturers missing that are not in JEP106, WCH for example. Not sure what to do about them? Discoverability is poor when I go to the website to check if WCH supports my chip and the manufacturer is not in the list.. That's was how I ended up here in the first place.. (Maybe this is not the best place to discuss? I'll add this comment to the issue too)