### PR TITLE
quick and dirty `probe-rs-tool` read capability to store in a iHex file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,6 +2533,7 @@ dependencies = [
  "figment",
  "git-version",
  "goblin",
+ "ihex",
  "indicatif",
  "insta",
  "itertools 0.13.0",

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -48,6 +48,7 @@ goblin = { version = "0.9", default-features = false, features = [
     "elf64",
     "endian_fd",
 ] }
+ihex = "3.0"
 indicatif = "0.17"
 insta = { version = "1.38", default-features = false, features = ["yaml"] }
 itm = { version = "0.9.0-rc.1", default-features = false }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/read.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/read.rs
@@ -1,3 +1,6 @@
+use std::io::Write;
+use std::path::PathBuf;
+
 use probe_rs::{probe::list::Lister, MemoryInterface};
 
 use crate::util::common_options::{ProbeOptions, ReadWriteBitWidth, ReadWriteOptions};
@@ -29,6 +32,9 @@ pub struct Cmd {
 
     /// Number of words to read from the target
     words: u64,
+
+    /// The path to the file to be created with the flash data (iHex format)
+    path: Option<PathBuf>,
 }
 
 impl Cmd {
@@ -42,12 +48,52 @@ impl Cmd {
             ReadWriteBitWidth::B8 => {
                 let mut values = vec![0; words];
                 core.read_8(self.read_write_options.address, &mut values)?;
-                for val in values {
-                    print!("{:02x} ", val);
+                if let Some(path) = &self.path {
+                    let mut records = vec![];
+                    const CHUNK_SIZE: usize = 16;
+                    for chunk in values.chunks(CHUNK_SIZE).enumerate() {
+                        let address =
+                            self.read_write_options.address as usize + chunk.0 * CHUNK_SIZE;
+                        records.push((address, chunk.1.to_vec()));
+                    }
+                    let mut file = std::fs::File::create(path)?;
+                    let mut out_records = vec![];
+                    // get first record to store starting upper address
+                    let (addr, _) = records[0];
+                    let mut segment_upper_address = addr >> 16;
+                    out_records.push(ihex::Record::StartLinearAddress(
+                        segment_upper_address as u32,
+                    ));
+                    // iterate through records and push them to output vector
+                    for (addr, value) in records.into_iter() {
+                        let upper = addr >> 16;
+                        // write extend linear address record if it has changed
+                        if upper != segment_upper_address {
+                            out_records.push(ihex::Record::ExtendedLinearAddress(upper as u16));
+                        }
+                        let offset = addr & 0xffff;
+                        out_records.push(ihex::Record::Data {
+                            offset: offset as u16,
+                            value: value.clone(),
+                        });
+                        segment_upper_address = upper;
+                    }
+                    // push EOF record
+                    out_records.push(ihex::Record::EndOfFile);
+                    let data = ihex::create_object_file_representation(&out_records)?;
+                    file.write_all(data.as_bytes())?;
+                    println!("File {:?} written.", path);
+                } else {
+                    for val in values {
+                        print!("{:02x} ", val);
+                    }
+                    println!();
                 }
-                println!();
             }
             ReadWriteBitWidth::B32 => {
+                if self.path.is_some() {
+                    println!("[PATH] only considered with 'b8' WIDTH")
+                }
                 let mut values = vec![0; words];
                 core.read_32(self.read_write_options.address, &mut values)?;
                 for val in values {
@@ -56,6 +102,9 @@ impl Cmd {
                 println!();
             }
             ReadWriteBitWidth::B64 => {
+                if self.path.is_some() {
+                    println!("[PATH] only considered with 'b8' WIDTH")
+                }
                 let mut values = vec![0; words];
                 core.read_64(self.read_write_options.address, &mut values)?;
                 for val in values {


### PR DESCRIPTION
I know this is not clean, and not the way to do it, but it is functional so I put it here for anyone to use if needed, because the "dump flash to iHex/Bin file" is something missing in probe-rs (I tryed to make it cleaner but would take much more time than I have for it, sorry)