### PR TITLE
feat: ensure serial number comparison is done case insensitively

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -10,7 +10,7 @@ use probe_rs::flashing::FormatKind;
 use probe_rs::gdb_server::GdbInstanceConfiguration;
 use probe_rs::probe::list::Lister;
 use probe_rs::rtt::ScanRegion;
-use probe_rs::{probe::DebugProbeSelector, Session};
+use probe_rs::{probe::DebugProbeSelector, probe::DebugProbeSerial, Session};
 use std::ffi::OsString;
 use std::time::Instant;
 use std::{fs, thread};
@@ -179,7 +179,11 @@ fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
             (Some(vid), Some(pid)) => Some(DebugProbeSelector {
                 vendor_id: u16::from_str_radix(vid, 16)?,
                 product_id: u16::from_str_radix(pid, 16)?,
-                serial_number: config.probe.serial.clone(),
+                serial_number: config
+                    .probe
+                    .serial
+                    .as_ref()
+                    .map(|s| DebugProbeSerial(s.clone())),
             }),
             (vid, pid) => {
                 if vid.is_some() {

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -31,6 +31,8 @@ mod ftdaye;
 use command_compacter::Command;
 use ftdaye::{error::FtdiError, ChipType};
 
+use super::DebugProbeSerial;
+
 #[derive(Debug)]
 struct JtagAdapter {
     device: ftdaye::Device,
@@ -639,7 +641,9 @@ fn get_device_info(device: &DeviceInfo) -> Option<DebugProbeInfo> {
             identifier: device.product_string().unwrap_or("FTDI").to_string(),
             vendor_id: device.vendor_id(),
             product_id: device.product_id(),
-            serial_number: device.serial_number().map(|s| s.to_string()),
+            serial_number: device
+                .serial_number()
+                .map(|s| DebugProbeSerial(s.to_string())),
             probe_factory: &FtdiProbeFactory,
             hid_interface: None,
         })

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -52,6 +52,8 @@ use crate::{
     },
 };
 
+use super::DebugProbeSerial;
+
 const SWO_BUFFER_SIZE: u16 = 128;
 const TIMEOUT_DEFAULT: Duration = Duration::from_millis(500);
 
@@ -281,13 +283,17 @@ fn requires_connection_handle(selector: &DebugProbeSelector) -> bool {
     // As some other devices can't handle the registration command, we only enable it for known
     // devices.
     let devices = [
-        (0x1366, 0x0101, Some("000000123456")), // Blue J-Link PRO clone
+        (
+            0x1366,
+            0x0101,
+            Some(DebugProbeSerial("000000123456".to_owned())),
+        ), // Blue J-Link PRO clone
     ];
 
     devices.contains(&(
         selector.vendor_id,
         selector.product_id,
-        selector.serial_number.as_deref(),
+        selector.serial_number.to_owned(),
     ))
 }
 

--- a/probe-rs/src/probe/stlink/usb_interface.rs
+++ b/probe-rs/src/probe/stlink/usb_interface.rs
@@ -93,7 +93,7 @@ fn selector_matches(selector: &DebugProbeSelector, info: &DeviceInfo) -> bool {
         && selector
             .serial_number
             .as_ref()
-            .map(|s| read_serial_number(info).as_ref() == Some(s))
+            .map(|s| s == read_serial_number(info).as_ref())
             .unwrap_or(true);
 
     res

--- a/rtthost/src/main.rs
+++ b/rtthost/src/main.rs
@@ -253,7 +253,8 @@ fn list_probes(mut stream: impl std::io::Write, probes: &[DebugProbeInfo]) {
             probe.identifier,
             probe
                 .serial_number
-                .as_deref()
+                .as_ref()
+                .map(|s| s.0.as_str())
                 .unwrap_or("(no serial number)")
         )
         .unwrap();


### PR DESCRIPTION
On Windows, nusb requires case-insensitive comparison of the serial number: https://github.com/kevinmehall/nusb/blob/main/src/enumeration.rs#L251C5-L261C6

This PR relates to #2905 , although already somehow fixed by #2723 .

While digging into the code, I found some places in which the probe serial number were still checked including the casing.
With the proposed approach, the serial number comparison is centralized in the `DebugProbeSerial` object in a single place.
There, eventually, one could make a platform specific equality check, such that only on Windows in gets relaxed by ignoring the casing.

If this work is of interest, I'll finish it up with some tests and by adding the missing documentation and by addressing eventual inputs.
If not, feel free to close this 😃