### PR TITLE
Extend the ITM api to support packet configuration

### DIFF
--- a/changelog/added-api-to-configure-itm.md
+++ b/changelog/added-api-to-configure-itm.md
@@ -1,0 +1,2 @@
+Extended the ITM api to support configurable packet transmission settings.
+


### PR DESCRIPTION
This PR adds a few public functions to the ITM implementation that help with enabling/disabling:
- DWT packet forwarding
- Synchronization packets
- Local timestamp packets
- Stimulus registers

It could also serve as a base if the `probe-rs itm` command is ever extended to support packet
configuration flags (e.g. `--disable-dwt-forwarding`).
