### PR TITLE
Blackmagic write word-aligned chunks

### DIFF
--- a/changelog/fixed-blackmagic-write-alignment.md
+++ b/changelog/fixed-blackmagic-write-alignment.md
@@ -1,0 +1,1 @@
+For Black Magic protocol, write in chunks of length multiple of the word size.

--- a/probe-rs/src/probe/blackmagic/arm.rs
+++ b/probe-rs/src/probe/blackmagic/arm.rs
@@ -736,7 +736,8 @@ impl BlackMagicProbeMemoryInterface<'_> {
     }
 
     fn write(&mut self, align: Align, offset: u64, data: &[u8]) -> Result<(), ArmError> {
-        let chunk_size = super::BLACK_MAGIC_REMOTE_SIZE_MAX / 2 - 42;
+        let word_size = 1 << (align as u8);
+        let chunk_size = word_size * ((super::BLACK_MAGIC_REMOTE_SIZE_MAX / 2 - 42) / word_size);
         for (chunk_index, chunk) in data.chunks(chunk_size).enumerate() {
             self.write_slice(
                 align,


### PR DESCRIPTION
This is a fix for bug #2941.
When sending large data _via_ several write commands to a Black Magic probe, make sure the data is split in chunks whose length is a multiple of the word size, otherwise the probe will reject the command.
