### PR TITLE
Bump nusb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,9 +2203,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nusb"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58c5baaf1902712d1c7ef734165376bf1e05f0ebfd00755fd4c4762c06b0c1a"
+checksum = "e4e1996397b9a2af6390bb9ef0386c429de1a81da246fa7ae31dc922be4b670b"
 dependencies = [
  "atomic-waker",
  "core-foundation 0.9.4",

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -58,7 +58,7 @@ object = { version = "0.36", default-features = false, features = [
     "read_core",
     "std",
 ] }
-nusb = "0.1.9"
+nusb = "0.1.12"
 futures-lite = { version = "2", default-features = false }
 async-io = "2"
 scroll = "0.12"

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -40,7 +40,7 @@ pub fn list_cmsisdap_devices() -> Vec<DebugProbeInfo> {
                 if !probes.iter().any(|p| {
                     p.vendor_id == info.vendor_id
                         && p.product_id == info.product_id
-                        && serial_eq_case_insensitive(&p.serial_number, &info.serial_number)
+                        && p.serial_number == info.serial_number
                 }) {
                     tracing::trace!("Adding new HID-only probe {:?}", info);
                     probes.push(info)
@@ -343,12 +343,4 @@ fn is_known_cmsis_dap_dev(device: &DeviceInfo) -> bool {
     KNOWN_DAPS
         .iter()
         .any(|&(vid, pid)| device.vendor_id() == vid && device.product_id() == pid)
-}
-
-fn serial_eq_case_insensitive(a: &Option<String>, b: &Option<String>) -> bool {
-    match (a, b) {
-        (Some(a), Some(b)) => a.eq_ignore_ascii_case(b),
-        (None, None) => true,
-        _ => false,
-    }
 }


### PR DESCRIPTION
Bump nusb to fix the Windows serial-number capitalization issue.

#2723 is not required anymore, hence the code has been reverted.

Test working:

probe-rs running with only #2723 reverted
```bash
$ target/debug/probe-rs.exe list
The following debug probes were found:
[0]: Rusty Probe with CMSIS-DAP v1/v2 Support -- 1209:4853:DC645020138A1122EF4014 (CMSIS-DAP)
[1]: HS-Probe CMSIS-DAP v1 Interface -- 1209:4853:dc645020138a1122ef4014 (CMSIS-DAP)
```

With also `nusb` to v0.1.12 (this PR):
```bash
$ target/debug/probe-rs.exe list
The following debug probes were found:
[0]: Rusty Probe with CMSIS-DAP v1/v2 Support -- 1209:4853:dc645020138a1122ef4014 (CMSIS-DAP)
```