### PR TITLE
Mark lazy-loaded flash algos as loaded

### DIFF
--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -86,6 +86,7 @@ impl<'session> Flasher<'session> {
     fn ensure_loaded(&mut self) -> Result<(), FlashError> {
         if !self.loaded {
             self.load()?;
+            self.loaded = true;
         }
 
         Ok(())


### PR DESCRIPTION
879c53e wants to prevent us from loading flash algorithms multiple times.  However, the commit never marked the algos as loaded. This commit marks the algorithms as loaded if it ever succeeded. I observed no issues with this commit when testing on an MIMXRT1170.

For MIMXRT1170 users, this removes a warning about "no program in flash" observed during flashing. As of this commit, the tool stops issuing subsequent resets that would detect the previously-erased flash.