### PR TITLE
arm: Fall back on SWDv2 wake from dormant on SWDv1 failure

### DIFF
--- a/changelog/added-support-domant-sequence-as-fallback-for-swdv2-targets.md
+++ b/changelog/added-support-domant-sequence-as-fallback-for-swdv2-targets.md
@@ -1,0 +1,1 @@
+arm: Fall back on SWDv2 wake from dormant on SWDv1 failure


### PR DESCRIPTION
* Previously the code assumed that the dormant sequence was only present/needed on Multidrop devices. This is not the case.
* Now we try to setup the debug port and wake the device using the SWDv1 method and fallback to the dormant sequence if this fails
* All credit to @konkers  https://github.com/konkers/probe-rs/commit/37660106aba307cbab5cf6c2b0da57b72b6dc4e9