### PR TITLE
Fix timeout in cortex_m_reset_system

### DIFF
--- a/changelog/fixed-timeout-cortex-m-reset-system.md
+++ b/changelog/fixed-timeout-cortex-m-reset-system.md
@@ -1,0 +1,1 @@
+Fix broken timeout in `cortex_m_reset_system`

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -381,7 +381,7 @@ fn cortex_m_reset_system(interface: &mut dyn ArmMemoryInterface) -> Result<(), A
 
     let start = Instant::now();
 
-    loop {
+    while start.elapsed() < Duration::from_millis(500) {
         let dhcsr = match interface.read_word_32(Dhcsr::get_mmio_address()) {
             Ok(val) => Dhcsr(val),
             // Some combinations of debug probe and target (in
@@ -397,10 +397,9 @@ fn cortex_m_reset_system(interface: &mut dyn ArmMemoryInterface) -> Result<(), A
         if !dhcsr.s_reset_st() {
             return Ok(());
         }
-        if start.elapsed() >= Duration::from_millis(500) {
-            return Err(ArmError::Timeout);
-        }
     }
+
+    Err(ArmError::Timeout)
 }
 
 /// A interface to operate debug sequences for ARM targets.


### PR DESCRIPTION
Previously `continue` on `Err` bypassed timeouting logic.