### PR TITLE
Fix clippy warnings added in 1.83, update Rust version in CI

### DIFF
--- a/probe-rs-target/src/flash_algorithm.rs
+++ b/probe-rs-target/src/flash_algorithm.rs
@@ -143,7 +143,7 @@ impl Base64 {
         deserializer.deserialize_str(Base64)
     }
 }
-impl<'de> serde::de::Visitor<'de> for Base64 {
+impl serde::de::Visitor<'_> for Base64 {
     type Value = Vec<u8>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -176,7 +176,7 @@ impl Bytes {
         deserializer.deserialize_bytes(Bytes)
     }
 }
-impl<'de> serde::de::Visitor<'de> for Bytes {
+impl serde::de::Visitor<'_> for Bytes {
     type Value = Vec<u8>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
@@ -987,7 +987,7 @@ pub struct CliData<'p> {
 }
 
 impl<'p> CliData<'p> {
-    fn new(core: Core<'p>, debug_info: Option<DebugInfo>) -> Result<CliData, CliError> {
+    fn new(core: Core<'p>, debug_info: Option<DebugInfo>) -> Result<CliData<'p>, CliError> {
         let mut cli_data = CliData {
             core,
             debug_info,

--- a/probe-rs/src/architecture/arm/component/tmc.rs
+++ b/probe-rs/src/architecture/arm/component/tmc.rs
@@ -238,7 +238,7 @@ impl<'a> Frame<'a> {
     }
 }
 
-impl<'a> Iterator for &mut Frame<'a> {
+impl Iterator for &mut Frame<'_> {
     type Item = (Id, u8);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -457,7 +457,7 @@ impl<'probe> Armv6m<'probe> {
     }
 }
 
-impl<'probe> CoreInterface for Armv6m<'probe> {
+impl CoreInterface for Armv6m<'_> {
     fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error> {
         // Wait until halted state is active again.
         let start = Instant::now();

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -299,7 +299,7 @@ impl<'probe> Armv7a<'probe> {
     }
 }
 
-impl<'probe> CoreInterface for Armv7a<'probe> {
+impl CoreInterface for Armv7a<'_> {
     fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error> {
         // Wait until halted state is active again.
         let start = Instant::now();
@@ -813,7 +813,7 @@ impl<'probe> CoreInterface for Armv7a<'probe> {
     }
 }
 
-impl<'probe> MemoryInterface for Armv7a<'probe> {
+impl MemoryInterface for Armv7a<'_> {
     fn supports_native_64bit_access(&mut self) -> bool {
         false
     }

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -642,7 +642,7 @@ impl<'probe> Armv7m<'probe> {
     }
 }
 
-impl<'probe> CoreInterface for Armv7m<'probe> {
+impl CoreInterface for Armv7m<'_> {
     fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error> {
         // Wait until halted state is active again.
         let start = Instant::now();

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -1024,7 +1024,7 @@ impl<'probe> Armv8a<'probe> {
     }
 }
 
-impl<'probe> CoreInterface for Armv8a<'probe> {
+impl CoreInterface for Armv8a<'_> {
     fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error> {
         // Wait until halted state is active again.
         let start = Instant::now();
@@ -1470,7 +1470,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
     }
 }
 
-impl<'probe> MemoryInterface for Armv8a<'probe> {
+impl MemoryInterface for Armv8a<'_> {
     fn supports_native_64bit_access(&mut self) -> bool {
         self.state.is_64_bit
     }

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -84,7 +84,7 @@ impl<'probe> Armv8m<'probe> {
     }
 }
 
-impl<'probe> CoreInterface for Armv8m<'probe> {
+impl CoreInterface for Armv8m<'_> {
     fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error> {
         // Wait until halted state is active again.
         let start = Instant::now();

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -74,7 +74,7 @@ impl<'probe: 'memory, 'memory: 'reader, 'reader> RomTableIterator<'probe, 'memor
     }
 }
 
-impl<'probe, 'memory, 'reader> Iterator for RomTableIterator<'probe, 'memory, 'reader> {
+impl Iterator for RomTableIterator<'_, '_, '_> {
     type Item = Result<RomTableEntryRaw, RomTableError>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -425,7 +425,7 @@ pub enum Component {
     /// For detailed information about Class 0x1 ROM Tables, see _Chapter D3 Class 0x1 ROM Tables_.
     Class1RomTable(ComponentId, RomTable),
     /// CoreSight component. For general information about CoreSight components, see the CoreSight Architecture Specification.
-
+    ///
     /// A CoreSight component can be a Class 0x9 ROM Table, which can be identified from the DEVARCH.ARCHID having the value 0x0AF7. See also _ROM Table Types on page D2-237_. For detailed information about Class 0x9 ROM Tables, see _Chapter D4 Class 0x9 ROM Tables_.
     CoresightComponent(ComponentId),
     /// Peripheral Test Block.

--- a/probe-rs/src/architecture/arm/swo/mod.rs
+++ b/probe-rs/src/architecture/arm/swo/mod.rs
@@ -181,7 +181,7 @@ impl<'a> SwoReader<'a> {
     }
 }
 
-impl<'a> std::io::Read for SwoReader<'a> {
+impl std::io::Read for SwoReader<'_> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         use std::{
             cmp,

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -185,7 +185,7 @@ impl<'state> Riscv32<'state> {
     }
 }
 
-impl<'state> CoreInterface for Riscv32<'state> {
+impl CoreInterface for Riscv32<'_> {
     fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), crate::Error> {
         self.interface.wait_for_core_halted(timeout)?;
         self.state.pc_written = false;

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -832,7 +832,7 @@ fn as_bytes_mut<T: DataType>(data: &mut [T]) -> &mut [u8] {
     }
 }
 
-impl<'probe> MemoryInterface for XtensaCommunicationInterface<'probe> {
+impl MemoryInterface for XtensaCommunicationInterface<'_> {
     fn read(&mut self, address: u64, dst: &mut [u8]) -> Result<(), crate::Error> {
         self.read_memory(address, dst)?;
 

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -224,7 +224,7 @@ impl<'probe> Xtensa<'probe> {
     }
 }
 
-impl<'probe> CoreMemoryInterface for Xtensa<'probe> {
+impl CoreMemoryInterface for Xtensa<'_> {
     type ErrorType = Error;
 
     fn memory(&self) -> &dyn MemoryInterface<Self::ErrorType> {
@@ -236,7 +236,7 @@ impl<'probe> CoreMemoryInterface for Xtensa<'probe> {
     }
 }
 
-impl<'probe> CoreInterface for Xtensa<'probe> {
+impl CoreInterface for Xtensa<'_> {
     fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error> {
         self.interface.wait_for_core_halted(timeout)?;
         self.on_halted()?;

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -219,7 +219,7 @@ pub struct Core<'probe> {
     inner: Box<dyn CoreInterface + 'probe>,
 }
 
-impl<'probe> CoreMemoryInterface for Core<'probe> {
+impl CoreMemoryInterface for Core<'_> {
     type ErrorType = Error;
 
     fn memory(&self) -> &dyn MemoryInterface<Self::ErrorType> {
@@ -582,7 +582,7 @@ impl<'probe> Core<'probe> {
     }
 }
 
-impl<'probe> CoreInterface for Core<'probe> {
+impl CoreInterface for Core<'_> {
     fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error> {
         self.wait_for_core_halted(timeout)
     }

--- a/probe-rs/src/debug/function_die.rs
+++ b/probe-rs/src/debug/function_die.rs
@@ -13,11 +13,11 @@ pub(crate) type Die<'abbrev, 'unit> =
 
 /// Reference to a DIE for a function
 #[derive(Clone)]
-pub(crate) struct FunctionDie<'abbrev, 'unit> {
+pub(crate) struct FunctionDie<'data> {
     /// A reference to the compilation unit this function belongs to.
-    pub(crate) unit_info: &'unit UnitInfo,
+    pub(crate) unit_info: &'data UnitInfo,
     /// The DIE (Debugging Information Entry) for the function.
-    pub(crate) function_die: Die<'abbrev, 'unit>,
+    pub(crate) function_die: Die<'data, 'data>,
     /// The optional specification DIE for the function, if it has one.
     /// - For regular functions, this applies to the `function_die`.
     /// - For inlined functions, this applies to the `abstract_die`.
@@ -25,29 +25,25 @@ pub(crate) struct FunctionDie<'abbrev, 'unit> {
     /// The specification DIE will contain separately declared attributes,
     /// e.g. for the function name.
     /// See DWARF spec, 2.13.2.
-    pub(crate) specification_die: Option<Die<'abbrev, 'unit>>,
+    pub(crate) specification_die: Option<Die<'data, 'data>>,
     /// Only present for inlined functions, where this is a reference
     /// to the declaration of the function.
-    pub(crate) abstract_die: Option<Die<'abbrev, 'unit>>,
+    pub(crate) abstract_die: Option<Die<'data, 'data>>,
     /// The address ranges for which this function is valid.
     pub(crate) ranges: Vec<Range<u64>>,
 }
 
-impl<'abbrev, 'unit> FunctionDie<'abbrev, 'unit> {
+impl<'a> FunctionDie<'a> {
     /// Create a new function DIE reference.
     /// We only return DIE's that are functions, with valid address ranges that represent machine code
     /// relevant to the address/program counter specified.
     /// Other DIE's will return None, and should be ignored.
     pub(crate) fn new(
-        function_die: Die<'abbrev, 'unit>,
-        unit_info: &'unit UnitInfo,
-        debug_info: &'abbrev DebugInfo,
+        function_die: Die<'a, 'a>,
+        unit_info: &'a UnitInfo,
+        debug_info: &'a DebugInfo,
         address: u64,
-    ) -> Result<Option<Self>, DebugError>
-    where
-        'abbrev: 'unit,
-        'unit: 'abbrev,
-    {
+    ) -> Result<Option<Self>, DebugError> {
         let is_inlined_function = match function_die.tag() {
             gimli::DW_TAG_subprogram => false,
             gimli::DW_TAG_inlined_subroutine => true,

--- a/probe-rs/src/debug/stack_frame.rs
+++ b/probe-rs/src/debug/stack_frame.rs
@@ -88,7 +88,7 @@ mod test {
     /// Helper struct used to format a StackFrame for testing.
     pub struct TestFormatter<'s>(pub &'s StackFrame);
 
-    impl<'s> std::fmt::Display for TestFormatter<'s> {
+    impl std::fmt::Display for TestFormatter<'_> {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
             writeln!(f, "Frame:")?;
             writeln!(f, " function:        {}", self.0.function_name)?;

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -67,7 +67,7 @@ impl UnitInfo {
         &'debug_info self,
         debug_info: &'debug_info super::DebugInfo,
         address: u64,
-    ) -> Result<Vec<FunctionDie>, DebugError> {
+    ) -> Result<Vec<FunctionDie<'debug_info>>, DebugError> {
         tracing::trace!("Searching Function DIE for address {:#010x}", address);
 
         let mut entries_cursor = self.unit.entries();
@@ -104,7 +104,7 @@ impl UnitInfo {
         debug_info: &'abbrev DebugInfo,
         address: u64,
         parent_offset: UnitOffset,
-    ) -> Result<Vec<FunctionDie<'abbrev, '_>>, DebugError> {
+    ) -> Result<Vec<FunctionDie<'abbrev>>, DebugError> {
         // If we don't have any entries at our unit offset, return an empty vector.
         // This cursor starts at, and includes the entries for the non-inlined function at 'parent_offset'.
         let Ok(mut cursor) = self.unit.entries_at_offset(parent_offset) else {

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -946,7 +946,7 @@ impl<O: Operation> ActiveFlasher<'_, O> {
     }
 }
 
-impl<'probe> ActiveFlasher<'probe, Erase> {
+impl ActiveFlasher<'_, Erase> {
     pub(super) fn erase_all(&mut self) -> Result<(), FlashError> {
         tracing::debug!("Erasing entire chip.");
         let algo = &self.flash_algorithm;
@@ -1019,7 +1019,7 @@ impl<'probe> ActiveFlasher<'probe, Erase> {
     }
 }
 
-impl<'p> ActiveFlasher<'p, Program> {
+impl ActiveFlasher<'_, Program> {
     pub(super) fn program_page(&mut self, page: &FlashPage) -> Result<(), FlashError> {
         let t1 = Instant::now();
 

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -250,7 +250,7 @@ enum RemoteCommand<'a> {
     },
 }
 
-impl<'a> RemoteCommand<'a> {
+impl RemoteCommand<'_> {
     /// Return the buffer from the payload of the specified value where the
     /// response should be written.
     fn response_buffer(&mut self) -> Option<&mut [u8]> {
@@ -279,7 +279,7 @@ impl<'a> RemoteCommand<'a> {
 // Implement `ToString` instead of `Display` as this is for generating
 // strings to send over the network, and is not meant for human consumption.
 #[allow(clippy::to_string_trait_impl)]
-impl<'a> std::string::ToString for RemoteCommand<'a> {
+impl std::string::ToString for RemoteCommand<'_> {
     fn to_string(&self) -> String {
         match self {
             RemoteCommand::Handshake(_) => "+#!GA#".to_string(),

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -282,7 +282,7 @@ impl CmsisDap {
         const BYTES_PER_REQUEST: usize = 16;
         // How many requests are needed to read/write at least MAX_LENGTH bits.
         const REQUESTS: usize =
-            (MAX_LENGTH + (BYTES_PER_REQUEST * 8 - 1)) / (BYTES_PER_REQUEST * 8);
+            MAX_LENGTH.div_ceil(BYTES_PER_REQUEST * 8);
 
         // Completely fill xR with 0s, capture result.
         let mut tdo_bytes: Vec<u8> = Vec::with_capacity(REQUESTS * BYTES_PER_REQUEST);

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -281,8 +281,7 @@ impl CmsisDap {
         // How many bytes to write out / read in per request.
         const BYTES_PER_REQUEST: usize = 16;
         // How many requests are needed to read/write at least MAX_LENGTH bits.
-        const REQUESTS: usize =
-            MAX_LENGTH.div_ceil(BYTES_PER_REQUEST * 8);
+        const REQUESTS: usize = MAX_LENGTH.div_ceil(BYTES_PER_REQUEST * 8);
 
         // Completely fill xR with 0s, capture result.
         let mut tdo_bytes: Vec<u8> = Vec::with_capacity(REQUESTS * BYTES_PER_REQUEST);

--- a/probe-rs/src/probe/jlink/swo.rs
+++ b/probe-rs/src/probe/jlink/swo.rs
@@ -68,7 +68,7 @@ pub struct SwoData<'a> {
     status: SwoStatus,
 }
 
-impl<'a> SwoData<'a> {
+impl SwoData<'_> {
     /// Returns whether the probe-internal buffer overflowed before the last read.
     ///
     /// This indicates that some device data was lost.
@@ -77,13 +77,13 @@ impl<'a> SwoData<'a> {
     }
 }
 
-impl<'a> AsRef<[u8]> for SwoData<'a> {
+impl AsRef<[u8]> for SwoData<'_> {
     fn as_ref(&self) -> &[u8] {
         self.data
     }
 }
 
-impl<'a> Deref for SwoData<'a> {
+impl Deref for SwoData<'_> {
     type Target = [u8];
     fn deref(&self) -> &Self::Target {
         self.data

--- a/probe-rs/src/vendor/microchip/sequences/atsam.rs
+++ b/probe-rs/src/vendor/microchip/sequences/atsam.rs
@@ -241,7 +241,7 @@ impl<'a> From<&'a mut dyn DapProbe> for SwdSequenceShim<'a> {
     }
 }
 
-impl<'a> SwdSequence for SwdSequenceShim<'a> {
+impl SwdSequence for SwdSequenceShim<'_> {
     fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError> {
         self.0.swj_sequence(bit_len, bits)
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.83.0"
 
 components = ["rustfmt", "clippy"]
 # Target used for tests

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -20,7 +20,7 @@ where
     Directory(&'a Path),
 }
 
-impl<'a, T> Kind<'a, T>
+impl<T> Kind<'_, T>
 where
     T: std::io::Seek + std::io::Read,
 {


### PR DESCRIPTION
Mostly automatic fixes, biggest change is a simplification of the lifetime in the `FunctionDie` struct.