### PR TITLE
Disable SWDT, fix H2

### DIFF
--- a/changelog/fixed-esp32s2-s3-swdt.md
+++ b/changelog/fixed-esp32s2-s3-swdt.md
@@ -1,0 +1,1 @@
+probe-rs now correctly disables all watchdogs of ESP32-S2 and ESP32-S3

--- a/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
@@ -36,11 +36,12 @@ impl ESP32H2 {
 impl RiscvDebugSequence for ESP32H2 {
     fn on_connect(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
         tracing::info!("Disabling esp32h2 watchdogs...");
+
         // disable super wdt
-        interface.write_word_32(0x600B1C20, 0x50D83AA1)?; // write protection off
-        let current = interface.read_word_32(0x600B_1C1C)?;
-        interface.write_word_32(0x600B_1C1C, current | 1 << 18)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
-        interface.write_word_32(0x600B1C20, 0x0)?; // write protection on
+        interface.write_word_32(0x600B1C24, 0x50D83AA1)?; // write protection off
+        let current = interface.read_word_32(0x600B1C20)?;
+        interface.write_word_32(0x600B1C20, current | 1 << 18)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
+        interface.write_word_32(0x600B1C24, 0x0)?; // write protection on
 
         // tg0 wdg
         interface.write_word_32(0x6000_8064, 0x50D83AA1)?; // write protection off
@@ -53,9 +54,9 @@ impl RiscvDebugSequence for ESP32H2 {
         interface.write_word_32(0x6000_9064, 0x0)?; // write protection on
 
         // rtc wdg
-        interface.write_word_32(0x600B_1C18, 0x50D83AA1)?; // write protection off
+        interface.write_word_32(0x600B_1C1C, 0x50D83AA1)?; // write protection off
         interface.write_word_32(0x600B_1C00, 0x0)?;
-        interface.write_word_32(0x600B_1C18, 0x0)?; // write protection on
+        interface.write_word_32(0x600B_1C1C, 0x0)?; // write protection on
 
         Ok(())
     }

--- a/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
@@ -22,6 +22,12 @@ pub struct ESP32S3 {
 }
 
 impl ESP32S3 {
+    const SWD_BASE: u64 = 0x60008000;
+    const SWD_WRITE_PROT: u64 = Self::SWD_BASE | 0xB8;
+    const SWD_CONF: u64 = Self::SWD_BASE | 0xB4;
+    const SWD_AUTO_FEED_EN: u32 = 1 << 31;
+    const SWD_WRITE_PROT_KEY: u32 = 0x8f1d312a;
+
     /// Creates a new debug sequence handle for the ESP32-S3.
     pub fn create() -> Arc<dyn XtensaDebugSequence> {
         Arc::new(Self {
@@ -42,6 +48,12 @@ impl XtensaDebugSequence for ESP32S3 {
         core.add_slow_memory_access_range(0x3C00_0000..0x3E00_0000);
 
         tracing::info!("Disabling ESP32-S3 watchdogs...");
+
+        // disable super wdt
+        core.write_word_32(Self::SWD_WRITE_PROT, Self::SWD_WRITE_PROT_KEY)?; // write protection off
+        let current = core.read_word_32(Self::SWD_CONF)?;
+        core.write_word_32(Self::SWD_CONF, current | Self::SWD_AUTO_FEED_EN)?;
+        core.write_word_32(Self::SWD_WRITE_PROT, 0x0)?; // write protection on
 
         // tg0 wdg
         const TIMG0_BASE: u64 = 0x6001f000;


### PR DESCRIPTION
H2 TRM is incorrect, values are updated from ESP-IDF. There is one more config register in the H2 that is not taken into account in the documentation, offsetting every address after by 4.