### PR TITLE
Add nRF54L15.

### DIFF
--- a/changelog/added-nrf54.md
+++ b/changelog/added-nrf54.md
@@ -1,0 +1,1 @@
+Added support for new nRF54 chips: nRF54L15.

--- a/probe-rs/targets/nRF54_Series.yaml
+++ b/probe-rs/targets/nRF54_Series.yaml
@@ -1,0 +1,65 @@
+# Written by hand because there's no CMSIS pack yet.
+# Uses algo from https://github.com/embassy-rs/nrf54l-flash-algo
+
+name: nRF54 Series
+manufacturer:
+  id: 0x44
+  cc: 0x2
+chip_detection:
+- !NordicFicrInfo
+  part_address: 0xffc31c
+  variant_address: 0xffc320
+  part: 0x54B15
+  variants:
+    0x41414242: nRF54L15 # QFN48, engineering B
+variants:
+- name: nRF54L15
+  cores:
+  - name: main
+    type: armv8m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0x0
+  memory_map:
+  - !Nvm
+    range:
+      start: 0x0
+      end: 0x180000
+    cores:
+    - main
+    access:
+      boot: true
+  - !Ram
+    range:
+      start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  flash_algorithms:
+  - algorithm
+
+flash_algorithms:
+- name: algorithm
+  description: nrf54l flash algorithm
+  default: true
+  instructions: QPKwEEvyAFHC8gAAxfIEAQN4C7EAIwtgAToDKj+/ACIKYAEhAXA8vwAgcEf+3kDysBHC8gABCHgBKBy/ASBwRwAgCHBL8gBRxfIEAQhgcEdA8rAQwvIAAAB4gPABAHBHC0ZA8rARwvIAAQl4ASkcvwEgcEfQtQKvS/IIBELyAQHF8gQExPj4FNT4+BPJB/vQEUYaRgDwevgBICBg1Pj4A8AH+9AAIMT4+ATU+PgDwAf70AAg0L1A8rAQwvIAAAF4ASABKRi/cEdL8gBBxfIEAcH4QAEIaMAH/NAAIHBH8LUDry3pAA8QKjXTQ0IT8AMEAOsEDAfQA0YORhb4AVsD+AFbY0X506LrBA4B6wQKLvADCAzrCANf6opyHtC48QEPJdsYIirwAwYC6soLT+rKAsLxAAkyaDUdCfAYBlX4BBsi+gvyAfoG9CJDTPgEKwpGnEXz0wvgA0YN4LjxAQ8G21JGUvgEG0z4BBucRfnTCusIAQ7wAwIysRpEEfgBawP4AWuTQvnTvegAD/C9//envwDU1NQ=
+  load_address: 0x20000020
+  pc_init: 0x1
+  pc_uninit: 0x2f
+  pc_program_page: 0x61
+  pc_erase_sector: 0x51
+  pc_erase_all: 0xb7
+  data_section_offset: 0x200001b4
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x180000
+    page_size: 0x1000
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 2000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+  cores:
+  - main


### PR DESCRIPTION
Current status: 
- flashing, running RTT etc all work. 
- No recover implementation yet. If APPROTECT trips, you have to do `nrfjprog --recover` to get rid of it.
- Ignoring the riscv core for now.

Uses algo from https://github.com/embassy-rs/nrf54l-flash-algo

Something interesting is nrf54l uses RRAM, not flash. You can directly write words anywhere,
changing both 0->1 and 1->0 bits. There's no page/sector erase operation.

I've made the erase implementation a nop in the flash algo. Do we have a better way of dealing
with NVMs like these? 
