### PR TITLE
Rework source location

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -876,7 +876,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                     };
 
                     match target_core.verify_and_set_breakpoint(
-                        &source_path,
+                        source_path.to_path(),
                         requested_breakpoint_line,
                         requested_breakpoint_column,
                         &args.source,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -26,7 +26,7 @@ use probe_rs::{
     Core, CoreStatus, HaltReason,
 };
 use time::UtcOffset;
-use typed_path::TypedPathBuf;
+use typed_path::TypedPath;
 
 /// [CoreData] is used to cache data needed by the debugger, on a per-core basis.
 pub struct CoreData {
@@ -315,7 +315,7 @@ impl<'p> CoreHandle<'p> {
     /// The Result<> contains the "verified" `address` and `SourceLocation` where the breakpoint that was set.
     pub(crate) fn verify_and_set_breakpoint(
         &mut self,
-        source_path: &TypedPathBuf,
+        source_path: TypedPath,
         requested_breakpoint_line: u64,
         requested_breakpoint_column: Option<u64>,
         requested_source: &Source,
@@ -366,21 +366,15 @@ impl<'p> CoreHandle<'p> {
                 location: SourceLocationScope::Specific(source_location),
             } = breakpoint.breakpoint_type
             {
-                let breakpoint_err = source_location
-                    .combined_typed_path()
-                    .as_ref()
-                    .ok_or_else(|| DebuggerError::Other(anyhow!("Unable to get source location")))
-                    .and_then(|requested_path| {
-                        self.verify_and_set_breakpoint(
-                            requested_path,
-                            source_location.line.unwrap_or(0),
-                            source_location.column.map(|col| match col {
-                                ColumnType::LeftEdge => 0_u64,
-                                ColumnType::Column(c) => c,
-                            }),
-                            &source,
-                        )
-                    });
+                let breakpoint_err = self.verify_and_set_breakpoint(
+                    source_location.path.to_path(),
+                    source_location.line.unwrap_or(0),
+                    source_location.column.map(|col| match col {
+                        ColumnType::LeftEdge => 0_u64,
+                        ColumnType::Column(c) => c,
+                    }),
+                    &source,
+                );
 
                 if let Err(breakpoint_error) = breakpoint_err {
                     return Err(DebuggerError::Other(anyhow!(

--- a/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
@@ -589,34 +589,26 @@ impl DebugCli {
                                 println!();
 
                                 if let Some(location) = &frame.source_location {
-                                    if location.directory.is_some() || location.file.is_some() {
-                                        print!("       ");
+                                    print!("       ");
 
-                                        if let Some(dir) = &location.directory {
-                                            print!("{}", dir.to_path().display());
-                                        }
+                                    print!("{}", location.path.to_path().display());
 
-                                        if let Some(file) = &location.file {
-                                            print!("/{file}");
+                                    if let Some(line) = location.line {
+                                        print!(":{line}");
 
-                                            if let Some(line) = location.line {
-                                                print!(":{line}");
-
-                                                if let Some(col) = location.column {
-                                                    match col {
-                                                        probe_rs::debug::ColumnType::LeftEdge => {
-                                                            print!(":1")
-                                                        }
-                                                        probe_rs::debug::ColumnType::Column(c) => {
-                                                            print!(":{c}")
-                                                        }
-                                                    }
+                                        if let Some(col) = location.column {
+                                            match col {
+                                                probe_rs::debug::ColumnType::LeftEdge => {
+                                                    print!(":1")
+                                                }
+                                                probe_rs::debug::ColumnType::Column(c) => {
+                                                    print!(":{c}")
                                                 }
                                             }
                                         }
-
-                                        println!();
                                     }
+
+                                    println!();
                                 }
                             }
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
@@ -466,29 +466,19 @@ fn print_stacktrace<S: Write + ?Sized>(
             continue;
         };
 
-        if location.directory.is_none() && location.file.is_none() {
-            continue;
-        }
-
         write!(output_stream, "       ")?;
 
-        if let Some(dir) = &location.directory {
-            write!(output_stream, "{}", dir.to_path().display())?;
-        }
+        write!(output_stream, "{}", location.path.to_path().display())?;
 
-        if let Some(file) = &location.file {
-            write!(output_stream, "/{file}")?;
+        if let Some(line) = location.line {
+            write!(output_stream, ":{line}")?;
 
-            if let Some(line) = location.line {
-                write!(output_stream, ":{line}")?;
-
-                if let Some(col) = location.column {
-                    let col = match col {
-                        probe_rs::debug::ColumnType::LeftEdge => 1,
-                        probe_rs::debug::ColumnType::Column(c) => c,
-                    };
-                    write!(output_stream, ":{col}")?;
-                }
+            if let Some(col) = location.column {
+                let col = match col {
+                    probe_rs::debug::ColumnType::LeftEdge => 1,
+                    probe_rs::debug::ColumnType::Column(c) => c,
+                };
+                write!(output_stream, ":{col}")?;
             }
         }
 

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -778,13 +778,13 @@ impl DebugInfo {
     #[tracing::instrument(skip_all)]
     pub fn get_breakpoint_location(
         &self,
-        path: &TypedPathBuf,
+        path: TypedPath,
         line: u64,
         column: Option<u64>,
     ) -> Result<VerifiedBreakpoint, DebugError> {
         tracing::debug!(
             "Looking for breakpoint location for {}:{}:{}",
-            path.to_path().display(),
+            path.display(),
             line,
             column
                 .map(|c| c.to_string())
@@ -943,10 +943,7 @@ impl DebugInfo {
 }
 
 /// Uses the [`TypedPathBuf::normalize`] function to normalize both paths before comparing them
-pub(crate) fn canonical_path_eq(
-    primary_path: &TypedPathBuf,
-    secondary_path: &TypedPathBuf,
-) -> bool {
+pub(crate) fn canonical_path_eq(primary_path: TypedPath, secondary_path: TypedPath) -> bool {
     primary_path.normalize() == secondary_path.normalize()
 }
 

--- a/probe-rs/src/debug/debug_step.rs
+++ b/probe-rs/src/debug/debug_step.rs
@@ -116,7 +116,7 @@ impl SteppingMode {
                     debug_info
                         .get_source_location(program_counter)
                         .map(|source_location| (
-                            source_location.file,
+                            source_location.path,
                             source_location.line,
                             source_location.column
                         )),
@@ -124,7 +124,7 @@ impl SteppingMode {
                     debug_info
                         .get_source_location(target_address)
                         .map(|source_location| (
-                            source_location.file,
+                            source_location.path,
                             source_location.line,
                             source_location.column
                         )),

--- a/probe-rs/src/debug/function_die.rs
+++ b/probe-rs/src/debug/function_die.rs
@@ -165,8 +165,7 @@ impl<'a> FunctionDie<'a> {
 
         let file_name_attr = self.attribute(debug_info, gimli::DW_AT_call_file)?;
 
-        let (directory, file) =
-            extract_file(debug_info, &self.unit_info.unit, file_name_attr.value())?;
+        let path = extract_file(debug_info, &self.unit_info.unit, file_name_attr.value())?;
         let line = self
             .attribute(debug_info, gimli::DW_AT_call_line)
             .and_then(|line| line.udata_value());
@@ -177,12 +176,7 @@ impl<'a> FunctionDie<'a> {
                     None => ColumnType::LeftEdge,
                     Some(c) => ColumnType::Column(c),
                 });
-        Some(SourceLocation {
-            line,
-            column,
-            file: Some(file),
-            directory: Some(directory),
-        })
+        Some(SourceLocation { line, column, path })
     }
 
     /// Resolve an attribute by looking through both the specification and die, or abstract specification and die, entries.

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -182,12 +182,11 @@ fn extract_file(
     debug_info: &DebugInfo,
     unit: &gimli::Unit<GimliReader>,
     attribute_value: AttributeValue<GimliReader>,
-) -> Option<(TypedPathBuf, String)> {
+) -> Option<TypedPathBuf> {
     match attribute_value {
         AttributeValue::FileIndex(index) => {
-            if let Some((Some(file), Some(path))) = debug_info.find_file_and_directory(unit, index)
-            {
-                Some((path, file))
+            if let Some(path) = debug_info.find_file_and_directory(unit, index) {
+                Some(path)
             } else {
                 tracing::warn!("Unable to extract file or path from {:?}.", attribute_value);
                 None

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_full_unwind.snap
@@ -1,6 +1,6 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
-assertion_line: 1996
+assertion_line: 1987
 expression: stack_frames
 snapshot_kind: text
 ---
@@ -9,8 +9,7 @@ snapshot_kind: text
     line: 344
     column:
       Column: 13
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -215,7 +214,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 5,\n\tinternal_depth_measure: usize = 6}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -225,8 +223,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -235,16 +232,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883184
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -441,7 +436,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 4,\n\tinternal_depth_measure: usize = 5}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -451,8 +445,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -461,16 +454,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883328
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -667,7 +658,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 3,\n\tinternal_depth_measure: usize = 4}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -677,8 +667,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -687,16 +676,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883472
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -893,7 +880,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 2,\n\tinternal_depth_measure: usize = 3}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -903,8 +889,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -913,16 +898,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883616
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -1119,7 +1102,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 1,\n\tinternal_depth_measure: usize = 2}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1129,8 +1111,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -1139,16 +1120,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883760
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -1345,7 +1324,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 0,\n\tinternal_depth_measure: usize = 1}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1355,8 +1333,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -1365,16 +1342,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883904
 - function_name: setup_data_types
   source_location:
     line: 325
     column:
       Column: 5
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -1571,7 +1546,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tint8_minus_twenty_three: i8 = -23,\n\tlocal_reference_to_global_const: &str = This global `const` value will only show up in the debugger in the variables where it is referenced,\n\tlocal_reference_to_global_static: &str = A 'global' static variable,\n\tlocal_reference_to_global_static_struct: *const probe_rs_debugger_test::ComplexEnum = *const probe_rs_debugger_test::ComplexEnum @ 0x20003CC4,\n\tghosted_variable: usize = 0,\n\tghosted_variable: &str = New value and type for a different name,\n\tint8_twenty_six: i8 = 26,\n\tint128: i128 = -196710231994021419720322,\n\tu_int128: u128 = 340282366920938266753142613410348491134,\n\tfloat64: f64 = 1.7608695652173911,\n\tfloat64_ptr: &f64 = &f64 @ 0x20003CDC,\n\temoji: char = 💩,\n\temoji_ptr: &char = &char @ 0x20003CE0,\n\ttrue_bool: bool = true,\n\tany_old_string_slice: &str = How long is a piece of String.,\n\tfunction_result: Result<(), &str> = Result<(), &str> @ 0x20003CE4,\n\tglobal_types: (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) = (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x20003448,\n\tthree_d_usize_array: Matrix<i32, 2, 3, 4> = Matrix<i32, 2, 3, 4> @ 0x20003484,\n\tthree_d_string_array: Matrix<&str, 2, 3, 6> = Matrix<&str, 2, 3, 6> @ 0x20003604,\n\tthree: SimpleEnum = SimpleEnum::Two,\n\tsimple_enum_pointer: &probe_rs_debugger_test::SimpleEnum = &probe_rs_debugger_test::SimpleEnum @ 0x20003A88,\n\tthree_level_recursive_struct: RecursiveStruct = RecursiveStruct @ 0x20003A8C,\n\tfirst_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003AB0,\n\tsecond_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003AE0,\n\tstruct_with_one_variant: Option<probe_rs_debugger_test::Univariant> = Option<probe_rs_debugger_test::Univariant> @ 0x20003B00,\n\tstuct_with_one_variant_pointer: &core::option::Option<probe_rs_debugger_test::Univariant> = &core::option::Option<probe_rs_debugger_test::Univariant> @ 0x20003CEC,\n\tlong_lived: ComplexStruct = ComplexStruct @ 0x20003B68,\n\tshort_lived: ComplexStruct = ComplexStruct @ 0x20003B78,\n\ta1: Struct<i32> = Struct<i32> @ 0x20003CF0,\n\ta2: i64 = 1,\n\ta3: i64 = 2,\n\ta4: i64 = 3,\n\ta5: (i32, i64) = (i32, i64) @ 0x20003D18,\n\ta6: Enum<i32> = Enum<i32> @ 0x20003BB8,\n\ta7: Enum<i32> = Enum<i32> @ 0x20003BD8,\n\t[i32; 10] = [\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55\n\t],\n\tmy_array_ptr: &[i32; 10] = &[i32; 10] @ 0x20003D2C,\n\t[i8; 10] = [\n\t\t1,\n\t\t2,\n\t\t3,\n\t\t4,\n\t\t5,\n\t\t6,\n\t\t7,\n\t\t8,\n\t\t9,\n\t\t0\n\t],\n\theapless_vec: Vec<i8, 10> = Vec<i8, 10> @ 0x20003C30,\n\tloop_counter: Wrapping<u8> = Wrapping<u8> @ 0x20003C40,\n\trtt_channels: Channels = Channels @ 0x20003C44}"
-      source_location: ~
       children:
         - name:
             Named: int8_minus_twenty_three
@@ -1581,8 +1555,7 @@ snapshot_kind: text
           source_location:
             line: 204
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: local_reference_to_global_const
           type_name:
@@ -1591,28 +1564,24 @@ snapshot_kind: text
           source_location:
             line: 207
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x200033F8"
-              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "84"
-                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "99"
-              source_location: ~
         - name:
             Named: local_reference_to_global_static
           type_name:
@@ -1621,28 +1590,24 @@ snapshot_kind: text
           source_location:
             line: 208
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003CBC"
-              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "65"
-                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "26"
-              source_location: ~
         - name:
             Named: local_reference_to_global_static_struct
           type_name:
@@ -1651,54 +1616,46 @@ snapshot_kind: text
           source_location:
             line: 209
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*local_reference_to_global_static_struct"
               type_name:
                 Struct: ComplexEnum
               value: ComplexEnum @ 0x20000048
-              source_location: ~
               children:
                 - name:
                     Named: Case1
                   type_name:
                     Struct: Case1
                   value: Case1 @ 0x20000048
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Base: u64
                       value: "0"
-                      source_location: ~
                     - name:
                         Named: __1
                       type_name:
                         Struct: ComplexStruct
                       value: ComplexStruct @ 0x20000058
-                      source_location: ~
                       children:
                         - name:
                             Named: x
                           type_name:
                             Base: i64
                           value: "24"
-                          source_location: ~
                         - name:
                             Named: y
                           type_name:
                             Base: i32
                           value: "25"
-                          source_location: ~
                         - name:
                             Named: z
                           type_name:
                             Base: i16
                           value: "26"
-                          source_location: ~
         - name:
             Named: ghosted_variable
           type_name:
@@ -1707,8 +1664,7 @@ snapshot_kind: text
           source_location:
             line: 210
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: ghosted_variable
           type_name:
@@ -1717,28 +1673,24 @@ snapshot_kind: text
           source_location:
             line: 211
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003404"
-              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "78"
-                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "39"
-              source_location: ~
         - name:
             Named: int8_twenty_six
           type_name:
@@ -1747,8 +1699,7 @@ snapshot_kind: text
           source_location:
             line: 212
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: int128
           type_name:
@@ -1757,8 +1708,7 @@ snapshot_kind: text
           source_location:
             line: 213
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: u_int128
           type_name:
@@ -1767,8 +1717,7 @@ snapshot_kind: text
           source_location:
             line: 214
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: float64
           type_name:
@@ -1777,8 +1726,7 @@ snapshot_kind: text
           source_location:
             line: 215
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: float64_ptr
           type_name:
@@ -1787,15 +1735,13 @@ snapshot_kind: text
           source_location:
             line: 216
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*float64_ptr"
               type_name:
                 Base: f64
               value: "1.7608695652173911"
-              source_location: ~
         - name:
             Named: emoji
           type_name:
@@ -1804,8 +1750,7 @@ snapshot_kind: text
           source_location:
             line: 217
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: emoji_ptr
           type_name:
@@ -1814,15 +1759,13 @@ snapshot_kind: text
           source_location:
             line: 218
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*emoji_ptr"
               type_name:
                 Base: char
               value: 💩
-              source_location: ~
         - name:
             Named: true_bool
           type_name:
@@ -1831,8 +1774,7 @@ snapshot_kind: text
           source_location:
             line: 219
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: any_old_string_slice
           type_name:
@@ -1841,28 +1783,24 @@ snapshot_kind: text
           source_location:
             line: 221
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003428"
-              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "72"
-                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "30"
-              source_location: ~
         - name:
             Named: function_result
           type_name:
@@ -1871,42 +1809,36 @@ snapshot_kind: text
           source_location:
             line: 222
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Err
               type_name:
                 Struct: Err
               value: Err @ 0x20003CE4
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: "&str"
                   value: Forcing the return of an Error variant
-                  source_location: ~
                   children:
                     - name:
                         Named: data_ptr
                       type_name:
                         Pointer: u8
                       value: "*raw u8 @ 0x20003CE4"
-                      source_location: ~
                       children:
                         - name:
                             Named: "*data_ptr"
                           type_name:
                             Base: u8
                           value: "70"
-                          source_location: ~
                     - name:
                         Named: length
                       type_name:
                         Base: usize
                       value: "38"
-                      source_location: ~
         - name:
             Named: global_types
           type_name:
@@ -1915,93 +1847,78 @@ snapshot_kind: text
           source_location:
             line: 223
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
               type_name:
                 Base: bool
               value: "false"
-              source_location: ~
             - name:
                 Named: __1
               type_name:
                 Base: isize
               value: "-1"
-              source_location: ~
             - name:
                 Named: __2
               type_name:
                 Base: char
               value: a
-              source_location: ~
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "68"
-              source_location: ~
             - name:
                 Named: __4
               type_name:
                 Base: i16
               value: "-16"
-              source_location: ~
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "-32"
-              source_location: ~
             - name:
                 Named: __6
               type_name:
                 Base: i64
               value: "-64"
-              source_location: ~
             - name:
                 Named: __7
               type_name:
                 Base: usize
               value: "1"
-              source_location: ~
             - name:
                 Named: __8
               type_name:
                 Base: u8
               value: "100"
-              source_location: ~
             - name:
                 Named: __9
               type_name:
                 Base: u16
               value: "16"
-              source_location: ~
             - name:
                 Named: __10
               type_name:
                 Base: u32
               value: "32"
-              source_location: ~
             - name:
                 Named: __11
               type_name:
                 Base: u64
               value: "64"
-              source_location: ~
             - name:
                 Named: __12
               type_name:
                 Base: f32
               value: "2.5"
-              source_location: ~
             - name:
                 Named: __13
               type_name:
                 Base: f64
               value: "3.5"
-              source_location: ~
         - name:
             Named: three_d_usize_array
           type_name:
@@ -2010,8 +1927,7 @@ snapshot_kind: text
           source_location:
             line: 224
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: raw
@@ -2027,7 +1943,6 @@ snapshot_kind: text
                       count: 2
                   count: 4
               value: "[[[i32; 3]; 2]; 4] = [\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t0,\n\t\t\t1,\n\t\t\t2\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t3,\n\t\t\t4,\n\t\t\t5\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t6,\n\t\t\t7,\n\t\t\t8\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t9,\n\t\t\t10,\n\t\t\t11\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t12,\n\t\t\t13,\n\t\t\t14\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t15,\n\t\t\t16,\n\t\t\t17\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t18,\n\t\t\t19,\n\t\t\t20\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t21,\n\t\t\t22,\n\t\t\t23\n\t\t]\n\t]]"
-              source_location: ~
               children:
                 - name:
                     Named: __0
@@ -2040,7 +1955,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t0,\n\t\t1,\n\t\t2\n\t],\n\t[i32; 3] = [\n\t\t3,\n\t\t4,\n\t\t5\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2050,26 +1964,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t0,\n\t1,\n\t2]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "0"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "1"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "2"
-                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2078,26 +1988,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t3,\n\t4,\n\t5]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "3"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "4"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "5"
-                          source_location: ~
                 - name:
                     Named: __1
                   type_name:
@@ -2109,7 +2015,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t6,\n\t\t7,\n\t\t8\n\t],\n\t[i32; 3] = [\n\t\t9,\n\t\t10,\n\t\t11\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2119,26 +2024,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t6,\n\t7,\n\t8]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "6"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "7"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "8"
-                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2147,26 +2048,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t9,\n\t10,\n\t11]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "9"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "10"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "11"
-                          source_location: ~
                 - name:
                     Named: __2
                   type_name:
@@ -2178,7 +2075,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t12,\n\t\t13,\n\t\t14\n\t],\n\t[i32; 3] = [\n\t\t15,\n\t\t16,\n\t\t17\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2188,26 +2084,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t12,\n\t13,\n\t14]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "12"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "13"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "14"
-                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2216,26 +2108,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t15,\n\t16,\n\t17]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "15"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "16"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "17"
-                          source_location: ~
                 - name:
                     Named: __3
                   type_name:
@@ -2247,7 +2135,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t18,\n\t\t19,\n\t\t20\n\t],\n\t[i32; 3] = [\n\t\t21,\n\t\t22,\n\t\t23\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2257,26 +2144,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t18,\n\t19,\n\t20]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "18"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "19"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "20"
-                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2285,26 +2168,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t21,\n\t22,\n\t23]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "21"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "22"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "23"
-                          source_location: ~
         - name:
             Named: three_d_string_array
           type_name:
@@ -2313,8 +2192,7 @@ snapshot_kind: text
           source_location:
             line: 232
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: raw
@@ -2330,7 +2208,6 @@ snapshot_kind: text
                       count: 2
                   count: 6
               value: "[[[&str; 3]; 2]; 6] = [\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tApple,\n\t\t\tBanana,\n\t\t\tCherry\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tDog,\n\t\t\tElephant,\n\t\t\tFish\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tGuitar,\n\t\t\tHorse,\n\t\t\tIce Cream\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tJaguar,\n\t\t\tKangaroo,\n\t\t\tLion\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tMoon,\n\t\t\tNewton,\n\t\t\tOwl\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tPencil,\n\t\t\tQueen,\n\t\t\tRainbow\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tSun,\n\t\t\tTree,\n\t\t\tUmbrella\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tViolin,\n\t\t\tWatch,\n\t\t\tXylophone\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tYellow,\n\t\t\tZebra,\n\t\t\tAlpha\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tBravo,\n\t\t\tCharlie,\n\t\t\tDelta\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tEcho,\n\t\t\tFoxtrot,\n\t\t\tGolf\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tHotel,\n\t\t\tIndia,\n\t\t\tJuliet\n\t\t]\n\t]]"
-              source_location: ~
               children:
                 - name:
                     Named: __0
@@ -2343,7 +2220,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tApple,\n\t\tBanana,\n\t\tCherry\n\t],\n\t[&str; 3] = [\n\t\tDog,\n\t\tElephant,\n\t\tFish\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2353,86 +2229,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tApple,\n\tBanana,\n\tCherry]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Apple
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003604"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Banana
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000360C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Cherry
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003614"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2441,86 +2304,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tDog,\n\tElephant,\n\tFish]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Dog
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000361C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Elephant
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003624"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Fish
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000362C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                 - name:
                     Named: __1
                   type_name:
@@ -2532,7 +2382,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tGuitar,\n\t\tHorse,\n\t\tIce Cream\n\t],\n\t[&str; 3] = [\n\t\tJaguar,\n\t\tKangaroo,\n\t\tLion\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2542,86 +2391,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tGuitar,\n\tHorse,\n\tIce Cream]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Guitar
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003634"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Horse
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000363C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Ice Cream
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003644"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2630,86 +2466,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tJaguar,\n\tKangaroo,\n\tLion]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Jaguar
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000364C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Kangaroo
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003654"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "75"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Lion
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000365C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "76"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                 - name:
                     Named: __2
                   type_name:
@@ -2721,7 +2544,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tMoon,\n\t\tNewton,\n\t\tOwl\n\t],\n\t[&str; 3] = [\n\t\tPencil,\n\t\tQueen,\n\t\tRainbow\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2731,86 +2553,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tMoon,\n\tNewton,\n\tOwl]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Moon
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003664"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "77"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Newton
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000366C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "78"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Owl
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003674"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "79"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2819,86 +2628,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tPencil,\n\tQueen,\n\tRainbow]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Pencil
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000367C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "80"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Queen
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003684"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "81"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Rainbow
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000368C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "82"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location: ~
                 - name:
                     Named: __3
                   type_name:
@@ -2910,7 +2706,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tSun,\n\t\tTree,\n\t\tUmbrella\n\t],\n\t[&str; 3] = [\n\t\tViolin,\n\t\tWatch,\n\t\tXylophone\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2920,86 +2715,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tSun,\n\tTree,\n\tUmbrella]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Sun
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003694"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "83"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Tree
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000369C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "84"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Umbrella
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036A4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "85"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3008,86 +2790,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tViolin,\n\tWatch,\n\tXylophone]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Violin
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036AC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "86"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Watch
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036B4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "87"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Xylophone
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036BC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "88"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
-                              source_location: ~
                 - name:
                     Named: __4
                   type_name:
@@ -3099,7 +2868,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tYellow,\n\t\tZebra,\n\t\tAlpha\n\t],\n\t[&str; 3] = [\n\t\tBravo,\n\t\tCharlie,\n\t\tDelta\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3109,86 +2877,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tYellow,\n\tZebra,\n\tAlpha]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Yellow
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036C4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "89"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Zebra
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036CC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "90"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Alpha
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036D4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3197,86 +2952,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tBravo,\n\tCharlie,\n\tDelta]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Bravo
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036DC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Charlie
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036E4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Delta
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036EC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                 - name:
                     Named: __5
                   type_name:
@@ -3288,7 +3030,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tEcho,\n\t\tFoxtrot,\n\t\tGolf\n\t],\n\t[&str; 3] = [\n\t\tHotel,\n\t\tIndia,\n\t\tJuliet\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3298,86 +3039,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tEcho,\n\tFoxtrot,\n\tGolf]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Echo
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036F4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Foxtrot
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036FC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Golf
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003704"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3386,86 +3114,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tHotel,\n\tIndia,\n\tJuliet]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Hotel
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000370C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: India
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003714"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Juliet
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000371C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
         - name:
             Named: three
           type_name:
@@ -3474,8 +3189,7 @@ snapshot_kind: text
           source_location:
             line: 249
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: simple_enum_pointer
           type_name:
@@ -3484,15 +3198,13 @@ snapshot_kind: text
           source_location:
             line: 250
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*simple_enum_pointer"
               type_name:
                 Enum: SimpleEnum
               value: "SimpleEnum::Two"
-              source_location: ~
         - name:
             Named: three_level_recursive_struct
           type_name:
@@ -3501,96 +3213,82 @@ snapshot_kind: text
           source_location:
             line: 252
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: depth
               type_name:
                 Base: u32
               value: "1"
-              source_location: ~
             - name:
                 Named: next_self
               type_name:
                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003A90"
-              source_location: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x20003A90
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x20003A90"
-                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RecursiveStruct
                           value: RecursiveStruct @ 0x20003A98
-                          source_location: ~
                           children:
                             - name:
                                 Named: depth
                               type_name:
                                 Base: u32
                               value: "2"
-                              source_location: ~
                             - name:
                                 Named: next_self
                               type_name:
                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003A9C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: Some
                                   type_name:
                                     Struct: Some
                                   value: Some @ 0x20003A9C
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: __0
                                       type_name:
                                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x20003A9C"
-                                      source_location: ~
                                       children:
                                         - name:
                                             Named: "*__0"
                                           type_name:
                                             Struct: RecursiveStruct
                                           value: RecursiveStruct @ 0x20003AA4
-                                          source_location: ~
                                           children:
                                             - name:
                                                 Named: depth
                                               type_name:
                                                 Base: u32
                                               value: "3"
-                                              source_location: ~
                                             - name:
                                                 Named: next_self
                                               type_name:
                                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003AA8"
-                                              source_location: ~
                                               children:
                                                 - name:
                                                     Named: None
                                                   type_name:
                                                     Struct: None
                                                   value: None @ 0x20003AA8
-                                                  source_location: ~
         - name:
             Named: first_case_of_struct_variants
           type_name:
@@ -3599,47 +3297,40 @@ snapshot_kind: text
           source_location:
             line: 263
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Case1
               type_name:
                 Struct: Case1
               value: Case1 @ 0x20003AB0
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: ComplexStruct
                   value: ComplexStruct @ 0x20003AC0
-                  source_location: ~
                   children:
                     - name:
                         Named: x
                       type_name:
                         Base: i64
                       value: "24"
-                      source_location: ~
                     - name:
                         Named: y
                       type_name:
                         Base: i32
                       value: "25"
-                      source_location: ~
                     - name:
                         Named: z
                       type_name:
                         Base: i16
                       value: "26"
-                      source_location: ~
         - name:
             Named: second_case_of_struct_variants
           type_name:
@@ -3648,34 +3339,29 @@ snapshot_kind: text
           source_location:
             line: 271
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Case2
               type_name:
                 Struct: Case2
               value: Case2 @ 0x20003AE0
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: u64
                   value: "1023"
-                  source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i16
                   value: "1967"
-                  source_location: ~
         - name:
             Named: struct_with_one_variant
           type_name:
@@ -3684,80 +3370,68 @@ snapshot_kind: text
           source_location:
             line: 273
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Some
               type_name:
                 Struct: Some
               value: Some @ 0x20003B00
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: Univariant
                   value: Univariant @ 0x20003B08
-                  source_location: ~
                   children:
                     - name:
                         Named: TupleOfComplexStruct
                       type_name:
                         Struct: TupleOfComplexStruct
                       value: TupleOfComplexStruct @ 0x20003B08
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x20003B08
-                          source_location: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "24"
-                              source_location: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "25"
-                              source_location: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "26"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x20003B18
-                          source_location: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "-3"
-                              source_location: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "-2"
-                              source_location: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "-1"
-                              source_location: ~
         - name:
             Named: stuct_with_one_variant_pointer
           type_name:
@@ -3766,87 +3440,74 @@ snapshot_kind: text
           source_location:
             line: 285
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*stuct_with_one_variant_pointer"
               type_name:
                 Struct: "Option<probe_rs_debugger_test::Univariant>"
               value: "Option<probe_rs_debugger_test::Univariant> @ 0x20003B00"
-              source_location: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x20003B00
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Struct: Univariant
                       value: Univariant @ 0x20003B08
-                      source_location: ~
                       children:
                         - name:
                             Named: TupleOfComplexStruct
                           type_name:
                             Struct: TupleOfComplexStruct
                           value: TupleOfComplexStruct @ 0x20003B08
-                          source_location: ~
                           children:
                             - name:
                                 Named: __0
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x20003B08
-                              source_location: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "24"
-                                  source_location: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "25"
-                                  source_location: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "26"
-                                  source_location: ~
                             - name:
                                 Named: __1
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x20003B18
-                              source_location: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "-3"
-                                  source_location: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "-2"
-                                  source_location: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "-1"
-                                  source_location: ~
         - name:
             Named: long_lived
           type_name:
@@ -3855,27 +3516,23 @@ snapshot_kind: text
           source_location:
             line: 287
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: x
               type_name:
                 Base: i64
               value: "10"
-              source_location: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
-              source_location: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
-              source_location: ~
         - name:
             Named: short_lived
           type_name:
@@ -3884,27 +3541,23 @@ snapshot_kind: text
           source_location:
             line: 289
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: x
               type_name:
                 Base: i64
               value: "20"
-              source_location: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
-              source_location: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
-              source_location: ~
         - name:
             Named: a1
           type_name:
@@ -3913,21 +3566,18 @@ snapshot_kind: text
           source_location:
             line: 290
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: b
               type_name:
                 Base: i32
               value: "-1"
-              source_location: ~
             - name:
                 Named: b1
               type_name:
                 Base: i64
               value: "0"
-              source_location: ~
         - name:
             Named: a2
           type_name:
@@ -3936,8 +3586,7 @@ snapshot_kind: text
           source_location:
             line: 291
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a3
           type_name:
@@ -3946,8 +3595,7 @@ snapshot_kind: text
           source_location:
             line: 292
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a4
           type_name:
@@ -3956,8 +3604,7 @@ snapshot_kind: text
           source_location:
             line: 293
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a5
           type_name:
@@ -3966,21 +3613,18 @@ snapshot_kind: text
           source_location:
             line: 294
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
               type_name:
                 Base: i32
               value: "4"
-              source_location: ~
             - name:
                 Named: __1
               type_name:
                 Base: i64
               value: "5"
-              source_location: ~
         - name:
             Named: a6
           type_name:
@@ -3989,28 +3633,24 @@ snapshot_kind: text
           source_location:
             line: 295
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Variant2
               type_name:
                 Struct: Variant2
               value: Variant2 @ 0x20003BB8
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i64
                   value: "7"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "6"
-                  source_location: ~
         - name:
             Named: a7
           type_name:
@@ -4019,28 +3659,24 @@ snapshot_kind: text
           source_location:
             line: 296
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Variant1
               type_name:
                 Struct: Variant1
               value: Variant1 @ 0x20003BD8
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "9"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i64
                   value: "8"
-                  source_location: ~
         - name:
             Named: my_array
           type_name:
@@ -4052,8 +3688,7 @@ snapshot_kind: text
           source_location:
             line: 298
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -4063,8 +3698,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __1
               type_name:
@@ -4073,8 +3707,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __2
               type_name:
@@ -4083,8 +3716,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __3
               type_name:
@@ -4093,8 +3725,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __4
               type_name:
@@ -4103,8 +3734,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __5
               type_name:
@@ -4113,8 +3743,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __6
               type_name:
@@ -4123,8 +3752,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __7
               type_name:
@@ -4133,8 +3761,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __8
               type_name:
@@ -4143,8 +3770,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __9
               type_name:
@@ -4153,8 +3779,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: my_array_ptr
           type_name:
@@ -4163,8 +3788,7 @@ snapshot_kind: text
           source_location:
             line: 299
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*my_array_ptr"
@@ -4174,68 +3798,57 @@ snapshot_kind: text
                     Base: i32
                   count: 10
               value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
         - name:
             Named: my_array_of_i8
           type_name:
@@ -4247,8 +3860,7 @@ snapshot_kind: text
           source_location:
             line: 300
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -4258,8 +3870,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __1
               type_name:
@@ -4268,8 +3879,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __2
               type_name:
@@ -4278,8 +3888,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __3
               type_name:
@@ -4288,8 +3897,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __4
               type_name:
@@ -4298,8 +3906,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __5
               type_name:
@@ -4308,8 +3915,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __6
               type_name:
@@ -4318,8 +3924,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __7
               type_name:
@@ -4328,8 +3933,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __8
               type_name:
@@ -4338,8 +3942,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __9
               type_name:
@@ -4348,8 +3951,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: heapless_vec
           type_name:
@@ -4358,15 +3960,13 @@ snapshot_kind: text
           source_location:
             line: 301
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: len
               type_name:
                 Base: usize
               value: "3"
-              source_location: ~
             - name:
                 Named: buffer
               type_name:
@@ -4375,268 +3975,227 @@ snapshot_kind: text
                     Base: MaybeUninit<i8>
                   count: 10
               value: "[MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C34\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C35\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C36\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C37\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C38\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C39\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3A\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3B\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3C\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3D\n\t}]"
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C34}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C34
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "1"
-                          source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C35}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C35
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "2"
-                          source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C36}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C36
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "3"
-                          source_location: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C37}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C37
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C38}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C38
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C39}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C39
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3A}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C3A
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3B}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C3B
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3C}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C3C
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3D}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C3D
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
         - name:
             Named: loop_counter
           type_name:
@@ -4645,15 +4204,13 @@ snapshot_kind: text
           source_location:
             line: 305
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
               type_name:
                 Base: u8
               value: "0"
-              source_location: ~
         - name:
             Named: rtt_channels
           type_name:
@@ -4662,250 +4219,213 @@ snapshot_kind: text
           source_location:
             line: 306
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: up
               type_name:
                 Struct: "(rtt_target::UpChannel, rtt_target::UpChannel)"
               value: "(rtt_target::UpChannel, rtt_target::UpChannel) @ 0x20003C44"
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x20003C44
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x20003C44"
-                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x20000094
-                          source_location: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x20000094"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "83"
-                                  source_location: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x20000098"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
-                              source_location: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000A0
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000A0
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
-                                      source_location: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000A4
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000A4
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
-                                      source_location: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000A8
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000A8
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
-                                      source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x20003C48
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x20003C48"
-                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x200000AC
-                          source_location: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x200000AC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x200000B0"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "0"
-                                  source_location: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
-                              source_location: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000B8
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000B8
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
-                                      source_location: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000BC
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000BC
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
-                                      source_location: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000C0
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000C0
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
-                                      source_location: ~
   canonical_frame_address: 536886968
 - function_name: __cortex_m_rt_main
   source_location:
     line: 55
     column:
       Column: 54
-    file: RP2040.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -5102,7 +4622,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tcore: Peripherals = Peripherals @ 0x20003EDF,\n\texternal_xtal_freq_hz: u32 = 12000000,\n\tpac: Peripherals = Peripherals @ 0x20003EE7,\n\twatchdog: Watchdog = Watchdog @ 0x20003EEC,\n\tclocks: ClocksManager = ClocksManager @ 0x20003EF0}"
-      source_location: ~
       children:
         - name:
             Named: core
@@ -5112,99 +4631,83 @@ snapshot_kind: text
           source_location:
             line: 24
             column: ~
-            file: RP2040.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: CBP
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
-              source_location: ~
         - name:
             Named: external_xtal_freq_hz
           type_name:
@@ -5213,8 +4716,7 @@ snapshot_kind: text
           source_location:
             line: 26
             column: ~
-            file: RP2040.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
         - name:
             Named: pac
           type_name:
@@ -5223,225 +4725,188 @@ snapshot_kind: text
           source_location:
             line: 27
             column: ~
-            file: RP2040.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: ADC
               type_name:
                 Struct: ADC
               value: ADC @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: BUSCTRL
               type_name:
                 Struct: BUSCTRL
               value: BUSCTRL @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: CLOCKS
               type_name:
                 Struct: CLOCKS
               value: CLOCKS @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: DMA
               type_name:
                 Struct: DMA
               value: DMA @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: I2C0
               type_name:
                 Struct: I2C0
               value: I2C0 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: I2C1
               type_name:
                 Struct: I2C1
               value: I2C1 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: IO_BANK0
               type_name:
                 Struct: IO_BANK0
               value: IO_BANK0 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: IO_QSPI
               type_name:
                 Struct: IO_QSPI
               value: IO_QSPI @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PADS_BANK0
               type_name:
                 Struct: PADS_BANK0
               value: PADS_BANK0 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PADS_QSPI
               type_name:
                 Struct: PADS_QSPI
               value: PADS_QSPI @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PIO0
               type_name:
                 Struct: PIO0
               value: PIO0 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PIO1
               type_name:
                 Struct: PIO1
               value: PIO1 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PLL_SYS
               type_name:
                 Struct: PLL_SYS
               value: PLL_SYS @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PLL_USB
               type_name:
                 Struct: PLL_USB
               value: PLL_USB @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PPB
               type_name:
                 Struct: PPB
               value: PPB @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PSM
               type_name:
                 Struct: PSM
               value: PSM @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PWM
               type_name:
                 Struct: PWM
               value: PWM @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: RESETS
               type_name:
                 Struct: RESETS
               value: RESETS @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: ROSC
               type_name:
                 Struct: ROSC
               value: ROSC @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: RTC
               type_name:
                 Struct: RTC
               value: RTC @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: SIO
               type_name:
                 Struct: SIO
               value: SIO @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: SYSCFG
               type_name:
                 Struct: SYSCFG
               value: SYSCFG @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: SYSINFO
               type_name:
                 Struct: SYSINFO
               value: SYSINFO @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: TBMAN
               type_name:
                 Struct: TBMAN
               value: TBMAN @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: TIMER
               type_name:
                 Struct: TIMER
               value: TIMER @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: UART1
               type_name:
                 Struct: UART1
               value: UART1 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: USBCTRL_DPRAM
               type_name:
                 Struct: USBCTRL_DPRAM
               value: USBCTRL_DPRAM @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: USBCTRL_REGS
               type_name:
                 Struct: USBCTRL_REGS
               value: USBCTRL_REGS @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: VREG_AND_CHIP_RESET
               type_name:
                 Struct: VREG_AND_CHIP_RESET
               value: VREG_AND_CHIP_RESET @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: WATCHDOG
               type_name:
                 Struct: WATCHDOG
               value: WATCHDOG @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: XIP_CTRL
               type_name:
                 Struct: XIP_CTRL
               value: XIP_CTRL @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: XIP_SSI
               type_name:
                 Struct: XIP_SSI
               value: XIP_SSI @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: XOSC
               type_name:
                 Struct: XOSC
               value: XOSC @ 0x20003EE7
-              source_location: ~
         - name:
             Named: watchdog
           type_name:
@@ -5450,21 +4915,18 @@ snapshot_kind: text
           source_location:
             line: 28
             column: ~
-            file: RP2040.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: watchdog
               type_name:
                 Struct: WATCHDOG
               value: WATCHDOG @ 0x20003EF0
-              source_location: ~
             - name:
                 Named: load_value
               type_name:
                 Base: u32
               value: "0"
-              source_location: ~
         - name:
             Named: clocks
           type_name:
@@ -5473,352 +4935,299 @@ snapshot_kind: text
           source_location:
             line: 30
             column: ~
-            file: RP2040.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: clocks
               type_name:
                 Struct: CLOCKS
               value: CLOCKS @ 0x20003F18
-              source_location: ~
             - name:
                 Named: gpio_output0_clock
               type_name:
                 Struct: GpioOutput0Clock
               value: GpioOutput0Clock @ 0x20003EF0
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EF4
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF0"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location: ~
             - name:
                 Named: gpio_output1_clock
               type_name:
                 Struct: GpioOutput1Clock
               value: GpioOutput1Clock @ 0x20003EF4
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EF8
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF4"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location: ~
             - name:
                 Named: gpio_output2_clock
               type_name:
                 Struct: GpioOutput2Clock
               value: GpioOutput2Clock @ 0x20003EF8
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EFC
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF8"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location: ~
             - name:
                 Named: gpio_output3_clock
               type_name:
                 Struct: GpioOutput3Clock
               value: GpioOutput3Clock @ 0x20003EFC
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F00
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EFC"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location: ~
             - name:
                 Named: reference_clock
               type_name:
                 Struct: ReferenceClock
               value: ReferenceClock @ 0x20003F00
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F04
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F00"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "12000000"
-                      source_location: ~
             - name:
                 Named: system_clock
               type_name:
                 Struct: SystemClock
               value: SystemClock @ 0x20003F04
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F08
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F04"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "125000000"
-                      source_location: ~
             - name:
                 Named: peripheral_clock
               type_name:
                 Struct: PeripheralClock
               value: PeripheralClock @ 0x20003F08
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F0C
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F08"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "125000000"
-                      source_location: ~
             - name:
                 Named: usb_clock
               type_name:
                 Struct: UsbClock
               value: UsbClock @ 0x20003F0C
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F10
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F0C"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "48000000"
-                      source_location: ~
             - name:
                 Named: adc_clock
               type_name:
                 Struct: AdcClock
               value: AdcClock @ 0x20003F10
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F14
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F10"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "48000000"
-                      source_location: ~
             - name:
                 Named: rtc_clock
               type_name:
                 Struct: RtcClock
               value: RtcClock @ 0x20003F14
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F18
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F14"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "46875"
-                      source_location: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
     line: 22
     column: LeftEdge
-    file: RP2040.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -6015,5 +5424,4 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_full_unwind.snap
@@ -1,6 +1,8 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1996
 expression: stack_frames
+snapshot_kind: text
 ---
 - function_name: test_deep_stack
   source_location:
@@ -213,17 +215,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 5,\n\tinternal_depth_measure: usize = 6}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "5"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "6"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 536883184
 - function_name: test_deep_stack
   source_location:
@@ -428,17 +445,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 4,\n\tinternal_depth_measure: usize = 5}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "4"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "5"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 536883328
 - function_name: test_deep_stack
   source_location:
@@ -643,17 +675,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 3,\n\tinternal_depth_measure: usize = 4}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "3"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "4"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 536883472
 - function_name: test_deep_stack
   source_location:
@@ -858,17 +905,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 2,\n\tinternal_depth_measure: usize = 3}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "2"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "3"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 536883616
 - function_name: test_deep_stack
   source_location:
@@ -1073,17 +1135,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 1,\n\tinternal_depth_measure: usize = 2}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "1"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "2"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 536883760
 - function_name: test_deep_stack
   source_location:
@@ -1288,17 +1365,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 0,\n\tinternal_depth_measure: usize = 1}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "0"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "1"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 536883904
 - function_name: setup_data_types
   source_location:
@@ -1503,316 +1595,611 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tint8_minus_twenty_three: i8 = -23,\n\tlocal_reference_to_global_const: &str = This global `const` value will only show up in the debugger in the variables where it is referenced,\n\tlocal_reference_to_global_static: &str = A 'global' static variable,\n\tlocal_reference_to_global_static_struct: *const probe_rs_debugger_test::ComplexEnum = *const probe_rs_debugger_test::ComplexEnum @ 0x20003CC4,\n\tghosted_variable: usize = 0,\n\tghosted_variable: &str = New value and type for a different name,\n\tint8_twenty_six: i8 = 26,\n\tint128: i128 = -196710231994021419720322,\n\tu_int128: u128 = 340282366920938266753142613410348491134,\n\tfloat64: f64 = 1.7608695652173911,\n\tfloat64_ptr: &f64 = &f64 @ 0x20003CDC,\n\temoji: char = 💩,\n\temoji_ptr: &char = &char @ 0x20003CE0,\n\ttrue_bool: bool = true,\n\tany_old_string_slice: &str = How long is a piece of String.,\n\tfunction_result: Result<(), &str> = Result<(), &str> @ 0x20003CE4,\n\tglobal_types: (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) = (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x20003448,\n\tthree_d_usize_array: Matrix<i32, 2, 3, 4> = Matrix<i32, 2, 3, 4> @ 0x20003484,\n\tthree_d_string_array: Matrix<&str, 2, 3, 6> = Matrix<&str, 2, 3, 6> @ 0x20003604,\n\tthree: SimpleEnum = SimpleEnum::Two,\n\tsimple_enum_pointer: &probe_rs_debugger_test::SimpleEnum = &probe_rs_debugger_test::SimpleEnum @ 0x20003A88,\n\tthree_level_recursive_struct: RecursiveStruct = RecursiveStruct @ 0x20003A8C,\n\tfirst_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003AB0,\n\tsecond_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003AE0,\n\tstruct_with_one_variant: Option<probe_rs_debugger_test::Univariant> = Option<probe_rs_debugger_test::Univariant> @ 0x20003B00,\n\tstuct_with_one_variant_pointer: &core::option::Option<probe_rs_debugger_test::Univariant> = &core::option::Option<probe_rs_debugger_test::Univariant> @ 0x20003CEC,\n\tlong_lived: ComplexStruct = ComplexStruct @ 0x20003B68,\n\tshort_lived: ComplexStruct = ComplexStruct @ 0x20003B78,\n\ta1: Struct<i32> = Struct<i32> @ 0x20003CF0,\n\ta2: i64 = 1,\n\ta3: i64 = 2,\n\ta4: i64 = 3,\n\ta5: (i32, i64) = (i32, i64) @ 0x20003D18,\n\ta6: Enum<i32> = Enum<i32> @ 0x20003BB8,\n\ta7: Enum<i32> = Enum<i32> @ 0x20003BD8,\n\t[i32; 10] = [\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55\n\t],\n\tmy_array_ptr: &[i32; 10] = &[i32; 10] @ 0x20003D2C,\n\t[i8; 10] = [\n\t\t1,\n\t\t2,\n\t\t3,\n\t\t4,\n\t\t5,\n\t\t6,\n\t\t7,\n\t\t8,\n\t\t9,\n\t\t0\n\t],\n\theapless_vec: Vec<i8, 10> = Vec<i8, 10> @ 0x20003C30,\n\tloop_counter: Wrapping<u8> = Wrapping<u8> @ 0x20003C40,\n\trtt_channels: Channels = Channels @ 0x20003C44}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: int8_minus_twenty_three
           type_name:
             Base: i8
           value: "-23"
+          source_location:
+            line: 204
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: local_reference_to_global_const
           type_name:
             Struct: "&str"
           value: "This global `const` value will only show up in the debugger in the variables where it is referenced"
+          source_location:
+            line: 207
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x200033F8"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "84"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "99"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: local_reference_to_global_static
           type_name:
             Struct: "&str"
           value: "A 'global' static variable"
+          source_location:
+            line: 208
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003CBC"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "65"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "26"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: local_reference_to_global_static_struct
           type_name:
             Pointer: "*const probe_rs_debugger_test::ComplexEnum"
           value: "*const probe_rs_debugger_test::ComplexEnum @ 0x20003CC4"
+          source_location:
+            line: 209
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*local_reference_to_global_static_struct"
               type_name:
                 Struct: ComplexEnum
               value: ComplexEnum @ 0x20000048
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: Case1
                   type_name:
                     Struct: Case1
                   value: Case1 @ 0x20000048
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Base: u64
                       value: "0"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: __1
                       type_name:
                         Struct: ComplexStruct
                       value: ComplexStruct @ 0x20000058
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: x
                           type_name:
                             Base: i64
                           value: "24"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: y
                           type_name:
                             Base: i32
                           value: "25"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: z
                           type_name:
                             Base: i16
                           value: "26"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
         - name:
             Named: ghosted_variable
           type_name:
             Base: usize
           value: "0"
+          source_location:
+            line: 210
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: ghosted_variable
           type_name:
             Struct: "&str"
           value: New value and type for a different name
+          source_location:
+            line: 211
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003404"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "78"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "39"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: int8_twenty_six
           type_name:
             Base: i8
           value: "26"
+          source_location:
+            line: 212
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: int128
           type_name:
             Base: i128
           value: "-196710231994021419720322"
+          source_location:
+            line: 213
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: u_int128
           type_name:
             Base: u128
           value: "340282366920938266753142613410348491134"
+          source_location:
+            line: 214
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: float64
           type_name:
             Base: f64
           value: "1.7608695652173911"
+          source_location:
+            line: 215
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: float64_ptr
           type_name:
             Pointer: "&f64"
           value: "&f64 @ 0x20003CDC"
+          source_location:
+            line: 216
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*float64_ptr"
               type_name:
                 Base: f64
               value: "1.7608695652173911"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: emoji
           type_name:
             Base: char
           value: 💩
+          source_location:
+            line: 217
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: emoji_ptr
           type_name:
             Pointer: "&char"
           value: "&char @ 0x20003CE0"
+          source_location:
+            line: 218
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*emoji_ptr"
               type_name:
                 Base: char
               value: 💩
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: true_bool
           type_name:
             Base: bool
           value: "true"
+          source_location:
+            line: 219
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: any_old_string_slice
           type_name:
             Struct: "&str"
           value: How long is a piece of String.
+          source_location:
+            line: 221
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003428"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "72"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "30"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: function_result
           type_name:
             Struct: "Result<(), &str>"
           value: "Result<(), &str> @ 0x20003CE4"
+          source_location:
+            line: 222
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Err
               type_name:
                 Struct: Err
               value: Err @ 0x20003CE4
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: "&str"
                   value: Forcing the return of an Error variant
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: data_ptr
                       type_name:
                         Pointer: u8
                       value: "*raw u8 @ 0x20003CE4"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: "*data_ptr"
                           type_name:
                             Base: u8
                           value: "70"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: length
                       type_name:
                         Base: usize
                       value: "38"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
         - name:
             Named: global_types
           type_name:
             Struct: "(bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64)"
           value: "(bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x20003448"
+          source_location:
+            line: 223
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: bool
               value: "false"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __1
               type_name:
                 Base: isize
               value: "-1"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __2
               type_name:
                 Base: char
               value: a
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "68"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __4
               type_name:
                 Base: i16
               value: "-16"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "-32"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __6
               type_name:
                 Base: i64
               value: "-64"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __7
               type_name:
                 Base: usize
               value: "1"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __8
               type_name:
                 Base: u8
               value: "100"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __9
               type_name:
                 Base: u16
               value: "16"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __10
               type_name:
                 Base: u32
               value: "32"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __11
               type_name:
                 Base: u64
               value: "64"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __12
               type_name:
                 Base: f32
               value: "2.5"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __13
               type_name:
                 Base: f64
               value: "3.5"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: three_d_usize_array
           type_name:
             Struct: "Matrix<i32, 2, 3, 4>"
           value: "Matrix<i32, 2, 3, 4> @ 0x20003484"
+          source_location:
+            line: 224
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: raw
@@ -1828,6 +2215,11 @@ expression: stack_frames
                       count: 2
                   count: 4
               value: "[[[i32; 3]; 2]; 4] = [\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t0,\n\t\t\t1,\n\t\t\t2\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t3,\n\t\t\t4,\n\t\t\t5\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t6,\n\t\t\t7,\n\t\t\t8\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t9,\n\t\t\t10,\n\t\t\t11\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t12,\n\t\t\t13,\n\t\t\t14\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t15,\n\t\t\t16,\n\t\t\t17\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t18,\n\t\t\t19,\n\t\t\t20\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t21,\n\t\t\t22,\n\t\t\t23\n\t\t]\n\t]]"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
@@ -1840,6 +2232,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t0,\n\t\t1,\n\t\t2\n\t],\n\t[i32; 3] = [\n\t\t3,\n\t\t4,\n\t\t5\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -1849,22 +2246,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t0,\n\t1,\n\t2]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "1"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "2"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -1873,22 +2290,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t3,\n\t4,\n\t5]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "3"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "4"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "5"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __1
                   type_name:
@@ -1900,6 +2337,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t6,\n\t\t7,\n\t\t8\n\t],\n\t[i32; 3] = [\n\t\t9,\n\t\t10,\n\t\t11\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -1909,22 +2351,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t6,\n\t7,\n\t8]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "6"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "7"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "8"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -1933,22 +2395,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t9,\n\t10,\n\t11]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "9"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "10"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "11"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __2
                   type_name:
@@ -1960,6 +2442,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t12,\n\t\t13,\n\t\t14\n\t],\n\t[i32; 3] = [\n\t\t15,\n\t\t16,\n\t\t17\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -1969,22 +2456,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t12,\n\t13,\n\t14]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "12"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "13"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "14"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -1993,22 +2500,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t15,\n\t16,\n\t17]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "15"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "16"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "17"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __3
                   type_name:
@@ -2020,6 +2547,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t18,\n\t\t19,\n\t\t20\n\t],\n\t[i32; 3] = [\n\t\t21,\n\t\t22,\n\t\t23\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2029,22 +2561,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t18,\n\t19,\n\t20]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "18"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "19"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "20"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2053,27 +2605,52 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t21,\n\t22,\n\t23]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "21"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "22"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "23"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
         - name:
             Named: three_d_string_array
           type_name:
             Struct: "Matrix<&str, 2, 3, 6>"
           value: "Matrix<&str, 2, 3, 6> @ 0x20003604"
+          source_location:
+            line: 232
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: raw
@@ -2089,6 +2666,11 @@ expression: stack_frames
                       count: 2
                   count: 6
               value: "[[[&str; 3]; 2]; 6] = [\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tApple,\n\t\t\tBanana,\n\t\t\tCherry\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tDog,\n\t\t\tElephant,\n\t\t\tFish\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tGuitar,\n\t\t\tHorse,\n\t\t\tIce Cream\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tJaguar,\n\t\t\tKangaroo,\n\t\t\tLion\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tMoon,\n\t\t\tNewton,\n\t\t\tOwl\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tPencil,\n\t\t\tQueen,\n\t\t\tRainbow\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tSun,\n\t\t\tTree,\n\t\t\tUmbrella\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tViolin,\n\t\t\tWatch,\n\t\t\tXylophone\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tYellow,\n\t\t\tZebra,\n\t\t\tAlpha\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tBravo,\n\t\t\tCharlie,\n\t\t\tDelta\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tEcho,\n\t\t\tFoxtrot,\n\t\t\tGolf\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tHotel,\n\t\t\tIndia,\n\t\t\tJuliet\n\t\t]\n\t]]"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
@@ -2101,6 +2683,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tApple,\n\t\tBanana,\n\t\tCherry\n\t],\n\t[&str; 3] = [\n\t\tDog,\n\t\tElephant,\n\t\tFish\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2110,73 +2697,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tApple,\n\tBanana,\n\tCherry]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Apple
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003604"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Banana
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000360C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Cherry
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003614"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2185,73 +2837,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tDog,\n\tElephant,\n\tFish]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Dog
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000361C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Elephant
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003624"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Fish
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000362C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __1
                   type_name:
@@ -2263,6 +2980,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tGuitar,\n\t\tHorse,\n\t\tIce Cream\n\t],\n\t[&str; 3] = [\n\t\tJaguar,\n\t\tKangaroo,\n\t\tLion\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2272,73 +2994,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tGuitar,\n\tHorse,\n\tIce Cream]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Guitar
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003634"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Horse
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000363C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Ice Cream
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003644"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2347,73 +3134,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tJaguar,\n\tKangaroo,\n\tLion]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Jaguar
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000364C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Kangaroo
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003654"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "75"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Lion
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000365C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "76"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __2
                   type_name:
@@ -2425,6 +3277,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tMoon,\n\t\tNewton,\n\t\tOwl\n\t],\n\t[&str; 3] = [\n\t\tPencil,\n\t\tQueen,\n\t\tRainbow\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2434,73 +3291,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tMoon,\n\tNewton,\n\tOwl]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Moon
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003664"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "77"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Newton
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000366C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "78"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Owl
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003674"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "79"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2509,73 +3431,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tPencil,\n\tQueen,\n\tRainbow]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Pencil
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000367C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "80"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Queen
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003684"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "81"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Rainbow
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000368C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "82"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __3
                   type_name:
@@ -2587,6 +3574,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tSun,\n\t\tTree,\n\t\tUmbrella\n\t],\n\t[&str; 3] = [\n\t\tViolin,\n\t\tWatch,\n\t\tXylophone\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2596,73 +3588,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tSun,\n\tTree,\n\tUmbrella]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Sun
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003694"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "83"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Tree
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000369C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "84"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Umbrella
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036A4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "85"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2671,73 +3728,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tViolin,\n\tWatch,\n\tXylophone]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Violin
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036AC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "86"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Watch
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036B4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "87"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Xylophone
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036BC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "88"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __4
                   type_name:
@@ -2749,6 +3871,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tYellow,\n\t\tZebra,\n\t\tAlpha\n\t],\n\t[&str; 3] = [\n\t\tBravo,\n\t\tCharlie,\n\t\tDelta\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2758,73 +3885,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tYellow,\n\tZebra,\n\tAlpha]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Yellow
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036C4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "89"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Zebra
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036CC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "90"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Alpha
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036D4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2833,73 +4025,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tBravo,\n\tCharlie,\n\tDelta]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Bravo
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036DC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Charlie
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036E4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Delta
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036EC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __5
                   type_name:
@@ -2911,6 +4168,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tEcho,\n\t\tFoxtrot,\n\t\tGolf\n\t],\n\t[&str; 3] = [\n\t\tHotel,\n\t\tIndia,\n\t\tJuliet\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2920,73 +4182,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tEcho,\n\tFoxtrot,\n\tGolf]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Echo
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036F4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Foxtrot
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036FC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Golf
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003704"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2995,505 +4322,965 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tHotel,\n\tIndia,\n\tJuliet]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Hotel
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000370C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: India
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003714"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Juliet
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000371C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
         - name:
             Named: three
           type_name:
             Enum: SimpleEnum
           value: "SimpleEnum::Two"
+          source_location:
+            line: 249
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: simple_enum_pointer
           type_name:
             Pointer: "&probe_rs_debugger_test::SimpleEnum"
           value: "&probe_rs_debugger_test::SimpleEnum @ 0x20003A88"
+          source_location:
+            line: 250
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*simple_enum_pointer"
               type_name:
                 Enum: SimpleEnum
               value: "SimpleEnum::Two"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: three_level_recursive_struct
           type_name:
             Struct: RecursiveStruct
           value: RecursiveStruct @ 0x20003A8C
+          source_location:
+            line: 252
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: depth
               type_name:
                 Base: u32
               value: "1"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: next_self
               type_name:
                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003A90"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x20003A90
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x20003A90"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RecursiveStruct
                           value: RecursiveStruct @ 0x20003A98
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: depth
                               type_name:
                                 Base: u32
                               value: "2"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: next_self
                               type_name:
                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003A9C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: Some
                                   type_name:
                                     Struct: Some
                                   value: Some @ 0x20003A9C
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: __0
                                       type_name:
                                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x20003A9C"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                                       children:
                                         - name:
                                             Named: "*__0"
                                           type_name:
                                             Struct: RecursiveStruct
                                           value: RecursiveStruct @ 0x20003AA4
+                                          source_location:
+                                            line: ~
+                                            column: ~
+                                            file: ~
+                                            directory: ~
                                           children:
                                             - name:
                                                 Named: depth
                                               type_name:
                                                 Base: u32
                                               value: "3"
+                                              source_location:
+                                                line: ~
+                                                column: ~
+                                                file: ~
+                                                directory: ~
                                             - name:
                                                 Named: next_self
                                               type_name:
                                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003AA8"
+                                              source_location:
+                                                line: ~
+                                                column: ~
+                                                file: ~
+                                                directory: ~
                                               children:
                                                 - name:
                                                     Named: None
                                                   type_name:
                                                     Struct: None
                                                   value: None @ 0x20003AA8
+                                                  source_location:
+                                                    line: ~
+                                                    column: ~
+                                                    file: ~
+                                                    directory: ~
         - name:
             Named: first_case_of_struct_variants
           type_name:
             Struct: ComplexEnum
           value: ComplexEnum @ 0x20003AB0
+          source_location:
+            line: 263
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Case1
               type_name:
                 Struct: Case1
               value: Case1 @ 0x20003AB0
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: ComplexStruct
                   value: ComplexStruct @ 0x20003AC0
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: x
                       type_name:
                         Base: i64
                       value: "24"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: y
                       type_name:
                         Base: i32
                       value: "25"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: z
                       type_name:
                         Base: i16
                       value: "26"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
         - name:
             Named: second_case_of_struct_variants
           type_name:
             Struct: ComplexEnum
           value: ComplexEnum @ 0x20003AE0
+          source_location:
+            line: 271
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Case2
               type_name:
                 Struct: Case2
               value: Case2 @ 0x20003AE0
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: u64
                   value: "1023"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i16
                   value: "1967"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: struct_with_one_variant
           type_name:
             Struct: "Option<probe_rs_debugger_test::Univariant>"
           value: "Option<probe_rs_debugger_test::Univariant> @ 0x20003B00"
+          source_location:
+            line: 273
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Some
               type_name:
                 Struct: Some
               value: Some @ 0x20003B00
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: Univariant
                   value: Univariant @ 0x20003B08
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: TupleOfComplexStruct
                       type_name:
                         Struct: TupleOfComplexStruct
                       value: TupleOfComplexStruct @ 0x20003B08
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x20003B08
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "24"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "25"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "26"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x20003B18
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "-3"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "-2"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "-1"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
         - name:
             Named: stuct_with_one_variant_pointer
           type_name:
             Pointer: "&core::option::Option<probe_rs_debugger_test::Univariant>"
           value: "&core::option::Option<probe_rs_debugger_test::Univariant> @ 0x20003CEC"
+          source_location:
+            line: 285
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*stuct_with_one_variant_pointer"
               type_name:
                 Struct: "Option<probe_rs_debugger_test::Univariant>"
               value: "Option<probe_rs_debugger_test::Univariant> @ 0x20003B00"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x20003B00
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Struct: Univariant
                       value: Univariant @ 0x20003B08
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: TupleOfComplexStruct
                           type_name:
                             Struct: TupleOfComplexStruct
                           value: TupleOfComplexStruct @ 0x20003B08
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: __0
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x20003B08
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "24"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "25"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "26"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: __1
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x20003B18
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "-3"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "-2"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "-1"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
         - name:
             Named: long_lived
           type_name:
             Struct: ComplexStruct
           value: ComplexStruct @ 0x20003B68
+          source_location:
+            line: 287
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: x
               type_name:
                 Base: i64
               value: "10"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: short_lived
           type_name:
             Struct: ComplexStruct
           value: ComplexStruct @ 0x20003B78
+          source_location:
+            line: 289
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: x
               type_name:
                 Base: i64
               value: "20"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: a1
           type_name:
             Struct: Struct<i32>
           value: Struct<i32> @ 0x20003CF0
+          source_location:
+            line: 290
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: b
               type_name:
                 Base: i32
               value: "-1"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: b1
               type_name:
                 Base: i64
               value: "0"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: a2
           type_name:
             Base: i64
           value: "1"
+          source_location:
+            line: 291
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: a3
           type_name:
             Base: i64
           value: "2"
+          source_location:
+            line: 292
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: a4
           type_name:
             Base: i64
           value: "3"
+          source_location:
+            line: 293
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: a5
           type_name:
             Struct: "(i32, i64)"
           value: "(i32, i64) @ 0x20003D18"
+          source_location:
+            line: 294
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: i32
               value: "4"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __1
               type_name:
                 Base: i64
               value: "5"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: a6
           type_name:
             Struct: Enum<i32>
           value: Enum<i32> @ 0x20003BB8
+          source_location:
+            line: 295
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Variant2
               type_name:
                 Struct: Variant2
               value: Variant2 @ 0x20003BB8
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i64
                   value: "7"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "6"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: a7
           type_name:
             Struct: Enum<i32>
           value: Enum<i32> @ 0x20003BD8
+          source_location:
+            line: 296
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Variant1
               type_name:
                 Struct: Variant1
               value: Variant1 @ 0x20003BD8
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "9"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i64
                   value: "8"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: my_array
           type_name:
@@ -3502,62 +5289,122 @@ expression: stack_frames
                 Base: i32
               count: 10
           value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
+          source_location:
+            line: 298
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __1
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __2
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __3
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __4
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __6
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __7
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __8
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __9
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: my_array_ptr
           type_name:
             Pointer: "&[i32; 10]"
           value: "&[i32; 10] @ 0x20003D2C"
+          source_location:
+            line: 299
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*my_array_ptr"
@@ -3567,57 +5414,112 @@ expression: stack_frames
                     Base: i32
                   count: 10
               value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: my_array_of_i8
           type_name:
@@ -3626,68 +5528,133 @@ expression: stack_frames
                 Base: i8
               count: 10
           value: "[i8; 10] = [\n\t1,\n\t2,\n\t3,\n\t4,\n\t5,\n\t6,\n\t7,\n\t8,\n\t9,\n\t0]"
+          source_location:
+            line: 300
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: i8
               value: "1"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __1
               type_name:
                 Base: i8
               value: "2"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __2
               type_name:
                 Base: i8
               value: "3"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "4"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __4
               type_name:
                 Base: i8
               value: "5"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __5
               type_name:
                 Base: i8
               value: "6"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __6
               type_name:
                 Base: i8
               value: "7"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __7
               type_name:
                 Base: i8
               value: "8"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __8
               type_name:
                 Base: i8
               value: "9"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __9
               type_name:
                 Base: i8
               value: "0"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: heapless_vec
           type_name:
             Struct: "Vec<i8, 10>"
           value: "Vec<i8, 10> @ 0x20003C30"
+          source_location:
+            line: 301
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: len
               type_name:
                 Base: usize
               value: "3"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: buffer
               type_name:
@@ -3696,442 +5663,837 @@ expression: stack_frames
                     Base: MaybeUninit<i8>
                   count: 10
               value: "[MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C34\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C35\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C36\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C37\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C38\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C39\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3A\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3B\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3C\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3D\n\t}]"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C34}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C34
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "1"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C35}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C35
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "2"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C36}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C36
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "3"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C37}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C37
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C38}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C38
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C39}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C39
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3A}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C3A
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3B}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C3B
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3C}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C3C
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3D}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C3D
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
         - name:
             Named: loop_counter
           type_name:
             Struct: Wrapping<u8>
           value: Wrapping<u8> @ 0x20003C40
+          source_location:
+            line: 305
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: u8
               value: "0"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: rtt_channels
           type_name:
             Struct: Channels
           value: Channels @ 0x20003C44
+          source_location:
+            line: 306
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: up
               type_name:
                 Struct: "(rtt_target::UpChannel, rtt_target::UpChannel)"
               value: "(rtt_target::UpChannel, rtt_target::UpChannel) @ 0x20003C44"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x20003C44
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x20003C44"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x20000094
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x20000094"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "83"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x20000098"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "70"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000A0
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000A0
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000A4
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000A4
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000A8
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000A8
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x20003C48
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x20003C48"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x200000AC
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x200000AC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "66"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x200000B0"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "0"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000B8
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000B8
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000BC
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000BC
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000C0
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000C0
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
   canonical_frame_address: 536886968
 - function_name: __cortex_m_rt_main
   source_location:
@@ -4336,586 +6698,1136 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tcore: Peripherals = Peripherals @ 0x20003EDF,\n\texternal_xtal_freq_hz: u32 = 12000000,\n\tpac: Peripherals = Peripherals @ 0x20003EE7,\n\twatchdog: Watchdog = Watchdog @ 0x20003EEC,\n\tclocks: ClocksManager = ClocksManager @ 0x20003EF0}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: core
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003EDF
+          source_location:
+            line: 24
+            column: ~
+            file: RP2040.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: CBP
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: external_xtal_freq_hz
           type_name:
             Base: u32
           value: "12000000"
+          source_location:
+            line: 26
+            column: ~
+            file: RP2040.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
         - name:
             Named: pac
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003EE7
+          source_location:
+            line: 27
+            column: ~
+            file: RP2040.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: ADC
               type_name:
                 Struct: ADC
               value: ADC @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: BUSCTRL
               type_name:
                 Struct: BUSCTRL
               value: BUSCTRL @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CLOCKS
               type_name:
                 Struct: CLOCKS
               value: CLOCKS @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DMA
               type_name:
                 Struct: DMA
               value: DMA @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: I2C0
               type_name:
                 Struct: I2C0
               value: I2C0 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: I2C1
               type_name:
                 Struct: I2C1
               value: I2C1 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: IO_BANK0
               type_name:
                 Struct: IO_BANK0
               value: IO_BANK0 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: IO_QSPI
               type_name:
                 Struct: IO_QSPI
               value: IO_QSPI @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PADS_BANK0
               type_name:
                 Struct: PADS_BANK0
               value: PADS_BANK0 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PADS_QSPI
               type_name:
                 Struct: PADS_QSPI
               value: PADS_QSPI @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PIO0
               type_name:
                 Struct: PIO0
               value: PIO0 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PIO1
               type_name:
                 Struct: PIO1
               value: PIO1 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PLL_SYS
               type_name:
                 Struct: PLL_SYS
               value: PLL_SYS @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PLL_USB
               type_name:
                 Struct: PLL_USB
               value: PLL_USB @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PPB
               type_name:
                 Struct: PPB
               value: PPB @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PSM
               type_name:
                 Struct: PSM
               value: PSM @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PWM
               type_name:
                 Struct: PWM
               value: PWM @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RESETS
               type_name:
                 Struct: RESETS
               value: RESETS @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ROSC
               type_name:
                 Struct: ROSC
               value: ROSC @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RTC
               type_name:
                 Struct: RTC
               value: RTC @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SIO
               type_name:
                 Struct: SIO
               value: SIO @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SYSCFG
               type_name:
                 Struct: SYSCFG
               value: SYSCFG @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SYSINFO
               type_name:
                 Struct: SYSINFO
               value: SYSINFO @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TBMAN
               type_name:
                 Struct: TBMAN
               value: TBMAN @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER
               type_name:
                 Struct: TIMER
               value: TIMER @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UART1
               type_name:
                 Struct: UART1
               value: UART1 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: USBCTRL_DPRAM
               type_name:
                 Struct: USBCTRL_DPRAM
               value: USBCTRL_DPRAM @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: USBCTRL_REGS
               type_name:
                 Struct: USBCTRL_REGS
               value: USBCTRL_REGS @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: VREG_AND_CHIP_RESET
               type_name:
                 Struct: VREG_AND_CHIP_RESET
               value: VREG_AND_CHIP_RESET @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: WATCHDOG
               type_name:
                 Struct: WATCHDOG
               value: WATCHDOG @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: XIP_CTRL
               type_name:
                 Struct: XIP_CTRL
               value: XIP_CTRL @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: XIP_SSI
               type_name:
                 Struct: XIP_SSI
               value: XIP_SSI @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: XOSC
               type_name:
                 Struct: XOSC
               value: XOSC @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: watchdog
           type_name:
             Struct: Watchdog
           value: Watchdog @ 0x20003EEC
+          source_location:
+            line: 28
+            column: ~
+            file: RP2040.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: watchdog
               type_name:
                 Struct: WATCHDOG
               value: WATCHDOG @ 0x20003EF0
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: load_value
               type_name:
                 Base: u32
               value: "0"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: clocks
           type_name:
             Struct: ClocksManager
           value: ClocksManager @ 0x20003EF0
+          source_location:
+            line: 30
+            column: ~
+            file: RP2040.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: clocks
               type_name:
                 Struct: CLOCKS
               value: CLOCKS @ 0x20003F18
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: gpio_output0_clock
               type_name:
                 Struct: GpioOutput0Clock
               value: GpioOutput0Clock @ 0x20003EF0
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EF4
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF0"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: gpio_output1_clock
               type_name:
                 Struct: GpioOutput1Clock
               value: GpioOutput1Clock @ 0x20003EF4
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EF8
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF4"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: gpio_output2_clock
               type_name:
                 Struct: GpioOutput2Clock
               value: GpioOutput2Clock @ 0x20003EF8
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EFC
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF8"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: gpio_output3_clock
               type_name:
                 Struct: GpioOutput3Clock
               value: GpioOutput3Clock @ 0x20003EFC
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F00
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EFC"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: reference_clock
               type_name:
                 Struct: ReferenceClock
               value: ReferenceClock @ 0x20003F00
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F04
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F00"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "12000000"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: system_clock
               type_name:
                 Struct: SystemClock
               value: SystemClock @ 0x20003F04
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F08
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F04"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "125000000"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: peripheral_clock
               type_name:
                 Struct: PeripheralClock
               value: PeripheralClock @ 0x20003F08
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F0C
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F08"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "125000000"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: usb_clock
               type_name:
                 Struct: UsbClock
               value: UsbClock @ 0x20003F0C
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F10
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F0C"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "48000000"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: adc_clock
               type_name:
                 Struct: AdcClock
               value: AdcClock @ 0x20003F10
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F14
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F10"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "48000000"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: rtc_clock
               type_name:
                 Struct: RtcClock
               value: RtcClock @ 0x20003F14
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F18
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F14"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "46875"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
@@ -5119,4 +8031,9 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_full_unwind.snap
@@ -215,11 +215,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 5,\n\tinternal_depth_measure: usize = 6}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -445,11 +441,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 4,\n\tinternal_depth_measure: usize = 5}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -675,11 +667,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 3,\n\tinternal_depth_measure: usize = 4}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -905,11 +893,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 2,\n\tinternal_depth_measure: usize = 3}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1135,11 +1119,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 1,\n\tinternal_depth_measure: usize = 2}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1365,11 +1345,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 0,\n\tinternal_depth_measure: usize = 1}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1595,11 +1571,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tint8_minus_twenty_three: i8 = -23,\n\tlocal_reference_to_global_const: &str = This global `const` value will only show up in the debugger in the variables where it is referenced,\n\tlocal_reference_to_global_static: &str = A 'global' static variable,\n\tlocal_reference_to_global_static_struct: *const probe_rs_debugger_test::ComplexEnum = *const probe_rs_debugger_test::ComplexEnum @ 0x20003CC4,\n\tghosted_variable: usize = 0,\n\tghosted_variable: &str = New value and type for a different name,\n\tint8_twenty_six: i8 = 26,\n\tint128: i128 = -196710231994021419720322,\n\tu_int128: u128 = 340282366920938266753142613410348491134,\n\tfloat64: f64 = 1.7608695652173911,\n\tfloat64_ptr: &f64 = &f64 @ 0x20003CDC,\n\temoji: char = 💩,\n\temoji_ptr: &char = &char @ 0x20003CE0,\n\ttrue_bool: bool = true,\n\tany_old_string_slice: &str = How long is a piece of String.,\n\tfunction_result: Result<(), &str> = Result<(), &str> @ 0x20003CE4,\n\tglobal_types: (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) = (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x20003448,\n\tthree_d_usize_array: Matrix<i32, 2, 3, 4> = Matrix<i32, 2, 3, 4> @ 0x20003484,\n\tthree_d_string_array: Matrix<&str, 2, 3, 6> = Matrix<&str, 2, 3, 6> @ 0x20003604,\n\tthree: SimpleEnum = SimpleEnum::Two,\n\tsimple_enum_pointer: &probe_rs_debugger_test::SimpleEnum = &probe_rs_debugger_test::SimpleEnum @ 0x20003A88,\n\tthree_level_recursive_struct: RecursiveStruct = RecursiveStruct @ 0x20003A8C,\n\tfirst_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003AB0,\n\tsecond_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003AE0,\n\tstruct_with_one_variant: Option<probe_rs_debugger_test::Univariant> = Option<probe_rs_debugger_test::Univariant> @ 0x20003B00,\n\tstuct_with_one_variant_pointer: &core::option::Option<probe_rs_debugger_test::Univariant> = &core::option::Option<probe_rs_debugger_test::Univariant> @ 0x20003CEC,\n\tlong_lived: ComplexStruct = ComplexStruct @ 0x20003B68,\n\tshort_lived: ComplexStruct = ComplexStruct @ 0x20003B78,\n\ta1: Struct<i32> = Struct<i32> @ 0x20003CF0,\n\ta2: i64 = 1,\n\ta3: i64 = 2,\n\ta4: i64 = 3,\n\ta5: (i32, i64) = (i32, i64) @ 0x20003D18,\n\ta6: Enum<i32> = Enum<i32> @ 0x20003BB8,\n\ta7: Enum<i32> = Enum<i32> @ 0x20003BD8,\n\t[i32; 10] = [\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55\n\t],\n\tmy_array_ptr: &[i32; 10] = &[i32; 10] @ 0x20003D2C,\n\t[i8; 10] = [\n\t\t1,\n\t\t2,\n\t\t3,\n\t\t4,\n\t\t5,\n\t\t6,\n\t\t7,\n\t\t8,\n\t\t9,\n\t\t0\n\t],\n\theapless_vec: Vec<i8, 10> = Vec<i8, 10> @ 0x20003C30,\n\tloop_counter: Wrapping<u8> = Wrapping<u8> @ 0x20003C40,\n\trtt_channels: Channels = Channels @ 0x20003C44}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: int8_minus_twenty_three
@@ -1627,32 +1599,20 @@ snapshot_kind: text
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x200033F8"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "84"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "99"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: local_reference_to_global_static
           type_name:
@@ -1669,32 +1629,20 @@ snapshot_kind: text
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003CBC"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "65"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "26"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: local_reference_to_global_static_struct
           type_name:
@@ -1711,74 +1659,46 @@ snapshot_kind: text
               type_name:
                 Struct: ComplexEnum
               value: ComplexEnum @ 0x20000048
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: Case1
                   type_name:
                     Struct: Case1
                   value: Case1 @ 0x20000048
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Base: u64
                       value: "0"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: __1
                       type_name:
                         Struct: ComplexStruct
                       value: ComplexStruct @ 0x20000058
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: x
                           type_name:
                             Base: i64
                           value: "24"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: y
                           type_name:
                             Base: i32
                           value: "25"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: z
                           type_name:
                             Base: i16
                           value: "26"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
         - name:
             Named: ghosted_variable
           type_name:
@@ -1805,32 +1725,20 @@ snapshot_kind: text
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003404"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "78"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "39"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: int8_twenty_six
           type_name:
@@ -1887,11 +1795,7 @@ snapshot_kind: text
               type_name:
                 Base: f64
               value: "1.7608695652173911"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: emoji
           type_name:
@@ -1918,11 +1822,7 @@ snapshot_kind: text
               type_name:
                 Base: char
               value: 💩
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: true_bool
           type_name:
@@ -1949,32 +1849,20 @@ snapshot_kind: text
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003428"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "72"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "30"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: function_result
           type_name:
@@ -1991,54 +1879,34 @@ snapshot_kind: text
               type_name:
                 Struct: Err
               value: Err @ 0x20003CE4
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: "&str"
                   value: Forcing the return of an Error variant
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: data_ptr
                       type_name:
                         Pointer: u8
                       value: "*raw u8 @ 0x20003CE4"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: "*data_ptr"
                           type_name:
                             Base: u8
                           value: "70"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: length
                       type_name:
                         Base: usize
                       value: "38"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
         - name:
             Named: global_types
           type_name:
@@ -2055,141 +1923,85 @@ snapshot_kind: text
               type_name:
                 Base: bool
               value: "false"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __1
               type_name:
                 Base: isize
               value: "-1"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __2
               type_name:
                 Base: char
               value: a
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "68"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __4
               type_name:
                 Base: i16
               value: "-16"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "-32"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __6
               type_name:
                 Base: i64
               value: "-64"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __7
               type_name:
                 Base: usize
               value: "1"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __8
               type_name:
                 Base: u8
               value: "100"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __9
               type_name:
                 Base: u16
               value: "16"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __10
               type_name:
                 Base: u32
               value: "32"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __11
               type_name:
                 Base: u64
               value: "64"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __12
               type_name:
                 Base: f32
               value: "2.5"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __13
               type_name:
                 Base: f64
               value: "3.5"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: three_d_usize_array
           type_name:
@@ -2215,11 +2027,7 @@ snapshot_kind: text
                       count: 2
                   count: 4
               value: "[[[i32; 3]; 2]; 4] = [\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t0,\n\t\t\t1,\n\t\t\t2\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t3,\n\t\t\t4,\n\t\t\t5\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t6,\n\t\t\t7,\n\t\t\t8\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t9,\n\t\t\t10,\n\t\t\t11\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t12,\n\t\t\t13,\n\t\t\t14\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t15,\n\t\t\t16,\n\t\t\t17\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t18,\n\t\t\t19,\n\t\t\t20\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t21,\n\t\t\t22,\n\t\t\t23\n\t\t]\n\t]]"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
@@ -2232,11 +2040,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t0,\n\t\t1,\n\t\t2\n\t],\n\t[i32; 3] = [\n\t\t3,\n\t\t4,\n\t\t5\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2246,42 +2050,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t0,\n\t1,\n\t2]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "1"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "2"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2290,42 +2078,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t3,\n\t4,\n\t5]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "3"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "4"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "5"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __1
                   type_name:
@@ -2337,11 +2109,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t6,\n\t\t7,\n\t\t8\n\t],\n\t[i32; 3] = [\n\t\t9,\n\t\t10,\n\t\t11\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2351,42 +2119,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t6,\n\t7,\n\t8]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "6"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "7"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "8"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2395,42 +2147,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t9,\n\t10,\n\t11]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "9"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "10"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "11"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __2
                   type_name:
@@ -2442,11 +2178,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t12,\n\t\t13,\n\t\t14\n\t],\n\t[i32; 3] = [\n\t\t15,\n\t\t16,\n\t\t17\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2456,42 +2188,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t12,\n\t13,\n\t14]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "12"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "13"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "14"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2500,42 +2216,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t15,\n\t16,\n\t17]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "15"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "16"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "17"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __3
                   type_name:
@@ -2547,11 +2247,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t18,\n\t\t19,\n\t\t20\n\t],\n\t[i32; 3] = [\n\t\t21,\n\t\t22,\n\t\t23\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2561,42 +2257,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t18,\n\t19,\n\t20]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "18"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "19"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "20"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2605,42 +2285,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t21,\n\t22,\n\t23]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "21"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "22"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "23"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
         - name:
             Named: three_d_string_array
           type_name:
@@ -2666,11 +2330,7 @@ snapshot_kind: text
                       count: 2
                   count: 6
               value: "[[[&str; 3]; 2]; 6] = [\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tApple,\n\t\t\tBanana,\n\t\t\tCherry\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tDog,\n\t\t\tElephant,\n\t\t\tFish\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tGuitar,\n\t\t\tHorse,\n\t\t\tIce Cream\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tJaguar,\n\t\t\tKangaroo,\n\t\t\tLion\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tMoon,\n\t\t\tNewton,\n\t\t\tOwl\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tPencil,\n\t\t\tQueen,\n\t\t\tRainbow\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tSun,\n\t\t\tTree,\n\t\t\tUmbrella\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tViolin,\n\t\t\tWatch,\n\t\t\tXylophone\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tYellow,\n\t\t\tZebra,\n\t\t\tAlpha\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tBravo,\n\t\t\tCharlie,\n\t\t\tDelta\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tEcho,\n\t\t\tFoxtrot,\n\t\t\tGolf\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tHotel,\n\t\t\tIndia,\n\t\t\tJuliet\n\t\t]\n\t]]"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
@@ -2683,11 +2343,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tApple,\n\t\tBanana,\n\t\tCherry\n\t],\n\t[&str; 3] = [\n\t\tDog,\n\t\tElephant,\n\t\tFish\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2697,138 +2353,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tApple,\n\tBanana,\n\tCherry]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Apple
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003604"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Banana
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000360C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Cherry
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003614"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2837,138 +2441,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tDog,\n\tElephant,\n\tFish]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Dog
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000361C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Elephant
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003624"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Fish
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000362C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __1
                   type_name:
@@ -2980,11 +2532,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tGuitar,\n\t\tHorse,\n\t\tIce Cream\n\t],\n\t[&str; 3] = [\n\t\tJaguar,\n\t\tKangaroo,\n\t\tLion\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2994,138 +2542,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tGuitar,\n\tHorse,\n\tIce Cream]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Guitar
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003634"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Horse
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000363C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Ice Cream
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003644"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3134,138 +2630,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tJaguar,\n\tKangaroo,\n\tLion]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Jaguar
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000364C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Kangaroo
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003654"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "75"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Lion
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000365C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "76"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __2
                   type_name:
@@ -3277,11 +2721,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tMoon,\n\t\tNewton,\n\t\tOwl\n\t],\n\t[&str; 3] = [\n\t\tPencil,\n\t\tQueen,\n\t\tRainbow\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3291,138 +2731,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tMoon,\n\tNewton,\n\tOwl]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Moon
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003664"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "77"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Newton
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000366C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "78"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Owl
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003674"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "79"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3431,138 +2819,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tPencil,\n\tQueen,\n\tRainbow]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Pencil
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000367C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "80"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Queen
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003684"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "81"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Rainbow
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000368C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "82"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __3
                   type_name:
@@ -3574,11 +2910,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tSun,\n\t\tTree,\n\t\tUmbrella\n\t],\n\t[&str; 3] = [\n\t\tViolin,\n\t\tWatch,\n\t\tXylophone\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3588,138 +2920,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tSun,\n\tTree,\n\tUmbrella]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Sun
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003694"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "83"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Tree
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000369C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "84"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Umbrella
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036A4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "85"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3728,138 +3008,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tViolin,\n\tWatch,\n\tXylophone]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Violin
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036AC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "86"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Watch
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036B4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "87"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Xylophone
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036BC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "88"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __4
                   type_name:
@@ -3871,11 +3099,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tYellow,\n\t\tZebra,\n\t\tAlpha\n\t],\n\t[&str; 3] = [\n\t\tBravo,\n\t\tCharlie,\n\t\tDelta\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3885,138 +3109,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tYellow,\n\tZebra,\n\tAlpha]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Yellow
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036C4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "89"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Zebra
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036CC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "90"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Alpha
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036D4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -4025,138 +3197,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tBravo,\n\tCharlie,\n\tDelta]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Bravo
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036DC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Charlie
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036E4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Delta
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036EC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __5
                   type_name:
@@ -4168,11 +3288,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tEcho,\n\t\tFoxtrot,\n\t\tGolf\n\t],\n\t[&str; 3] = [\n\t\tHotel,\n\t\tIndia,\n\t\tJuliet\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -4182,138 +3298,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tEcho,\n\tFoxtrot,\n\tGolf]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Echo
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036F4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Foxtrot
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036FC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Golf
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003704"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -4322,138 +3386,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tHotel,\n\tIndia,\n\tJuliet]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Hotel
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000370C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: India
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003714"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Juliet
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000371C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
         - name:
             Named: three
           type_name:
@@ -4480,11 +3492,7 @@ snapshot_kind: text
               type_name:
                 Enum: SimpleEnum
               value: "SimpleEnum::Two"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: three_level_recursive_struct
           type_name:
@@ -4501,140 +3509,88 @@ snapshot_kind: text
               type_name:
                 Base: u32
               value: "1"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: next_self
               type_name:
                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003A90"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x20003A90
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x20003A90"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RecursiveStruct
                           value: RecursiveStruct @ 0x20003A98
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: depth
                               type_name:
                                 Base: u32
                               value: "2"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: next_self
                               type_name:
                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003A9C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: Some
                                   type_name:
                                     Struct: Some
                                   value: Some @ 0x20003A9C
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: __0
                                       type_name:
                                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x20003A9C"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                                       children:
                                         - name:
                                             Named: "*__0"
                                           type_name:
                                             Struct: RecursiveStruct
                                           value: RecursiveStruct @ 0x20003AA4
-                                          source_location:
-                                            line: ~
-                                            column: ~
-                                            file: ~
-                                            directory: ~
+                                          source_location: ~
                                           children:
                                             - name:
                                                 Named: depth
                                               type_name:
                                                 Base: u32
                                               value: "3"
-                                              source_location:
-                                                line: ~
-                                                column: ~
-                                                file: ~
-                                                directory: ~
+                                              source_location: ~
                                             - name:
                                                 Named: next_self
                                               type_name:
                                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003AA8"
-                                              source_location:
-                                                line: ~
-                                                column: ~
-                                                file: ~
-                                                directory: ~
+                                              source_location: ~
                                               children:
                                                 - name:
                                                     Named: None
                                                   type_name:
                                                     Struct: None
                                                   value: None @ 0x20003AA8
-                                                  source_location:
-                                                    line: ~
-                                                    column: ~
-                                                    file: ~
-                                                    directory: ~
+                                                  source_location: ~
         - name:
             Named: first_case_of_struct_variants
           type_name:
@@ -4651,63 +3607,39 @@ snapshot_kind: text
               type_name:
                 Struct: Case1
               value: Case1 @ 0x20003AB0
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: ComplexStruct
                   value: ComplexStruct @ 0x20003AC0
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: x
                       type_name:
                         Base: i64
                       value: "24"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: y
                       type_name:
                         Base: i32
                       value: "25"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: z
                       type_name:
                         Base: i16
                       value: "26"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
         - name:
             Named: second_case_of_struct_variants
           type_name:
@@ -4724,42 +3656,26 @@ snapshot_kind: text
               type_name:
                 Struct: Case2
               value: Case2 @ 0x20003AE0
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: u64
                   value: "1023"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i16
                   value: "1967"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: struct_with_one_variant
           type_name:
@@ -4776,116 +3692,72 @@ snapshot_kind: text
               type_name:
                 Struct: Some
               value: Some @ 0x20003B00
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: Univariant
                   value: Univariant @ 0x20003B08
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: TupleOfComplexStruct
                       type_name:
                         Struct: TupleOfComplexStruct
                       value: TupleOfComplexStruct @ 0x20003B08
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x20003B08
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "24"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "25"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "26"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x20003B18
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "-3"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "-2"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "-1"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
         - name:
             Named: stuct_with_one_variant_pointer
           type_name:
@@ -4902,127 +3774,79 @@ snapshot_kind: text
               type_name:
                 Struct: "Option<probe_rs_debugger_test::Univariant>"
               value: "Option<probe_rs_debugger_test::Univariant> @ 0x20003B00"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x20003B00
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Struct: Univariant
                       value: Univariant @ 0x20003B08
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: TupleOfComplexStruct
                           type_name:
                             Struct: TupleOfComplexStruct
                           value: TupleOfComplexStruct @ 0x20003B08
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: __0
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x20003B08
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "24"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "25"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "26"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: __1
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x20003B18
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "-3"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "-2"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "-1"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
         - name:
             Named: long_lived
           type_name:
@@ -5039,31 +3863,19 @@ snapshot_kind: text
               type_name:
                 Base: i64
               value: "10"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: short_lived
           type_name:
@@ -5080,31 +3892,19 @@ snapshot_kind: text
               type_name:
                 Base: i64
               value: "20"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: a1
           type_name:
@@ -5121,21 +3921,13 @@ snapshot_kind: text
               type_name:
                 Base: i32
               value: "-1"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: b1
               type_name:
                 Base: i64
               value: "0"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: a2
           type_name:
@@ -5182,21 +3974,13 @@ snapshot_kind: text
               type_name:
                 Base: i32
               value: "4"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __1
               type_name:
                 Base: i64
               value: "5"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: a6
           type_name:
@@ -5213,32 +3997,20 @@ snapshot_kind: text
               type_name:
                 Struct: Variant2
               value: Variant2 @ 0x20003BB8
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i64
                   value: "7"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "6"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: a7
           type_name:
@@ -5255,32 +4027,20 @@ snapshot_kind: text
               type_name:
                 Struct: Variant1
               value: Variant1 @ 0x20003BD8
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "9"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i64
                   value: "8"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: my_array
           type_name:
@@ -5414,112 +4174,68 @@ snapshot_kind: text
                     Base: i32
                   count: 10
               value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: my_array_of_i8
           type_name:
@@ -5650,11 +4366,7 @@ snapshot_kind: text
               type_name:
                 Base: usize
               value: "3"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: buffer
               type_name:
@@ -5663,432 +4375,268 @@ snapshot_kind: text
                     Base: MaybeUninit<i8>
                   count: 10
               value: "[MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C34\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C35\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C36\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C37\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C38\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C39\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3A\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3B\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3C\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3D\n\t}]"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C34}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C34
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "1"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C35}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C35
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "2"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C36}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C36
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "3"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C37}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C37
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C38}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C38
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C39}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C39
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3A}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C3A
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3B}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C3B
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3C}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C3C
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3D}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003C3D
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
         - name:
             Named: loop_counter
           type_name:
@@ -6105,11 +4653,7 @@ snapshot_kind: text
               type_name:
                 Base: u8
               value: "0"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: rtt_channels
           type_name:
@@ -6126,374 +4670,234 @@ snapshot_kind: text
               type_name:
                 Struct: "(rtt_target::UpChannel, rtt_target::UpChannel)"
               value: "(rtt_target::UpChannel, rtt_target::UpChannel) @ 0x20003C44"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x20003C44
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x20003C44"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x20000094
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x20000094"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "83"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x20000098"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000A0
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000A0
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000A4
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000A4
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000A8
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000A8
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x20003C48
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x20003C48"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x200000AC
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x200000AC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x200000B0"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "0"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000B8
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000B8
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000BC
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000BC
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000C0
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000C0
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
   canonical_frame_address: 536886968
 - function_name: __cortex_m_rt_main
   source_location:
@@ -6698,11 +5102,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tcore: Peripherals = Peripherals @ 0x20003EDF,\n\texternal_xtal_freq_hz: u32 = 12000000,\n\tpac: Peripherals = Peripherals @ 0x20003EE7,\n\twatchdog: Watchdog = Watchdog @ 0x20003EEC,\n\tclocks: ClocksManager = ClocksManager @ 0x20003EF0}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: core
@@ -6720,151 +5120,91 @@ snapshot_kind: text
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: external_xtal_freq_hz
           type_name:
@@ -6891,361 +5231,217 @@ snapshot_kind: text
               type_name:
                 Struct: ADC
               value: ADC @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: BUSCTRL
               type_name:
                 Struct: BUSCTRL
               value: BUSCTRL @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CLOCKS
               type_name:
                 Struct: CLOCKS
               value: CLOCKS @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DMA
               type_name:
                 Struct: DMA
               value: DMA @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: I2C0
               type_name:
                 Struct: I2C0
               value: I2C0 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: I2C1
               type_name:
                 Struct: I2C1
               value: I2C1 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: IO_BANK0
               type_name:
                 Struct: IO_BANK0
               value: IO_BANK0 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: IO_QSPI
               type_name:
                 Struct: IO_QSPI
               value: IO_QSPI @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PADS_BANK0
               type_name:
                 Struct: PADS_BANK0
               value: PADS_BANK0 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PADS_QSPI
               type_name:
                 Struct: PADS_QSPI
               value: PADS_QSPI @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PIO0
               type_name:
                 Struct: PIO0
               value: PIO0 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PIO1
               type_name:
                 Struct: PIO1
               value: PIO1 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PLL_SYS
               type_name:
                 Struct: PLL_SYS
               value: PLL_SYS @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PLL_USB
               type_name:
                 Struct: PLL_USB
               value: PLL_USB @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PPB
               type_name:
                 Struct: PPB
               value: PPB @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PSM
               type_name:
                 Struct: PSM
               value: PSM @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PWM
               type_name:
                 Struct: PWM
               value: PWM @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RESETS
               type_name:
                 Struct: RESETS
               value: RESETS @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ROSC
               type_name:
                 Struct: ROSC
               value: ROSC @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RTC
               type_name:
                 Struct: RTC
               value: RTC @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SIO
               type_name:
                 Struct: SIO
               value: SIO @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SYSCFG
               type_name:
                 Struct: SYSCFG
               value: SYSCFG @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SYSINFO
               type_name:
                 Struct: SYSINFO
               value: SYSINFO @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TBMAN
               type_name:
                 Struct: TBMAN
               value: TBMAN @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER
               type_name:
                 Struct: TIMER
               value: TIMER @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UART1
               type_name:
                 Struct: UART1
               value: UART1 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: USBCTRL_DPRAM
               type_name:
                 Struct: USBCTRL_DPRAM
               value: USBCTRL_DPRAM @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: USBCTRL_REGS
               type_name:
                 Struct: USBCTRL_REGS
               value: USBCTRL_REGS @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: VREG_AND_CHIP_RESET
               type_name:
                 Struct: VREG_AND_CHIP_RESET
               value: VREG_AND_CHIP_RESET @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: WATCHDOG
               type_name:
                 Struct: WATCHDOG
               value: WATCHDOG @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: XIP_CTRL
               type_name:
                 Struct: XIP_CTRL
               value: XIP_CTRL @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: XIP_SSI
               type_name:
                 Struct: XIP_SSI
               value: XIP_SSI @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: XOSC
               type_name:
                 Struct: XOSC
               value: XOSC @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: watchdog
           type_name:
@@ -7262,21 +5458,13 @@ snapshot_kind: text
               type_name:
                 Struct: WATCHDOG
               value: WATCHDOG @ 0x20003EF0
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: load_value
               type_name:
                 Base: u32
               value: "0"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: clocks
           type_name:
@@ -7293,541 +5481,337 @@ snapshot_kind: text
               type_name:
                 Struct: CLOCKS
               value: CLOCKS @ 0x20003F18
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: gpio_output0_clock
               type_name:
                 Struct: GpioOutput0Clock
               value: GpioOutput0Clock @ 0x20003EF0
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EF4
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF0"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: gpio_output1_clock
               type_name:
                 Struct: GpioOutput1Clock
               value: GpioOutput1Clock @ 0x20003EF4
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EF8
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF4"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: gpio_output2_clock
               type_name:
                 Struct: GpioOutput2Clock
               value: GpioOutput2Clock @ 0x20003EF8
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EFC
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF8"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: gpio_output3_clock
               type_name:
                 Struct: GpioOutput3Clock
               value: GpioOutput3Clock @ 0x20003EFC
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F00
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EFC"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: reference_clock
               type_name:
                 Struct: ReferenceClock
               value: ReferenceClock @ 0x20003F00
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F04
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F00"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "12000000"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: system_clock
               type_name:
                 Struct: SystemClock
               value: SystemClock @ 0x20003F04
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F08
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F04"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "125000000"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: peripheral_clock
               type_name:
                 Struct: PeripheralClock
               value: PeripheralClock @ 0x20003F08
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F0C
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F08"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "125000000"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: usb_clock
               type_name:
                 Struct: UsbClock
               value: UsbClock @ 0x20003F0C
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F10
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F0C"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "48000000"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: adc_clock
               type_name:
                 Struct: AdcClock
               value: AdcClock @ 0x20003F10
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F14
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F10"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "48000000"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: rtc_clock
               type_name:
                 Struct: RtcClock
               value: RtcClock @ 0x20003F14
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F18
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F14"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "46875"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
@@ -8031,9 +6015,5 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_full_unwind.snap
@@ -6,10 +6,10 @@ snapshot_kind: text
 ---
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 344
     column:
       Column: 13
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -221,25 +221,25 @@ snapshot_kind: text
             Base: usize
           value: "5"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "6"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883184
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -443,25 +443,25 @@ snapshot_kind: text
             Base: usize
           value: "4"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "5"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883328
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -665,25 +665,25 @@ snapshot_kind: text
             Base: usize
           value: "3"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "4"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883472
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -887,25 +887,25 @@ snapshot_kind: text
             Base: usize
           value: "2"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "3"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883616
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -1109,25 +1109,25 @@ snapshot_kind: text
             Base: usize
           value: "1"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "2"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883760
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -1331,25 +1331,25 @@ snapshot_kind: text
             Base: usize
           value: "0"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "1"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883904
 - function_name: setup_data_types
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 325
     column:
       Column: 5
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -1553,18 +1553,18 @@ snapshot_kind: text
             Base: i8
           value: "-23"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 204
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: local_reference_to_global_const
           type_name:
             Struct: "&str"
           value: "This global `const` value will only show up in the debugger in the variables where it is referenced"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 207
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
@@ -1588,9 +1588,9 @@ snapshot_kind: text
             Struct: "&str"
           value: "A 'global' static variable"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 208
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
@@ -1614,9 +1614,9 @@ snapshot_kind: text
             Pointer: "*const probe_rs_debugger_test::ComplexEnum"
           value: "*const probe_rs_debugger_test::ComplexEnum @ 0x20003CC4"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 209
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*local_reference_to_global_static_struct"
@@ -1662,18 +1662,18 @@ snapshot_kind: text
             Base: usize
           value: "0"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 210
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: ghosted_variable
           type_name:
             Struct: "&str"
           value: New value and type for a different name
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 211
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
@@ -1697,45 +1697,45 @@ snapshot_kind: text
             Base: i8
           value: "26"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 212
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: int128
           type_name:
             Base: i128
           value: "-196710231994021419720322"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 213
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: u_int128
           type_name:
             Base: u128
           value: "340282366920938266753142613410348491134"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 214
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: float64
           type_name:
             Base: f64
           value: "1.7608695652173911"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 215
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: float64_ptr
           type_name:
             Pointer: "&f64"
           value: "&f64 @ 0x20003CDC"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 216
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*float64_ptr"
@@ -1748,18 +1748,18 @@ snapshot_kind: text
             Base: char
           value: 💩
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 217
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: emoji_ptr
           type_name:
             Pointer: "&char"
           value: "&char @ 0x20003CE0"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 218
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*emoji_ptr"
@@ -1772,18 +1772,18 @@ snapshot_kind: text
             Base: bool
           value: "true"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 219
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: any_old_string_slice
           type_name:
             Struct: "&str"
           value: How long is a piece of String.
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 221
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
@@ -1807,9 +1807,9 @@ snapshot_kind: text
             Struct: "Result<(), &str>"
           value: "Result<(), &str> @ 0x20003CE4"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 222
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Err
@@ -1845,9 +1845,9 @@ snapshot_kind: text
             Struct: "(bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64)"
           value: "(bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x20003448"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 223
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -1925,9 +1925,9 @@ snapshot_kind: text
             Struct: "Matrix<i32, 2, 3, 4>"
           value: "Matrix<i32, 2, 3, 4> @ 0x20003484"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 224
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: raw
@@ -2190,9 +2190,9 @@ snapshot_kind: text
             Struct: "Matrix<&str, 2, 3, 6>"
           value: "Matrix<&str, 2, 3, 6> @ 0x20003604"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 232
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: raw
@@ -3187,18 +3187,18 @@ snapshot_kind: text
             Enum: SimpleEnum
           value: "SimpleEnum::Two"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 249
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: simple_enum_pointer
           type_name:
             Pointer: "&probe_rs_debugger_test::SimpleEnum"
           value: "&probe_rs_debugger_test::SimpleEnum @ 0x20003A88"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 250
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*simple_enum_pointer"
@@ -3211,9 +3211,9 @@ snapshot_kind: text
             Struct: RecursiveStruct
           value: RecursiveStruct @ 0x20003A8C
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 252
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: depth
@@ -3295,9 +3295,9 @@ snapshot_kind: text
             Struct: ComplexEnum
           value: ComplexEnum @ 0x20003AB0
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 263
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Case1
@@ -3337,9 +3337,9 @@ snapshot_kind: text
             Struct: ComplexEnum
           value: ComplexEnum @ 0x20003AE0
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 271
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Case2
@@ -3368,9 +3368,9 @@ snapshot_kind: text
             Struct: "Option<probe_rs_debugger_test::Univariant>"
           value: "Option<probe_rs_debugger_test::Univariant> @ 0x20003B00"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 273
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Some
@@ -3438,9 +3438,9 @@ snapshot_kind: text
             Pointer: "&core::option::Option<probe_rs_debugger_test::Univariant>"
           value: "&core::option::Option<probe_rs_debugger_test::Univariant> @ 0x20003CEC"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 285
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*stuct_with_one_variant_pointer"
@@ -3514,9 +3514,9 @@ snapshot_kind: text
             Struct: ComplexStruct
           value: ComplexStruct @ 0x20003B68
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 287
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: x
@@ -3539,9 +3539,9 @@ snapshot_kind: text
             Struct: ComplexStruct
           value: ComplexStruct @ 0x20003B78
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 289
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: x
@@ -3564,9 +3564,9 @@ snapshot_kind: text
             Struct: Struct<i32>
           value: Struct<i32> @ 0x20003CF0
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 290
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: b
@@ -3584,36 +3584,36 @@ snapshot_kind: text
             Base: i64
           value: "1"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 291
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a3
           type_name:
             Base: i64
           value: "2"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 292
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a4
           type_name:
             Base: i64
           value: "3"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 293
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a5
           type_name:
             Struct: "(i32, i64)"
           value: "(i32, i64) @ 0x20003D18"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 294
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -3631,9 +3631,9 @@ snapshot_kind: text
             Struct: Enum<i32>
           value: Enum<i32> @ 0x20003BB8
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 295
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Variant2
@@ -3657,9 +3657,9 @@ snapshot_kind: text
             Struct: Enum<i32>
           value: Enum<i32> @ 0x20003BD8
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 296
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Variant1
@@ -3686,9 +3686,9 @@ snapshot_kind: text
               count: 10
           value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 298
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -3696,99 +3696,99 @@ snapshot_kind: text
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __1
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __2
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __3
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __4
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __6
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __7
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __8
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __9
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: my_array_ptr
           type_name:
             Pointer: "&[i32; 10]"
           value: "&[i32; 10] @ 0x20003D2C"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 299
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*my_array_ptr"
@@ -3858,9 +3858,9 @@ snapshot_kind: text
               count: 10
           value: "[i8; 10] = [\n\t1,\n\t2,\n\t3,\n\t4,\n\t5,\n\t6,\n\t7,\n\t8,\n\t9,\n\t0]"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 300
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -3868,99 +3868,99 @@ snapshot_kind: text
                 Base: i8
               value: "1"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __1
               type_name:
                 Base: i8
               value: "2"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __2
               type_name:
                 Base: i8
               value: "3"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "4"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __4
               type_name:
                 Base: i8
               value: "5"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __5
               type_name:
                 Base: i8
               value: "6"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __6
               type_name:
                 Base: i8
               value: "7"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __7
               type_name:
                 Base: i8
               value: "8"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __8
               type_name:
                 Base: i8
               value: "9"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __9
               type_name:
                 Base: i8
               value: "0"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: heapless_vec
           type_name:
             Struct: "Vec<i8, 10>"
           value: "Vec<i8, 10> @ 0x20003C30"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 301
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: len
@@ -4202,9 +4202,9 @@ snapshot_kind: text
             Struct: Wrapping<u8>
           value: Wrapping<u8> @ 0x20003C40
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 305
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -4217,9 +4217,9 @@ snapshot_kind: text
             Struct: Channels
           value: Channels @ 0x20003C44
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 306
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: up
@@ -4422,10 +4422,10 @@ snapshot_kind: text
   canonical_frame_address: 536886968
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
     line: 55
     column:
       Column: 54
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -4629,9 +4629,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003EDF
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 24
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: CBP
@@ -4714,18 +4714,18 @@ snapshot_kind: text
             Base: u32
           value: "12000000"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 26
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
         - name:
             Named: pac
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003EE7
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 27
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: ADC
@@ -4913,9 +4913,9 @@ snapshot_kind: text
             Struct: Watchdog
           value: Watchdog @ 0x20003EEC
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 28
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: watchdog
@@ -4933,9 +4933,9 @@ snapshot_kind: text
             Struct: ClocksManager
           value: ClocksManager @ 0x20003EF0
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 30
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: clocks
@@ -5225,9 +5225,9 @@ snapshot_kind: text
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
     line: 22
     column: LeftEdge
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_full_unwind_static_variables.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_full_unwind_static_variables.snap
@@ -1,6 +1,8 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 2023
 expression: static_variables
+snapshot_kind: text
 ---
 Child Variables:
   name: StaticScopeRoot
@@ -20,257 +22,461 @@ Child Variables:
                 Base: u8
               count: 256
           value: "[u8; 256] = [\n\t0,\n\t181,\n\t50,\n\t75,\n\t33,\n\t32,\n\t88,\n\t96,\n\t152,\n\t104,\n\t... and 246 more]"
+          source_location:
+            line: 67
+            column: ~
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
           children:
             - name:
                 Named: __0
               type_name:
                 Base: u8
               value: "0"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __1
               type_name:
                 Base: u8
               value: "181"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __2
               type_name:
                 Base: u8
               value: "50"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __3
               type_name:
                 Base: u8
               value: "75"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __4
               type_name:
                 Base: u8
               value: "33"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __5
               type_name:
                 Base: u8
               value: "32"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __6
               type_name:
                 Base: u8
               value: "88"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __7
               type_name:
                 Base: u8
               value: "96"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __8
               type_name:
                 Base: u8
               value: "152"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __9
               type_name:
                 Base: u8
               value: "104"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __10
               type_name:
                 Base: u8
               value: "2"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __11
               type_name:
                 Base: u8
               value: "33"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __12
               type_name:
                 Base: u8
               value: "136"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __13
               type_name:
                 Base: u8
               value: "67"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __14
               type_name:
                 Base: u8
               value: "152"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __15
               type_name:
                 Base: u8
               value: "96"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __16
               type_name:
                 Base: u8
               value: "216"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __17
               type_name:
                 Base: u8
               value: "96"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __18
               type_name:
                 Base: u8
               value: "24"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __19
               type_name:
                 Base: u8
               value: "97"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __20
               type_name:
                 Base: u8
               value: "88"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __21
               type_name:
                 Base: u8
               value: "97"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __22
               type_name:
                 Base: u8
               value: "46"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __23
               type_name:
                 Base: u8
               value: "75"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __24
               type_name:
                 Base: u8
               value: "0"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __25
               type_name:
                 Base: u8
               value: "33"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __26
               type_name:
                 Base: u8
               value: "153"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __27
               type_name:
                 Base: u8
               value: "96"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __28
               type_name:
                 Base: u8
               value: "2"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __29
               type_name:
                 Base: u8
               value: "33"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __30
               type_name:
                 Base: u8
               value: "89"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __31
               type_name:
                 Base: u8
               value: "97"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __32
               type_name:
                 Base: u8
               value: "1"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __33
               type_name:
                 Base: u8
               value: "33"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __34
               type_name:
                 Base: u8
               value: "240"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __35
               type_name:
                 Base: u8
               value: "34"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __36
               type_name:
                 Base: u8
               value: "153"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __37
               type_name:
                 Base: u8
               value: "80"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __38
               type_name:
                 Base: u8
               value: "43"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __39
               type_name:
                 Base: u8
               value: "73"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __40
               type_name:
                 Base: u8
               value: "25"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __41
               type_name:
                 Base: u8
               value: "96"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __42
               type_name:
                 Base: u8
               value: "1"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __43
               type_name:
                 Base: u8
               value: "33"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __44
               type_name:
                 Base: u8
               value: "153"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __45
               type_name:
                 Base: u8
               value: "96"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __46
               type_name:
                 Base: u8
               value: "53"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __47
               type_name:
                 Base: u8
               value: "32"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __48
               type_name:
                 Base: u8
               value: "0"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __49
               type_name:
                 Base: u8
               value: "240"
+              source_location:
+                line: 67
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name: Artifical
               type_name: Unknown
               value: "... and 206 more"
@@ -302,6 +508,10 @@ Child Variables:
                         Named: CACHED_PTR
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                      source_location:
+                        line: 80
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: memset4
               type_name: Namespace
@@ -317,6 +527,10 @@ Child Variables:
                       type_name:
                         Struct: AtomicU16
                       value: AtomicU16 @ 0x20000070
+                      source_location:
+                        line: 132
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                       children:
                         - name:
                             Named: v
@@ -344,6 +558,10 @@ Child Variables:
                       type_name:
                         Struct: AtomicU16
                       value: AtomicU16 @ 0x20000072
+                      source_location:
+                        line: 132
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                       children:
                         - name:
                             Named: v
@@ -370,6 +588,10 @@ Child Variables:
                         Named: CACHED_PTR
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                      source_location:
+                        line: 132
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: float_funcs
               type_name: Namespace
@@ -389,6 +611,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_ufix
                   type_name: Namespace
@@ -403,6 +629,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: int_to_float
                   type_name: Namespace
@@ -417,6 +647,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: int64_to_float
                   type_name: Namespace
@@ -431,6 +665,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_int
                   type_name: Namespace
@@ -445,6 +683,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_fix
                   type_name: Namespace
@@ -459,6 +701,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: uint_to_float
                   type_name: Namespace
@@ -473,6 +719,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: ufix64_to_float
                   type_name: Namespace
@@ -487,6 +737,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fsub
                   type_name: Namespace
@@ -501,6 +755,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fmul
                   type_name: Namespace
@@ -515,6 +773,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_uint
                   type_name: Namespace
@@ -529,6 +791,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fcos
                   type_name: Namespace
@@ -543,6 +809,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: ftan
                   type_name: Namespace
@@ -557,6 +827,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fexp
                   type_name: Namespace
@@ -571,6 +845,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: uint64_to_float
                   type_name: Namespace
@@ -585,6 +863,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_fix64
                   type_name: Namespace
@@ -599,6 +881,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fsin
                   type_name: Namespace
@@ -613,6 +899,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fcmp
                   type_name: Namespace
@@ -627,6 +917,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fix64_to_float
                   type_name: Namespace
@@ -641,6 +935,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_uint64
                   type_name: Namespace
@@ -655,6 +953,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_ufix64
                   type_name: Namespace
@@ -669,6 +971,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_double
                   type_name: Namespace
@@ -683,6 +989,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fdiv
                   type_name: Namespace
@@ -697,6 +1007,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fsqrt
                   type_name: Namespace
@@ -711,6 +1025,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fix_to_float
                   type_name: Namespace
@@ -725,6 +1043,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: ufix_to_float
                   type_name: Namespace
@@ -739,6 +1061,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fln
                   type_name: Namespace
@@ -753,6 +1079,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fatan2
                   type_name: Namespace
@@ -767,6 +1097,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_int64
                   type_name: Namespace
@@ -781,6 +1115,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: double_funcs
               type_name: Namespace
@@ -800,6 +1138,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dmul
                   type_name: Namespace
@@ -814,6 +1156,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: ddiv
                   type_name: Namespace
@@ -828,6 +1174,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_float
                   type_name: Namespace
@@ -842,6 +1192,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_int
                   type_name: Namespace
@@ -856,6 +1210,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dcmp
                   type_name: Namespace
@@ -870,6 +1228,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: ufix64_to_double
                   type_name: Namespace
@@ -884,6 +1246,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fix_to_double
                   type_name: Namespace
@@ -898,6 +1264,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: ufix_to_double
                   type_name: Namespace
@@ -912,6 +1282,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dtan
                   type_name: Namespace
@@ -926,6 +1300,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fix64_to_double
                   type_name: Namespace
@@ -940,6 +1318,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_fix64
                   type_name: Namespace
@@ -954,6 +1336,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_fix
                   type_name: Namespace
@@ -968,6 +1354,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_ufix
                   type_name: Namespace
@@ -982,6 +1372,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: int_to_double
                   type_name: Namespace
@@ -996,6 +1390,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dcos
                   type_name: Namespace
@@ -1010,6 +1408,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dsin
                   type_name: Namespace
@@ -1024,6 +1426,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dexp
                   type_name: Namespace
@@ -1038,6 +1444,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dln
                   type_name: Namespace
@@ -1052,6 +1462,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: int64_to_double
                   type_name: Namespace
@@ -1066,6 +1480,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: uint64_to_double
                   type_name: Namespace
@@ -1080,6 +1498,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_int64
                   type_name: Namespace
@@ -1094,6 +1516,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_uint64
                   type_name: Namespace
@@ -1108,6 +1534,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dsub
                   type_name: Namespace
@@ -1122,6 +1552,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dsqrt
                   type_name: Namespace
@@ -1136,6 +1570,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_uint
                   type_name: Namespace
@@ -1150,6 +1588,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: uint_to_double
                   type_name: Namespace
@@ -1164,6 +1606,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: datan2
                   type_name: Namespace
@@ -1178,6 +1624,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_ufix64
                   type_name: Namespace
@@ -1192,6 +1642,10 @@ Child Variables:
                             Named: CACHED_PTR
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                          source_location:
+                            line: 80
+                            column: ~
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: popcount32
               type_name: Namespace
@@ -1206,6 +1660,10 @@ Child Variables:
                         Named: CACHED_PTR
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                      source_location:
+                        line: 80
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: memset
               type_name: Namespace
@@ -1220,6 +1678,10 @@ Child Variables:
                         Named: CACHED_PTR
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                      source_location:
+                        line: 132
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: flash_exit_xip
               type_name: Namespace
@@ -1234,6 +1696,10 @@ Child Variables:
                         Named: CACHED_PTR
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                      source_location:
+                        line: 132
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: flash_range_erase
               type_name: Namespace
@@ -1248,6 +1714,10 @@ Child Variables:
                         Named: CACHED_PTR
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                      source_location:
+                        line: 132
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: reverse32
               type_name: Namespace
@@ -1262,6 +1732,10 @@ Child Variables:
                         Named: CACHED_PTR
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                      source_location:
+                        line: 80
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: memcpy44
               type_name: Namespace
@@ -1277,6 +1751,10 @@ Child Variables:
                       type_name:
                         Struct: AtomicU16
                       value: AtomicU16 @ 0x20000076
+                      source_location:
+                        line: 132
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                       children:
                         - name:
                             Named: v
@@ -1303,6 +1781,10 @@ Child Variables:
                         Named: CACHED_PTR
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                      source_location:
+                        line: 132
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: flash_range_program
               type_name: Namespace
@@ -1317,6 +1799,10 @@ Child Variables:
                         Named: CACHED_PTR
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                      source_location:
+                        line: 132
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: clz32
               type_name: Namespace
@@ -1332,6 +1818,10 @@ Child Variables:
                       type_name:
                         Struct: AtomicU16
                       value: AtomicU16 @ 0x20000078
+                      source_location:
+                        line: 80
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                       children:
                         - name:
                             Named: v
@@ -1358,6 +1848,10 @@ Child Variables:
                         Named: CACHED_PTR
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                      source_location:
+                        line: 132
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: ctz32
               type_name: Namespace
@@ -1372,6 +1866,10 @@ Child Variables:
                         Named: CACHED_PTR
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                      source_location:
+                        line: 80
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: flash_enter_cmd_xip
               type_name: Namespace
@@ -1386,6 +1884,10 @@ Child Variables:
                         Named: CACHED_PTR
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                      source_location:
+                        line: 132
+                        column: ~
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
         - name:
             Namespace: critical_section_impl
           type_name: Namespace
@@ -1396,6 +1898,10 @@ Child Variables:
               type_name:
                 Struct: AtomicU8
               value: AtomicU8 @ 0x20000074
+              source_location:
+                line: 14
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/critical_section_impl.rs
               children:
                 - name:
                     Named: v
@@ -1417,6 +1923,10 @@ Child Variables:
                 Named: ALARMS
               type_name: Unknown
               value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+              source_location:
+                line: 25
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/timer.rs
     - name:
         Named: "<core::convert::Infallible as core::fmt::Debug>::{vtable}"
       type_name: Unknown
@@ -1438,12 +1948,20 @@ Child Variables:
                 Base: Vector
               count: 32
           value: "[Vector; 32] = [\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000140,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000144,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000148,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000014C,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000150,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000154,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000158,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000015C,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000160,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000164,\n\t\t_reserved: u32 = 268461611\n\t},\n\t... and 22 more]"
+          source_location:
+            line: 86
+            column: ~
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
           children:
             - name:
                 Named: __0
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000140,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1465,6 +1983,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000144,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1486,6 +2008,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000148,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1507,6 +2033,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000014C,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1528,6 +2058,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000150,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1549,6 +2083,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000154,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1570,6 +2108,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000158,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1591,6 +2133,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000015C,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1612,6 +2158,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000160,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1633,6 +2183,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000164,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1654,6 +2208,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000168,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1675,6 +2233,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000016C,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1696,6 +2258,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000170,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1717,6 +2283,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000174,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1738,6 +2308,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000178,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1759,6 +2333,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000017C,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1780,6 +2358,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000180,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1801,6 +2383,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000184,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1822,6 +2408,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000188,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1843,6 +2433,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000018C,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1864,6 +2458,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000190,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1885,6 +2483,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000194,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1906,6 +2508,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000198,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1927,6 +2533,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000019C,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1948,6 +2558,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A0,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1969,6 +2583,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A4,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1990,6 +2608,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A8,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2011,6 +2633,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001AC,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2032,6 +2658,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B0,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2053,6 +2683,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B4,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2074,6 +2708,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B8,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2095,6 +2733,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001BC,\n\t_reserved: u32 = 268461611}"
+              source_location:
+                line: 86
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2116,6 +2758,10 @@ Child Variables:
           type_name:
             Base: bool
           value: "true"
+          source_location:
+            line: 1598
+            column: ~
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
     - name:
         Namespace: cortex_m_rt
       type_name: Namespace
@@ -2125,11 +2771,19 @@ Child Variables:
             Named: __ONCE__
           type_name: Unknown
           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+          source_location:
+            line: 857
+            column: ~
+            path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
         - name:
             Named: __RESET_VECTOR
           type_name:
             Pointer: "unsafe extern \"C\" fn() -> !"
           value: "*raw unsafe extern \"C\" fn() -> ! @ 0x10000104"
+          source_location:
+            line: 1048
+            column: ~
+            path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
           children:
             - name:
                 Named: "*__RESET_VECTOR"
@@ -2144,12 +2798,20 @@ Child Variables:
                 Base: Vector
               count: 14
           value: "[Vector; 14] = [\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000108,\n\t\treserved: usize = 268461611\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000010C,\n\t\treserved: usize = 268482803\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000110,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000114,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000118,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000011C,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000120,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000124,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000128,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000012C,\n\t\treserved: usize = 268436319\n\t},\n\t... and 4 more]"
+          source_location:
+            line: 1140
+            column: ~
+            path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
           children:
             - name:
                 Named: __0
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000108,\n\treserved: usize = 268461611}"
+              source_location:
+                line: 1140
+                column: ~
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2171,6 +2833,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000010C,\n\treserved: usize = 268482803}"
+              source_location:
+                line: 1140
+                column: ~
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2192,6 +2858,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000110,\n\treserved: usize = 0}"
+              source_location:
+                line: 1140
+                column: ~
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2213,6 +2883,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000114,\n\treserved: usize = 0}"
+              source_location:
+                line: 1140
+                column: ~
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2234,6 +2908,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000118,\n\treserved: usize = 0}"
+              source_location:
+                line: 1140
+                column: ~
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2255,6 +2933,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000011C,\n\treserved: usize = 0}"
+              source_location:
+                line: 1140
+                column: ~
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2276,6 +2958,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000120,\n\treserved: usize = 0}"
+              source_location:
+                line: 1140
+                column: ~
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2297,6 +2983,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000124,\n\treserved: usize = 0}"
+              source_location:
+                line: 1140
+                column: ~
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2318,6 +3008,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000128,\n\treserved: usize = 0}"
+              source_location:
+                line: 1140
+                column: ~
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2339,6 +3033,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000012C,\n\treserved: usize = 268436319}"
+              source_location:
+                line: 1140
+                column: ~
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2360,6 +3058,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000130,\n\treserved: usize = 0}"
+              source_location:
+                line: 1140
+                column: ~
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2381,6 +3083,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000134,\n\treserved: usize = 0}"
+              source_location:
+                line: 1140
+                column: ~
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2402,6 +3108,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000138,\n\treserved: usize = 268461611}"
+              source_location:
+                line: 1140
+                column: ~
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2423,6 +3133,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000013C,\n\treserved: usize = 268436301}"
+              source_location:
+                line: 1140
+                column: ~
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2453,76 +3167,136 @@ Child Variables:
           type_name:
             Base: bool
           value: "false"
+          source_location:
+            line: 15
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: I
           type_name:
             Base: isize
           value: "-1"
+          source_location:
+            line: 16
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: C
           type_name:
             Base: char
           value: a
+          source_location:
+            line: 17
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: I8
           type_name:
             Base: i8
           value: "68"
+          source_location:
+            line: 18
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: I16
           type_name:
             Base: i16
           value: "-16"
+          source_location:
+            line: 19
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: I32
           type_name:
             Base: i32
           value: "-32"
+          source_location:
+            line: 20
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: I64
           type_name:
             Base: i64
           value: "-64"
+          source_location:
+            line: 21
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: U
           type_name:
             Base: usize
           value: "1"
+          source_location:
+            line: 22
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: U8
           type_name:
             Base: u8
           value: "100"
+          source_location:
+            line: 23
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: U16
           type_name:
             Base: u16
           value: "16"
+          source_location:
+            line: 24
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: U32
           type_name:
             Base: u32
           value: "32"
+          source_location:
+            line: 25
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: U64
           type_name:
             Base: u64
           value: "64"
+          source_location:
+            line: 26
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: F32
           type_name:
             Base: f32
           value: "2.5"
+          source_location:
+            line: 27
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: F64
           type_name:
             Base: f64
           value: "3.5"
+          source_location:
+            line: 28
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: GLOBAL_STATIC
           type_name:
             Struct: "&str"
           value: "A 'global' static variable"
+          source_location:
+            line: 30
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
@@ -2545,6 +3319,10 @@ Child Variables:
           type_name:
             Struct: ComplexEnum
           value: ComplexEnum @ 0x20000048
+          source_location:
+            line: 64
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Case1
@@ -2588,6 +3366,10 @@ Child Variables:
               type_name:
                 Struct: "&str"
               value: "A 'local' to main() static variable ...will be optimized out if not used in the code."
+              source_location:
+                line: 205
+                column: ~
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
               children:
                 - name:
                     Named: data_ptr
@@ -2610,6 +3392,10 @@ Child Variables:
               type_name:
                 Base: "MaybeUninit<probe_rs_debugger_test::setup_data_types::RttControlBlock>"
               value: "MaybeUninit<probe_rs_debugger_test::setup_data_types::RttControlBlock> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<probe_rs_debugger_test::setup_data_types::RttControlBlock> = ManuallyDrop<probe_rs_debugger_test::setup_data_types::RttControlBlock> @ 0x2000007C}"
+              source_location:
+                line: 138
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/init.rs
               children:
                 - name:
                     Named: uninit
@@ -2923,6 +3709,10 @@ Child Variables:
               type_name:
                 Base: "MaybeUninit<[u8; 1024]>"
               value: "MaybeUninit<[u8; 1024]> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<[u8; 1024]> = ManuallyDrop<[u8; 1024]> @ 0x200000C4}"
+              source_location:
+                line: 34
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/init.rs
               children:
                 - name:
                     Named: uninit
@@ -3202,6 +3992,10 @@ Child Variables:
               type_name:
                 Base: "MaybeUninit<[u8; 1024]>"
               value: "MaybeUninit<[u8; 1024]> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<[u8; 1024]> = ManuallyDrop<[u8; 1024]> @ 0x200004C4}"
+              source_location:
+                line: 34
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/init.rs
               children:
                 - name:
                     Named: uninit
@@ -3729,6 +4523,10 @@ Child Variables:
               type_name:
                 Struct: "Mutex<core::cell::RefCell<core::option::Option<rtt_target::TerminalChannel>>>"
               value: "Mutex<core::cell::RefCell<core::option::Option<rtt_target::TerminalChannel>>> @ 0x200008C4"
+              source_location:
+                line: 7
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/print.rs
               children:
                 - name:
                     Named: inner
@@ -3843,8 +4641,16 @@ Child Variables:
                 Named: CORE_PERIPHERALS
               type_name: Unknown
               value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+              source_location:
+                line: 159
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/peripheral/mod.rs
             - name:
                 Named: TAKEN
               type_name:
                 Base: bool
               value: "true"
+              source_location:
+                line: 162
+                column: ~
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/peripheral/mod.rs

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_full_unwind_static_variables.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_full_unwind_static_variables.snap
@@ -23,9 +23,9 @@ Child Variables:
               count: 256
           value: "[u8; 256] = [\n\t0,\n\t181,\n\t50,\n\t75,\n\t33,\n\t32,\n\t88,\n\t96,\n\t152,\n\t104,\n\t... and 246 more]"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             line: 67
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -33,450 +33,450 @@ Child Variables:
                 Base: u8
               value: "0"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __1
               type_name:
                 Base: u8
               value: "181"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __2
               type_name:
                 Base: u8
               value: "50"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __3
               type_name:
                 Base: u8
               value: "75"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __4
               type_name:
                 Base: u8
               value: "33"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __5
               type_name:
                 Base: u8
               value: "32"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __6
               type_name:
                 Base: u8
               value: "88"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __7
               type_name:
                 Base: u8
               value: "96"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __8
               type_name:
                 Base: u8
               value: "152"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __9
               type_name:
                 Base: u8
               value: "104"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __10
               type_name:
                 Base: u8
               value: "2"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __11
               type_name:
                 Base: u8
               value: "33"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __12
               type_name:
                 Base: u8
               value: "136"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __13
               type_name:
                 Base: u8
               value: "67"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __14
               type_name:
                 Base: u8
               value: "152"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __15
               type_name:
                 Base: u8
               value: "96"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __16
               type_name:
                 Base: u8
               value: "216"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __17
               type_name:
                 Base: u8
               value: "96"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __18
               type_name:
                 Base: u8
               value: "24"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __19
               type_name:
                 Base: u8
               value: "97"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __20
               type_name:
                 Base: u8
               value: "88"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __21
               type_name:
                 Base: u8
               value: "97"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __22
               type_name:
                 Base: u8
               value: "46"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __23
               type_name:
                 Base: u8
               value: "75"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __24
               type_name:
                 Base: u8
               value: "0"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __25
               type_name:
                 Base: u8
               value: "33"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __26
               type_name:
                 Base: u8
               value: "153"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __27
               type_name:
                 Base: u8
               value: "96"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __28
               type_name:
                 Base: u8
               value: "2"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __29
               type_name:
                 Base: u8
               value: "33"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __30
               type_name:
                 Base: u8
               value: "89"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __31
               type_name:
                 Base: u8
               value: "97"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __32
               type_name:
                 Base: u8
               value: "1"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __33
               type_name:
                 Base: u8
               value: "33"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __34
               type_name:
                 Base: u8
               value: "240"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __35
               type_name:
                 Base: u8
               value: "34"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __36
               type_name:
                 Base: u8
               value: "153"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __37
               type_name:
                 Base: u8
               value: "80"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __38
               type_name:
                 Base: u8
               value: "43"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __39
               type_name:
                 Base: u8
               value: "73"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __40
               type_name:
                 Base: u8
               value: "25"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __41
               type_name:
                 Base: u8
               value: "96"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __42
               type_name:
                 Base: u8
               value: "1"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __43
               type_name:
                 Base: u8
               value: "33"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __44
               type_name:
                 Base: u8
               value: "153"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __45
               type_name:
                 Base: u8
               value: "96"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __46
               type_name:
                 Base: u8
               value: "53"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __47
               type_name:
                 Base: u8
               value: "32"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __48
               type_name:
                 Base: u8
               value: "0"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name:
                 Named: __49
               type_name:
                 Base: u8
               value: "240"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
                 line: 67
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp-pico-0.8.0/src/lib.rs
             - name: Artifical
               type_name: Unknown
               value: "... and 206 more"
@@ -509,9 +509,9 @@ Child Variables:
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 80
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: memset4
               type_name: Namespace
@@ -528,9 +528,9 @@ Child Variables:
                         Struct: AtomicU16
                       value: AtomicU16 @ 0x20000070
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 132
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                       children:
                         - name:
                             Named: v
@@ -559,9 +559,9 @@ Child Variables:
                         Struct: AtomicU16
                       value: AtomicU16 @ 0x20000072
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 132
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                       children:
                         - name:
                             Named: v
@@ -589,9 +589,9 @@ Child Variables:
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 132
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: float_funcs
               type_name: Namespace
@@ -612,9 +612,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_ufix
                   type_name: Namespace
@@ -630,9 +630,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: int_to_float
                   type_name: Namespace
@@ -648,9 +648,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: int64_to_float
                   type_name: Namespace
@@ -666,9 +666,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_int
                   type_name: Namespace
@@ -684,9 +684,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_fix
                   type_name: Namespace
@@ -702,9 +702,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: uint_to_float
                   type_name: Namespace
@@ -720,9 +720,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: ufix64_to_float
                   type_name: Namespace
@@ -738,9 +738,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fsub
                   type_name: Namespace
@@ -756,9 +756,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fmul
                   type_name: Namespace
@@ -774,9 +774,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_uint
                   type_name: Namespace
@@ -792,9 +792,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fcos
                   type_name: Namespace
@@ -810,9 +810,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: ftan
                   type_name: Namespace
@@ -828,9 +828,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fexp
                   type_name: Namespace
@@ -846,9 +846,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: uint64_to_float
                   type_name: Namespace
@@ -864,9 +864,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_fix64
                   type_name: Namespace
@@ -882,9 +882,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fsin
                   type_name: Namespace
@@ -900,9 +900,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fcmp
                   type_name: Namespace
@@ -918,9 +918,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fix64_to_float
                   type_name: Namespace
@@ -936,9 +936,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_uint64
                   type_name: Namespace
@@ -954,9 +954,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_ufix64
                   type_name: Namespace
@@ -972,9 +972,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_double
                   type_name: Namespace
@@ -990,9 +990,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fdiv
                   type_name: Namespace
@@ -1008,9 +1008,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fsqrt
                   type_name: Namespace
@@ -1026,9 +1026,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fix_to_float
                   type_name: Namespace
@@ -1044,9 +1044,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: ufix_to_float
                   type_name: Namespace
@@ -1062,9 +1062,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fln
                   type_name: Namespace
@@ -1080,9 +1080,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fatan2
                   type_name: Namespace
@@ -1098,9 +1098,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: float_to_int64
                   type_name: Namespace
@@ -1116,9 +1116,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: double_funcs
               type_name: Namespace
@@ -1139,9 +1139,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dmul
                   type_name: Namespace
@@ -1157,9 +1157,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: ddiv
                   type_name: Namespace
@@ -1175,9 +1175,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_float
                   type_name: Namespace
@@ -1193,9 +1193,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_int
                   type_name: Namespace
@@ -1211,9 +1211,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dcmp
                   type_name: Namespace
@@ -1229,9 +1229,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: ufix64_to_double
                   type_name: Namespace
@@ -1247,9 +1247,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fix_to_double
                   type_name: Namespace
@@ -1265,9 +1265,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: ufix_to_double
                   type_name: Namespace
@@ -1283,9 +1283,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dtan
                   type_name: Namespace
@@ -1301,9 +1301,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: fix64_to_double
                   type_name: Namespace
@@ -1319,9 +1319,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_fix64
                   type_name: Namespace
@@ -1337,9 +1337,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_fix
                   type_name: Namespace
@@ -1355,9 +1355,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_ufix
                   type_name: Namespace
@@ -1373,9 +1373,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: int_to_double
                   type_name: Namespace
@@ -1391,9 +1391,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dcos
                   type_name: Namespace
@@ -1409,9 +1409,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dsin
                   type_name: Namespace
@@ -1427,9 +1427,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dexp
                   type_name: Namespace
@@ -1445,9 +1445,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dln
                   type_name: Namespace
@@ -1463,9 +1463,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: int64_to_double
                   type_name: Namespace
@@ -1481,9 +1481,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: uint64_to_double
                   type_name: Namespace
@@ -1499,9 +1499,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_int64
                   type_name: Namespace
@@ -1517,9 +1517,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_uint64
                   type_name: Namespace
@@ -1535,9 +1535,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dsub
                   type_name: Namespace
@@ -1553,9 +1553,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: dsqrt
                   type_name: Namespace
@@ -1571,9 +1571,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_uint
                   type_name: Namespace
@@ -1589,9 +1589,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: uint_to_double
                   type_name: Namespace
@@ -1607,9 +1607,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: datan2
                   type_name: Namespace
@@ -1625,9 +1625,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                 - name:
                     Namespace: double_to_ufix64
                   type_name: Namespace
@@ -1643,9 +1643,9 @@ Child Variables:
                           type_name: Unknown
                           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                           source_location:
+                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                             line: 80
                             column: ~
-                            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: popcount32
               type_name: Namespace
@@ -1661,9 +1661,9 @@ Child Variables:
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 80
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: memset
               type_name: Namespace
@@ -1679,9 +1679,9 @@ Child Variables:
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 132
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: flash_exit_xip
               type_name: Namespace
@@ -1697,9 +1697,9 @@ Child Variables:
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 132
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: flash_range_erase
               type_name: Namespace
@@ -1715,9 +1715,9 @@ Child Variables:
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 132
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: reverse32
               type_name: Namespace
@@ -1733,9 +1733,9 @@ Child Variables:
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 80
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: memcpy44
               type_name: Namespace
@@ -1752,9 +1752,9 @@ Child Variables:
                         Struct: AtomicU16
                       value: AtomicU16 @ 0x20000076
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 132
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                       children:
                         - name:
                             Named: v
@@ -1782,9 +1782,9 @@ Child Variables:
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 132
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: flash_range_program
               type_name: Namespace
@@ -1800,9 +1800,9 @@ Child Variables:
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 132
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: clz32
               type_name: Namespace
@@ -1819,9 +1819,9 @@ Child Variables:
                         Struct: AtomicU16
                       value: AtomicU16 @ 0x20000078
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 80
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                       children:
                         - name:
                             Named: v
@@ -1849,9 +1849,9 @@ Child Variables:
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 132
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: ctz32
               type_name: Namespace
@@ -1867,9 +1867,9 @@ Child Variables:
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 80
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
             - name:
                 Namespace: flash_enter_cmd_xip
               type_name: Namespace
@@ -1885,9 +1885,9 @@ Child Variables:
                       type_name: Unknown
                       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
                       source_location:
+                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
                         line: 132
                         column: ~
-                        path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/rom_data.rs
         - name:
             Namespace: critical_section_impl
           type_name: Namespace
@@ -1899,9 +1899,9 @@ Child Variables:
                 Struct: AtomicU8
               value: AtomicU8 @ 0x20000074
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/critical_section_impl.rs
                 line: 14
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/critical_section_impl.rs
               children:
                 - name:
                     Named: v
@@ -1924,9 +1924,9 @@ Child Variables:
               type_name: Unknown
               value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/timer.rs
                 line: 25
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-hal-0.9.2/src/timer.rs
     - name:
         Named: "<core::convert::Infallible as core::fmt::Debug>::{vtable}"
       type_name: Unknown
@@ -1949,9 +1949,9 @@ Child Variables:
               count: 32
           value: "[Vector; 32] = [\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000140,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000144,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000148,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000014C,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000150,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000154,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000158,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000015C,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000160,\n\t\t_reserved: u32 = 268461611\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000164,\n\t\t_reserved: u32 = 268461611\n\t},\n\t... and 22 more]"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
             line: 86
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -1959,9 +1959,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000140,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -1984,9 +1984,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000144,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2009,9 +2009,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000148,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2034,9 +2034,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000014C,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2059,9 +2059,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000150,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2084,9 +2084,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000154,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2109,9 +2109,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000158,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2134,9 +2134,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000015C,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2159,9 +2159,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000160,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2184,9 +2184,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000164,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2209,9 +2209,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000168,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2234,9 +2234,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000016C,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2259,9 +2259,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000170,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2284,9 +2284,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000174,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2309,9 +2309,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000178,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2334,9 +2334,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000017C,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2359,9 +2359,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000180,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2384,9 +2384,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000184,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2409,9 +2409,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000188,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2434,9 +2434,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000018C,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2459,9 +2459,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000190,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2484,9 +2484,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000194,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2509,9 +2509,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000198,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2534,9 +2534,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000019C,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2559,9 +2559,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A0,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2584,9 +2584,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A4,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2609,9 +2609,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A8,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2634,9 +2634,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001AC,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2659,9 +2659,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B0,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2684,9 +2684,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B4,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2709,9 +2709,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B8,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2734,9 +2734,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001BC,\n\t_reserved: u32 = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
                 line: 86
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
               children:
                 - name:
                     Named: _handler
@@ -2759,9 +2759,9 @@ Child Variables:
             Base: bool
           value: "true"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
             line: 1598
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rp2040-pac-0.5.0/src/lib.rs
     - name:
         Namespace: cortex_m_rt
       type_name: Namespace
@@ -2772,18 +2772,18 @@ Child Variables:
           type_name: Unknown
           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
           source_location:
+            path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
             line: 857
             column: ~
-            path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
         - name:
             Named: __RESET_VECTOR
           type_name:
             Pointer: "unsafe extern \"C\" fn() -> !"
           value: "*raw unsafe extern \"C\" fn() -> ! @ 0x10000104"
           source_location:
+            path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
             line: 1048
             column: ~
-            path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
           children:
             - name:
                 Named: "*__RESET_VECTOR"
@@ -2799,9 +2799,9 @@ Child Variables:
               count: 14
           value: "[Vector; 14] = [\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000108,\n\t\treserved: usize = 268461611\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000010C,\n\t\treserved: usize = 268482803\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000110,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000114,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000118,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000011C,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000120,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000124,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000128,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000012C,\n\t\treserved: usize = 268436319\n\t},\n\t... and 4 more]"
           source_location:
+            path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
             line: 1140
             column: ~
-            path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -2809,9 +2809,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000108,\n\treserved: usize = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
                 line: 1140
                 column: ~
-                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2834,9 +2834,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000010C,\n\treserved: usize = 268482803}"
               source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
                 line: 1140
                 column: ~
-                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2859,9 +2859,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000110,\n\treserved: usize = 0}"
               source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
                 line: 1140
                 column: ~
-                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2884,9 +2884,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000114,\n\treserved: usize = 0}"
               source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
                 line: 1140
                 column: ~
-                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2909,9 +2909,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000118,\n\treserved: usize = 0}"
               source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
                 line: 1140
                 column: ~
-                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2934,9 +2934,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000011C,\n\treserved: usize = 0}"
               source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
                 line: 1140
                 column: ~
-                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2959,9 +2959,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000120,\n\treserved: usize = 0}"
               source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
                 line: 1140
                 column: ~
-                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -2984,9 +2984,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000124,\n\treserved: usize = 0}"
               source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
                 line: 1140
                 column: ~
-                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -3009,9 +3009,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000128,\n\treserved: usize = 0}"
               source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
                 line: 1140
                 column: ~
-                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -3034,9 +3034,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000012C,\n\treserved: usize = 268436319}"
               source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
                 line: 1140
                 column: ~
-                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -3059,9 +3059,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000130,\n\treserved: usize = 0}"
               source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
                 line: 1140
                 column: ~
-                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -3084,9 +3084,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000134,\n\treserved: usize = 0}"
               source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
                 line: 1140
                 column: ~
-                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -3109,9 +3109,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000138,\n\treserved: usize = 268461611}"
               source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
                 line: 1140
                 column: ~
-                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -3134,9 +3134,9 @@ Child Variables:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000013C,\n\treserved: usize = 268436301}"
               source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
                 line: 1140
                 column: ~
-                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
               children:
                 - name:
                     Named: handler
@@ -3168,135 +3168,135 @@ Child Variables:
             Base: bool
           value: "false"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 15
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: I
           type_name:
             Base: isize
           value: "-1"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 16
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: C
           type_name:
             Base: char
           value: a
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 17
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: I8
           type_name:
             Base: i8
           value: "68"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 18
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: I16
           type_name:
             Base: i16
           value: "-16"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 19
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: I32
           type_name:
             Base: i32
           value: "-32"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 20
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: I64
           type_name:
             Base: i64
           value: "-64"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 21
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: U
           type_name:
             Base: usize
           value: "1"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 22
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: U8
           type_name:
             Base: u8
           value: "100"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 23
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: U16
           type_name:
             Base: u16
           value: "16"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 24
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: U32
           type_name:
             Base: u32
           value: "32"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 25
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: U64
           type_name:
             Base: u64
           value: "64"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 26
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: F32
           type_name:
             Base: f32
           value: "2.5"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 27
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: F64
           type_name:
             Base: f64
           value: "3.5"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 28
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: GLOBAL_STATIC
           type_name:
             Struct: "&str"
           value: "A 'global' static variable"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 30
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
@@ -3320,9 +3320,9 @@ Child Variables:
             Struct: ComplexEnum
           value: ComplexEnum @ 0x20000048
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 64
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Case1
@@ -3367,9 +3367,9 @@ Child Variables:
                 Struct: "&str"
               value: "A 'local' to main() static variable ...will be optimized out if not used in the code."
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 205
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
               children:
                 - name:
                     Named: data_ptr
@@ -3393,9 +3393,9 @@ Child Variables:
                 Base: "MaybeUninit<probe_rs_debugger_test::setup_data_types::RttControlBlock>"
               value: "MaybeUninit<probe_rs_debugger_test::setup_data_types::RttControlBlock> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<probe_rs_debugger_test::setup_data_types::RttControlBlock> = ManuallyDrop<probe_rs_debugger_test::setup_data_types::RttControlBlock> @ 0x2000007C}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/init.rs
                 line: 138
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/init.rs
               children:
                 - name:
                     Named: uninit
@@ -3710,9 +3710,9 @@ Child Variables:
                 Base: "MaybeUninit<[u8; 1024]>"
               value: "MaybeUninit<[u8; 1024]> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<[u8; 1024]> = ManuallyDrop<[u8; 1024]> @ 0x200000C4}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/init.rs
                 line: 34
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/init.rs
               children:
                 - name:
                     Named: uninit
@@ -3993,9 +3993,9 @@ Child Variables:
                 Base: "MaybeUninit<[u8; 1024]>"
               value: "MaybeUninit<[u8; 1024]> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<[u8; 1024]> = ManuallyDrop<[u8; 1024]> @ 0x200004C4}"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/init.rs
                 line: 34
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/init.rs
               children:
                 - name:
                     Named: uninit
@@ -4524,9 +4524,9 @@ Child Variables:
                 Struct: "Mutex<core::cell::RefCell<core::option::Option<rtt_target::TerminalChannel>>>"
               value: "Mutex<core::cell::RefCell<core::option::Option<rtt_target::TerminalChannel>>> @ 0x200008C4"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/print.rs
                 line: 7
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/print.rs
               children:
                 - name:
                     Named: inner
@@ -4642,15 +4642,15 @@ Child Variables:
               type_name: Unknown
               value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/peripheral/mod.rs
                 line: 159
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/peripheral/mod.rs
             - name:
                 Named: TAKEN
               type_name:
                 Base: bool
               value: "true"
               source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/peripheral/mod.rs
                 line: 162
                 column: ~
-                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/peripheral/mod.rs

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_svcall.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_svcall.snap
@@ -1,6 +1,6 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
-assertion_line: 1996
+assertion_line: 1987
 expression: stack_frames
 snapshot_kind: text
 ---
@@ -9,8 +9,7 @@ snapshot_kind: text
     line: 371
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -215,15 +214,13 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536886920
 - function_name: __cortex_m_rt_SVCall
   source_location:
     line: 116
     column:
       Column: 5
-    file: RP2040.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -428,15 +425,13 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536886920
 - function_name: __cortex_m_rt_SVCall_trampoline
   source_location:
     line: 114
     column:
       Column: 13
-    file: RP2040.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -633,7 +628,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536886928
 - function_name: SVC
   source_location: ~
@@ -839,8 +833,7 @@ snapshot_kind: text
     line: 80
     column:
       Column: 2
-    file: RP2040.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -1041,15 +1034,13 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536886968
 - function_name: __cortex_m_rt_main
   source_location:
     line: 55
     column:
       Column: 54
-    file: RP2040.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -1246,7 +1237,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tcore: Peripherals = Peripherals @ 0x20003EDF,\n\texternal_xtal_freq_hz: u32 = 12000000,\n\tpac: Peripherals = Peripherals @ 0x20003EE7,\n\twatchdog: Watchdog = Watchdog @ 0x20003EEC,\n\tclocks: ClocksManager = ClocksManager @ 0x20003EF0}"
-      source_location: ~
       children:
         - name:
             Named: core
@@ -1256,99 +1246,83 @@ snapshot_kind: text
           source_location:
             line: 24
             column: ~
-            file: RP2040.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: CBP
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003EDF
-              source_location: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
-              source_location: ~
         - name:
             Named: external_xtal_freq_hz
           type_name:
@@ -1357,8 +1331,7 @@ snapshot_kind: text
           source_location:
             line: 26
             column: ~
-            file: RP2040.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
         - name:
             Named: pac
           type_name:
@@ -1367,225 +1340,188 @@ snapshot_kind: text
           source_location:
             line: 27
             column: ~
-            file: RP2040.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: ADC
               type_name:
                 Struct: ADC
               value: ADC @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: BUSCTRL
               type_name:
                 Struct: BUSCTRL
               value: BUSCTRL @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: CLOCKS
               type_name:
                 Struct: CLOCKS
               value: CLOCKS @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: DMA
               type_name:
                 Struct: DMA
               value: DMA @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: I2C0
               type_name:
                 Struct: I2C0
               value: I2C0 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: I2C1
               type_name:
                 Struct: I2C1
               value: I2C1 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: IO_BANK0
               type_name:
                 Struct: IO_BANK0
               value: IO_BANK0 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: IO_QSPI
               type_name:
                 Struct: IO_QSPI
               value: IO_QSPI @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PADS_BANK0
               type_name:
                 Struct: PADS_BANK0
               value: PADS_BANK0 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PADS_QSPI
               type_name:
                 Struct: PADS_QSPI
               value: PADS_QSPI @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PIO0
               type_name:
                 Struct: PIO0
               value: PIO0 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PIO1
               type_name:
                 Struct: PIO1
               value: PIO1 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PLL_SYS
               type_name:
                 Struct: PLL_SYS
               value: PLL_SYS @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PLL_USB
               type_name:
                 Struct: PLL_USB
               value: PLL_USB @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PPB
               type_name:
                 Struct: PPB
               value: PPB @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PSM
               type_name:
                 Struct: PSM
               value: PSM @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: PWM
               type_name:
                 Struct: PWM
               value: PWM @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: RESETS
               type_name:
                 Struct: RESETS
               value: RESETS @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: ROSC
               type_name:
                 Struct: ROSC
               value: ROSC @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: RTC
               type_name:
                 Struct: RTC
               value: RTC @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: SIO
               type_name:
                 Struct: SIO
               value: SIO @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: SYSCFG
               type_name:
                 Struct: SYSCFG
               value: SYSCFG @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: SYSINFO
               type_name:
                 Struct: SYSINFO
               value: SYSINFO @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: TBMAN
               type_name:
                 Struct: TBMAN
               value: TBMAN @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: TIMER
               type_name:
                 Struct: TIMER
               value: TIMER @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: UART1
               type_name:
                 Struct: UART1
               value: UART1 @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: USBCTRL_DPRAM
               type_name:
                 Struct: USBCTRL_DPRAM
               value: USBCTRL_DPRAM @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: USBCTRL_REGS
               type_name:
                 Struct: USBCTRL_REGS
               value: USBCTRL_REGS @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: VREG_AND_CHIP_RESET
               type_name:
                 Struct: VREG_AND_CHIP_RESET
               value: VREG_AND_CHIP_RESET @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: WATCHDOG
               type_name:
                 Struct: WATCHDOG
               value: WATCHDOG @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: XIP_CTRL
               type_name:
                 Struct: XIP_CTRL
               value: XIP_CTRL @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: XIP_SSI
               type_name:
                 Struct: XIP_SSI
               value: XIP_SSI @ 0x20003EE7
-              source_location: ~
             - name:
                 Named: XOSC
               type_name:
                 Struct: XOSC
               value: XOSC @ 0x20003EE7
-              source_location: ~
         - name:
             Named: watchdog
           type_name:
@@ -1594,21 +1530,18 @@ snapshot_kind: text
           source_location:
             line: 28
             column: ~
-            file: RP2040.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: watchdog
               type_name:
                 Struct: WATCHDOG
               value: WATCHDOG @ 0x20003EF0
-              source_location: ~
             - name:
                 Named: load_value
               type_name:
                 Base: u32
               value: "0"
-              source_location: ~
         - name:
             Named: clocks
           type_name:
@@ -1617,352 +1550,299 @@ snapshot_kind: text
           source_location:
             line: 30
             column: ~
-            file: RP2040.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: clocks
               type_name:
                 Struct: CLOCKS
               value: CLOCKS @ 0x20003F18
-              source_location: ~
             - name:
                 Named: gpio_output0_clock
               type_name:
                 Struct: GpioOutput0Clock
               value: GpioOutput0Clock @ 0x20003EF0
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EF4
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF0"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location: ~
             - name:
                 Named: gpio_output1_clock
               type_name:
                 Struct: GpioOutput1Clock
               value: GpioOutput1Clock @ 0x20003EF4
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EF8
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF4"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location: ~
             - name:
                 Named: gpio_output2_clock
               type_name:
                 Struct: GpioOutput2Clock
               value: GpioOutput2Clock @ 0x20003EF8
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EFC
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF8"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location: ~
             - name:
                 Named: gpio_output3_clock
               type_name:
                 Struct: GpioOutput3Clock
               value: GpioOutput3Clock @ 0x20003EFC
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F00
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EFC"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location: ~
             - name:
                 Named: reference_clock
               type_name:
                 Struct: ReferenceClock
               value: ReferenceClock @ 0x20003F00
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F04
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F00"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "12000000"
-                      source_location: ~
             - name:
                 Named: system_clock
               type_name:
                 Struct: SystemClock
               value: SystemClock @ 0x20003F04
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F08
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F04"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "125000000"
-                      source_location: ~
             - name:
                 Named: peripheral_clock
               type_name:
                 Struct: PeripheralClock
               value: PeripheralClock @ 0x20003F08
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F0C
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F08"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "125000000"
-                      source_location: ~
             - name:
                 Named: usb_clock
               type_name:
                 Struct: UsbClock
               value: UsbClock @ 0x20003F0C
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F10
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F0C"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "48000000"
-                      source_location: ~
             - name:
                 Named: adc_clock
               type_name:
                 Struct: AdcClock
               value: AdcClock @ 0x20003F10
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F14
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F10"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "48000000"
-                      source_location: ~
             - name:
                 Named: rtc_clock
               type_name:
                 Struct: RtcClock
               value: RtcClock @ 0x20003F14
-              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F18
-                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F14"
-                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "46875"
-                      source_location: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
     line: 22
     column: LeftEdge
-    file: RP2040.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -2159,5 +2039,4 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_svcall.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_svcall.snap
@@ -215,11 +215,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536886920
 - function_name: __cortex_m_rt_SVCall
   source_location:
@@ -432,11 +428,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536886920
 - function_name: __cortex_m_rt_SVCall_trampoline
   source_location:
@@ -641,11 +633,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536886928
 - function_name: SVC
   source_location: ~
@@ -1053,11 +1041,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536886968
 - function_name: __cortex_m_rt_main
   source_location:
@@ -1262,11 +1246,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tcore: Peripherals = Peripherals @ 0x20003EDF,\n\texternal_xtal_freq_hz: u32 = 12000000,\n\tpac: Peripherals = Peripherals @ 0x20003EE7,\n\twatchdog: Watchdog = Watchdog @ 0x20003EEC,\n\tclocks: ClocksManager = ClocksManager @ 0x20003EF0}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: core
@@ -1284,151 +1264,91 @@ snapshot_kind: text
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003EDF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: external_xtal_freq_hz
           type_name:
@@ -1455,361 +1375,217 @@ snapshot_kind: text
               type_name:
                 Struct: ADC
               value: ADC @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: BUSCTRL
               type_name:
                 Struct: BUSCTRL
               value: BUSCTRL @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CLOCKS
               type_name:
                 Struct: CLOCKS
               value: CLOCKS @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DMA
               type_name:
                 Struct: DMA
               value: DMA @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: I2C0
               type_name:
                 Struct: I2C0
               value: I2C0 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: I2C1
               type_name:
                 Struct: I2C1
               value: I2C1 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: IO_BANK0
               type_name:
                 Struct: IO_BANK0
               value: IO_BANK0 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: IO_QSPI
               type_name:
                 Struct: IO_QSPI
               value: IO_QSPI @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PADS_BANK0
               type_name:
                 Struct: PADS_BANK0
               value: PADS_BANK0 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PADS_QSPI
               type_name:
                 Struct: PADS_QSPI
               value: PADS_QSPI @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PIO0
               type_name:
                 Struct: PIO0
               value: PIO0 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PIO1
               type_name:
                 Struct: PIO1
               value: PIO1 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PLL_SYS
               type_name:
                 Struct: PLL_SYS
               value: PLL_SYS @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PLL_USB
               type_name:
                 Struct: PLL_USB
               value: PLL_USB @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PPB
               type_name:
                 Struct: PPB
               value: PPB @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PSM
               type_name:
                 Struct: PSM
               value: PSM @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PWM
               type_name:
                 Struct: PWM
               value: PWM @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RESETS
               type_name:
                 Struct: RESETS
               value: RESETS @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ROSC
               type_name:
                 Struct: ROSC
               value: ROSC @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RTC
               type_name:
                 Struct: RTC
               value: RTC @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SIO
               type_name:
                 Struct: SIO
               value: SIO @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SYSCFG
               type_name:
                 Struct: SYSCFG
               value: SYSCFG @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SYSINFO
               type_name:
                 Struct: SYSINFO
               value: SYSINFO @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TBMAN
               type_name:
                 Struct: TBMAN
               value: TBMAN @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER
               type_name:
                 Struct: TIMER
               value: TIMER @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UART1
               type_name:
                 Struct: UART1
               value: UART1 @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: USBCTRL_DPRAM
               type_name:
                 Struct: USBCTRL_DPRAM
               value: USBCTRL_DPRAM @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: USBCTRL_REGS
               type_name:
                 Struct: USBCTRL_REGS
               value: USBCTRL_REGS @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: VREG_AND_CHIP_RESET
               type_name:
                 Struct: VREG_AND_CHIP_RESET
               value: VREG_AND_CHIP_RESET @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: WATCHDOG
               type_name:
                 Struct: WATCHDOG
               value: WATCHDOG @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: XIP_CTRL
               type_name:
                 Struct: XIP_CTRL
               value: XIP_CTRL @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: XIP_SSI
               type_name:
                 Struct: XIP_SSI
               value: XIP_SSI @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: XOSC
               type_name:
                 Struct: XOSC
               value: XOSC @ 0x20003EE7
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: watchdog
           type_name:
@@ -1826,21 +1602,13 @@ snapshot_kind: text
               type_name:
                 Struct: WATCHDOG
               value: WATCHDOG @ 0x20003EF0
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: load_value
               type_name:
                 Base: u32
               value: "0"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: clocks
           type_name:
@@ -1857,541 +1625,337 @@ snapshot_kind: text
               type_name:
                 Struct: CLOCKS
               value: CLOCKS @ 0x20003F18
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: gpio_output0_clock
               type_name:
                 Struct: GpioOutput0Clock
               value: GpioOutput0Clock @ 0x20003EF0
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EF4
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF0"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: gpio_output1_clock
               type_name:
                 Struct: GpioOutput1Clock
               value: GpioOutput1Clock @ 0x20003EF4
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EF8
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF4"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: gpio_output2_clock
               type_name:
                 Struct: GpioOutput2Clock
               value: GpioOutput2Clock @ 0x20003EF8
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EFC
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF8"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: gpio_output3_clock
               type_name:
                 Struct: GpioOutput3Clock
               value: GpioOutput3Clock @ 0x20003EFC
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F00
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EFC"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: reference_clock
               type_name:
                 Struct: ReferenceClock
               value: ReferenceClock @ 0x20003F00
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F04
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F00"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "12000000"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: system_clock
               type_name:
                 Struct: SystemClock
               value: SystemClock @ 0x20003F04
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F08
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F04"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "125000000"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: peripheral_clock
               type_name:
                 Struct: PeripheralClock
               value: PeripheralClock @ 0x20003F08
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F0C
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F08"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "125000000"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: usb_clock
               type_name:
                 Struct: UsbClock
               value: UsbClock @ 0x20003F0C
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F10
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F0C"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "48000000"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: adc_clock
               type_name:
                 Struct: AdcClock
               value: AdcClock @ 0x20003F10
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F14
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F10"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "48000000"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: rtc_clock
               type_name:
                 Struct: RtcClock
               value: RtcClock @ 0x20003F14
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F18
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F14"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "46875"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
@@ -2595,9 +2159,5 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_svcall.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_svcall.snap
@@ -1,6 +1,8 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1996
 expression: stack_frames
+snapshot_kind: text
 ---
 - function_name: software_breakpoint
   source_location:
@@ -213,6 +215,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536886920
 - function_name: __cortex_m_rt_SVCall
   source_location:
@@ -425,6 +432,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536886920
 - function_name: __cortex_m_rt_SVCall_trampoline
   source_location:
@@ -629,6 +641,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536886928
 - function_name: SVC
   source_location: ~
@@ -1036,6 +1053,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536886968
 - function_name: __cortex_m_rt_main
   source_location:
@@ -1240,586 +1262,1136 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tcore: Peripherals = Peripherals @ 0x20003EDF,\n\texternal_xtal_freq_hz: u32 = 12000000,\n\tpac: Peripherals = Peripherals @ 0x20003EE7,\n\twatchdog: Watchdog = Watchdog @ 0x20003EEC,\n\tclocks: ClocksManager = ClocksManager @ 0x20003EF0}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: core
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003EDF
+          source_location:
+            line: 24
+            column: ~
+            file: RP2040.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: CBP
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003EDF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: external_xtal_freq_hz
           type_name:
             Base: u32
           value: "12000000"
+          source_location:
+            line: 26
+            column: ~
+            file: RP2040.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
         - name:
             Named: pac
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003EE7
+          source_location:
+            line: 27
+            column: ~
+            file: RP2040.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: ADC
               type_name:
                 Struct: ADC
               value: ADC @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: BUSCTRL
               type_name:
                 Struct: BUSCTRL
               value: BUSCTRL @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CLOCKS
               type_name:
                 Struct: CLOCKS
               value: CLOCKS @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DMA
               type_name:
                 Struct: DMA
               value: DMA @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: I2C0
               type_name:
                 Struct: I2C0
               value: I2C0 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: I2C1
               type_name:
                 Struct: I2C1
               value: I2C1 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: IO_BANK0
               type_name:
                 Struct: IO_BANK0
               value: IO_BANK0 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: IO_QSPI
               type_name:
                 Struct: IO_QSPI
               value: IO_QSPI @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PADS_BANK0
               type_name:
                 Struct: PADS_BANK0
               value: PADS_BANK0 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PADS_QSPI
               type_name:
                 Struct: PADS_QSPI
               value: PADS_QSPI @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PIO0
               type_name:
                 Struct: PIO0
               value: PIO0 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PIO1
               type_name:
                 Struct: PIO1
               value: PIO1 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PLL_SYS
               type_name:
                 Struct: PLL_SYS
               value: PLL_SYS @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PLL_USB
               type_name:
                 Struct: PLL_USB
               value: PLL_USB @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PPB
               type_name:
                 Struct: PPB
               value: PPB @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PSM
               type_name:
                 Struct: PSM
               value: PSM @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PWM
               type_name:
                 Struct: PWM
               value: PWM @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RESETS
               type_name:
                 Struct: RESETS
               value: RESETS @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ROSC
               type_name:
                 Struct: ROSC
               value: ROSC @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RTC
               type_name:
                 Struct: RTC
               value: RTC @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SIO
               type_name:
                 Struct: SIO
               value: SIO @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SYSCFG
               type_name:
                 Struct: SYSCFG
               value: SYSCFG @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SYSINFO
               type_name:
                 Struct: SYSINFO
               value: SYSINFO @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TBMAN
               type_name:
                 Struct: TBMAN
               value: TBMAN @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER
               type_name:
                 Struct: TIMER
               value: TIMER @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UART1
               type_name:
                 Struct: UART1
               value: UART1 @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: USBCTRL_DPRAM
               type_name:
                 Struct: USBCTRL_DPRAM
               value: USBCTRL_DPRAM @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: USBCTRL_REGS
               type_name:
                 Struct: USBCTRL_REGS
               value: USBCTRL_REGS @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: VREG_AND_CHIP_RESET
               type_name:
                 Struct: VREG_AND_CHIP_RESET
               value: VREG_AND_CHIP_RESET @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: WATCHDOG
               type_name:
                 Struct: WATCHDOG
               value: WATCHDOG @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: XIP_CTRL
               type_name:
                 Struct: XIP_CTRL
               value: XIP_CTRL @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: XIP_SSI
               type_name:
                 Struct: XIP_SSI
               value: XIP_SSI @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: XOSC
               type_name:
                 Struct: XOSC
               value: XOSC @ 0x20003EE7
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: watchdog
           type_name:
             Struct: Watchdog
           value: Watchdog @ 0x20003EEC
+          source_location:
+            line: 28
+            column: ~
+            file: RP2040.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: watchdog
               type_name:
                 Struct: WATCHDOG
               value: WATCHDOG @ 0x20003EF0
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: load_value
               type_name:
                 Base: u32
               value: "0"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: clocks
           type_name:
             Struct: ClocksManager
           value: ClocksManager @ 0x20003EF0
+          source_location:
+            line: 30
+            column: ~
+            file: RP2040.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: clocks
               type_name:
                 Struct: CLOCKS
               value: CLOCKS @ 0x20003F18
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: gpio_output0_clock
               type_name:
                 Struct: GpioOutput0Clock
               value: GpioOutput0Clock @ 0x20003EF0
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EF4
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF0"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: gpio_output1_clock
               type_name:
                 Struct: GpioOutput1Clock
               value: GpioOutput1Clock @ 0x20003EF4
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EF8
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF4"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: gpio_output2_clock
               type_name:
                 Struct: GpioOutput2Clock
               value: GpioOutput2Clock @ 0x20003EF8
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003EFC
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EF8"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: gpio_output3_clock
               type_name:
                 Struct: GpioOutput3Clock
               value: GpioOutput3Clock @ 0x20003EFC
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F00
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003EFC"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "0"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: reference_clock
               type_name:
                 Struct: ReferenceClock
               value: ReferenceClock @ 0x20003F00
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F04
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F00"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "12000000"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: system_clock
               type_name:
                 Struct: SystemClock
               value: SystemClock @ 0x20003F04
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F08
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F04"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "125000000"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: peripheral_clock
               type_name:
                 Struct: PeripheralClock
               value: PeripheralClock @ 0x20003F08
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F0C
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F08"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "125000000"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: usb_clock
               type_name:
                 Struct: UsbClock
               value: UsbClock @ 0x20003F0C
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F10
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F0C"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "48000000"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: adc_clock
               type_name:
                 Struct: AdcClock
               value: AdcClock @ 0x20003F10
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F14
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F10"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "48000000"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: rtc_clock
               type_name:
                 Struct: RtcClock
               value: RtcClock @ 0x20003F14
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: shared_dev
                   type_name:
                     Struct: ShareableClocks
                   value: ShareableClocks @ 0x20003F18
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _internal
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                 - name:
                     Named: frequency
                   type_name:
                     Struct: "Rate<u32, 1, 1>"
                   value: "Rate<u32, 1, 1> @ 0x20003F14"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: raw
                       type_name:
                         Base: u32
                       value: "46875"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
@@ -2023,4 +2595,9 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_svcall.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_svcall.snap
@@ -6,10 +6,10 @@ snapshot_kind: text
 ---
 - function_name: software_breakpoint
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 371
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -217,10 +217,10 @@ snapshot_kind: text
   canonical_frame_address: 536886920
 - function_name: __cortex_m_rt_SVCall
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
     line: 116
     column:
       Column: 5
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -428,10 +428,10 @@ snapshot_kind: text
   canonical_frame_address: 536886920
 - function_name: __cortex_m_rt_SVCall_trampoline
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
     line: 114
     column:
       Column: 13
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -830,10 +830,10 @@ snapshot_kind: text
   canonical_frame_address: ~
 - function_name: trigger_supervisor_call
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
     line: 80
     column:
       Column: 2
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -1037,10 +1037,10 @@ snapshot_kind: text
   canonical_frame_address: 536886968
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
     line: 55
     column:
       Column: 54
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -1244,9 +1244,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003EDF
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 24
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: CBP
@@ -1329,18 +1329,18 @@ snapshot_kind: text
             Base: u32
           value: "12000000"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 26
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
         - name:
             Named: pac
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003EE7
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 27
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: ADC
@@ -1528,9 +1528,9 @@ snapshot_kind: text
             Struct: Watchdog
           value: Watchdog @ 0x20003EEC
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 28
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: watchdog
@@ -1548,9 +1548,9 @@ snapshot_kind: text
             Struct: ClocksManager
           value: ClocksManager @ 0x20003EF0
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 30
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: clocks
@@ -1840,9 +1840,9 @@ snapshot_kind: text
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
     line: 22
     column: LeftEdge
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_systick.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_systick.snap
@@ -6,10 +6,10 @@ snapshot_kind: text
 ---
 - function_name: software_breakpoint
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 371
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -217,10 +217,10 @@ snapshot_kind: text
   canonical_frame_address: 536886880
 - function_name: __cortex_m_rt_SysTick
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
     line: 101
     column:
       Column: 5
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -428,10 +428,10 @@ snapshot_kind: text
   canonical_frame_address: 536886880
 - function_name: __cortex_m_rt_SysTick_trampoline
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
     line: 97
     column:
       Column: 13
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -830,10 +830,10 @@ snapshot_kind: text
   canonical_frame_address: ~
 - function_name: __delay
   source_location:
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
     line: 62
     column:
       Column: 5
-    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
   registers:
     - core_register:
         id: 0
@@ -1041,25 +1041,25 @@ snapshot_kind: text
             Base: u32
           value: "858993459"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
             line: 56
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
         - name:
             Named: real_cyc
           type_name:
             Base: u32
           value: "48000000"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
             line: 61
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
   canonical_frame_address: 536886944
 - function_name: delay
   source_location:
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
     line: 29
     column:
       Column: 5
-    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
   registers:
     - core_register:
         id: 0
@@ -1267,16 +1267,16 @@ snapshot_kind: text
             Base: u32
           value: "3758153744"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
             line: 28
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
   canonical_frame_address: 536886944
 - function_name: enable_systick
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
     line: 93
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -1479,9 +1479,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003EAF
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 83
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: CBP
@@ -1564,9 +1564,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003EA6
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 83
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: CBP
@@ -1649,16 +1649,16 @@ snapshot_kind: text
             Struct: SYST
           value: SYST @ 0x20003EA7
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 84
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   canonical_frame_address: 536886968
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
     line: 55
     column:
       Column: 54
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -1862,9 +1862,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003EDF
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 24
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: CBP
@@ -1947,18 +1947,18 @@ snapshot_kind: text
             Base: u32
           value: "12000000"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 26
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
         - name:
             Named: pac
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003EE7
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 27
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: ADC
@@ -2146,9 +2146,9 @@ snapshot_kind: text
             Struct: Watchdog
           value: Watchdog @ 0x20003EEC
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 28
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: watchdog
@@ -2166,9 +2166,9 @@ snapshot_kind: text
             Struct: ClocksManager
           value: ClocksManager @ 0x20003EF0
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
             line: 30
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: clocks
@@ -2458,9 +2458,9 @@ snapshot_kind: text
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
     line: 22
     column: LeftEdge
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_systick.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040_systick.snap
@@ -1,14 +1,15 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1987
 expression: stack_frames
+snapshot_kind: text
 ---
 - function_name: software_breakpoint
   source_location:
     line: 371
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -219,8 +220,7 @@ expression: stack_frames
     line: 101
     column:
       Column: 5
-    file: RP2040.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -431,8 +431,7 @@ expression: stack_frames
     line: 97
     column:
       Column: 13
-    file: RP2040.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -834,8 +833,7 @@ expression: stack_frames
     line: 62
     column:
       Column: 5
-    file: inline.rs
-    directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
   registers:
     - core_register:
         id: 0
@@ -1042,19 +1040,26 @@ expression: stack_frames
           type_name:
             Base: u32
           value: "858993459"
+          source_location:
+            line: 56
+            column: ~
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
         - name:
             Named: real_cyc
           type_name:
             Base: u32
           value: "48000000"
+          source_location:
+            line: 61
+            column: ~
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
   canonical_frame_address: 536886944
 - function_name: delay
   source_location:
     line: 29
     column:
       Column: 5
-    file: asm.rs
-    directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
   registers:
     - core_register:
         id: 0
@@ -1261,14 +1266,17 @@ expression: stack_frames
           type_name:
             Base: u32
           value: "3758153744"
+          source_location:
+            line: 28
+            column: ~
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
   canonical_frame_address: 536886944
 - function_name: enable_systick
   source_location:
     line: 93
     column:
       Column: 9
-    file: RP2040.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -1470,6 +1478,10 @@ expression: stack_frames
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003EAF
+          source_location:
+            line: 83
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: CBP
@@ -1551,6 +1563,10 @@ expression: stack_frames
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003EA6
+          source_location:
+            line: 83
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: CBP
@@ -1632,14 +1648,17 @@ expression: stack_frames
           type_name:
             Struct: SYST
           value: SYST @ 0x20003EA7
+          source_location:
+            line: 84
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   canonical_frame_address: 536886968
 - function_name: __cortex_m_rt_main
   source_location:
     line: 55
     column:
       Column: 54
-    file: RP2040.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0
@@ -1842,6 +1861,10 @@ expression: stack_frames
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003EDF
+          source_location:
+            line: 24
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: CBP
@@ -1923,11 +1946,19 @@ expression: stack_frames
           type_name:
             Base: u32
           value: "12000000"
+          source_location:
+            line: 26
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
         - name:
             Named: pac
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003EE7
+          source_location:
+            line: 27
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: ADC
@@ -2114,6 +2145,10 @@ expression: stack_frames
           type_name:
             Struct: Watchdog
           value: Watchdog @ 0x20003EEC
+          source_location:
+            line: 28
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: watchdog
@@ -2130,6 +2165,10 @@ expression: stack_frames
           type_name:
             Struct: ClocksManager
           value: ClocksManager @ 0x20003EF0
+          source_location:
+            line: 30
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
           children:
             - name:
                 Named: clocks
@@ -2421,8 +2460,7 @@ expression: stack_frames
   source_location:
     line: 22
     column: LeftEdge
-    file: RP2040.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
   registers:
     - core_register:
         id: 0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a.snap
@@ -215,11 +215,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tconst_void_pointer: void* = void* @ 0x2000004C,\n\tconst_void_const_pointer: const void* = void* @ 0x00001760}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: const_void_pointer
@@ -236,11 +232,7 @@ snapshot_kind: text
                 Named: "*const_void_pointer"
               type_name: Unknown
               value: const void
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: const_void_const_pointer
           type_name:
@@ -258,11 +250,7 @@ snapshot_kind: text
                 Named: "*const_void_const_pointer"
               type_name: Unknown
               value: const void
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
   canonical_frame_address: 536875096
 - function_name: print_pointers
   source_location:
@@ -467,11 +455,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tvoid_pointer: void* = void* @ 20000050,\n\tvoid_const_pointer: const void* = void* @ 1764}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: void_pointer
@@ -699,11 +683,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstring: int* = int* @ 0x20000054}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: string
@@ -723,11 +703,7 @@ snapshot_kind: text
                   - Const
                   - Base: int
               value: "1819043144"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
   canonical_frame_address: 536875112
 - function_name: Reset_Handler
   source_location:
@@ -932,11 +908,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tpSrc: uint32_t* = uint32_t* @ 0x2000106C,\n\tpDest: uint32_t* = uint32_t* @ 0x20001068}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: pSrc
@@ -958,11 +930,7 @@ snapshot_kind: text
                       - Typedef: __uint32_t
                       - Base: long unsigned int
               value: "536875128"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: pDest
           type_name:
@@ -983,9 +951,5 @@ snapshot_kind: text
                       - Typedef: __uint32_t
                       - Base: long unsigned int
               value: "484133903"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
   canonical_frame_address: 536875128

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a.snap
@@ -1,6 +1,6 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
-assertion_line: 1987
+assertion_line: 1984
 expression: stack_frames
 snapshot_kind: text
 ---
@@ -223,7 +223,8 @@ snapshot_kind: text
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 71
-            column: ~
+            column:
+              Column: 24
           children:
             - name:
                 Named: "*const_void_pointer"
@@ -239,7 +240,8 @@ snapshot_kind: text
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 72
-            column: ~
+            column:
+              Column: 30
           children:
             - name:
                 Named: "*const_void_const_pointer"
@@ -457,7 +459,8 @@ snapshot_kind: text
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 84
-            column: ~
+            column:
+              Column: 18
         - name:
             Named: void_const_pointer
           type_name:
@@ -468,7 +471,8 @@ snapshot_kind: text
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 85
-            column: ~
+            column:
+              Column: 24
   canonical_frame_address: 536875104
 - function_name: main
   source_location:
@@ -681,7 +685,8 @@ snapshot_kind: text
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 98
-            column: ~
+            column:
+              Column: 19
           children:
             - name:
                 Named: "*string"
@@ -902,7 +907,8 @@ snapshot_kind: text
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup\\startup_samd51.c"
             line: 501
-            column: ~
+            column:
+              Column: 19
           children:
             - name:
                 Named: "*pSrc"
@@ -921,7 +927,8 @@ snapshot_kind: text
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup\\startup_samd51.c"
             line: 501
-            column: ~
+            column:
+              Column: 26
           children:
             - name:
                 Named: "*pDest"

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a.snap
@@ -1,6 +1,6 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
-assertion_line: 1996
+assertion_line: 1987
 expression: stack_frames
 snapshot_kind: text
 ---
@@ -9,8 +9,7 @@ snapshot_kind: text
     line: 80
     column:
       Column: 5
-    file: main.c
-    directory: "C:\\_Hobby\\probe-rs-test-c-firmware"
+    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
   registers:
     - core_register:
         id: 0
@@ -215,7 +214,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tconst_void_pointer: void* = void* @ 0x2000004C,\n\tconst_void_const_pointer: const void* = void* @ 0x00001760}"
-      source_location: ~
       children:
         - name:
             Named: const_void_pointer
@@ -225,14 +223,12 @@ snapshot_kind: text
           source_location:
             line: 71
             column: ~
-            file: main.c
-            directory: "C:\\_Hobby\\probe-rs-test-c-firmware"
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
           children:
             - name:
                 Named: "*const_void_pointer"
               type_name: Unknown
               value: const void
-              source_location: ~
         - name:
             Named: const_void_const_pointer
           type_name:
@@ -243,22 +239,19 @@ snapshot_kind: text
           source_location:
             line: 72
             column: ~
-            file: main.c
-            directory: "C:\\_Hobby\\probe-rs-test-c-firmware"
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
           children:
             - name:
                 Named: "*const_void_const_pointer"
               type_name: Unknown
               value: const void
-              source_location: ~
   canonical_frame_address: 536875096
 - function_name: print_pointers
   source_location:
     line: 94
     column:
       Column: 1
-    file: main.c
-    directory: "C:\\_Hobby\\probe-rs-test-c-firmware"
+    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
   registers:
     - core_register:
         id: 0
@@ -455,7 +448,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tvoid_pointer: void* = void* @ 20000050,\n\tvoid_const_pointer: const void* = void* @ 1764}"
-      source_location: ~
       children:
         - name:
             Named: void_pointer
@@ -465,8 +457,7 @@ snapshot_kind: text
           source_location:
             line: 84
             column: ~
-            file: main.c
-            directory: "C:\\_Hobby\\probe-rs-test-c-firmware"
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
         - name:
             Named: void_const_pointer
           type_name:
@@ -477,16 +468,14 @@ snapshot_kind: text
           source_location:
             line: 85
             column: ~
-            file: main.c
-            directory: "C:\\_Hobby\\probe-rs-test-c-firmware"
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
   canonical_frame_address: 536875104
 - function_name: main
   source_location:
     line: 111
     column:
       Column: 9
-    file: main.c
-    directory: "C:\\_Hobby\\probe-rs-test-c-firmware"
+    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
   registers:
     - core_register:
         id: 0
@@ -683,7 +672,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstring: int* = int* @ 0x20000054}"
-      source_location: ~
       children:
         - name:
             Named: string
@@ -693,8 +681,7 @@ snapshot_kind: text
           source_location:
             line: 98
             column: ~
-            file: main.c
-            directory: "C:\\_Hobby\\probe-rs-test-c-firmware"
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
           children:
             - name:
                 Named: "*string"
@@ -703,15 +690,13 @@ snapshot_kind: text
                   - Const
                   - Base: int
               value: "1819043144"
-              source_location: ~
   canonical_frame_address: 536875112
 - function_name: Reset_Handler
   source_location:
     line: 536
     column:
       Column: 15
-    file: startup_samd51.c
-    directory: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup"
+    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup\\startup_samd51.c"
   registers:
     - core_register:
         id: 0
@@ -908,7 +893,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tpSrc: uint32_t* = uint32_t* @ 0x2000106C,\n\tpDest: uint32_t* = uint32_t* @ 0x20001068}"
-      source_location: ~
       children:
         - name:
             Named: pSrc
@@ -918,8 +902,7 @@ snapshot_kind: text
           source_location:
             line: 501
             column: ~
-            file: startup_samd51.c
-            directory: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup"
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup\\startup_samd51.c"
           children:
             - name:
                 Named: "*pSrc"
@@ -930,7 +913,6 @@ snapshot_kind: text
                       - Typedef: __uint32_t
                       - Base: long unsigned int
               value: "536875128"
-              source_location: ~
         - name:
             Named: pDest
           type_name:
@@ -939,8 +921,7 @@ snapshot_kind: text
           source_location:
             line: 501
             column: ~
-            file: startup_samd51.c
-            directory: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup"
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup\\startup_samd51.c"
           children:
             - name:
                 Named: "*pDest"
@@ -951,5 +932,4 @@ snapshot_kind: text
                       - Typedef: __uint32_t
                       - Base: long unsigned int
               value: "484133903"
-              source_location: ~
   canonical_frame_address: 536875128

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a.snap
@@ -6,10 +6,10 @@ snapshot_kind: text
 ---
 - function_name: print_const_pointers
   source_location:
+    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
     line: 80
     column:
       Column: 5
-    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
   registers:
     - core_register:
         id: 0
@@ -221,9 +221,9 @@ snapshot_kind: text
             Pointer: ~
           value: void* @ 0x2000004C
           source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 71
             column: ~
-            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
           children:
             - name:
                 Named: "*const_void_pointer"
@@ -237,9 +237,9 @@ snapshot_kind: text
               - Pointer: ~
           value: void* @ 0x00001760
           source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 72
             column: ~
-            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
           children:
             - name:
                 Named: "*const_void_const_pointer"
@@ -248,10 +248,10 @@ snapshot_kind: text
   canonical_frame_address: 536875096
 - function_name: print_pointers
   source_location:
+    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
     line: 94
     column:
       Column: 1
-    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
   registers:
     - core_register:
         id: 0
@@ -455,9 +455,9 @@ snapshot_kind: text
             Pointer: ~
           value: void* @ 20000050
           source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 84
             column: ~
-            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
         - name:
             Named: void_const_pointer
           type_name:
@@ -466,16 +466,16 @@ snapshot_kind: text
               - Pointer: ~
           value: void* @ 1764
           source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 85
             column: ~
-            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
   canonical_frame_address: 536875104
 - function_name: main
   source_location:
+    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
     line: 111
     column:
       Column: 9
-    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
   registers:
     - core_register:
         id: 0
@@ -679,9 +679,9 @@ snapshot_kind: text
             Pointer: int
           value: int* @ 0x20000054
           source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 98
             column: ~
-            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
           children:
             - name:
                 Named: "*string"
@@ -693,10 +693,10 @@ snapshot_kind: text
   canonical_frame_address: 536875112
 - function_name: Reset_Handler
   source_location:
+    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup\\startup_samd51.c"
     line: 536
     column:
       Column: 15
-    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup\\startup_samd51.c"
   registers:
     - core_register:
         id: 0
@@ -900,9 +900,9 @@ snapshot_kind: text
             Pointer: uint32_t
           value: uint32_t* @ 0x2000106C
           source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup\\startup_samd51.c"
             line: 501
             column: ~
-            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup\\startup_samd51.c"
           children:
             - name:
                 Named: "*pSrc"
@@ -919,9 +919,9 @@ snapshot_kind: text
             Pointer: uint32_t
           value: uint32_t* @ 0x20001068
           source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup\\startup_samd51.c"
             line: 501
             column: ~
-            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup\\startup_samd51.c"
           children:
             - name:
                 Named: "*pDest"

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a.snap
@@ -1,6 +1,8 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1996
 expression: stack_frames
+snapshot_kind: text
 ---
 - function_name: print_const_pointers
   source_location:
@@ -213,17 +215,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tconst_void_pointer: void* = void* @ 0x2000004C,\n\tconst_void_const_pointer: const void* = void* @ 0x00001760}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: const_void_pointer
           type_name:
             Pointer: ~
           value: void* @ 0x2000004C
+          source_location:
+            line: 71
+            column: ~
+            file: main.c
+            directory: "C:\\_Hobby\\probe-rs-test-c-firmware"
           children:
             - name:
                 Named: "*const_void_pointer"
               type_name: Unknown
               value: const void
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: const_void_const_pointer
           type_name:
@@ -231,11 +248,21 @@ expression: stack_frames
               - Const
               - Pointer: ~
           value: void* @ 0x00001760
+          source_location:
+            line: 72
+            column: ~
+            file: main.c
+            directory: "C:\\_Hobby\\probe-rs-test-c-firmware"
           children:
             - name:
                 Named: "*const_void_const_pointer"
               type_name: Unknown
               value: const void
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
   canonical_frame_address: 536875096
 - function_name: print_pointers
   source_location:
@@ -440,12 +467,22 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tvoid_pointer: void* = void* @ 20000050,\n\tvoid_const_pointer: const void* = void* @ 1764}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: void_pointer
           type_name:
             Pointer: ~
           value: void* @ 20000050
+          source_location:
+            line: 84
+            column: ~
+            file: main.c
+            directory: "C:\\_Hobby\\probe-rs-test-c-firmware"
         - name:
             Named: void_const_pointer
           type_name:
@@ -453,6 +490,11 @@ expression: stack_frames
               - Const
               - Pointer: ~
           value: void* @ 1764
+          source_location:
+            line: 85
+            column: ~
+            file: main.c
+            directory: "C:\\_Hobby\\probe-rs-test-c-firmware"
   canonical_frame_address: 536875104
 - function_name: main
   source_location:
@@ -657,12 +699,22 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstring: int* = int* @ 0x20000054}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: string
           type_name:
             Pointer: int
           value: int* @ 0x20000054
+          source_location:
+            line: 98
+            column: ~
+            file: main.c
+            directory: "C:\\_Hobby\\probe-rs-test-c-firmware"
           children:
             - name:
                 Named: "*string"
@@ -671,6 +723,11 @@ expression: stack_frames
                   - Const
                   - Base: int
               value: "1819043144"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
   canonical_frame_address: 536875112
 - function_name: Reset_Handler
   source_location:
@@ -875,12 +932,22 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tpSrc: uint32_t* = uint32_t* @ 0x2000106C,\n\tpDest: uint32_t* = uint32_t* @ 0x20001068}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: pSrc
           type_name:
             Pointer: uint32_t
           value: uint32_t* @ 0x2000106C
+          source_location:
+            line: 501
+            column: ~
+            file: startup_samd51.c
+            directory: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup"
           children:
             - name:
                 Named: "*pSrc"
@@ -891,11 +958,21 @@ expression: stack_frames
                       - Typedef: __uint32_t
                       - Base: long unsigned int
               value: "536875128"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: pDest
           type_name:
             Pointer: uint32_t
           value: uint32_t* @ 0x20001068
+          source_location:
+            line: 501
+            column: ~
+            file: startup_samd51.c
+            directory: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup"
           children:
             - name:
                 Named: "*pDest"
@@ -906,4 +983,9 @@ expression: stack_frames
                       - Typedef: __uint32_t
                       - Base: long unsigned int
               value: "484133903"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
   canonical_frame_address: 536875128

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a_static_variables.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a_static_variables.snap
@@ -1,7 +1,8 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
-assertion_line: 2036
+assertion_line: 2023
 expression: static_variables
+snapshot_kind: text
 ---
 Child Variables:
   name: StaticScopeRoot
@@ -12,10 +13,18 @@ Child Variables:
         Named: exception_table
       type_name: Unknown
       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+      source_location:
+        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup\\startup_samd51.c"
+        line: 239
+        column: ~
     - name:
         Named: _aTerminalId
       type_name: Unknown
       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+      source_location:
+        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+        line: 258
+        column: ~
     - name:
         Named: _SEGGER_RTT
       type_name:
@@ -23,6 +32,10 @@ Child Variables:
           - Typedef: SEGGER_RTT_CB
           - Struct: "<unnamed struct>"
       value: SEGGER_RTT_CB @ 0x20002000
+      source_location:
+        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+        line: 348
+        column: ~
       children:
         - name:
             Named: acID
@@ -32,97 +45,173 @@ Child Variables:
                 Base: char
               count: 16
           value: "char[16] = [\n\tS,\n\tE,\n\tG,\n\tG,\n\tE,\n\tR,\n\t ,\n\tR,\n\tT,\n\tT,\n\t... and 6 more]"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+            line: 332
+            column: ~
           children:
             - name:
                 Named: __0
               type_name:
                 Base: char
               value: S
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __1
               type_name:
                 Base: char
               value: E
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __2
               type_name:
                 Base: char
               value: G
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __3
               type_name:
                 Base: char
               value: G
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __4
               type_name:
                 Base: char
               value: E
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __5
               type_name:
                 Base: char
               value: R
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __6
               type_name:
                 Base: char
               value: " "
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __7
               type_name:
                 Base: char
               value: R
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __8
               type_name:
                 Base: char
               value: T
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __9
               type_name:
                 Base: char
               value: T
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __10
               type_name:
                 Base: char
               value: "\u0000"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __11
               type_name:
                 Base: char
               value: "\u0000"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __12
               type_name:
                 Base: char
               value: "\u0000"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __13
               type_name:
                 Base: char
               value: "\u0000"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __14
               type_name:
                 Base: char
               value: "\u0000"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
             - name:
                 Named: __15
               type_name:
                 Base: char
               value: "\u0000"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 332
+                column: ~
         - name:
             Named: MaxNumUpBuffers
           type_name:
             Base: int
           value: "1"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+            line: 333
+            column: ~
         - name:
             Named: MaxNumDownBuffers
           type_name:
             Base: int
           value: "1"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+            line: 334
+            column: ~
         - name:
             Named: aUp
           type_name:
@@ -133,6 +222,10 @@ Child Variables:
                   - Struct: "<unnamed struct>"
               count: 1
           value: "SEGGER_RTT_BUFFER_UP[1] = [\n\tSEGGER_RTT_BUFFER_UP @ 0x20002018]"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+            line: 335
+            column: ~
           children:
             - name:
                 Named: __0
@@ -141,12 +234,20 @@ Child Variables:
                   - Typedef: SEGGER_RTT_BUFFER_UP
                   - Struct: "<unnamed struct>"
               value: SEGGER_RTT_BUFFER_UP @ 0x20002018
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 335
+                column: ~
               children:
                 - name:
                     Named: sName
                   type_name:
                     Pointer: char
                   value: char* @ 0x20002018
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                    line: 305
+                    column: ~
                   children:
                     - name:
                         Named: "*sName"
@@ -160,6 +261,10 @@ Child Variables:
                   type_name:
                     Pointer: char
                   value: char* @ 0x2000201C
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                    line: 306
+                    column: ~
                   children:
                     - name:
                         Named: "*pBuffer"
@@ -171,11 +276,19 @@ Child Variables:
                   type_name:
                     Base: unsigned int
                   value: "1024"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                    line: 307
+                    column: ~
                 - name:
                     Named: WrOff
                   type_name:
                     Base: unsigned int
                   value: "113"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                    line: 308
+                    column: ~
                 - name:
                     Named: RdOff
                   type_name:
@@ -183,11 +296,19 @@ Child Variables:
                       - Volatile
                       - Base: unsigned int
                   value: "113"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                    line: 309
+                    column: ~
                 - name:
                     Named: Flags
                   type_name:
                     Base: unsigned int
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                    line: 310
+                    column: ~
         - name:
             Named: aDown
           type_name:
@@ -198,6 +319,10 @@ Child Variables:
                   - Struct: "<unnamed struct>"
               count: 1
           value: "SEGGER_RTT_BUFFER_DOWN[1] = [\n\tSEGGER_RTT_BUFFER_DOWN @ 0x20002030]"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+            line: 336
+            column: ~
           children:
             - name:
                 Named: __0
@@ -206,12 +331,20 @@ Child Variables:
                   - Typedef: SEGGER_RTT_BUFFER_DOWN
                   - Struct: "<unnamed struct>"
               value: SEGGER_RTT_BUFFER_DOWN @ 0x20002030
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                line: 336
+                column: ~
               children:
                 - name:
                     Named: sName
                   type_name:
                     Pointer: char
                   value: char* @ 0x20002030
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                    line: 318
+                    column: ~
                   children:
                     - name:
                         Named: "*sName"
@@ -225,6 +358,10 @@ Child Variables:
                   type_name:
                     Pointer: char
                   value: char* @ 0x20002034
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                    line: 319
+                    column: ~
                   children:
                     - name:
                         Named: "*pBuffer"
@@ -236,6 +373,10 @@ Child Variables:
                   type_name:
                     Base: unsigned int
                   value: "16"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                    line: 320
+                    column: ~
                 - name:
                     Named: WrOff
                   type_name:
@@ -243,16 +384,28 @@ Child Variables:
                       - Volatile
                       - Base: unsigned int
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                    line: 321
+                    column: ~
                 - name:
                     Named: RdOff
                   type_name:
                     Base: unsigned int
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                    line: 322
+                    column: ~
                 - name:
                     Named: Flags
                   type_name:
                     Base: unsigned int
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
+                    line: 323
+                    column: ~
     - name:
         Named: _acUpBuffer
       type_name:
@@ -261,257 +414,461 @@ Child Variables:
             Base: char
           count: 1024
       value: "char[1024] = [\n\tH,\n\te,\n\tl,\n\tl,\n\to,\n\t ,\n\tH,\n\te,\n\tl,\n\tl,\n\t... and 1014 more]"
+      source_location:
+        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+        line: 280
+        column: ~
       children:
         - name:
             Named: __0
           type_name:
             Base: char
           value: H
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __1
           type_name:
             Base: char
           value: e
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __2
           type_name:
             Base: char
           value: l
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __3
           type_name:
             Base: char
           value: l
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __4
           type_name:
             Base: char
           value: o
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __5
           type_name:
             Base: char
           value: " "
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __6
           type_name:
             Base: char
           value: H
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __7
           type_name:
             Base: char
           value: e
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __8
           type_name:
             Base: char
           value: l
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __9
           type_name:
             Base: char
           value: l
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __10
           type_name:
             Base: char
           value: o
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __11
           type_name:
             Base: char
           value: ","
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __12
           type_name:
             Base: char
           value: " "
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __13
           type_name:
             Base: char
           value: W
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __14
           type_name:
             Base: char
           value: o
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __15
           type_name:
             Base: char
           value: r
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __16
           type_name:
             Base: char
           value: l
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __17
           type_name:
             Base: char
           value: d
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __18
           type_name:
             Base: char
           value: "!"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __19
           type_name:
             Base: char
           value: "\r"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __20
           type_name:
             Base: char
           value: "\n"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __21
           type_name:
             Base: char
           value: v
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __22
           type_name:
             Base: char
           value: o
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __23
           type_name:
             Base: char
           value: i
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __24
           type_name:
             Base: char
           value: d
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __25
           type_name:
             Base: char
           value: "*"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __26
           type_name:
             Base: char
           value: " "
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __27
           type_name:
             Base: char
           value: "5"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __28
           type_name:
             Base: char
           value: "3"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __29
           type_name:
             Base: char
           value: "6"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __30
           type_name:
             Base: char
           value: "8"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __31
           type_name:
             Base: char
           value: "7"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __32
           type_name:
             Base: char
           value: "0"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __33
           type_name:
             Base: char
           value: "9"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __34
           type_name:
             Base: char
           value: "1"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __35
           type_name:
             Base: char
           value: "2"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __36
           type_name:
             Base: char
           value: "\r"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __37
           type_name:
             Base: char
           value: "\n"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __38
           type_name:
             Base: char
           value: v
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __39
           type_name:
             Base: char
           value: o
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __40
           type_name:
             Base: char
           value: i
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __41
           type_name:
             Base: char
           value: d
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __42
           type_name:
             Base: char
           value: "*"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __43
           type_name:
             Base: char
           value: " "
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __44
           type_name:
             Base: char
           value: c
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __45
           type_name:
             Base: char
           value: o
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __46
           type_name:
             Base: char
           value: n
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __47
           type_name:
             Base: char
           value: s
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __48
           type_name:
             Base: char
           value: t
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name:
             Named: __49
           type_name:
             Base: char
           value: " "
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 280
+            column: ~
         - name: Artifical
           type_name: Unknown
           value: "... and 974 more"
@@ -523,91 +880,163 @@ Child Variables:
             Base: char
           count: 16
       value: "char[16] = [\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t... and 6 more]"
+      source_location:
+        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+        line: 281
+        column: ~
       children:
         - name:
             Named: __0
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __1
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __2
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __3
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __4
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __5
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __6
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __7
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __8
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __9
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __10
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __11
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __12
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __13
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __14
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
         - name:
             Named: __15
           type_name:
             Base: char
           value: "\u0000"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+            line: 281
+            column: ~
     - name:
         Named: _ActiveTerminal
       type_name: Unknown
       value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+      source_location:
+        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
+        line: 284
+        column: ~
     - name:
         Named: foo
       type_name:
@@ -615,6 +1044,10 @@ Child Variables:
           - Typedef: Foo_t
           - Struct: "<unnamed struct>"
       value: Foo_t @ 0x20000000
+      source_location:
+        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+        line: 38
+        column: ~
       children:
         - name: Unknown
           type_name:
@@ -635,6 +1068,10 @@ Child Variables:
                           - Typedef: __uint8_t
                           - Base: unsigned char
                   value: "128"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                    line: 19
+                    column: ~
                 - name:
                     Named: b
                   type_name:
@@ -644,6 +1081,10 @@ Child Variables:
                           - Typedef: __uint8_t
                           - Base: unsigned char
                   value: "79"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                    line: 20
+                    column: ~
                 - name:
                     Named: c
                   type_name:
@@ -653,6 +1094,10 @@ Child Variables:
                           - Typedef: __uint8_t
                           - Base: unsigned char
                   value: "18"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                    line: 21
+                    column: ~
                 - name:
                     Named: d
                   type_name:
@@ -662,6 +1107,10 @@ Child Variables:
                           - Typedef: __uint8_t
                           - Base: unsigned char
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                    line: 22
+                    column: ~
             - name:
                 Named: x
               type_name:
@@ -671,11 +1120,19 @@ Child Variables:
                       - Typedef: __uint32_t
                       - Base: long unsigned int
               value: "1200000"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 24
+                column: ~
         - name:
             Named: unsigned_bitfields
           type_name:
             Struct: "<unnamed struct>"
           value: "<unnamed struct> @ 0x20000004"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+            line: 30
+            column: ~
           children:
             - name:
                 Named: f
@@ -690,6 +1147,10 @@ Child Variables:
                           - Typedef: __uint8_t
                           - Base: unsigned char
               value: "31"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 28
+                column: ~
             - name:
                 Named: g
               type_name:
@@ -703,11 +1164,19 @@ Child Variables:
                           - Typedef: __uint8_t
                           - Base: unsigned char
               value: "7"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 29
+                column: ~
         - name:
             Named: signed_bitfields
           type_name:
             Struct: "<unnamed struct>"
           value: "<unnamed struct> @ 0x20000005"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+            line: 35
+            column: ~
           children:
             - name:
                 Named: f
@@ -722,6 +1191,10 @@ Child Variables:
                           - Typedef: __int8_t
                           - Base: signed char
               value: "15"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 33
+                column: ~
             - name:
                 Named: g
               type_name:
@@ -735,6 +1208,10 @@ Child Variables:
                           - Typedef: __int8_t
                           - Base: signed char
               value: "-1"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 34
+                column: ~
     - name:
         Named: foo_array
       type_name:
@@ -749,6 +1226,10 @@ Child Variables:
                       - Struct: "<unnamed struct>"
               count: 2
       value: "const Foo_t[2] = [\n\tFoo_t @ 0x00001684,\n\tFoo_t @ 0x0000168C]"
+      source_location:
+        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+        line: 53
+        column: ~
       children:
         - name:
             Named: __0
@@ -759,6 +1240,10 @@ Child Variables:
                   - Typedef: Foo_t
                   - Struct: "<unnamed struct>"
           value: Foo_t @ 0x00001684
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+            line: 53
+            column: ~
           children:
             - name: Unknown
               type_name:
@@ -779,6 +1264,10 @@ Child Variables:
                               - Typedef: __uint8_t
                               - Base: unsigned char
                       value: "0"
+                      source_location:
+                        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                        line: 19
+                        column: ~
                     - name:
                         Named: b
                       type_name:
@@ -788,6 +1277,10 @@ Child Variables:
                               - Typedef: __uint8_t
                               - Base: unsigned char
                       value: "0"
+                      source_location:
+                        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                        line: 20
+                        column: ~
                     - name:
                         Named: c
                       type_name:
@@ -797,6 +1290,10 @@ Child Variables:
                               - Typedef: __uint8_t
                               - Base: unsigned char
                       value: "0"
+                      source_location:
+                        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                        line: 21
+                        column: ~
                     - name:
                         Named: d
                       type_name:
@@ -806,6 +1303,10 @@ Child Variables:
                               - Typedef: __uint8_t
                               - Base: unsigned char
                       value: "0"
+                      source_location:
+                        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                        line: 22
+                        column: ~
                 - name:
                     Named: x
                   type_name:
@@ -815,11 +1316,19 @@ Child Variables:
                           - Typedef: __uint32_t
                           - Base: long unsigned int
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                    line: 24
+                    column: ~
             - name:
                 Named: unsigned_bitfields
               type_name:
                 Struct: "<unnamed struct>"
               value: "<unnamed struct> @ 0x00001688"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 30
+                column: ~
               children:
                 - name:
                     Named: f
@@ -834,6 +1343,10 @@ Child Variables:
                               - Typedef: __uint8_t
                               - Base: unsigned char
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                    line: 28
+                    column: ~
                 - name:
                     Named: g
                   type_name:
@@ -847,11 +1360,19 @@ Child Variables:
                               - Typedef: __uint8_t
                               - Base: unsigned char
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                    line: 29
+                    column: ~
             - name:
                 Named: signed_bitfields
               type_name:
                 Struct: "<unnamed struct>"
               value: "<unnamed struct> @ 0x00001689"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 35
+                column: ~
               children:
                 - name:
                     Named: f
@@ -866,6 +1387,10 @@ Child Variables:
                               - Typedef: __int8_t
                               - Base: signed char
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                    line: 33
+                    column: ~
                 - name:
                     Named: g
                   type_name:
@@ -879,6 +1404,10 @@ Child Variables:
                               - Typedef: __int8_t
                               - Base: signed char
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                    line: 34
+                    column: ~
         - name:
             Named: __1
           type_name:
@@ -888,6 +1417,10 @@ Child Variables:
                   - Typedef: Foo_t
                   - Struct: "<unnamed struct>"
           value: Foo_t @ 0x0000168C
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+            line: 53
+            column: ~
           children:
             - name: Unknown
               type_name:
@@ -908,6 +1441,10 @@ Child Variables:
                               - Typedef: __uint8_t
                               - Base: unsigned char
                       value: "0"
+                      source_location:
+                        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                        line: 19
+                        column: ~
                     - name:
                         Named: b
                       type_name:
@@ -917,6 +1454,10 @@ Child Variables:
                               - Typedef: __uint8_t
                               - Base: unsigned char
                       value: "0"
+                      source_location:
+                        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                        line: 20
+                        column: ~
                     - name:
                         Named: c
                       type_name:
@@ -926,6 +1467,10 @@ Child Variables:
                               - Typedef: __uint8_t
                               - Base: unsigned char
                       value: "0"
+                      source_location:
+                        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                        line: 21
+                        column: ~
                     - name:
                         Named: d
                       type_name:
@@ -935,6 +1480,10 @@ Child Variables:
                               - Typedef: __uint8_t
                               - Base: unsigned char
                       value: "0"
+                      source_location:
+                        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                        line: 22
+                        column: ~
                 - name:
                     Named: x
                   type_name:
@@ -944,11 +1493,19 @@ Child Variables:
                           - Typedef: __uint32_t
                           - Base: long unsigned int
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                    line: 24
+                    column: ~
             - name:
                 Named: unsigned_bitfields
               type_name:
                 Struct: "<unnamed struct>"
               value: "<unnamed struct> @ 0x00001690"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 30
+                column: ~
               children:
                 - name:
                     Named: f
@@ -963,6 +1520,10 @@ Child Variables:
                               - Typedef: __uint8_t
                               - Base: unsigned char
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                    line: 28
+                    column: ~
                 - name:
                     Named: g
                   type_name:
@@ -976,11 +1537,19 @@ Child Variables:
                               - Typedef: __uint8_t
                               - Base: unsigned char
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                    line: 29
+                    column: ~
             - name:
                 Named: signed_bitfields
               type_name:
                 Struct: "<unnamed struct>"
               value: "<unnamed struct> @ 0x00001691"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 35
+                column: ~
               children:
                 - name:
                     Named: f
@@ -995,6 +1564,10 @@ Child Variables:
                               - Typedef: __int8_t
                               - Base: signed char
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                    line: 33
+                    column: ~
                 - name:
                     Named: g
                   type_name:
@@ -1008,6 +1581,10 @@ Child Variables:
                               - Typedef: __int8_t
                               - Base: signed char
                   value: "0"
+                  source_location:
+                    path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                    line: 34
+                    column: ~
     - name:
         Named: nested_array
       type_name:
@@ -1023,6 +1600,10 @@ Child Variables:
               count: 9
           count: 6
       value: "uint8_t[9][6] = [\n\tuint8_t[9] = [\n\t\t0,\n\t\t1,\n\t\t2,\n\t\t3,\n\t\t4,\n\t\t5,\n\t\t6,\n\t\t7,\n\t\t8\n\t],\n\tuint8_t[9] = [\n\t\t10,\n\t\t11,\n\t\t12,\n\t\t13,\n\t\t14,\n\t\t15,\n\t\t16,\n\t\t17,\n\t\t18\n\t],\n\tuint8_t[9] = [\n\t\t20,\n\t\t21,\n\t\t22,\n\t\t23,\n\t\t24,\n\t\t25,\n\t\t26,\n\t\t27,\n\t\t28\n\t],\n\tuint8_t[9] = [\n\t\t30,\n\t\t31,\n\t\t32,\n\t\t33,\n\t\t34,\n\t\t35,\n\t\t36,\n\t\t37,\n\t\t38\n\t],\n\tuint8_t[9] = [\n\t\t40,\n\t\t41,\n\t\t42,\n\t\t43,\n\t\t44,\n\t\t45,\n\t\t46,\n\t\t47,\n\t\t48\n\t],\n\tuint8_t[9] = [\n\t\t50,\n\t\t51,\n\t\t52,\n\t\t53,\n\t\t54,\n\t\t55,\n\t\t56,\n\t\t57,\n\t\t58\n\t]]"
+      source_location:
+        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+        line: 54
+        column: ~
       children:
         - name:
             Named: __0
@@ -1036,6 +1617,10 @@ Child Variables:
                       - Base: unsigned char
               count: 9
           value: "uint8_t[9] = [\n\t0,\n\t1,\n\t2,\n\t3,\n\t4,\n\t5,\n\t6,\n\t7,\n\t8]"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+            line: 54
+            column: ~
           children:
             - name:
                 Named: __0
@@ -1046,6 +1631,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "0"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __1
               type_name:
@@ -1055,6 +1644,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "1"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __2
               type_name:
@@ -1064,6 +1657,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "2"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __3
               type_name:
@@ -1073,6 +1670,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "3"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __4
               type_name:
@@ -1082,6 +1683,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "4"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __5
               type_name:
@@ -1091,6 +1696,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "5"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __6
               type_name:
@@ -1100,6 +1709,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "6"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __7
               type_name:
@@ -1109,6 +1722,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "7"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __8
               type_name:
@@ -1118,6 +1735,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "8"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
         - name:
             Named: __1
           type_name:
@@ -1130,6 +1751,10 @@ Child Variables:
                       - Base: unsigned char
               count: 9
           value: "uint8_t[9] = [\n\t10,\n\t11,\n\t12,\n\t13,\n\t14,\n\t15,\n\t16,\n\t17,\n\t18]"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+            line: 54
+            column: ~
           children:
             - name:
                 Named: __0
@@ -1140,6 +1765,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "10"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __1
               type_name:
@@ -1149,6 +1778,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "11"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __2
               type_name:
@@ -1158,6 +1791,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "12"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __3
               type_name:
@@ -1167,6 +1804,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "13"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __4
               type_name:
@@ -1176,6 +1817,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "14"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __5
               type_name:
@@ -1185,6 +1830,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "15"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __6
               type_name:
@@ -1194,6 +1843,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "16"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __7
               type_name:
@@ -1203,6 +1856,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "17"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __8
               type_name:
@@ -1212,6 +1869,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "18"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
         - name:
             Named: __2
           type_name:
@@ -1224,6 +1885,10 @@ Child Variables:
                       - Base: unsigned char
               count: 9
           value: "uint8_t[9] = [\n\t20,\n\t21,\n\t22,\n\t23,\n\t24,\n\t25,\n\t26,\n\t27,\n\t28]"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+            line: 54
+            column: ~
           children:
             - name:
                 Named: __0
@@ -1234,6 +1899,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "20"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __1
               type_name:
@@ -1243,6 +1912,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "21"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __2
               type_name:
@@ -1252,6 +1925,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "22"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __3
               type_name:
@@ -1261,6 +1938,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "23"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __4
               type_name:
@@ -1270,6 +1951,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "24"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __5
               type_name:
@@ -1279,6 +1964,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "25"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __6
               type_name:
@@ -1288,6 +1977,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "26"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __7
               type_name:
@@ -1297,6 +1990,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "27"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __8
               type_name:
@@ -1306,6 +2003,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "28"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
         - name:
             Named: __3
           type_name:
@@ -1318,6 +2019,10 @@ Child Variables:
                       - Base: unsigned char
               count: 9
           value: "uint8_t[9] = [\n\t30,\n\t31,\n\t32,\n\t33,\n\t34,\n\t35,\n\t36,\n\t37,\n\t38]"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+            line: 54
+            column: ~
           children:
             - name:
                 Named: __0
@@ -1328,6 +2033,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "30"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __1
               type_name:
@@ -1337,6 +2046,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "31"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __2
               type_name:
@@ -1346,6 +2059,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "32"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __3
               type_name:
@@ -1355,6 +2072,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "33"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __4
               type_name:
@@ -1364,6 +2085,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "34"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __5
               type_name:
@@ -1373,6 +2098,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "35"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __6
               type_name:
@@ -1382,6 +2111,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "36"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __7
               type_name:
@@ -1391,6 +2124,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "37"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __8
               type_name:
@@ -1400,6 +2137,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "38"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
         - name:
             Named: __4
           type_name:
@@ -1412,6 +2153,10 @@ Child Variables:
                       - Base: unsigned char
               count: 9
           value: "uint8_t[9] = [\n\t40,\n\t41,\n\t42,\n\t43,\n\t44,\n\t45,\n\t46,\n\t47,\n\t48]"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+            line: 54
+            column: ~
           children:
             - name:
                 Named: __0
@@ -1422,6 +2167,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "40"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __1
               type_name:
@@ -1431,6 +2180,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "41"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __2
               type_name:
@@ -1440,6 +2193,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "42"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __3
               type_name:
@@ -1449,6 +2206,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "43"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __4
               type_name:
@@ -1458,6 +2219,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "44"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __5
               type_name:
@@ -1467,6 +2232,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "45"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __6
               type_name:
@@ -1476,6 +2245,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "46"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __7
               type_name:
@@ -1485,6 +2258,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "47"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __8
               type_name:
@@ -1494,6 +2271,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "48"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
         - name:
             Named: __5
           type_name:
@@ -1506,6 +2287,10 @@ Child Variables:
                       - Base: unsigned char
               count: 9
           value: "uint8_t[9] = [\n\t50,\n\t51,\n\t52,\n\t53,\n\t54,\n\t55,\n\t56,\n\t57,\n\t58]"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+            line: 54
+            column: ~
           children:
             - name:
                 Named: __0
@@ -1516,6 +2301,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "50"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __1
               type_name:
@@ -1525,6 +2314,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "51"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __2
               type_name:
@@ -1534,6 +2327,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "52"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __3
               type_name:
@@ -1543,6 +2340,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "53"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __4
               type_name:
@@ -1552,6 +2353,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "54"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __5
               type_name:
@@ -1561,6 +2366,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "55"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __6
               type_name:
@@ -1570,6 +2379,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "56"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __7
               type_name:
@@ -1579,6 +2392,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "57"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
             - name:
                 Named: __8
               type_name:
@@ -1588,6 +2405,10 @@ Child Variables:
                       - Typedef: __uint8_t
                       - Base: unsigned char
               value: "58"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 54
+                column: ~
     - name:
         Named: nested_array2
       type_name:
@@ -1603,6 +2424,10 @@ Child Variables:
               count: 3
           count: 2
       value: "uint16_t[3][2] = [\n\tuint16_t[3] = [\n\t\t0,\n\t\t1,\n\t\t2\n\t],\n\tuint16_t[3] = [\n\t\t3,\n\t\t4,\n\t\t5\n\t]]"
+      source_location:
+        path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+        line: 65
+        column: ~
       children:
         - name:
             Named: __0
@@ -1616,6 +2441,10 @@ Child Variables:
                       - Base: short unsigned int
               count: 3
           value: "uint16_t[3] = [\n\t0,\n\t1,\n\t2]"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+            line: 65
+            column: ~
           children:
             - name:
                 Named: __0
@@ -1626,6 +2455,10 @@ Child Variables:
                       - Typedef: __uint16_t
                       - Base: short unsigned int
               value: "0"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 65
+                column: ~
             - name:
                 Named: __1
               type_name:
@@ -1635,6 +2468,10 @@ Child Variables:
                       - Typedef: __uint16_t
                       - Base: short unsigned int
               value: "1"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 65
+                column: ~
             - name:
                 Named: __2
               type_name:
@@ -1644,6 +2481,10 @@ Child Variables:
                       - Typedef: __uint16_t
                       - Base: short unsigned int
               value: "2"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 65
+                column: ~
         - name:
             Named: __1
           type_name:
@@ -1656,6 +2497,10 @@ Child Variables:
                       - Base: short unsigned int
               count: 3
           value: "uint16_t[3] = [\n\t3,\n\t4,\n\t5]"
+          source_location:
+            path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+            line: 65
+            column: ~
           children:
             - name:
                 Named: __0
@@ -1666,6 +2511,10 @@ Child Variables:
                       - Typedef: __uint16_t
                       - Base: short unsigned int
               value: "3"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 65
+                column: ~
             - name:
                 Named: __1
               type_name:
@@ -1675,6 +2524,10 @@ Child Variables:
                       - Typedef: __uint16_t
                       - Base: short unsigned int
               value: "4"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 65
+                column: ~
             - name:
                 Named: __2
               type_name:
@@ -1684,3 +2537,7 @@ Child Variables:
                       - Typedef: __uint16_t
                       - Base: short unsigned int
               value: "5"
+              source_location:
+                path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
+                line: 65
+                column: ~

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a_static_variables.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a_static_variables.snap
@@ -1,6 +1,6 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
-assertion_line: 2023
+assertion_line: 2020
 expression: static_variables
 snapshot_kind: text
 ---
@@ -16,7 +16,8 @@ Child Variables:
       source_location:
         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup\\startup_samd51.c"
         line: 239
-        column: ~
+        column:
+          Column: 21
     - name:
         Named: _aTerminalId
       type_name: Unknown
@@ -24,7 +25,8 @@ Child Variables:
       source_location:
         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
         line: 258
-        column: ~
+        column:
+          Column: 22
     - name:
         Named: _SEGGER_RTT
       type_name:
@@ -35,7 +37,8 @@ Child Variables:
       source_location:
         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
         line: 348
-        column: ~
+        column:
+          Column: 22
       children:
         - name:
             Named: acID
@@ -48,7 +51,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
             line: 332
-            column: ~
+            column:
+              Column: 27
           children:
             - name:
                 Named: __0
@@ -58,7 +62,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __1
               type_name:
@@ -67,7 +72,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __2
               type_name:
@@ -76,7 +82,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __3
               type_name:
@@ -85,7 +92,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __4
               type_name:
@@ -94,7 +102,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __5
               type_name:
@@ -103,7 +112,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __6
               type_name:
@@ -112,7 +122,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __7
               type_name:
@@ -121,7 +132,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __8
               type_name:
@@ -130,7 +142,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __9
               type_name:
@@ -139,7 +152,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __10
               type_name:
@@ -148,7 +162,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __11
               type_name:
@@ -157,7 +172,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __12
               type_name:
@@ -166,7 +182,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __13
               type_name:
@@ -175,7 +192,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __14
               type_name:
@@ -184,7 +202,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
             - name:
                 Named: __15
               type_name:
@@ -193,7 +212,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 332
-                column: ~
+                column:
+                  Column: 27
         - name:
             Named: MaxNumUpBuffers
           type_name:
@@ -202,7 +222,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
             line: 333
-            column: ~
+            column:
+              Column: 27
         - name:
             Named: MaxNumDownBuffers
           type_name:
@@ -211,7 +232,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
             line: 334
-            column: ~
+            column:
+              Column: 27
         - name:
             Named: aUp
           type_name:
@@ -225,7 +247,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
             line: 335
-            column: ~
+            column:
+              Column: 27
           children:
             - name:
                 Named: __0
@@ -237,7 +260,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 335
-                column: ~
+                column:
+                  Column: 27
               children:
                 - name:
                     Named: sName
@@ -247,7 +271,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                     line: 305
-                    column: ~
+                    column:
+                      Column: 22
                   children:
                     - name:
                         Named: "*sName"
@@ -264,7 +289,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                     line: 306
-                    column: ~
+                    column:
+                      Column: 22
                   children:
                     - name:
                         Named: "*pBuffer"
@@ -279,7 +305,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                     line: 307
-                    column: ~
+                    column:
+                      Column: 22
                 - name:
                     Named: WrOff
                   type_name:
@@ -288,7 +315,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                     line: 308
-                    column: ~
+                    column:
+                      Column: 22
                 - name:
                     Named: RdOff
                   type_name:
@@ -299,7 +327,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                     line: 309
-                    column: ~
+                    column:
+                      Column: 22
                 - name:
                     Named: Flags
                   type_name:
@@ -308,7 +337,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                     line: 310
-                    column: ~
+                    column:
+                      Column: 22
         - name:
             Named: aDown
           type_name:
@@ -322,7 +352,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
             line: 336
-            column: ~
+            column:
+              Column: 27
           children:
             - name:
                 Named: __0
@@ -334,7 +365,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                 line: 336
-                column: ~
+                column:
+                  Column: 27
               children:
                 - name:
                     Named: sName
@@ -344,7 +376,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                     line: 318
-                    column: ~
+                    column:
+                      Column: 22
                   children:
                     - name:
                         Named: "*sName"
@@ -361,7 +394,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                     line: 319
-                    column: ~
+                    column:
+                      Column: 22
                   children:
                     - name:
                         Named: "*pBuffer"
@@ -376,7 +410,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                     line: 320
-                    column: ~
+                    column:
+                      Column: 22
                 - name:
                     Named: WrOff
                   type_name:
@@ -387,7 +422,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                     line: 321
-                    column: ~
+                    column:
+                      Column: 22
                 - name:
                     Named: RdOff
                   type_name:
@@ -396,7 +432,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                     line: 322
-                    column: ~
+                    column:
+                      Column: 22
                 - name:
                     Named: Flags
                   type_name:
@@ -405,7 +442,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.h"
                     line: 323
-                    column: ~
+                    column:
+                      Column: 22
     - name:
         Named: _acUpBuffer
       type_name:
@@ -417,7 +455,8 @@ Child Variables:
       source_location:
         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
         line: 280
-        column: ~
+        column:
+          Column: 3
       children:
         - name:
             Named: __0
@@ -427,7 +466,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __1
           type_name:
@@ -436,7 +476,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __2
           type_name:
@@ -445,7 +486,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __3
           type_name:
@@ -454,7 +496,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __4
           type_name:
@@ -463,7 +506,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __5
           type_name:
@@ -472,7 +516,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __6
           type_name:
@@ -481,7 +526,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __7
           type_name:
@@ -490,7 +536,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __8
           type_name:
@@ -499,7 +546,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __9
           type_name:
@@ -508,7 +556,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __10
           type_name:
@@ -517,7 +566,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __11
           type_name:
@@ -526,7 +576,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __12
           type_name:
@@ -535,7 +586,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __13
           type_name:
@@ -544,7 +596,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __14
           type_name:
@@ -553,7 +606,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __15
           type_name:
@@ -562,7 +616,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __16
           type_name:
@@ -571,7 +626,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __17
           type_name:
@@ -580,7 +636,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __18
           type_name:
@@ -589,7 +646,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __19
           type_name:
@@ -598,7 +656,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __20
           type_name:
@@ -607,7 +666,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __21
           type_name:
@@ -616,7 +676,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __22
           type_name:
@@ -625,7 +686,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __23
           type_name:
@@ -634,7 +696,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __24
           type_name:
@@ -643,7 +706,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __25
           type_name:
@@ -652,7 +716,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __26
           type_name:
@@ -661,7 +726,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __27
           type_name:
@@ -670,7 +736,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __28
           type_name:
@@ -679,7 +746,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __29
           type_name:
@@ -688,7 +756,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __30
           type_name:
@@ -697,7 +766,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __31
           type_name:
@@ -706,7 +776,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __32
           type_name:
@@ -715,7 +786,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __33
           type_name:
@@ -724,7 +796,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __34
           type_name:
@@ -733,7 +806,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __35
           type_name:
@@ -742,7 +816,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __36
           type_name:
@@ -751,7 +826,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __37
           type_name:
@@ -760,7 +836,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __38
           type_name:
@@ -769,7 +846,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __39
           type_name:
@@ -778,7 +856,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __40
           type_name:
@@ -787,7 +866,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __41
           type_name:
@@ -796,7 +876,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __42
           type_name:
@@ -805,7 +886,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __43
           type_name:
@@ -814,7 +896,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __44
           type_name:
@@ -823,7 +906,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __45
           type_name:
@@ -832,7 +916,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __46
           type_name:
@@ -841,7 +926,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __47
           type_name:
@@ -850,7 +936,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __48
           type_name:
@@ -859,7 +946,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __49
           type_name:
@@ -868,7 +956,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 280
-            column: ~
+            column:
+              Column: 3
         - name: Artifical
           type_name: Unknown
           value: "... and 974 more"
@@ -883,7 +972,8 @@ Child Variables:
       source_location:
         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
         line: 281
-        column: ~
+        column:
+          Column: 3
       children:
         - name:
             Named: __0
@@ -893,7 +983,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __1
           type_name:
@@ -902,7 +993,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __2
           type_name:
@@ -911,7 +1003,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __3
           type_name:
@@ -920,7 +1013,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __4
           type_name:
@@ -929,7 +1023,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __5
           type_name:
@@ -938,7 +1033,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __6
           type_name:
@@ -947,7 +1043,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __7
           type_name:
@@ -956,7 +1053,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __8
           type_name:
@@ -965,7 +1063,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __9
           type_name:
@@ -974,7 +1073,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __10
           type_name:
@@ -983,7 +1083,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __11
           type_name:
@@ -992,7 +1093,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __12
           type_name:
@@ -1001,7 +1103,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __13
           type_name:
@@ -1010,7 +1113,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __14
           type_name:
@@ -1019,7 +1123,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
         - name:
             Named: __15
           type_name:
@@ -1028,7 +1133,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
             line: 281
-            column: ~
+            column:
+              Column: 3
     - name:
         Named: _ActiveTerminal
       type_name: Unknown
@@ -1036,7 +1142,8 @@ Child Variables:
       source_location:
         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\SEGGER\\RTT\\SEGGER_RTT.c"
         line: 284
-        column: ~
+        column:
+          Column: 22
     - name:
         Named: foo
       type_name:
@@ -1047,7 +1154,8 @@ Child Variables:
       source_location:
         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
         line: 38
-        column: ~
+        column:
+          Column: 14
       children:
         - name: Unknown
           type_name:
@@ -1071,7 +1179,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                     line: 19
-                    column: ~
+                    column:
+                      Column: 21
                 - name:
                     Named: b
                   type_name:
@@ -1084,7 +1193,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                     line: 20
-                    column: ~
+                    column:
+                      Column: 21
                 - name:
                     Named: c
                   type_name:
@@ -1097,7 +1207,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                     line: 21
-                    column: ~
+                    column:
+                      Column: 21
                 - name:
                     Named: d
                   type_name:
@@ -1110,7 +1221,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                     line: 22
-                    column: ~
+                    column:
+                      Column: 21
             - name:
                 Named: x
               type_name:
@@ -1123,7 +1235,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 24
-                column: ~
+                column:
+                  Column: 18
         - name:
             Named: unsigned_bitfields
           type_name:
@@ -1132,7 +1245,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 30
-            column: ~
+            column:
+              Column: 7
           children:
             - name:
                 Named: f
@@ -1150,7 +1264,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 28
-                column: ~
+                column:
+                  Column: 17
             - name:
                 Named: g
               type_name:
@@ -1167,7 +1282,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 29
-                column: ~
+                column:
+                  Column: 17
         - name:
             Named: signed_bitfields
           type_name:
@@ -1176,7 +1292,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 35
-            column: ~
+            column:
+              Column: 7
           children:
             - name:
                 Named: f
@@ -1194,7 +1311,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 33
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: g
               type_name:
@@ -1211,7 +1329,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 34
-                column: ~
+                column:
+                  Column: 16
     - name:
         Named: foo_array
       type_name:
@@ -1229,7 +1348,8 @@ Child Variables:
       source_location:
         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
         line: 53
-        column: ~
+        column:
+          Column: 13
       children:
         - name:
             Named: __0
@@ -1243,7 +1363,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 53
-            column: ~
+            column:
+              Column: 13
           children:
             - name: Unknown
               type_name:
@@ -1267,7 +1388,8 @@ Child Variables:
                       source_location:
                         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                         line: 19
-                        column: ~
+                        column:
+                          Column: 21
                     - name:
                         Named: b
                       type_name:
@@ -1280,7 +1402,8 @@ Child Variables:
                       source_location:
                         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                         line: 20
-                        column: ~
+                        column:
+                          Column: 21
                     - name:
                         Named: c
                       type_name:
@@ -1293,7 +1416,8 @@ Child Variables:
                       source_location:
                         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                         line: 21
-                        column: ~
+                        column:
+                          Column: 21
                     - name:
                         Named: d
                       type_name:
@@ -1306,7 +1430,8 @@ Child Variables:
                       source_location:
                         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                         line: 22
-                        column: ~
+                        column:
+                          Column: 21
                 - name:
                     Named: x
                   type_name:
@@ -1319,7 +1444,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                     line: 24
-                    column: ~
+                    column:
+                      Column: 18
             - name:
                 Named: unsigned_bitfields
               type_name:
@@ -1328,7 +1454,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 30
-                column: ~
+                column:
+                  Column: 7
               children:
                 - name:
                     Named: f
@@ -1346,7 +1473,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                     line: 28
-                    column: ~
+                    column:
+                      Column: 17
                 - name:
                     Named: g
                   type_name:
@@ -1363,7 +1491,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                     line: 29
-                    column: ~
+                    column:
+                      Column: 17
             - name:
                 Named: signed_bitfields
               type_name:
@@ -1372,7 +1501,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 35
-                column: ~
+                column:
+                  Column: 7
               children:
                 - name:
                     Named: f
@@ -1390,7 +1520,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                     line: 33
-                    column: ~
+                    column:
+                      Column: 16
                 - name:
                     Named: g
                   type_name:
@@ -1407,7 +1538,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                     line: 34
-                    column: ~
+                    column:
+                      Column: 16
         - name:
             Named: __1
           type_name:
@@ -1420,7 +1552,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 53
-            column: ~
+            column:
+              Column: 13
           children:
             - name: Unknown
               type_name:
@@ -1444,7 +1577,8 @@ Child Variables:
                       source_location:
                         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                         line: 19
-                        column: ~
+                        column:
+                          Column: 21
                     - name:
                         Named: b
                       type_name:
@@ -1457,7 +1591,8 @@ Child Variables:
                       source_location:
                         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                         line: 20
-                        column: ~
+                        column:
+                          Column: 21
                     - name:
                         Named: c
                       type_name:
@@ -1470,7 +1605,8 @@ Child Variables:
                       source_location:
                         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                         line: 21
-                        column: ~
+                        column:
+                          Column: 21
                     - name:
                         Named: d
                       type_name:
@@ -1483,7 +1619,8 @@ Child Variables:
                       source_location:
                         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                         line: 22
-                        column: ~
+                        column:
+                          Column: 21
                 - name:
                     Named: x
                   type_name:
@@ -1496,7 +1633,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                     line: 24
-                    column: ~
+                    column:
+                      Column: 18
             - name:
                 Named: unsigned_bitfields
               type_name:
@@ -1505,7 +1643,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 30
-                column: ~
+                column:
+                  Column: 7
               children:
                 - name:
                     Named: f
@@ -1523,7 +1662,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                     line: 28
-                    column: ~
+                    column:
+                      Column: 17
                 - name:
                     Named: g
                   type_name:
@@ -1540,7 +1680,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                     line: 29
-                    column: ~
+                    column:
+                      Column: 17
             - name:
                 Named: signed_bitfields
               type_name:
@@ -1549,7 +1690,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 35
-                column: ~
+                column:
+                  Column: 7
               children:
                 - name:
                     Named: f
@@ -1567,7 +1709,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                     line: 33
-                    column: ~
+                    column:
+                      Column: 16
                 - name:
                     Named: g
                   type_name:
@@ -1584,7 +1727,8 @@ Child Variables:
                   source_location:
                     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                     line: 34
-                    column: ~
+                    column:
+                      Column: 16
     - name:
         Named: nested_array
       type_name:
@@ -1603,7 +1747,8 @@ Child Variables:
       source_location:
         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
         line: 54
-        column: ~
+        column:
+          Column: 16
       children:
         - name:
             Named: __0
@@ -1620,7 +1765,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 54
-            column: ~
+            column:
+              Column: 16
           children:
             - name:
                 Named: __0
@@ -1634,7 +1780,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __1
               type_name:
@@ -1647,7 +1794,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __2
               type_name:
@@ -1660,7 +1808,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __3
               type_name:
@@ -1673,7 +1822,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __4
               type_name:
@@ -1686,7 +1836,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __5
               type_name:
@@ -1699,7 +1850,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __6
               type_name:
@@ -1712,7 +1864,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __7
               type_name:
@@ -1725,7 +1878,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __8
               type_name:
@@ -1738,7 +1892,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
         - name:
             Named: __1
           type_name:
@@ -1754,7 +1909,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 54
-            column: ~
+            column:
+              Column: 16
           children:
             - name:
                 Named: __0
@@ -1768,7 +1924,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __1
               type_name:
@@ -1781,7 +1938,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __2
               type_name:
@@ -1794,7 +1952,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __3
               type_name:
@@ -1807,7 +1966,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __4
               type_name:
@@ -1820,7 +1980,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __5
               type_name:
@@ -1833,7 +1994,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __6
               type_name:
@@ -1846,7 +2008,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __7
               type_name:
@@ -1859,7 +2022,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __8
               type_name:
@@ -1872,7 +2036,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
         - name:
             Named: __2
           type_name:
@@ -1888,7 +2053,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 54
-            column: ~
+            column:
+              Column: 16
           children:
             - name:
                 Named: __0
@@ -1902,7 +2068,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __1
               type_name:
@@ -1915,7 +2082,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __2
               type_name:
@@ -1928,7 +2096,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __3
               type_name:
@@ -1941,7 +2110,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __4
               type_name:
@@ -1954,7 +2124,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __5
               type_name:
@@ -1967,7 +2138,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __6
               type_name:
@@ -1980,7 +2152,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __7
               type_name:
@@ -1993,7 +2166,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __8
               type_name:
@@ -2006,7 +2180,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
         - name:
             Named: __3
           type_name:
@@ -2022,7 +2197,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 54
-            column: ~
+            column:
+              Column: 16
           children:
             - name:
                 Named: __0
@@ -2036,7 +2212,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __1
               type_name:
@@ -2049,7 +2226,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __2
               type_name:
@@ -2062,7 +2240,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __3
               type_name:
@@ -2075,7 +2254,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __4
               type_name:
@@ -2088,7 +2268,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __5
               type_name:
@@ -2101,7 +2282,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __6
               type_name:
@@ -2114,7 +2296,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __7
               type_name:
@@ -2127,7 +2310,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __8
               type_name:
@@ -2140,7 +2324,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
         - name:
             Named: __4
           type_name:
@@ -2156,7 +2341,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 54
-            column: ~
+            column:
+              Column: 16
           children:
             - name:
                 Named: __0
@@ -2170,7 +2356,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __1
               type_name:
@@ -2183,7 +2370,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __2
               type_name:
@@ -2196,7 +2384,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __3
               type_name:
@@ -2209,7 +2398,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __4
               type_name:
@@ -2222,7 +2412,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __5
               type_name:
@@ -2235,7 +2426,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __6
               type_name:
@@ -2248,7 +2440,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __7
               type_name:
@@ -2261,7 +2454,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __8
               type_name:
@@ -2274,7 +2468,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
         - name:
             Named: __5
           type_name:
@@ -2290,7 +2485,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 54
-            column: ~
+            column:
+              Column: 16
           children:
             - name:
                 Named: __0
@@ -2304,7 +2500,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __1
               type_name:
@@ -2317,7 +2514,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __2
               type_name:
@@ -2330,7 +2528,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __3
               type_name:
@@ -2343,7 +2542,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __4
               type_name:
@@ -2356,7 +2556,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __5
               type_name:
@@ -2369,7 +2570,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __6
               type_name:
@@ -2382,7 +2584,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __7
               type_name:
@@ -2395,7 +2598,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
             - name:
                 Named: __8
               type_name:
@@ -2408,7 +2612,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 54
-                column: ~
+                column:
+                  Column: 16
     - name:
         Named: nested_array2
       type_name:
@@ -2427,7 +2632,8 @@ Child Variables:
       source_location:
         path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
         line: 65
-        column: ~
+        column:
+          Column: 17
       children:
         - name:
             Named: __0
@@ -2444,7 +2650,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 65
-            column: ~
+            column:
+              Column: 17
           children:
             - name:
                 Named: __0
@@ -2458,7 +2665,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 65
-                column: ~
+                column:
+                  Column: 17
             - name:
                 Named: __1
               type_name:
@@ -2471,7 +2679,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 65
-                column: ~
+                column:
+                  Column: 17
             - name:
                 Named: __2
               type_name:
@@ -2484,7 +2693,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 65
-                column: ~
+                column:
+                  Column: 17
         - name:
             Named: __1
           type_name:
@@ -2500,7 +2710,8 @@ Child Variables:
           source_location:
             path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
             line: 65
-            column: ~
+            column:
+              Column: 17
           children:
             - name:
                 Named: __0
@@ -2514,7 +2725,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 65
-                column: ~
+                column:
+                  Column: 17
             - name:
                 Named: __1
               type_name:
@@ -2527,7 +2739,8 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 65
-                column: ~
+                column:
+                  Column: 17
             - name:
                 Named: __2
               type_name:
@@ -2540,4 +2753,5 @@ Child Variables:
               source_location:
                 path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
                 line: 65
-                column: ~
+                column:
+                  Column: 17

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__esp32c3_full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__esp32c3_full_unwind.snap
@@ -6,10 +6,10 @@ snapshot_kind: text
 ---
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 348
     column:
       Column: 13
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -360,25 +360,25 @@ snapshot_kind: text
             Base: usize
           value: "5"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "6"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 1070395504
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -700,25 +700,25 @@ snapshot_kind: text
             Base: usize
           value: "4"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "5"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 1070395648
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -1040,25 +1040,25 @@ snapshot_kind: text
             Base: usize
           value: "3"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "4"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 1070395792
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -1380,25 +1380,25 @@ snapshot_kind: text
             Base: usize
           value: "2"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "3"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 1070395936
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -1720,25 +1720,25 @@ snapshot_kind: text
             Base: usize
           value: "1"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "2"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 1070396080
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -2060,25 +2060,25 @@ snapshot_kind: text
             Base: usize
           value: "0"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "1"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 1070396224
 - function_name: setup_data_types
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 325
     column:
       Column: 5
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -2400,18 +2400,18 @@ snapshot_kind: text
             Base: i8
           value: "-23"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 204
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: local_reference_to_global_const
           type_name:
             Struct: "&str"
           value: "This global `const` value will only show up in the debugger in the variables where it is referenced"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 207
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
@@ -2435,9 +2435,9 @@ snapshot_kind: text
             Struct: "&str"
           value: "A 'global' static variable"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 208
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
@@ -2461,9 +2461,9 @@ snapshot_kind: text
             Pointer: "*const probe_rs_debugger_test::ComplexEnum"
           value: "*const probe_rs_debugger_test::ComplexEnum @ 0x3FCCFCEC"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 209
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*local_reference_to_global_static_struct"
@@ -2509,18 +2509,18 @@ snapshot_kind: text
             Base: usize
           value: "0"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 210
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: ghosted_variable
           type_name:
             Struct: "&str"
           value: New value and type for a different name
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 211
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
@@ -2544,45 +2544,45 @@ snapshot_kind: text
             Base: i8
           value: "26"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 212
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: int128
           type_name:
             Base: i128
           value: "-196710231994021419720322"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 213
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: u_int128
           type_name:
             Base: u128
           value: "340282366920938266753142613410348491134"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 214
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: float64
           type_name:
             Base: f64
           value: "1.7608695652173911"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 215
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: float64_ptr
           type_name:
             Pointer: "&f64"
           value: "&f64 @ 0x3FCCFD04"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 216
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*float64_ptr"
@@ -2595,18 +2595,18 @@ snapshot_kind: text
             Base: char
           value: 💩
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 217
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: emoji_ptr
           type_name:
             Pointer: "&char"
           value: "&char @ 0x3FCCFD08"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 218
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*emoji_ptr"
@@ -2619,18 +2619,18 @@ snapshot_kind: text
             Base: bool
           value: "true"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 219
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: any_old_string_slice
           type_name:
             Struct: "&str"
           value: How long is a piece of String.
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 221
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
@@ -2654,9 +2654,9 @@ snapshot_kind: text
             Struct: "Result<(), &str>"
           value: "Result<(), &str> @ 0x3FCCFD0C"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 222
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Err
@@ -2692,9 +2692,9 @@ snapshot_kind: text
             Struct: "(bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64)"
           value: "(bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x3FCCF470"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 223
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -2772,9 +2772,9 @@ snapshot_kind: text
             Struct: "Matrix<i32, 2, 3, 4>"
           value: "Matrix<i32, 2, 3, 4> @ 0x3FCCF4AC"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 224
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: raw
@@ -3037,9 +3037,9 @@ snapshot_kind: text
             Struct: "Matrix<&str, 2, 3, 6>"
           value: "Matrix<&str, 2, 3, 6> @ 0x3FCCF62C"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 232
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: raw
@@ -4034,18 +4034,18 @@ snapshot_kind: text
             Enum: SimpleEnum
           value: "SimpleEnum::Two"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 249
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: simple_enum_pointer
           type_name:
             Pointer: "&probe_rs_debugger_test::SimpleEnum"
           value: "&probe_rs_debugger_test::SimpleEnum @ 0x3FCCFAB0"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 250
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*simple_enum_pointer"
@@ -4058,9 +4058,9 @@ snapshot_kind: text
             Struct: RecursiveStruct
           value: RecursiveStruct @ 0x3FCCFAB4
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 252
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: depth
@@ -4142,9 +4142,9 @@ snapshot_kind: text
             Struct: ComplexEnum
           value: ComplexEnum @ 0x3FCCFAD8
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 263
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Case1
@@ -4184,9 +4184,9 @@ snapshot_kind: text
             Struct: ComplexEnum
           value: ComplexEnum @ 0x3FCCFB08
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 271
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Case2
@@ -4215,9 +4215,9 @@ snapshot_kind: text
             Struct: "Option<probe_rs_debugger_test::Univariant>"
           value: "Option<probe_rs_debugger_test::Univariant> @ 0x3FCCFB28"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 273
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Some
@@ -4285,9 +4285,9 @@ snapshot_kind: text
             Pointer: "&core::option::Option<probe_rs_debugger_test::Univariant>"
           value: "&core::option::Option<probe_rs_debugger_test::Univariant> @ 0x3FCCFD14"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 285
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*stuct_with_one_variant_pointer"
@@ -4361,9 +4361,9 @@ snapshot_kind: text
             Struct: ComplexStruct
           value: ComplexStruct @ 0x3FCCFB90
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 287
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: x
@@ -4386,9 +4386,9 @@ snapshot_kind: text
             Struct: ComplexStruct
           value: ComplexStruct @ 0x3FCCFBA0
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 289
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: x
@@ -4411,9 +4411,9 @@ snapshot_kind: text
             Struct: Struct<i32>
           value: Struct<i32> @ 0x3FCCFD18
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 290
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: b
@@ -4431,36 +4431,36 @@ snapshot_kind: text
             Base: i64
           value: "1"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 291
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a3
           type_name:
             Base: i64
           value: "2"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 292
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a4
           type_name:
             Base: i64
           value: "3"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 293
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a5
           type_name:
             Struct: "(i32, i64)"
           value: "(i32, i64) @ 0x3FCCFD40"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 294
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -4478,9 +4478,9 @@ snapshot_kind: text
             Struct: Enum<i32>
           value: Enum<i32> @ 0x3FCCFBE0
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 295
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Variant2
@@ -4504,9 +4504,9 @@ snapshot_kind: text
             Struct: Enum<i32>
           value: Enum<i32> @ 0x3FCCFC00
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 296
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Variant1
@@ -4533,9 +4533,9 @@ snapshot_kind: text
               count: 10
           value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 298
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -4543,99 +4543,99 @@ snapshot_kind: text
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __1
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __2
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __3
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __4
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __6
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __7
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __8
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __9
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: my_array_ptr
           type_name:
             Pointer: "&[i32; 10]"
           value: "&[i32; 10] @ 0x3FCCFD50"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 299
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*my_array_ptr"
@@ -4705,9 +4705,9 @@ snapshot_kind: text
               count: 10
           value: "[i8; 10] = [\n\t1,\n\t2,\n\t3,\n\t4,\n\t5,\n\t6,\n\t7,\n\t8,\n\t9,\n\t0]"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 300
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -4715,99 +4715,99 @@ snapshot_kind: text
                 Base: i8
               value: "1"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __1
               type_name:
                 Base: i8
               value: "2"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __2
               type_name:
                 Base: i8
               value: "3"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "4"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __4
               type_name:
                 Base: i8
               value: "5"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __5
               type_name:
                 Base: i8
               value: "6"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __6
               type_name:
                 Base: i8
               value: "7"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __7
               type_name:
                 Base: i8
               value: "8"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __8
               type_name:
                 Base: i8
               value: "9"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __9
               type_name:
                 Base: i8
               value: "0"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: heapless_vec
           type_name:
             Struct: "Vec<i8, 10>"
           value: "Vec<i8, 10> @ 0x3FCCFC58"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 301
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: len
@@ -5049,9 +5049,9 @@ snapshot_kind: text
             Struct: Wrapping<u8>
           value: Wrapping<u8> @ 0x3FCCFC6B
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 305
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -5064,9 +5064,9 @@ snapshot_kind: text
             Struct: Channels
           value: Channels @ 0x3FCCFC6C
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 306
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: up
@@ -5269,10 +5269,10 @@ snapshot_kind: text
   canonical_frame_address: 1070399200
 - function_name: __risc_v_rt__main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
     line: 26
     column:
       Column: 54
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
   registers:
     - core_register:
         id: 4096
@@ -5599,9 +5599,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x3FCCFEFE
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
             line: 18
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
           children:
             - name:
                 Named: ADC1
@@ -6038,9 +6038,9 @@ snapshot_kind: text
             Struct: SystemParts
           value: SystemParts @ 0x3FCCFEFF
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
             line: 19
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
           children:
             - name:
                 Named: _private
@@ -6124,9 +6124,9 @@ snapshot_kind: text
             Struct: Clocks
           value: Clocks @ 0x3FCCFF00
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
             line: 20
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
           children:
             - name:
                 Named: _private
@@ -6184,9 +6184,9 @@ snapshot_kind: text
             Struct: Delay
           value: Delay @ 0x3FCCFF18
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
             line: 23
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
           children:
             - name:
                 Named: freq
@@ -6202,10 +6202,10 @@ snapshot_kind: text
   canonical_frame_address: 1070399392
 - function_name: hal_main
   source_location:
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
     line: 521
     column:
       Column: 9
-    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -6527,36 +6527,36 @@ snapshot_kind: text
             Base: usize
           value: "0"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
             line: 505
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
         - name:
             Named: a1
           type_name:
             Base: usize
           value: "0"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
             line: 505
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
         - name:
             Named: a2
           type_name:
             Base: usize
           value: "0"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
             line: 505
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
         - name:
             Named: stack_chk_guard
           type_name:
             Pointer: "*mut u32"
           value: "*mut u32 @ 0x3FCCFFC0"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
             line: 516
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
           children:
             - name:
                 Named: "*stack_chk_guard"
@@ -6566,10 +6566,10 @@ snapshot_kind: text
   canonical_frame_address: 1070399440
 - function_name: start_rust
   source_location:
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src/lib.rs
     line: 70
     column:
       Column: 5
-    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -6891,25 +6891,25 @@ snapshot_kind: text
             Base: usize
           value: "0"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src/lib.rs
             line: 56
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src/lib.rs
         - name:
             Named: a1
           type_name:
             Base: usize
           value: "0"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src/lib.rs
             line: 56
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src/lib.rs
         - name:
             Named: a2
           type_name:
             Base: usize
           value: "0"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src/lib.rs
             line: 56
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src/lib.rs
   canonical_frame_address: 1070399472

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__esp32c3_full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__esp32c3_full_unwind.snap
@@ -354,11 +354,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 5,\n\tinternal_depth_measure: usize = 6}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -702,11 +698,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 4,\n\tinternal_depth_measure: usize = 5}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1050,11 +1042,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 3,\n\tinternal_depth_measure: usize = 4}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1398,11 +1386,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 2,\n\tinternal_depth_measure: usize = 3}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1746,11 +1730,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 1,\n\tinternal_depth_measure: usize = 2}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -2094,11 +2074,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 0,\n\tinternal_depth_measure: usize = 1}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -2442,11 +2418,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tint8_minus_twenty_three: i8 = -23,\n\tlocal_reference_to_global_const: &str = This global `const` value will only show up in the debugger in the variables where it is referenced,\n\tlocal_reference_to_global_static: &str = A 'global' static variable,\n\tlocal_reference_to_global_static_struct: *const probe_rs_debugger_test::ComplexEnum = *const probe_rs_debugger_test::ComplexEnum @ 0x3FCCFCEC,\n\tghosted_variable: usize = 0,\n\tghosted_variable: &str = New value and type for a different name,\n\tint8_twenty_six: i8 = 26,\n\tint128: i128 = -196710231994021419720322,\n\tu_int128: u128 = 340282366920938266753142613410348491134,\n\tfloat64: f64 = 1.7608695652173911,\n\tfloat64_ptr: &f64 = &f64 @ 0x3FCCFD04,\n\temoji: char = 💩,\n\temoji_ptr: &char = &char @ 0x3FCCFD08,\n\ttrue_bool: bool = true,\n\tany_old_string_slice: &str = How long is a piece of String.,\n\tfunction_result: Result<(), &str> = Result<(), &str> @ 0x3FCCFD0C,\n\tglobal_types: (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) = (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x3FCCF470,\n\tthree_d_usize_array: Matrix<i32, 2, 3, 4> = Matrix<i32, 2, 3, 4> @ 0x3FCCF4AC,\n\tthree_d_string_array: Matrix<&str, 2, 3, 6> = Matrix<&str, 2, 3, 6> @ 0x3FCCF62C,\n\tthree: SimpleEnum = SimpleEnum::Two,\n\tsimple_enum_pointer: &probe_rs_debugger_test::SimpleEnum = &probe_rs_debugger_test::SimpleEnum @ 0x3FCCFAB0,\n\tthree_level_recursive_struct: RecursiveStruct = RecursiveStruct @ 0x3FCCFAB4,\n\tfirst_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x3FCCFAD8,\n\tsecond_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x3FCCFB08,\n\tstruct_with_one_variant: Option<probe_rs_debugger_test::Univariant> = Option<probe_rs_debugger_test::Univariant> @ 0x3FCCFB28,\n\tstuct_with_one_variant_pointer: &core::option::Option<probe_rs_debugger_test::Univariant> = &core::option::Option<probe_rs_debugger_test::Univariant> @ 0x3FCCFD14,\n\tlong_lived: ComplexStruct = ComplexStruct @ 0x3FCCFB90,\n\tshort_lived: ComplexStruct = ComplexStruct @ 0x3FCCFBA0,\n\ta1: Struct<i32> = Struct<i32> @ 0x3FCCFD18,\n\ta2: i64 = 1,\n\ta3: i64 = 2,\n\ta4: i64 = 3,\n\ta5: (i32, i64) = (i32, i64) @ 0x3FCCFD40,\n\ta6: Enum<i32> = Enum<i32> @ 0x3FCCFBE0,\n\ta7: Enum<i32> = Enum<i32> @ 0x3FCCFC00,\n\t[i32; 10] = [\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55\n\t],\n\tmy_array_ptr: &[i32; 10] = &[i32; 10] @ 0x3FCCFD50,\n\t[i8; 10] = [\n\t\t1,\n\t\t2,\n\t\t3,\n\t\t4,\n\t\t5,\n\t\t6,\n\t\t7,\n\t\t8,\n\t\t9,\n\t\t0\n\t],\n\theapless_vec: Vec<i8, 10> = Vec<i8, 10> @ 0x3FCCFC58,\n\tloop_counter: Wrapping<u8> = Wrapping<u8> @ 0x3FCCFC6B,\n\trtt_channels: Channels = Channels @ 0x3FCCFC6C}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: int8_minus_twenty_three
@@ -2474,32 +2446,20 @@ snapshot_kind: text
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x3FCCF420"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "84"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "99"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: local_reference_to_global_static
           type_name:
@@ -2516,32 +2476,20 @@ snapshot_kind: text
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x3FCCFCE4"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "65"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "26"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: local_reference_to_global_static_struct
           type_name:
@@ -2558,74 +2506,46 @@ snapshot_kind: text
               type_name:
                 Struct: ComplexEnum
               value: ComplexEnum @ 0x3FC80D70
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: Case1
                   type_name:
                     Struct: Case1
                   value: Case1 @ 0x3FC80D70
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Base: u64
                       value: "0"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: __1
                       type_name:
                         Struct: ComplexStruct
                       value: ComplexStruct @ 0x3FC80D80
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: x
                           type_name:
                             Base: i64
                           value: "24"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: y
                           type_name:
                             Base: i32
                           value: "25"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: z
                           type_name:
                             Base: i16
                           value: "26"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
         - name:
             Named: ghosted_variable
           type_name:
@@ -2652,32 +2572,20 @@ snapshot_kind: text
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x3FCCF42C"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "78"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "39"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: int8_twenty_six
           type_name:
@@ -2734,11 +2642,7 @@ snapshot_kind: text
               type_name:
                 Base: f64
               value: "1.7608695652173911"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: emoji
           type_name:
@@ -2765,11 +2669,7 @@ snapshot_kind: text
               type_name:
                 Base: char
               value: 💩
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: true_bool
           type_name:
@@ -2796,32 +2696,20 @@ snapshot_kind: text
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x3FCCF450"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "72"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "30"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: function_result
           type_name:
@@ -2838,54 +2726,34 @@ snapshot_kind: text
               type_name:
                 Struct: Err
               value: Err @ 0x3FCCFD0C
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: "&str"
                   value: Forcing the return of an Error variant
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: data_ptr
                       type_name:
                         Pointer: u8
                       value: "*raw u8 @ 0x3FCCFD0C"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: "*data_ptr"
                           type_name:
                             Base: u8
                           value: "70"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: length
                       type_name:
                         Base: usize
                       value: "38"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
         - name:
             Named: global_types
           type_name:
@@ -2902,141 +2770,85 @@ snapshot_kind: text
               type_name:
                 Base: bool
               value: "false"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __1
               type_name:
                 Base: isize
               value: "-1"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __2
               type_name:
                 Base: char
               value: a
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "68"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __4
               type_name:
                 Base: i16
               value: "-16"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "-32"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __6
               type_name:
                 Base: i64
               value: "-64"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __7
               type_name:
                 Base: usize
               value: "1"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __8
               type_name:
                 Base: u8
               value: "100"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __9
               type_name:
                 Base: u16
               value: "16"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __10
               type_name:
                 Base: u32
               value: "32"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __11
               type_name:
                 Base: u64
               value: "64"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __12
               type_name:
                 Base: f32
               value: "2.5"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __13
               type_name:
                 Base: f64
               value: "3.5"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: three_d_usize_array
           type_name:
@@ -3062,11 +2874,7 @@ snapshot_kind: text
                       count: 2
                   count: 4
               value: "[[[i32; 3]; 2]; 4] = [\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t0,\n\t\t\t1,\n\t\t\t2\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t3,\n\t\t\t4,\n\t\t\t5\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t6,\n\t\t\t7,\n\t\t\t8\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t9,\n\t\t\t10,\n\t\t\t11\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t12,\n\t\t\t13,\n\t\t\t14\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t15,\n\t\t\t16,\n\t\t\t17\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t18,\n\t\t\t19,\n\t\t\t20\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t21,\n\t\t\t22,\n\t\t\t23\n\t\t]\n\t]]"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
@@ -3079,11 +2887,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t0,\n\t\t1,\n\t\t2\n\t],\n\t[i32; 3] = [\n\t\t3,\n\t\t4,\n\t\t5\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3093,42 +2897,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t0,\n\t1,\n\t2]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "1"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "2"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3137,42 +2925,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t3,\n\t4,\n\t5]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "3"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "4"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "5"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __1
                   type_name:
@@ -3184,11 +2956,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t6,\n\t\t7,\n\t\t8\n\t],\n\t[i32; 3] = [\n\t\t9,\n\t\t10,\n\t\t11\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3198,42 +2966,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t6,\n\t7,\n\t8]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "6"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "7"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "8"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3242,42 +2994,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t9,\n\t10,\n\t11]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "9"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "10"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "11"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __2
                   type_name:
@@ -3289,11 +3025,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t12,\n\t\t13,\n\t\t14\n\t],\n\t[i32; 3] = [\n\t\t15,\n\t\t16,\n\t\t17\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3303,42 +3035,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t12,\n\t13,\n\t14]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "12"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "13"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "14"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3347,42 +3063,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t15,\n\t16,\n\t17]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "15"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "16"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "17"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __3
                   type_name:
@@ -3394,11 +3094,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t18,\n\t\t19,\n\t\t20\n\t],\n\t[i32; 3] = [\n\t\t21,\n\t\t22,\n\t\t23\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3408,42 +3104,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t18,\n\t19,\n\t20]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "18"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "19"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "20"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3452,42 +3132,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t21,\n\t22,\n\t23]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "21"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "22"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "23"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
         - name:
             Named: three_d_string_array
           type_name:
@@ -3513,11 +3177,7 @@ snapshot_kind: text
                       count: 2
                   count: 6
               value: "[[[&str; 3]; 2]; 6] = [\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tApple,\n\t\t\tBanana,\n\t\t\tCherry\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tDog,\n\t\t\tElephant,\n\t\t\tFish\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tGuitar,\n\t\t\tHorse,\n\t\t\tIce Cream\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tJaguar,\n\t\t\tKangaroo,\n\t\t\tLion\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tMoon,\n\t\t\tNewton,\n\t\t\tOwl\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tPencil,\n\t\t\tQueen,\n\t\t\tRainbow\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tSun,\n\t\t\tTree,\n\t\t\tUmbrella\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tViolin,\n\t\t\tWatch,\n\t\t\tXylophone\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tYellow,\n\t\t\tZebra,\n\t\t\tAlpha\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tBravo,\n\t\t\tCharlie,\n\t\t\tDelta\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tEcho,\n\t\t\tFoxtrot,\n\t\t\tGolf\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tHotel,\n\t\t\tIndia,\n\t\t\tJuliet\n\t\t]\n\t]]"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
@@ -3530,11 +3190,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tApple,\n\t\tBanana,\n\t\tCherry\n\t],\n\t[&str; 3] = [\n\t\tDog,\n\t\tElephant,\n\t\tFish\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3544,138 +3200,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tApple,\n\tBanana,\n\tCherry]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Apple
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF62C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Banana
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF634"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Cherry
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF63C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3684,138 +3288,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tDog,\n\tElephant,\n\tFish]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Dog
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF644"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Elephant
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF64C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Fish
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF654"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __1
                   type_name:
@@ -3827,11 +3379,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tGuitar,\n\t\tHorse,\n\t\tIce Cream\n\t],\n\t[&str; 3] = [\n\t\tJaguar,\n\t\tKangaroo,\n\t\tLion\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3841,138 +3389,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tGuitar,\n\tHorse,\n\tIce Cream]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Guitar
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF65C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Horse
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF664"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Ice Cream
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF66C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3981,138 +3477,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tJaguar,\n\tKangaroo,\n\tLion]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Jaguar
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF674"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Kangaroo
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF67C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "75"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Lion
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF684"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "76"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __2
                   type_name:
@@ -4124,11 +3568,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tMoon,\n\t\tNewton,\n\t\tOwl\n\t],\n\t[&str; 3] = [\n\t\tPencil,\n\t\tQueen,\n\t\tRainbow\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -4138,138 +3578,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tMoon,\n\tNewton,\n\tOwl]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Moon
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF68C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "77"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Newton
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF694"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "78"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Owl
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF69C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "79"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -4278,138 +3666,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tPencil,\n\tQueen,\n\tRainbow]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Pencil
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6A4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "80"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Queen
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6AC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "81"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Rainbow
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6B4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "82"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __3
                   type_name:
@@ -4421,11 +3757,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tSun,\n\t\tTree,\n\t\tUmbrella\n\t],\n\t[&str; 3] = [\n\t\tViolin,\n\t\tWatch,\n\t\tXylophone\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -4435,138 +3767,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tSun,\n\tTree,\n\tUmbrella]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Sun
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6BC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "83"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Tree
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6C4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "84"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Umbrella
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6CC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "85"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -4575,138 +3855,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tViolin,\n\tWatch,\n\tXylophone]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Violin
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6D4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "86"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Watch
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6DC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "87"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Xylophone
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6E4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "88"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __4
                   type_name:
@@ -4718,11 +3946,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tYellow,\n\t\tZebra,\n\t\tAlpha\n\t],\n\t[&str; 3] = [\n\t\tBravo,\n\t\tCharlie,\n\t\tDelta\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -4732,138 +3956,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tYellow,\n\tZebra,\n\tAlpha]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Yellow
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6EC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "89"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Zebra
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6F4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "90"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Alpha
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6FC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -4872,138 +4044,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tBravo,\n\tCharlie,\n\tDelta]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Bravo
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF704"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Charlie
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF70C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Delta
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF714"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __5
                   type_name:
@@ -5015,11 +4135,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tEcho,\n\t\tFoxtrot,\n\t\tGolf\n\t],\n\t[&str; 3] = [\n\t\tHotel,\n\t\tIndia,\n\t\tJuliet\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -5029,138 +4145,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tEcho,\n\tFoxtrot,\n\tGolf]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Echo
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF71C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Foxtrot
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF724"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Golf
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF72C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -5169,138 +4233,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tHotel,\n\tIndia,\n\tJuliet]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Hotel
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF734"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: India
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF73C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Juliet
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF744"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
         - name:
             Named: three
           type_name:
@@ -5327,11 +4339,7 @@ snapshot_kind: text
               type_name:
                 Enum: SimpleEnum
               value: "SimpleEnum::Two"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: three_level_recursive_struct
           type_name:
@@ -5348,140 +4356,88 @@ snapshot_kind: text
               type_name:
                 Base: u32
               value: "1"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: next_self
               type_name:
                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x3FCCFAB8"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x3FCCFAB8
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x3FCCFAB8"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RecursiveStruct
                           value: RecursiveStruct @ 0x3FCCFAC0
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: depth
                               type_name:
                                 Base: u32
                               value: "2"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: next_self
                               type_name:
                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x3FCCFAC4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: Some
                                   type_name:
                                     Struct: Some
                                   value: Some @ 0x3FCCFAC4
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: __0
                                       type_name:
                                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x3FCCFAC4"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                                       children:
                                         - name:
                                             Named: "*__0"
                                           type_name:
                                             Struct: RecursiveStruct
                                           value: RecursiveStruct @ 0x3FCCFACC
-                                          source_location:
-                                            line: ~
-                                            column: ~
-                                            file: ~
-                                            directory: ~
+                                          source_location: ~
                                           children:
                                             - name:
                                                 Named: depth
                                               type_name:
                                                 Base: u32
                                               value: "3"
-                                              source_location:
-                                                line: ~
-                                                column: ~
-                                                file: ~
-                                                directory: ~
+                                              source_location: ~
                                             - name:
                                                 Named: next_self
                                               type_name:
                                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x3FCCFAD0"
-                                              source_location:
-                                                line: ~
-                                                column: ~
-                                                file: ~
-                                                directory: ~
+                                              source_location: ~
                                               children:
                                                 - name:
                                                     Named: None
                                                   type_name:
                                                     Struct: None
                                                   value: None @ 0x3FCCFAD0
-                                                  source_location:
-                                                    line: ~
-                                                    column: ~
-                                                    file: ~
-                                                    directory: ~
+                                                  source_location: ~
         - name:
             Named: first_case_of_struct_variants
           type_name:
@@ -5498,63 +4454,39 @@ snapshot_kind: text
               type_name:
                 Struct: Case1
               value: Case1 @ 0x3FCCFAD8
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: ComplexStruct
                   value: ComplexStruct @ 0x3FCCFAE8
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: x
                       type_name:
                         Base: i64
                       value: "24"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: y
                       type_name:
                         Base: i32
                       value: "25"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: z
                       type_name:
                         Base: i16
                       value: "26"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
         - name:
             Named: second_case_of_struct_variants
           type_name:
@@ -5571,42 +4503,26 @@ snapshot_kind: text
               type_name:
                 Struct: Case2
               value: Case2 @ 0x3FCCFB08
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: u64
                   value: "1023"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i16
                   value: "1967"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: struct_with_one_variant
           type_name:
@@ -5623,116 +4539,72 @@ snapshot_kind: text
               type_name:
                 Struct: Some
               value: Some @ 0x3FCCFB28
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: Univariant
                   value: Univariant @ 0x3FCCFB30
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: TupleOfComplexStruct
                       type_name:
                         Struct: TupleOfComplexStruct
                       value: TupleOfComplexStruct @ 0x3FCCFB30
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x3FCCFB30
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "24"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "25"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "26"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x3FCCFB40
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "-3"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "-2"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "-1"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
         - name:
             Named: stuct_with_one_variant_pointer
           type_name:
@@ -5749,127 +4621,79 @@ snapshot_kind: text
               type_name:
                 Struct: "Option<probe_rs_debugger_test::Univariant>"
               value: "Option<probe_rs_debugger_test::Univariant> @ 0x3FCCFB28"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x3FCCFB28
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Struct: Univariant
                       value: Univariant @ 0x3FCCFB30
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: TupleOfComplexStruct
                           type_name:
                             Struct: TupleOfComplexStruct
                           value: TupleOfComplexStruct @ 0x3FCCFB30
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: __0
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x3FCCFB30
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "24"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "25"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "26"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: __1
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x3FCCFB40
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "-3"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "-2"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "-1"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
         - name:
             Named: long_lived
           type_name:
@@ -5886,31 +4710,19 @@ snapshot_kind: text
               type_name:
                 Base: i64
               value: "10"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: short_lived
           type_name:
@@ -5927,31 +4739,19 @@ snapshot_kind: text
               type_name:
                 Base: i64
               value: "20"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: a1
           type_name:
@@ -5968,21 +4768,13 @@ snapshot_kind: text
               type_name:
                 Base: i32
               value: "-1"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: b1
               type_name:
                 Base: i64
               value: "0"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: a2
           type_name:
@@ -6029,21 +4821,13 @@ snapshot_kind: text
               type_name:
                 Base: i32
               value: "4"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __1
               type_name:
                 Base: i64
               value: "5"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: a6
           type_name:
@@ -6060,32 +4844,20 @@ snapshot_kind: text
               type_name:
                 Struct: Variant2
               value: Variant2 @ 0x3FCCFBE0
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i64
                   value: "7"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "6"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: a7
           type_name:
@@ -6102,32 +4874,20 @@ snapshot_kind: text
               type_name:
                 Struct: Variant1
               value: Variant1 @ 0x3FCCFC00
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "9"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i64
                   value: "8"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: my_array
           type_name:
@@ -6261,112 +5021,68 @@ snapshot_kind: text
                     Base: i32
                   count: 10
               value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: my_array_of_i8
           type_name:
@@ -6497,11 +5213,7 @@ snapshot_kind: text
               type_name:
                 Base: usize
               value: "3"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: buffer
               type_name:
@@ -6510,432 +5222,268 @@ snapshot_kind: text
                     Base: MaybeUninit<i8>
                   count: 10
               value: "[MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5C\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5D\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5E\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5F\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC60\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC61\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC62\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC63\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC64\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC65\n\t}]"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5C}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC5C
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "1"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5D}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC5D
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "2"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5E}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC5E
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "3"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5F}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC5F
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC60}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC60
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC61}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC61
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC62}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC62
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC63}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC63
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC64}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC64
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC65}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC65
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
         - name:
             Named: loop_counter
           type_name:
@@ -6952,11 +5500,7 @@ snapshot_kind: text
               type_name:
                 Base: u8
               value: "0"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: rtt_channels
           type_name:
@@ -6973,374 +5517,234 @@ snapshot_kind: text
               type_name:
                 Struct: "(rtt_target::UpChannel, rtt_target::UpChannel)"
               value: "(rtt_target::UpChannel, rtt_target::UpChannel) @ 0x3FCCFC6C"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x3FCCFC6C
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x3FCCFC6C"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x3FC80DB4
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x3FC80DB4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "83"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x3FC80DB8"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DC0
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DC0
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DC4
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DC4
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DC8
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DC8
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x3FCCFC70
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x3FCCFC70"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x3FC80DCC
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x3FC80DCC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x3FC80DD0"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "0"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DD8
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DD8
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DDC
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DDC
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DE0
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DE0
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
   canonical_frame_address: 1070399200
 - function_name: __risc_v_rt__main
   source_location:
@@ -7668,11 +6072,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tperipherals: Peripherals = Peripherals @ 0x3FCCFEFE,\n\tsystem: SystemParts = SystemParts @ 0x3FCCFEFF,\n\tclocks: Clocks = Clocks @ 0x3FCCFF00,\n\tdelay: Delay = Delay @ 0x3FCCFF18}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: peripherals
@@ -7690,820 +6090,508 @@ snapshot_kind: text
               type_name:
                 Struct: ADC1
               value: ADC1 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: ADC2
               type_name:
                 Struct: ADC2
               value: ADC2 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: AES
               type_name:
                 Struct: AES
               value: AES @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: APB_CTRL
               type_name:
                 Struct: APB_CTRL
               value: APB_CTRL @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: ASSIST_DEBUG
               type_name:
                 Struct: ASSIST_DEBUG
               value: ASSIST_DEBUG @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: BT
               type_name:
                 Struct: BT
               value: BT @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: DMA
               type_name:
                 Struct: DMA
               value: DMA @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: DS
               type_name:
                 Struct: DS
               value: DS @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: EFUSE
               type_name:
                 Struct: EFUSE
               value: EFUSE @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: EXTMEM
               type_name:
                 Struct: EXTMEM
               value: EXTMEM @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: GPIO
               type_name:
                 Struct: GPIO
               value: GPIO @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: GPIO_SD
               type_name:
                 Struct: GPIO_SD
               value: GPIO_SD @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: HMAC
               type_name:
                 Struct: HMAC
               value: HMAC @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: I2C0
               type_name:
                 Struct: I2C0
               value: I2C0 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: I2S0
               type_name:
                 Struct: I2S0
               value: I2S0 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: INTERRUPT_CORE0
               type_name:
                 Struct: INTERRUPT_CORE0
               value: INTERRUPT_CORE0 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: IO_MUX
               type_name:
                 Struct: IO_MUX
               value: IO_MUX @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: LEDC
               type_name:
                 Struct: LEDC
               value: LEDC @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: LPWR
               type_name:
                 Struct: LPWR
               value: LPWR @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: RMT
               type_name:
                 Struct: RMT
               value: RMT @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: RNG
               type_name:
                 Struct: RNG
               value: RNG @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: RSA
               type_name:
                 Struct: RSA
               value: RSA @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: SENSITIVE
               type_name:
                 Struct: SENSITIVE
               value: SENSITIVE @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: SHA
               type_name:
                 Struct: SHA
               value: SHA @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: SPI2
               type_name:
                 Struct: SPI2
               value: SPI2 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: SYSTEM
               type_name:
                 Struct: SYSTEM
               value: SYSTEM @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: SYSTIMER
               type_name:
                 Struct: SYSTIMER
               value: SYSTIMER @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: TIMG0
               type_name:
                 Struct: TIMG0
               value: TIMG0 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: TIMG1
               type_name:
                 Struct: TIMG1
               value: TIMG1 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: TWAI0
               type_name:
                 Struct: TWAI0
               value: TWAI0 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: UART1
               type_name:
                 Struct: UART1
               value: UART1 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: UHCI0
               type_name:
                 Struct: UHCI0
               value: UHCI0 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: UHCI1
               type_name:
                 Struct: UHCI1
               value: UHCI1 @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: USB_DEVICE
               type_name:
                 Struct: USB_DEVICE
               value: USB_DEVICE @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: WIFI
               type_name:
                 Struct: WIFI
               value: WIFI @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: XTS_AES
               type_name:
                 Struct: XTS_AES
               value: XTS_AES @ 0x3FCCFEFE
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: system
           type_name:
@@ -8520,147 +6608,91 @@ snapshot_kind: text
               type_name:
                 Struct: "PeripheralRef<esp_hal::soc::implementation::peripherals::peripherals::SYSTEM>"
               value: "PeripheralRef<esp_hal::soc::implementation::peripherals::peripherals::SYSTEM> @ 0x3FCCFEFF"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: inner
                   type_name:
                     Struct: SYSTEM
                   value: SYSTEM @ 0x3FCCFEFF
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _inner
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: clock_control
               type_name:
                 Struct: SystemClockControl
               value: SystemClockControl @ 0x3FCCFEFF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _private
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: cpu_control
               type_name:
                 Struct: CpuControl
               value: CpuControl @ 0x3FCCFEFF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _private
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: radio_clock_control
               type_name:
                 Struct: RadioClockControl
               value: RadioClockControl @ 0x3FCCFEFF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: _private
                   type_name:
                     Base: ()
                   value: ()
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: software_interrupt_control
               type_name:
                 Struct: SoftwareInterruptControl
               value: SoftwareInterruptControl @ 0x3FCCFEFF
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: software_interrupt0
                   type_name:
                     Struct: SoftwareInterrupt<0>
                   value: SoftwareInterrupt<0> @ 0x3FCCFEFF
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: software_interrupt1
                   type_name:
                     Struct: SoftwareInterrupt<1>
                   value: SoftwareInterrupt<1> @ 0x3FCCFEFF
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: software_interrupt2
                   type_name:
                     Struct: SoftwareInterrupt<2>
                   value: SoftwareInterrupt<2> @ 0x3FCCFEFF
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: software_interrupt3
                   type_name:
                     Struct: SoftwareInterrupt<3>
                   value: SoftwareInterrupt<3> @ 0x3FCCFEFF
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: clocks
           type_name:
@@ -8677,96 +6709,60 @@ snapshot_kind: text
               type_name:
                 Struct: "PeripheralRef<esp_hal::system::SystemClockControl>"
               value: "PeripheralRef<esp_hal::system::SystemClockControl> @ 0x3FCCFF0C"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: inner
                   type_name:
                     Struct: SystemClockControl
                   value: SystemClockControl @ 0x3FCCFF0C
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: _private
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
             - name:
                 Named: cpu_clock
               type_name:
                 Struct: "Rate<u32, 1, 1>"
               value: "Rate<u32, 1, 1> @ 0x3FCCFF00"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: raw
                   type_name:
                     Base: u32
                   value: "80000000"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: apb_clock
               type_name:
                 Struct: "Rate<u32, 1, 1>"
               value: "Rate<u32, 1, 1> @ 0x3FCCFF04"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: raw
                   type_name:
                     Base: u32
                   value: "80000000"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: xtal_clock
               type_name:
                 Struct: "Rate<u32, 1, 1>"
               value: "Rate<u32, 1, 1> @ 0x3FCCFF08"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: raw
                   type_name:
                     Base: u32
                   value: "40000000"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: delay
           type_name:
@@ -8783,22 +6779,14 @@ snapshot_kind: text
               type_name:
                 Struct: "Rate<u64, 1, 1>"
               value: "Rate<u64, 1, 1> @ 0x3FCCFF18"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: raw
                   type_name:
                     Base: u64
                   value: "16000000"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
   canonical_frame_address: 1070399392
 - function_name: hal_main
   source_location:
@@ -9121,11 +7109,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\ta0: usize = 0,\n\ta1: usize = 0,\n\ta2: usize = 0,\n\tstack_chk_guard: *mut u32 = *mut u32 @ 0x3FCCFFC0}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: a0
@@ -9173,11 +7157,7 @@ snapshot_kind: text
               type_name:
                 Base: u32
               value: "< Probe(Other(\"The coredump does not include the memory for address 0x3fc825f4 of size 0x4\")) >"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
   canonical_frame_address: 1070399440
 - function_name: start_rust
   source_location:
@@ -9500,11 +7480,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\ta0: usize = 0,\n\ta1: usize = 0,\n\ta2: usize = 0}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: a0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__esp32c3_full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__esp32c3_full_unwind.snap
@@ -1,6 +1,6 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
-assertion_line: 1996
+assertion_line: 1987
 expression: stack_frames
 snapshot_kind: text
 ---
@@ -9,8 +9,7 @@ snapshot_kind: text
     line: 348
     column:
       Column: 13
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -354,7 +353,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 5,\n\tinternal_depth_measure: usize = 6}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -364,8 +362,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -374,16 +371,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 1070395504
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -698,7 +693,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 4,\n\tinternal_depth_measure: usize = 5}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -708,8 +702,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -718,16 +711,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 1070395648
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -1042,7 +1033,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 3,\n\tinternal_depth_measure: usize = 4}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1052,8 +1042,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -1062,16 +1051,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 1070395792
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -1386,7 +1373,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 2,\n\tinternal_depth_measure: usize = 3}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1396,8 +1382,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -1406,16 +1391,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 1070395936
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -1730,7 +1713,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 1,\n\tinternal_depth_measure: usize = 2}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1740,8 +1722,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -1750,16 +1731,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 1070396080
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -2074,7 +2053,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 0,\n\tinternal_depth_measure: usize = 1}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -2084,8 +2062,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -2094,16 +2071,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 1070396224
 - function_name: setup_data_types
   source_location:
     line: 325
     column:
       Column: 5
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -2418,7 +2393,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tint8_minus_twenty_three: i8 = -23,\n\tlocal_reference_to_global_const: &str = This global `const` value will only show up in the debugger in the variables where it is referenced,\n\tlocal_reference_to_global_static: &str = A 'global' static variable,\n\tlocal_reference_to_global_static_struct: *const probe_rs_debugger_test::ComplexEnum = *const probe_rs_debugger_test::ComplexEnum @ 0x3FCCFCEC,\n\tghosted_variable: usize = 0,\n\tghosted_variable: &str = New value and type for a different name,\n\tint8_twenty_six: i8 = 26,\n\tint128: i128 = -196710231994021419720322,\n\tu_int128: u128 = 340282366920938266753142613410348491134,\n\tfloat64: f64 = 1.7608695652173911,\n\tfloat64_ptr: &f64 = &f64 @ 0x3FCCFD04,\n\temoji: char = 💩,\n\temoji_ptr: &char = &char @ 0x3FCCFD08,\n\ttrue_bool: bool = true,\n\tany_old_string_slice: &str = How long is a piece of String.,\n\tfunction_result: Result<(), &str> = Result<(), &str> @ 0x3FCCFD0C,\n\tglobal_types: (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) = (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x3FCCF470,\n\tthree_d_usize_array: Matrix<i32, 2, 3, 4> = Matrix<i32, 2, 3, 4> @ 0x3FCCF4AC,\n\tthree_d_string_array: Matrix<&str, 2, 3, 6> = Matrix<&str, 2, 3, 6> @ 0x3FCCF62C,\n\tthree: SimpleEnum = SimpleEnum::Two,\n\tsimple_enum_pointer: &probe_rs_debugger_test::SimpleEnum = &probe_rs_debugger_test::SimpleEnum @ 0x3FCCFAB0,\n\tthree_level_recursive_struct: RecursiveStruct = RecursiveStruct @ 0x3FCCFAB4,\n\tfirst_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x3FCCFAD8,\n\tsecond_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x3FCCFB08,\n\tstruct_with_one_variant: Option<probe_rs_debugger_test::Univariant> = Option<probe_rs_debugger_test::Univariant> @ 0x3FCCFB28,\n\tstuct_with_one_variant_pointer: &core::option::Option<probe_rs_debugger_test::Univariant> = &core::option::Option<probe_rs_debugger_test::Univariant> @ 0x3FCCFD14,\n\tlong_lived: ComplexStruct = ComplexStruct @ 0x3FCCFB90,\n\tshort_lived: ComplexStruct = ComplexStruct @ 0x3FCCFBA0,\n\ta1: Struct<i32> = Struct<i32> @ 0x3FCCFD18,\n\ta2: i64 = 1,\n\ta3: i64 = 2,\n\ta4: i64 = 3,\n\ta5: (i32, i64) = (i32, i64) @ 0x3FCCFD40,\n\ta6: Enum<i32> = Enum<i32> @ 0x3FCCFBE0,\n\ta7: Enum<i32> = Enum<i32> @ 0x3FCCFC00,\n\t[i32; 10] = [\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55\n\t],\n\tmy_array_ptr: &[i32; 10] = &[i32; 10] @ 0x3FCCFD50,\n\t[i8; 10] = [\n\t\t1,\n\t\t2,\n\t\t3,\n\t\t4,\n\t\t5,\n\t\t6,\n\t\t7,\n\t\t8,\n\t\t9,\n\t\t0\n\t],\n\theapless_vec: Vec<i8, 10> = Vec<i8, 10> @ 0x3FCCFC58,\n\tloop_counter: Wrapping<u8> = Wrapping<u8> @ 0x3FCCFC6B,\n\trtt_channels: Channels = Channels @ 0x3FCCFC6C}"
-      source_location: ~
       children:
         - name:
             Named: int8_minus_twenty_three
@@ -2428,8 +2402,7 @@ snapshot_kind: text
           source_location:
             line: 204
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: local_reference_to_global_const
           type_name:
@@ -2438,28 +2411,24 @@ snapshot_kind: text
           source_location:
             line: 207
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x3FCCF420"
-              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "84"
-                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "99"
-              source_location: ~
         - name:
             Named: local_reference_to_global_static
           type_name:
@@ -2468,28 +2437,24 @@ snapshot_kind: text
           source_location:
             line: 208
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x3FCCFCE4"
-              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "65"
-                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "26"
-              source_location: ~
         - name:
             Named: local_reference_to_global_static_struct
           type_name:
@@ -2498,54 +2463,46 @@ snapshot_kind: text
           source_location:
             line: 209
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*local_reference_to_global_static_struct"
               type_name:
                 Struct: ComplexEnum
               value: ComplexEnum @ 0x3FC80D70
-              source_location: ~
               children:
                 - name:
                     Named: Case1
                   type_name:
                     Struct: Case1
                   value: Case1 @ 0x3FC80D70
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Base: u64
                       value: "0"
-                      source_location: ~
                     - name:
                         Named: __1
                       type_name:
                         Struct: ComplexStruct
                       value: ComplexStruct @ 0x3FC80D80
-                      source_location: ~
                       children:
                         - name:
                             Named: x
                           type_name:
                             Base: i64
                           value: "24"
-                          source_location: ~
                         - name:
                             Named: y
                           type_name:
                             Base: i32
                           value: "25"
-                          source_location: ~
                         - name:
                             Named: z
                           type_name:
                             Base: i16
                           value: "26"
-                          source_location: ~
         - name:
             Named: ghosted_variable
           type_name:
@@ -2554,8 +2511,7 @@ snapshot_kind: text
           source_location:
             line: 210
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: ghosted_variable
           type_name:
@@ -2564,28 +2520,24 @@ snapshot_kind: text
           source_location:
             line: 211
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x3FCCF42C"
-              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "78"
-                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "39"
-              source_location: ~
         - name:
             Named: int8_twenty_six
           type_name:
@@ -2594,8 +2546,7 @@ snapshot_kind: text
           source_location:
             line: 212
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: int128
           type_name:
@@ -2604,8 +2555,7 @@ snapshot_kind: text
           source_location:
             line: 213
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: u_int128
           type_name:
@@ -2614,8 +2564,7 @@ snapshot_kind: text
           source_location:
             line: 214
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: float64
           type_name:
@@ -2624,8 +2573,7 @@ snapshot_kind: text
           source_location:
             line: 215
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: float64_ptr
           type_name:
@@ -2634,15 +2582,13 @@ snapshot_kind: text
           source_location:
             line: 216
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*float64_ptr"
               type_name:
                 Base: f64
               value: "1.7608695652173911"
-              source_location: ~
         - name:
             Named: emoji
           type_name:
@@ -2651,8 +2597,7 @@ snapshot_kind: text
           source_location:
             line: 217
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: emoji_ptr
           type_name:
@@ -2661,15 +2606,13 @@ snapshot_kind: text
           source_location:
             line: 218
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*emoji_ptr"
               type_name:
                 Base: char
               value: 💩
-              source_location: ~
         - name:
             Named: true_bool
           type_name:
@@ -2678,8 +2621,7 @@ snapshot_kind: text
           source_location:
             line: 219
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: any_old_string_slice
           type_name:
@@ -2688,28 +2630,24 @@ snapshot_kind: text
           source_location:
             line: 221
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x3FCCF450"
-              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "72"
-                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "30"
-              source_location: ~
         - name:
             Named: function_result
           type_name:
@@ -2718,42 +2656,36 @@ snapshot_kind: text
           source_location:
             line: 222
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Err
               type_name:
                 Struct: Err
               value: Err @ 0x3FCCFD0C
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: "&str"
                   value: Forcing the return of an Error variant
-                  source_location: ~
                   children:
                     - name:
                         Named: data_ptr
                       type_name:
                         Pointer: u8
                       value: "*raw u8 @ 0x3FCCFD0C"
-                      source_location: ~
                       children:
                         - name:
                             Named: "*data_ptr"
                           type_name:
                             Base: u8
                           value: "70"
-                          source_location: ~
                     - name:
                         Named: length
                       type_name:
                         Base: usize
                       value: "38"
-                      source_location: ~
         - name:
             Named: global_types
           type_name:
@@ -2762,93 +2694,78 @@ snapshot_kind: text
           source_location:
             line: 223
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
               type_name:
                 Base: bool
               value: "false"
-              source_location: ~
             - name:
                 Named: __1
               type_name:
                 Base: isize
               value: "-1"
-              source_location: ~
             - name:
                 Named: __2
               type_name:
                 Base: char
               value: a
-              source_location: ~
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "68"
-              source_location: ~
             - name:
                 Named: __4
               type_name:
                 Base: i16
               value: "-16"
-              source_location: ~
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "-32"
-              source_location: ~
             - name:
                 Named: __6
               type_name:
                 Base: i64
               value: "-64"
-              source_location: ~
             - name:
                 Named: __7
               type_name:
                 Base: usize
               value: "1"
-              source_location: ~
             - name:
                 Named: __8
               type_name:
                 Base: u8
               value: "100"
-              source_location: ~
             - name:
                 Named: __9
               type_name:
                 Base: u16
               value: "16"
-              source_location: ~
             - name:
                 Named: __10
               type_name:
                 Base: u32
               value: "32"
-              source_location: ~
             - name:
                 Named: __11
               type_name:
                 Base: u64
               value: "64"
-              source_location: ~
             - name:
                 Named: __12
               type_name:
                 Base: f32
               value: "2.5"
-              source_location: ~
             - name:
                 Named: __13
               type_name:
                 Base: f64
               value: "3.5"
-              source_location: ~
         - name:
             Named: three_d_usize_array
           type_name:
@@ -2857,8 +2774,7 @@ snapshot_kind: text
           source_location:
             line: 224
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: raw
@@ -2874,7 +2790,6 @@ snapshot_kind: text
                       count: 2
                   count: 4
               value: "[[[i32; 3]; 2]; 4] = [\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t0,\n\t\t\t1,\n\t\t\t2\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t3,\n\t\t\t4,\n\t\t\t5\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t6,\n\t\t\t7,\n\t\t\t8\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t9,\n\t\t\t10,\n\t\t\t11\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t12,\n\t\t\t13,\n\t\t\t14\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t15,\n\t\t\t16,\n\t\t\t17\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t18,\n\t\t\t19,\n\t\t\t20\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t21,\n\t\t\t22,\n\t\t\t23\n\t\t]\n\t]]"
-              source_location: ~
               children:
                 - name:
                     Named: __0
@@ -2887,7 +2802,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t0,\n\t\t1,\n\t\t2\n\t],\n\t[i32; 3] = [\n\t\t3,\n\t\t4,\n\t\t5\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2897,26 +2811,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t0,\n\t1,\n\t2]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "0"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "1"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "2"
-                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2925,26 +2835,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t3,\n\t4,\n\t5]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "3"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "4"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "5"
-                          source_location: ~
                 - name:
                     Named: __1
                   type_name:
@@ -2956,7 +2862,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t6,\n\t\t7,\n\t\t8\n\t],\n\t[i32; 3] = [\n\t\t9,\n\t\t10,\n\t\t11\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2966,26 +2871,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t6,\n\t7,\n\t8]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "6"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "7"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "8"
-                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2994,26 +2895,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t9,\n\t10,\n\t11]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "9"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "10"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "11"
-                          source_location: ~
                 - name:
                     Named: __2
                   type_name:
@@ -3025,7 +2922,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t12,\n\t\t13,\n\t\t14\n\t],\n\t[i32; 3] = [\n\t\t15,\n\t\t16,\n\t\t17\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3035,26 +2931,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t12,\n\t13,\n\t14]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "12"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "13"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "14"
-                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3063,26 +2955,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t15,\n\t16,\n\t17]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "15"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "16"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "17"
-                          source_location: ~
                 - name:
                     Named: __3
                   type_name:
@@ -3094,7 +2982,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t18,\n\t\t19,\n\t\t20\n\t],\n\t[i32; 3] = [\n\t\t21,\n\t\t22,\n\t\t23\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3104,26 +2991,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t18,\n\t19,\n\t20]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "18"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "19"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "20"
-                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3132,26 +3015,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t21,\n\t22,\n\t23]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "21"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "22"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "23"
-                          source_location: ~
         - name:
             Named: three_d_string_array
           type_name:
@@ -3160,8 +3039,7 @@ snapshot_kind: text
           source_location:
             line: 232
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: raw
@@ -3177,7 +3055,6 @@ snapshot_kind: text
                       count: 2
                   count: 6
               value: "[[[&str; 3]; 2]; 6] = [\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tApple,\n\t\t\tBanana,\n\t\t\tCherry\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tDog,\n\t\t\tElephant,\n\t\t\tFish\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tGuitar,\n\t\t\tHorse,\n\t\t\tIce Cream\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tJaguar,\n\t\t\tKangaroo,\n\t\t\tLion\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tMoon,\n\t\t\tNewton,\n\t\t\tOwl\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tPencil,\n\t\t\tQueen,\n\t\t\tRainbow\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tSun,\n\t\t\tTree,\n\t\t\tUmbrella\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tViolin,\n\t\t\tWatch,\n\t\t\tXylophone\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tYellow,\n\t\t\tZebra,\n\t\t\tAlpha\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tBravo,\n\t\t\tCharlie,\n\t\t\tDelta\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tEcho,\n\t\t\tFoxtrot,\n\t\t\tGolf\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tHotel,\n\t\t\tIndia,\n\t\t\tJuliet\n\t\t]\n\t]]"
-              source_location: ~
               children:
                 - name:
                     Named: __0
@@ -3190,7 +3067,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tApple,\n\t\tBanana,\n\t\tCherry\n\t],\n\t[&str; 3] = [\n\t\tDog,\n\t\tElephant,\n\t\tFish\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3200,86 +3076,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tApple,\n\tBanana,\n\tCherry]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Apple
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF62C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Banana
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF634"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Cherry
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF63C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3288,86 +3151,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tDog,\n\tElephant,\n\tFish]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Dog
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF644"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Elephant
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF64C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Fish
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF654"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                 - name:
                     Named: __1
                   type_name:
@@ -3379,7 +3229,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tGuitar,\n\t\tHorse,\n\t\tIce Cream\n\t],\n\t[&str; 3] = [\n\t\tJaguar,\n\t\tKangaroo,\n\t\tLion\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3389,86 +3238,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tGuitar,\n\tHorse,\n\tIce Cream]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Guitar
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF65C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Horse
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF664"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Ice Cream
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF66C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3477,86 +3313,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tJaguar,\n\tKangaroo,\n\tLion]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Jaguar
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF674"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Kangaroo
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF67C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "75"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Lion
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF684"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "76"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                 - name:
                     Named: __2
                   type_name:
@@ -3568,7 +3391,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tMoon,\n\t\tNewton,\n\t\tOwl\n\t],\n\t[&str; 3] = [\n\t\tPencil,\n\t\tQueen,\n\t\tRainbow\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3578,86 +3400,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tMoon,\n\tNewton,\n\tOwl]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Moon
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF68C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "77"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Newton
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF694"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "78"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Owl
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF69C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "79"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3666,86 +3475,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tPencil,\n\tQueen,\n\tRainbow]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Pencil
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6A4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "80"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Queen
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6AC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "81"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Rainbow
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6B4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "82"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location: ~
                 - name:
                     Named: __3
                   type_name:
@@ -3757,7 +3553,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tSun,\n\t\tTree,\n\t\tUmbrella\n\t],\n\t[&str; 3] = [\n\t\tViolin,\n\t\tWatch,\n\t\tXylophone\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3767,86 +3562,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tSun,\n\tTree,\n\tUmbrella]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Sun
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6BC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "83"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Tree
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6C4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "84"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Umbrella
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6CC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "85"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3855,86 +3637,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tViolin,\n\tWatch,\n\tXylophone]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Violin
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6D4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "86"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Watch
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6DC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "87"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Xylophone
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6E4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "88"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
-                              source_location: ~
                 - name:
                     Named: __4
                   type_name:
@@ -3946,7 +3715,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tYellow,\n\t\tZebra,\n\t\tAlpha\n\t],\n\t[&str; 3] = [\n\t\tBravo,\n\t\tCharlie,\n\t\tDelta\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3956,86 +3724,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tYellow,\n\tZebra,\n\tAlpha]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Yellow
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6EC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "89"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Zebra
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6F4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "90"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Alpha
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6FC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -4044,86 +3799,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tBravo,\n\tCharlie,\n\tDelta]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Bravo
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF704"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Charlie
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF70C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Delta
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF714"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                 - name:
                     Named: __5
                   type_name:
@@ -4135,7 +3877,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tEcho,\n\t\tFoxtrot,\n\t\tGolf\n\t],\n\t[&str; 3] = [\n\t\tHotel,\n\t\tIndia,\n\t\tJuliet\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -4145,86 +3886,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tEcho,\n\tFoxtrot,\n\tGolf]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Echo
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF71C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Foxtrot
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF724"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Golf
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF72C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -4233,86 +3961,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tHotel,\n\tIndia,\n\tJuliet]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Hotel
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF734"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: India
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF73C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Juliet
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF744"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
         - name:
             Named: three
           type_name:
@@ -4321,8 +4036,7 @@ snapshot_kind: text
           source_location:
             line: 249
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: simple_enum_pointer
           type_name:
@@ -4331,15 +4045,13 @@ snapshot_kind: text
           source_location:
             line: 250
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*simple_enum_pointer"
               type_name:
                 Enum: SimpleEnum
               value: "SimpleEnum::Two"
-              source_location: ~
         - name:
             Named: three_level_recursive_struct
           type_name:
@@ -4348,96 +4060,82 @@ snapshot_kind: text
           source_location:
             line: 252
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: depth
               type_name:
                 Base: u32
               value: "1"
-              source_location: ~
             - name:
                 Named: next_self
               type_name:
                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x3FCCFAB8"
-              source_location: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x3FCCFAB8
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x3FCCFAB8"
-                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RecursiveStruct
                           value: RecursiveStruct @ 0x3FCCFAC0
-                          source_location: ~
                           children:
                             - name:
                                 Named: depth
                               type_name:
                                 Base: u32
                               value: "2"
-                              source_location: ~
                             - name:
                                 Named: next_self
                               type_name:
                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x3FCCFAC4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: Some
                                   type_name:
                                     Struct: Some
                                   value: Some @ 0x3FCCFAC4
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: __0
                                       type_name:
                                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x3FCCFAC4"
-                                      source_location: ~
                                       children:
                                         - name:
                                             Named: "*__0"
                                           type_name:
                                             Struct: RecursiveStruct
                                           value: RecursiveStruct @ 0x3FCCFACC
-                                          source_location: ~
                                           children:
                                             - name:
                                                 Named: depth
                                               type_name:
                                                 Base: u32
                                               value: "3"
-                                              source_location: ~
                                             - name:
                                                 Named: next_self
                                               type_name:
                                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x3FCCFAD0"
-                                              source_location: ~
                                               children:
                                                 - name:
                                                     Named: None
                                                   type_name:
                                                     Struct: None
                                                   value: None @ 0x3FCCFAD0
-                                                  source_location: ~
         - name:
             Named: first_case_of_struct_variants
           type_name:
@@ -4446,47 +4144,40 @@ snapshot_kind: text
           source_location:
             line: 263
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Case1
               type_name:
                 Struct: Case1
               value: Case1 @ 0x3FCCFAD8
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: ComplexStruct
                   value: ComplexStruct @ 0x3FCCFAE8
-                  source_location: ~
                   children:
                     - name:
                         Named: x
                       type_name:
                         Base: i64
                       value: "24"
-                      source_location: ~
                     - name:
                         Named: y
                       type_name:
                         Base: i32
                       value: "25"
-                      source_location: ~
                     - name:
                         Named: z
                       type_name:
                         Base: i16
                       value: "26"
-                      source_location: ~
         - name:
             Named: second_case_of_struct_variants
           type_name:
@@ -4495,34 +4186,29 @@ snapshot_kind: text
           source_location:
             line: 271
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Case2
               type_name:
                 Struct: Case2
               value: Case2 @ 0x3FCCFB08
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: u64
                   value: "1023"
-                  source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i16
                   value: "1967"
-                  source_location: ~
         - name:
             Named: struct_with_one_variant
           type_name:
@@ -4531,80 +4217,68 @@ snapshot_kind: text
           source_location:
             line: 273
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Some
               type_name:
                 Struct: Some
               value: Some @ 0x3FCCFB28
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: Univariant
                   value: Univariant @ 0x3FCCFB30
-                  source_location: ~
                   children:
                     - name:
                         Named: TupleOfComplexStruct
                       type_name:
                         Struct: TupleOfComplexStruct
                       value: TupleOfComplexStruct @ 0x3FCCFB30
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x3FCCFB30
-                          source_location: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "24"
-                              source_location: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "25"
-                              source_location: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "26"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x3FCCFB40
-                          source_location: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "-3"
-                              source_location: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "-2"
-                              source_location: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "-1"
-                              source_location: ~
         - name:
             Named: stuct_with_one_variant_pointer
           type_name:
@@ -4613,87 +4287,74 @@ snapshot_kind: text
           source_location:
             line: 285
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*stuct_with_one_variant_pointer"
               type_name:
                 Struct: "Option<probe_rs_debugger_test::Univariant>"
               value: "Option<probe_rs_debugger_test::Univariant> @ 0x3FCCFB28"
-              source_location: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x3FCCFB28
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Struct: Univariant
                       value: Univariant @ 0x3FCCFB30
-                      source_location: ~
                       children:
                         - name:
                             Named: TupleOfComplexStruct
                           type_name:
                             Struct: TupleOfComplexStruct
                           value: TupleOfComplexStruct @ 0x3FCCFB30
-                          source_location: ~
                           children:
                             - name:
                                 Named: __0
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x3FCCFB30
-                              source_location: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "24"
-                                  source_location: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "25"
-                                  source_location: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "26"
-                                  source_location: ~
                             - name:
                                 Named: __1
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x3FCCFB40
-                              source_location: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "-3"
-                                  source_location: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "-2"
-                                  source_location: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "-1"
-                                  source_location: ~
         - name:
             Named: long_lived
           type_name:
@@ -4702,27 +4363,23 @@ snapshot_kind: text
           source_location:
             line: 287
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: x
               type_name:
                 Base: i64
               value: "10"
-              source_location: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
-              source_location: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
-              source_location: ~
         - name:
             Named: short_lived
           type_name:
@@ -4731,27 +4388,23 @@ snapshot_kind: text
           source_location:
             line: 289
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: x
               type_name:
                 Base: i64
               value: "20"
-              source_location: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
-              source_location: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
-              source_location: ~
         - name:
             Named: a1
           type_name:
@@ -4760,21 +4413,18 @@ snapshot_kind: text
           source_location:
             line: 290
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: b
               type_name:
                 Base: i32
               value: "-1"
-              source_location: ~
             - name:
                 Named: b1
               type_name:
                 Base: i64
               value: "0"
-              source_location: ~
         - name:
             Named: a2
           type_name:
@@ -4783,8 +4433,7 @@ snapshot_kind: text
           source_location:
             line: 291
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a3
           type_name:
@@ -4793,8 +4442,7 @@ snapshot_kind: text
           source_location:
             line: 292
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a4
           type_name:
@@ -4803,8 +4451,7 @@ snapshot_kind: text
           source_location:
             line: 293
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a5
           type_name:
@@ -4813,21 +4460,18 @@ snapshot_kind: text
           source_location:
             line: 294
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
               type_name:
                 Base: i32
               value: "4"
-              source_location: ~
             - name:
                 Named: __1
               type_name:
                 Base: i64
               value: "5"
-              source_location: ~
         - name:
             Named: a6
           type_name:
@@ -4836,28 +4480,24 @@ snapshot_kind: text
           source_location:
             line: 295
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Variant2
               type_name:
                 Struct: Variant2
               value: Variant2 @ 0x3FCCFBE0
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i64
                   value: "7"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "6"
-                  source_location: ~
         - name:
             Named: a7
           type_name:
@@ -4866,28 +4506,24 @@ snapshot_kind: text
           source_location:
             line: 296
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Variant1
               type_name:
                 Struct: Variant1
               value: Variant1 @ 0x3FCCFC00
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "9"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i64
                   value: "8"
-                  source_location: ~
         - name:
             Named: my_array
           type_name:
@@ -4899,8 +4535,7 @@ snapshot_kind: text
           source_location:
             line: 298
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -4910,8 +4545,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __1
               type_name:
@@ -4920,8 +4554,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __2
               type_name:
@@ -4930,8 +4563,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __3
               type_name:
@@ -4940,8 +4572,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __4
               type_name:
@@ -4950,8 +4581,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __5
               type_name:
@@ -4960,8 +4590,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __6
               type_name:
@@ -4970,8 +4599,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __7
               type_name:
@@ -4980,8 +4608,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __8
               type_name:
@@ -4990,8 +4617,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __9
               type_name:
@@ -5000,8 +4626,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: my_array_ptr
           type_name:
@@ -5010,8 +4635,7 @@ snapshot_kind: text
           source_location:
             line: 299
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*my_array_ptr"
@@ -5021,68 +4645,57 @@ snapshot_kind: text
                     Base: i32
                   count: 10
               value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
         - name:
             Named: my_array_of_i8
           type_name:
@@ -5094,8 +4707,7 @@ snapshot_kind: text
           source_location:
             line: 300
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -5105,8 +4717,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __1
               type_name:
@@ -5115,8 +4726,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __2
               type_name:
@@ -5125,8 +4735,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __3
               type_name:
@@ -5135,8 +4744,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __4
               type_name:
@@ -5145,8 +4753,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __5
               type_name:
@@ -5155,8 +4762,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __6
               type_name:
@@ -5165,8 +4771,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __7
               type_name:
@@ -5175,8 +4780,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __8
               type_name:
@@ -5185,8 +4789,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __9
               type_name:
@@ -5195,8 +4798,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: heapless_vec
           type_name:
@@ -5205,15 +4807,13 @@ snapshot_kind: text
           source_location:
             line: 301
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: len
               type_name:
                 Base: usize
               value: "3"
-              source_location: ~
             - name:
                 Named: buffer
               type_name:
@@ -5222,268 +4822,227 @@ snapshot_kind: text
                     Base: MaybeUninit<i8>
                   count: 10
               value: "[MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5C\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5D\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5E\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5F\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC60\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC61\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC62\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC63\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC64\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC65\n\t}]"
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5C}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC5C
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "1"
-                          source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5D}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC5D
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "2"
-                          source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5E}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC5E
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "3"
-                          source_location: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5F}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC5F
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC60}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC60
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC61}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC61
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC62}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC62
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC63}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC63
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC64}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC64
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC65}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC65
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
         - name:
             Named: loop_counter
           type_name:
@@ -5492,15 +5051,13 @@ snapshot_kind: text
           source_location:
             line: 305
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
               type_name:
                 Base: u8
               value: "0"
-              source_location: ~
         - name:
             Named: rtt_channels
           type_name:
@@ -5509,250 +5066,213 @@ snapshot_kind: text
           source_location:
             line: 306
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: up
               type_name:
                 Struct: "(rtt_target::UpChannel, rtt_target::UpChannel)"
               value: "(rtt_target::UpChannel, rtt_target::UpChannel) @ 0x3FCCFC6C"
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x3FCCFC6C
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x3FCCFC6C"
-                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x3FC80DB4
-                          source_location: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x3FC80DB4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "83"
-                                  source_location: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x3FC80DB8"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
-                              source_location: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DC0
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DC0
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
-                                      source_location: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DC4
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DC4
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
-                                      source_location: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DC8
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DC8
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
-                                      source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x3FCCFC70
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x3FCCFC70"
-                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x3FC80DCC
-                          source_location: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x3FC80DCC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x3FC80DD0"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "0"
-                                  source_location: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
-                              source_location: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DD8
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DD8
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
-                                      source_location: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DDC
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DDC
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
-                                      source_location: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DE0
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DE0
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
-                                      source_location: ~
   canonical_frame_address: 1070399200
 - function_name: __risc_v_rt__main
   source_location:
     line: 26
     column:
       Column: 54
-    file: esp32c3.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
   registers:
     - core_register:
         id: 4096
@@ -6072,7 +5592,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tperipherals: Peripherals = Peripherals @ 0x3FCCFEFE,\n\tsystem: SystemParts = SystemParts @ 0x3FCCFEFF,\n\tclocks: Clocks = Clocks @ 0x3FCCFF00,\n\tdelay: Delay = Delay @ 0x3FCCFF18}"
-      source_location: ~
       children:
         - name:
             Named: peripherals
@@ -6082,516 +5601,437 @@ snapshot_kind: text
           source_location:
             line: 18
             column: ~
-            file: esp32c3.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
           children:
             - name:
                 Named: ADC1
               type_name:
                 Struct: ADC1
               value: ADC1 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: ADC2
               type_name:
                 Struct: ADC2
               value: ADC2 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: AES
               type_name:
                 Struct: AES
               value: AES @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: APB_CTRL
               type_name:
                 Struct: APB_CTRL
               value: APB_CTRL @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: ASSIST_DEBUG
               type_name:
                 Struct: ASSIST_DEBUG
               value: ASSIST_DEBUG @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: BT
               type_name:
                 Struct: BT
               value: BT @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: DMA
               type_name:
                 Struct: DMA
               value: DMA @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: DS
               type_name:
                 Struct: DS
               value: DS @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: EFUSE
               type_name:
                 Struct: EFUSE
               value: EFUSE @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: EXTMEM
               type_name:
                 Struct: EXTMEM
               value: EXTMEM @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: GPIO
               type_name:
                 Struct: GPIO
               value: GPIO @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: GPIO_SD
               type_name:
                 Struct: GPIO_SD
               value: GPIO_SD @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: HMAC
               type_name:
                 Struct: HMAC
               value: HMAC @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: I2C0
               type_name:
                 Struct: I2C0
               value: I2C0 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: I2S0
               type_name:
                 Struct: I2S0
               value: I2S0 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: INTERRUPT_CORE0
               type_name:
                 Struct: INTERRUPT_CORE0
               value: INTERRUPT_CORE0 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: IO_MUX
               type_name:
                 Struct: IO_MUX
               value: IO_MUX @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: LEDC
               type_name:
                 Struct: LEDC
               value: LEDC @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: LPWR
               type_name:
                 Struct: LPWR
               value: LPWR @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: RMT
               type_name:
                 Struct: RMT
               value: RMT @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: RNG
               type_name:
                 Struct: RNG
               value: RNG @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: RSA
               type_name:
                 Struct: RSA
               value: RSA @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: SENSITIVE
               type_name:
                 Struct: SENSITIVE
               value: SENSITIVE @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: SHA
               type_name:
                 Struct: SHA
               value: SHA @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: SPI2
               type_name:
                 Struct: SPI2
               value: SPI2 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: SYSTEM
               type_name:
                 Struct: SYSTEM
               value: SYSTEM @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: SYSTIMER
               type_name:
                 Struct: SYSTIMER
               value: SYSTIMER @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: TIMG0
               type_name:
                 Struct: TIMG0
               value: TIMG0 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: TIMG1
               type_name:
                 Struct: TIMG1
               value: TIMG1 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: TWAI0
               type_name:
                 Struct: TWAI0
               value: TWAI0 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: UART1
               type_name:
                 Struct: UART1
               value: UART1 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: UHCI0
               type_name:
                 Struct: UHCI0
               value: UHCI0 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: UHCI1
               type_name:
                 Struct: UHCI1
               value: UHCI1 @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: USB_DEVICE
               type_name:
                 Struct: USB_DEVICE
               value: USB_DEVICE @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: WIFI
               type_name:
                 Struct: WIFI
               value: WIFI @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: XTS_AES
               type_name:
                 Struct: XTS_AES
               value: XTS_AES @ 0x3FCCFEFE
-              source_location: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
         - name:
             Named: system
           type_name:
@@ -6600,99 +6040,84 @@ snapshot_kind: text
           source_location:
             line: 19
             column: ~
-            file: esp32c3.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
           children:
             - name:
                 Named: _private
               type_name:
                 Struct: "PeripheralRef<esp_hal::soc::implementation::peripherals::peripherals::SYSTEM>"
               value: "PeripheralRef<esp_hal::soc::implementation::peripherals::peripherals::SYSTEM> @ 0x3FCCFEFF"
-              source_location: ~
               children:
                 - name:
                     Named: inner
                   type_name:
                     Struct: SYSTEM
                   value: SYSTEM @ 0x3FCCFEFF
-                  source_location: ~
                   children:
                     - name:
                         Named: _inner
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
             - name:
                 Named: clock_control
               type_name:
                 Struct: SystemClockControl
               value: SystemClockControl @ 0x3FCCFEFF
-              source_location: ~
               children:
                 - name:
                     Named: _private
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: cpu_control
               type_name:
                 Struct: CpuControl
               value: CpuControl @ 0x3FCCFEFF
-              source_location: ~
               children:
                 - name:
                     Named: _private
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: radio_clock_control
               type_name:
                 Struct: RadioClockControl
               value: RadioClockControl @ 0x3FCCFEFF
-              source_location: ~
               children:
                 - name:
                     Named: _private
                   type_name:
                     Base: ()
                   value: ()
-                  source_location: ~
             - name:
                 Named: software_interrupt_control
               type_name:
                 Struct: SoftwareInterruptControl
               value: SoftwareInterruptControl @ 0x3FCCFEFF
-              source_location: ~
               children:
                 - name:
                     Named: software_interrupt0
                   type_name:
                     Struct: SoftwareInterrupt<0>
                   value: SoftwareInterrupt<0> @ 0x3FCCFEFF
-                  source_location: ~
                 - name:
                     Named: software_interrupt1
                   type_name:
                     Struct: SoftwareInterrupt<1>
                   value: SoftwareInterrupt<1> @ 0x3FCCFEFF
-                  source_location: ~
                 - name:
                     Named: software_interrupt2
                   type_name:
                     Struct: SoftwareInterrupt<2>
                   value: SoftwareInterrupt<2> @ 0x3FCCFEFF
-                  source_location: ~
                 - name:
                     Named: software_interrupt3
                   type_name:
                     Struct: SoftwareInterrupt<3>
                   value: SoftwareInterrupt<3> @ 0x3FCCFEFF
-                  source_location: ~
         - name:
             Named: clocks
           type_name:
@@ -6701,68 +6126,58 @@ snapshot_kind: text
           source_location:
             line: 20
             column: ~
-            file: esp32c3.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
           children:
             - name:
                 Named: _private
               type_name:
                 Struct: "PeripheralRef<esp_hal::system::SystemClockControl>"
               value: "PeripheralRef<esp_hal::system::SystemClockControl> @ 0x3FCCFF0C"
-              source_location: ~
               children:
                 - name:
                     Named: inner
                   type_name:
                     Struct: SystemClockControl
                   value: SystemClockControl @ 0x3FCCFF0C
-                  source_location: ~
                   children:
                     - name:
                         Named: _private
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
             - name:
                 Named: cpu_clock
               type_name:
                 Struct: "Rate<u32, 1, 1>"
               value: "Rate<u32, 1, 1> @ 0x3FCCFF00"
-              source_location: ~
               children:
                 - name:
                     Named: raw
                   type_name:
                     Base: u32
                   value: "80000000"
-                  source_location: ~
             - name:
                 Named: apb_clock
               type_name:
                 Struct: "Rate<u32, 1, 1>"
               value: "Rate<u32, 1, 1> @ 0x3FCCFF04"
-              source_location: ~
               children:
                 - name:
                     Named: raw
                   type_name:
                     Base: u32
                   value: "80000000"
-                  source_location: ~
             - name:
                 Named: xtal_clock
               type_name:
                 Struct: "Rate<u32, 1, 1>"
               value: "Rate<u32, 1, 1> @ 0x3FCCFF08"
-              source_location: ~
               children:
                 - name:
                     Named: raw
                   type_name:
                     Base: u32
                   value: "40000000"
-                  source_location: ~
         - name:
             Named: delay
           type_name:
@@ -6771,30 +6186,26 @@ snapshot_kind: text
           source_location:
             line: 23
             column: ~
-            file: esp32c3.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/esp32c3.rs
           children:
             - name:
                 Named: freq
               type_name:
                 Struct: "Rate<u64, 1, 1>"
               value: "Rate<u64, 1, 1> @ 0x3FCCFF18"
-              source_location: ~
               children:
                 - name:
                     Named: raw
                   type_name:
                     Base: u64
                   value: "16000000"
-                  source_location: ~
   canonical_frame_address: 1070399392
 - function_name: hal_main
   source_location:
     line: 521
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -7109,7 +6520,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\ta0: usize = 0,\n\ta1: usize = 0,\n\ta2: usize = 0,\n\tstack_chk_guard: *mut u32 = *mut u32 @ 0x3FCCFFC0}"
-      source_location: ~
       children:
         - name:
             Named: a0
@@ -7119,8 +6529,7 @@ snapshot_kind: text
           source_location:
             line: 505
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
         - name:
             Named: a1
           type_name:
@@ -7129,8 +6538,7 @@ snapshot_kind: text
           source_location:
             line: 505
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
         - name:
             Named: a2
           type_name:
@@ -7139,8 +6547,7 @@ snapshot_kind: text
           source_location:
             line: 505
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
         - name:
             Named: stack_chk_guard
           type_name:
@@ -7149,23 +6556,20 @@ snapshot_kind: text
           source_location:
             line: 516
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src/lib.rs
           children:
             - name:
                 Named: "*stack_chk_guard"
               type_name:
                 Base: u32
               value: "< Probe(Other(\"The coredump does not include the memory for address 0x3fc825f4 of size 0x4\")) >"
-              source_location: ~
   canonical_frame_address: 1070399440
 - function_name: start_rust
   source_location:
     line: 70
     column:
       Column: 5
-    file: lib.rs
-    directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src/lib.rs
   registers:
     - core_register:
         id: 4096
@@ -7480,7 +6884,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\ta0: usize = 0,\n\ta1: usize = 0,\n\ta2: usize = 0}"
-      source_location: ~
       children:
         - name:
             Named: a0
@@ -7490,8 +6893,7 @@ snapshot_kind: text
           source_location:
             line: 56
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src/lib.rs
         - name:
             Named: a1
           type_name:
@@ -7500,8 +6902,7 @@ snapshot_kind: text
           source_location:
             line: 56
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src/lib.rs
         - name:
             Named: a2
           type_name:
@@ -7510,6 +6911,5 @@ snapshot_kind: text
           source_location:
             line: 56
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src/lib.rs
   canonical_frame_address: 1070399472

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__esp32c3_full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__esp32c3_full_unwind.snap
@@ -1,6 +1,8 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1996
 expression: stack_frames
+snapshot_kind: text
 ---
 - function_name: test_deep_stack
   source_location:
@@ -352,17 +354,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 5,\n\tinternal_depth_measure: usize = 6}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "5"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "6"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 1070395504
 - function_name: test_deep_stack
   source_location:
@@ -685,17 +702,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 4,\n\tinternal_depth_measure: usize = 5}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "4"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "5"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 1070395648
 - function_name: test_deep_stack
   source_location:
@@ -1018,17 +1050,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 3,\n\tinternal_depth_measure: usize = 4}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "3"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "4"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 1070395792
 - function_name: test_deep_stack
   source_location:
@@ -1351,17 +1398,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 2,\n\tinternal_depth_measure: usize = 3}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "2"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "3"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 1070395936
 - function_name: test_deep_stack
   source_location:
@@ -1684,17 +1746,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 1,\n\tinternal_depth_measure: usize = 2}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "1"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "2"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 1070396080
 - function_name: test_deep_stack
   source_location:
@@ -2017,17 +2094,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 0,\n\tinternal_depth_measure: usize = 1}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "0"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "1"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 1070396224
 - function_name: setup_data_types
   source_location:
@@ -2350,316 +2442,611 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tint8_minus_twenty_three: i8 = -23,\n\tlocal_reference_to_global_const: &str = This global `const` value will only show up in the debugger in the variables where it is referenced,\n\tlocal_reference_to_global_static: &str = A 'global' static variable,\n\tlocal_reference_to_global_static_struct: *const probe_rs_debugger_test::ComplexEnum = *const probe_rs_debugger_test::ComplexEnum @ 0x3FCCFCEC,\n\tghosted_variable: usize = 0,\n\tghosted_variable: &str = New value and type for a different name,\n\tint8_twenty_six: i8 = 26,\n\tint128: i128 = -196710231994021419720322,\n\tu_int128: u128 = 340282366920938266753142613410348491134,\n\tfloat64: f64 = 1.7608695652173911,\n\tfloat64_ptr: &f64 = &f64 @ 0x3FCCFD04,\n\temoji: char = 💩,\n\temoji_ptr: &char = &char @ 0x3FCCFD08,\n\ttrue_bool: bool = true,\n\tany_old_string_slice: &str = How long is a piece of String.,\n\tfunction_result: Result<(), &str> = Result<(), &str> @ 0x3FCCFD0C,\n\tglobal_types: (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) = (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x3FCCF470,\n\tthree_d_usize_array: Matrix<i32, 2, 3, 4> = Matrix<i32, 2, 3, 4> @ 0x3FCCF4AC,\n\tthree_d_string_array: Matrix<&str, 2, 3, 6> = Matrix<&str, 2, 3, 6> @ 0x3FCCF62C,\n\tthree: SimpleEnum = SimpleEnum::Two,\n\tsimple_enum_pointer: &probe_rs_debugger_test::SimpleEnum = &probe_rs_debugger_test::SimpleEnum @ 0x3FCCFAB0,\n\tthree_level_recursive_struct: RecursiveStruct = RecursiveStruct @ 0x3FCCFAB4,\n\tfirst_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x3FCCFAD8,\n\tsecond_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x3FCCFB08,\n\tstruct_with_one_variant: Option<probe_rs_debugger_test::Univariant> = Option<probe_rs_debugger_test::Univariant> @ 0x3FCCFB28,\n\tstuct_with_one_variant_pointer: &core::option::Option<probe_rs_debugger_test::Univariant> = &core::option::Option<probe_rs_debugger_test::Univariant> @ 0x3FCCFD14,\n\tlong_lived: ComplexStruct = ComplexStruct @ 0x3FCCFB90,\n\tshort_lived: ComplexStruct = ComplexStruct @ 0x3FCCFBA0,\n\ta1: Struct<i32> = Struct<i32> @ 0x3FCCFD18,\n\ta2: i64 = 1,\n\ta3: i64 = 2,\n\ta4: i64 = 3,\n\ta5: (i32, i64) = (i32, i64) @ 0x3FCCFD40,\n\ta6: Enum<i32> = Enum<i32> @ 0x3FCCFBE0,\n\ta7: Enum<i32> = Enum<i32> @ 0x3FCCFC00,\n\t[i32; 10] = [\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55\n\t],\n\tmy_array_ptr: &[i32; 10] = &[i32; 10] @ 0x3FCCFD50,\n\t[i8; 10] = [\n\t\t1,\n\t\t2,\n\t\t3,\n\t\t4,\n\t\t5,\n\t\t6,\n\t\t7,\n\t\t8,\n\t\t9,\n\t\t0\n\t],\n\theapless_vec: Vec<i8, 10> = Vec<i8, 10> @ 0x3FCCFC58,\n\tloop_counter: Wrapping<u8> = Wrapping<u8> @ 0x3FCCFC6B,\n\trtt_channels: Channels = Channels @ 0x3FCCFC6C}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: int8_minus_twenty_three
           type_name:
             Base: i8
           value: "-23"
+          source_location:
+            line: 204
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: local_reference_to_global_const
           type_name:
             Struct: "&str"
           value: "This global `const` value will only show up in the debugger in the variables where it is referenced"
+          source_location:
+            line: 207
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x3FCCF420"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "84"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "99"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: local_reference_to_global_static
           type_name:
             Struct: "&str"
           value: "A 'global' static variable"
+          source_location:
+            line: 208
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x3FCCFCE4"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "65"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "26"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: local_reference_to_global_static_struct
           type_name:
             Pointer: "*const probe_rs_debugger_test::ComplexEnum"
           value: "*const probe_rs_debugger_test::ComplexEnum @ 0x3FCCFCEC"
+          source_location:
+            line: 209
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*local_reference_to_global_static_struct"
               type_name:
                 Struct: ComplexEnum
               value: ComplexEnum @ 0x3FC80D70
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: Case1
                   type_name:
                     Struct: Case1
                   value: Case1 @ 0x3FC80D70
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Base: u64
                       value: "0"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: __1
                       type_name:
                         Struct: ComplexStruct
                       value: ComplexStruct @ 0x3FC80D80
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: x
                           type_name:
                             Base: i64
                           value: "24"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: y
                           type_name:
                             Base: i32
                           value: "25"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: z
                           type_name:
                             Base: i16
                           value: "26"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
         - name:
             Named: ghosted_variable
           type_name:
             Base: usize
           value: "0"
+          source_location:
+            line: 210
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: ghosted_variable
           type_name:
             Struct: "&str"
           value: New value and type for a different name
+          source_location:
+            line: 211
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x3FCCF42C"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "78"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "39"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: int8_twenty_six
           type_name:
             Base: i8
           value: "26"
+          source_location:
+            line: 212
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: int128
           type_name:
             Base: i128
           value: "-196710231994021419720322"
+          source_location:
+            line: 213
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: u_int128
           type_name:
             Base: u128
           value: "340282366920938266753142613410348491134"
+          source_location:
+            line: 214
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: float64
           type_name:
             Base: f64
           value: "1.7608695652173911"
+          source_location:
+            line: 215
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: float64_ptr
           type_name:
             Pointer: "&f64"
           value: "&f64 @ 0x3FCCFD04"
+          source_location:
+            line: 216
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*float64_ptr"
               type_name:
                 Base: f64
               value: "1.7608695652173911"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: emoji
           type_name:
             Base: char
           value: 💩
+          source_location:
+            line: 217
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: emoji_ptr
           type_name:
             Pointer: "&char"
           value: "&char @ 0x3FCCFD08"
+          source_location:
+            line: 218
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*emoji_ptr"
               type_name:
                 Base: char
               value: 💩
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: true_bool
           type_name:
             Base: bool
           value: "true"
+          source_location:
+            line: 219
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: any_old_string_slice
           type_name:
             Struct: "&str"
           value: How long is a piece of String.
+          source_location:
+            line: 221
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x3FCCF450"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "72"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "30"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: function_result
           type_name:
             Struct: "Result<(), &str>"
           value: "Result<(), &str> @ 0x3FCCFD0C"
+          source_location:
+            line: 222
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Err
               type_name:
                 Struct: Err
               value: Err @ 0x3FCCFD0C
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: "&str"
                   value: Forcing the return of an Error variant
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: data_ptr
                       type_name:
                         Pointer: u8
                       value: "*raw u8 @ 0x3FCCFD0C"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: "*data_ptr"
                           type_name:
                             Base: u8
                           value: "70"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: length
                       type_name:
                         Base: usize
                       value: "38"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
         - name:
             Named: global_types
           type_name:
             Struct: "(bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64)"
           value: "(bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x3FCCF470"
+          source_location:
+            line: 223
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: bool
               value: "false"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __1
               type_name:
                 Base: isize
               value: "-1"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __2
               type_name:
                 Base: char
               value: a
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "68"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __4
               type_name:
                 Base: i16
               value: "-16"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "-32"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __6
               type_name:
                 Base: i64
               value: "-64"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __7
               type_name:
                 Base: usize
               value: "1"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __8
               type_name:
                 Base: u8
               value: "100"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __9
               type_name:
                 Base: u16
               value: "16"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __10
               type_name:
                 Base: u32
               value: "32"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __11
               type_name:
                 Base: u64
               value: "64"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __12
               type_name:
                 Base: f32
               value: "2.5"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __13
               type_name:
                 Base: f64
               value: "3.5"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: three_d_usize_array
           type_name:
             Struct: "Matrix<i32, 2, 3, 4>"
           value: "Matrix<i32, 2, 3, 4> @ 0x3FCCF4AC"
+          source_location:
+            line: 224
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: raw
@@ -2675,6 +3062,11 @@ expression: stack_frames
                       count: 2
                   count: 4
               value: "[[[i32; 3]; 2]; 4] = [\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t0,\n\t\t\t1,\n\t\t\t2\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t3,\n\t\t\t4,\n\t\t\t5\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t6,\n\t\t\t7,\n\t\t\t8\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t9,\n\t\t\t10,\n\t\t\t11\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t12,\n\t\t\t13,\n\t\t\t14\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t15,\n\t\t\t16,\n\t\t\t17\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t18,\n\t\t\t19,\n\t\t\t20\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t21,\n\t\t\t22,\n\t\t\t23\n\t\t]\n\t]]"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
@@ -2687,6 +3079,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t0,\n\t\t1,\n\t\t2\n\t],\n\t[i32; 3] = [\n\t\t3,\n\t\t4,\n\t\t5\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2696,22 +3093,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t0,\n\t1,\n\t2]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "1"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "2"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2720,22 +3137,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t3,\n\t4,\n\t5]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "3"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "4"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "5"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __1
                   type_name:
@@ -2747,6 +3184,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t6,\n\t\t7,\n\t\t8\n\t],\n\t[i32; 3] = [\n\t\t9,\n\t\t10,\n\t\t11\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2756,22 +3198,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t6,\n\t7,\n\t8]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "6"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "7"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "8"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2780,22 +3242,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t9,\n\t10,\n\t11]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "9"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "10"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "11"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __2
                   type_name:
@@ -2807,6 +3289,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t12,\n\t\t13,\n\t\t14\n\t],\n\t[i32; 3] = [\n\t\t15,\n\t\t16,\n\t\t17\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2816,22 +3303,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t12,\n\t13,\n\t14]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "12"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "13"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "14"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2840,22 +3347,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t15,\n\t16,\n\t17]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "15"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "16"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "17"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __3
                   type_name:
@@ -2867,6 +3394,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t18,\n\t\t19,\n\t\t20\n\t],\n\t[i32; 3] = [\n\t\t21,\n\t\t22,\n\t\t23\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2876,22 +3408,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t18,\n\t19,\n\t20]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "18"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "19"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "20"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2900,27 +3452,52 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t21,\n\t22,\n\t23]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "21"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "22"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "23"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
         - name:
             Named: three_d_string_array
           type_name:
             Struct: "Matrix<&str, 2, 3, 6>"
           value: "Matrix<&str, 2, 3, 6> @ 0x3FCCF62C"
+          source_location:
+            line: 232
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: raw
@@ -2936,6 +3513,11 @@ expression: stack_frames
                       count: 2
                   count: 6
               value: "[[[&str; 3]; 2]; 6] = [\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tApple,\n\t\t\tBanana,\n\t\t\tCherry\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tDog,\n\t\t\tElephant,\n\t\t\tFish\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tGuitar,\n\t\t\tHorse,\n\t\t\tIce Cream\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tJaguar,\n\t\t\tKangaroo,\n\t\t\tLion\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tMoon,\n\t\t\tNewton,\n\t\t\tOwl\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tPencil,\n\t\t\tQueen,\n\t\t\tRainbow\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tSun,\n\t\t\tTree,\n\t\t\tUmbrella\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tViolin,\n\t\t\tWatch,\n\t\t\tXylophone\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tYellow,\n\t\t\tZebra,\n\t\t\tAlpha\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tBravo,\n\t\t\tCharlie,\n\t\t\tDelta\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tEcho,\n\t\t\tFoxtrot,\n\t\t\tGolf\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tHotel,\n\t\t\tIndia,\n\t\t\tJuliet\n\t\t]\n\t]]"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
@@ -2948,6 +3530,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tApple,\n\t\tBanana,\n\t\tCherry\n\t],\n\t[&str; 3] = [\n\t\tDog,\n\t\tElephant,\n\t\tFish\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2957,73 +3544,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tApple,\n\tBanana,\n\tCherry]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Apple
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF62C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Banana
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF634"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Cherry
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF63C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3032,73 +3684,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tDog,\n\tElephant,\n\tFish]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Dog
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF644"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Elephant
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF64C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Fish
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF654"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __1
                   type_name:
@@ -3110,6 +3827,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tGuitar,\n\t\tHorse,\n\t\tIce Cream\n\t],\n\t[&str; 3] = [\n\t\tJaguar,\n\t\tKangaroo,\n\t\tLion\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -3119,73 +3841,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tGuitar,\n\tHorse,\n\tIce Cream]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Guitar
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF65C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Horse
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF664"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Ice Cream
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF66C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3194,73 +3981,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tJaguar,\n\tKangaroo,\n\tLion]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Jaguar
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF674"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Kangaroo
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF67C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "75"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Lion
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF684"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "76"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __2
                   type_name:
@@ -3272,6 +4124,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tMoon,\n\t\tNewton,\n\t\tOwl\n\t],\n\t[&str; 3] = [\n\t\tPencil,\n\t\tQueen,\n\t\tRainbow\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -3281,73 +4138,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tMoon,\n\tNewton,\n\tOwl]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Moon
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF68C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "77"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Newton
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF694"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "78"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Owl
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF69C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "79"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3356,73 +4278,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tPencil,\n\tQueen,\n\tRainbow]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Pencil
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6A4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "80"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Queen
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6AC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "81"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Rainbow
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6B4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "82"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __3
                   type_name:
@@ -3434,6 +4421,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tSun,\n\t\tTree,\n\t\tUmbrella\n\t],\n\t[&str; 3] = [\n\t\tViolin,\n\t\tWatch,\n\t\tXylophone\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -3443,73 +4435,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tSun,\n\tTree,\n\tUmbrella]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Sun
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6BC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "83"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Tree
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6C4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "84"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Umbrella
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6CC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "85"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3518,73 +4575,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tViolin,\n\tWatch,\n\tXylophone]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Violin
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6D4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "86"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Watch
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6DC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "87"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Xylophone
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6E4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "88"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __4
                   type_name:
@@ -3596,6 +4718,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tYellow,\n\t\tZebra,\n\t\tAlpha\n\t],\n\t[&str; 3] = [\n\t\tBravo,\n\t\tCharlie,\n\t\tDelta\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -3605,73 +4732,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tYellow,\n\tZebra,\n\tAlpha]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Yellow
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6EC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "89"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Zebra
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6F4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "90"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Alpha
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF6FC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3680,73 +4872,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tBravo,\n\tCharlie,\n\tDelta]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Bravo
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF704"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Charlie
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF70C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Delta
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF714"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __5
                   type_name:
@@ -3758,6 +5015,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tEcho,\n\t\tFoxtrot,\n\t\tGolf\n\t],\n\t[&str; 3] = [\n\t\tHotel,\n\t\tIndia,\n\t\tJuliet\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -3767,73 +5029,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tEcho,\n\tFoxtrot,\n\tGolf]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Echo
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF71C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Foxtrot
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF724"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Golf
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF72C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3842,505 +5169,965 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tHotel,\n\tIndia,\n\tJuliet]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Hotel
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF734"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: India
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF73C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Juliet
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x3FCCF744"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
         - name:
             Named: three
           type_name:
             Enum: SimpleEnum
           value: "SimpleEnum::Two"
+          source_location:
+            line: 249
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: simple_enum_pointer
           type_name:
             Pointer: "&probe_rs_debugger_test::SimpleEnum"
           value: "&probe_rs_debugger_test::SimpleEnum @ 0x3FCCFAB0"
+          source_location:
+            line: 250
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*simple_enum_pointer"
               type_name:
                 Enum: SimpleEnum
               value: "SimpleEnum::Two"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: three_level_recursive_struct
           type_name:
             Struct: RecursiveStruct
           value: RecursiveStruct @ 0x3FCCFAB4
+          source_location:
+            line: 252
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: depth
               type_name:
                 Base: u32
               value: "1"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: next_self
               type_name:
                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x3FCCFAB8"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x3FCCFAB8
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x3FCCFAB8"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RecursiveStruct
                           value: RecursiveStruct @ 0x3FCCFAC0
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: depth
                               type_name:
                                 Base: u32
                               value: "2"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: next_self
                               type_name:
                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x3FCCFAC4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: Some
                                   type_name:
                                     Struct: Some
                                   value: Some @ 0x3FCCFAC4
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: __0
                                       type_name:
                                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x3FCCFAC4"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                                       children:
                                         - name:
                                             Named: "*__0"
                                           type_name:
                                             Struct: RecursiveStruct
                                           value: RecursiveStruct @ 0x3FCCFACC
+                                          source_location:
+                                            line: ~
+                                            column: ~
+                                            file: ~
+                                            directory: ~
                                           children:
                                             - name:
                                                 Named: depth
                                               type_name:
                                                 Base: u32
                                               value: "3"
+                                              source_location:
+                                                line: ~
+                                                column: ~
+                                                file: ~
+                                                directory: ~
                                             - name:
                                                 Named: next_self
                                               type_name:
                                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x3FCCFAD0"
+                                              source_location:
+                                                line: ~
+                                                column: ~
+                                                file: ~
+                                                directory: ~
                                               children:
                                                 - name:
                                                     Named: None
                                                   type_name:
                                                     Struct: None
                                                   value: None @ 0x3FCCFAD0
+                                                  source_location:
+                                                    line: ~
+                                                    column: ~
+                                                    file: ~
+                                                    directory: ~
         - name:
             Named: first_case_of_struct_variants
           type_name:
             Struct: ComplexEnum
           value: ComplexEnum @ 0x3FCCFAD8
+          source_location:
+            line: 263
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Case1
               type_name:
                 Struct: Case1
               value: Case1 @ 0x3FCCFAD8
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: ComplexStruct
                   value: ComplexStruct @ 0x3FCCFAE8
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: x
                       type_name:
                         Base: i64
                       value: "24"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: y
                       type_name:
                         Base: i32
                       value: "25"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: z
                       type_name:
                         Base: i16
                       value: "26"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
         - name:
             Named: second_case_of_struct_variants
           type_name:
             Struct: ComplexEnum
           value: ComplexEnum @ 0x3FCCFB08
+          source_location:
+            line: 271
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Case2
               type_name:
                 Struct: Case2
               value: Case2 @ 0x3FCCFB08
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: u64
                   value: "1023"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i16
                   value: "1967"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: struct_with_one_variant
           type_name:
             Struct: "Option<probe_rs_debugger_test::Univariant>"
           value: "Option<probe_rs_debugger_test::Univariant> @ 0x3FCCFB28"
+          source_location:
+            line: 273
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Some
               type_name:
                 Struct: Some
               value: Some @ 0x3FCCFB28
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: Univariant
                   value: Univariant @ 0x3FCCFB30
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: TupleOfComplexStruct
                       type_name:
                         Struct: TupleOfComplexStruct
                       value: TupleOfComplexStruct @ 0x3FCCFB30
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x3FCCFB30
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "24"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "25"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "26"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x3FCCFB40
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "-3"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "-2"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "-1"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
         - name:
             Named: stuct_with_one_variant_pointer
           type_name:
             Pointer: "&core::option::Option<probe_rs_debugger_test::Univariant>"
           value: "&core::option::Option<probe_rs_debugger_test::Univariant> @ 0x3FCCFD14"
+          source_location:
+            line: 285
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*stuct_with_one_variant_pointer"
               type_name:
                 Struct: "Option<probe_rs_debugger_test::Univariant>"
               value: "Option<probe_rs_debugger_test::Univariant> @ 0x3FCCFB28"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x3FCCFB28
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Struct: Univariant
                       value: Univariant @ 0x3FCCFB30
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: TupleOfComplexStruct
                           type_name:
                             Struct: TupleOfComplexStruct
                           value: TupleOfComplexStruct @ 0x3FCCFB30
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: __0
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x3FCCFB30
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "24"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "25"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "26"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: __1
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x3FCCFB40
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "-3"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "-2"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "-1"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
         - name:
             Named: long_lived
           type_name:
             Struct: ComplexStruct
           value: ComplexStruct @ 0x3FCCFB90
+          source_location:
+            line: 287
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: x
               type_name:
                 Base: i64
               value: "10"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: short_lived
           type_name:
             Struct: ComplexStruct
           value: ComplexStruct @ 0x3FCCFBA0
+          source_location:
+            line: 289
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: x
               type_name:
                 Base: i64
               value: "20"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: a1
           type_name:
             Struct: Struct<i32>
           value: Struct<i32> @ 0x3FCCFD18
+          source_location:
+            line: 290
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: b
               type_name:
                 Base: i32
               value: "-1"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: b1
               type_name:
                 Base: i64
               value: "0"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: a2
           type_name:
             Base: i64
           value: "1"
+          source_location:
+            line: 291
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: a3
           type_name:
             Base: i64
           value: "2"
+          source_location:
+            line: 292
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: a4
           type_name:
             Base: i64
           value: "3"
+          source_location:
+            line: 293
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: a5
           type_name:
             Struct: "(i32, i64)"
           value: "(i32, i64) @ 0x3FCCFD40"
+          source_location:
+            line: 294
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: i32
               value: "4"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __1
               type_name:
                 Base: i64
               value: "5"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: a6
           type_name:
             Struct: Enum<i32>
           value: Enum<i32> @ 0x3FCCFBE0
+          source_location:
+            line: 295
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Variant2
               type_name:
                 Struct: Variant2
               value: Variant2 @ 0x3FCCFBE0
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i64
                   value: "7"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "6"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: a7
           type_name:
             Struct: Enum<i32>
           value: Enum<i32> @ 0x3FCCFC00
+          source_location:
+            line: 296
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Variant1
               type_name:
                 Struct: Variant1
               value: Variant1 @ 0x3FCCFC00
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "9"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i64
                   value: "8"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: my_array
           type_name:
@@ -4349,62 +6136,122 @@ expression: stack_frames
                 Base: i32
               count: 10
           value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
+          source_location:
+            line: 298
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __1
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __2
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __3
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __4
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __6
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __7
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __8
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __9
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: my_array_ptr
           type_name:
             Pointer: "&[i32; 10]"
           value: "&[i32; 10] @ 0x3FCCFD50"
+          source_location:
+            line: 299
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*my_array_ptr"
@@ -4414,57 +6261,112 @@ expression: stack_frames
                     Base: i32
                   count: 10
               value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: my_array_of_i8
           type_name:
@@ -4473,68 +6375,133 @@ expression: stack_frames
                 Base: i8
               count: 10
           value: "[i8; 10] = [\n\t1,\n\t2,\n\t3,\n\t4,\n\t5,\n\t6,\n\t7,\n\t8,\n\t9,\n\t0]"
+          source_location:
+            line: 300
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: i8
               value: "1"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __1
               type_name:
                 Base: i8
               value: "2"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __2
               type_name:
                 Base: i8
               value: "3"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "4"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __4
               type_name:
                 Base: i8
               value: "5"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __5
               type_name:
                 Base: i8
               value: "6"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __6
               type_name:
                 Base: i8
               value: "7"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __7
               type_name:
                 Base: i8
               value: "8"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __8
               type_name:
                 Base: i8
               value: "9"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __9
               type_name:
                 Base: i8
               value: "0"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: heapless_vec
           type_name:
             Struct: "Vec<i8, 10>"
           value: "Vec<i8, 10> @ 0x3FCCFC58"
+          source_location:
+            line: 301
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: len
               type_name:
                 Base: usize
               value: "3"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: buffer
               type_name:
@@ -4543,442 +6510,837 @@ expression: stack_frames
                     Base: MaybeUninit<i8>
                   count: 10
               value: "[MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5C\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5D\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5E\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5F\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC60\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC61\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC62\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC63\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC64\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC65\n\t}]"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5C}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC5C
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "1"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5D}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC5D
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "2"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5E}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC5E
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "3"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC5F}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC5F
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC60}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC60
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC61}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC61
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC62}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC62
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC63}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC63
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC64}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC64
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x3FCCFC65}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x3FCCFC65
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
         - name:
             Named: loop_counter
           type_name:
             Struct: Wrapping<u8>
           value: Wrapping<u8> @ 0x3FCCFC6B
+          source_location:
+            line: 305
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: u8
               value: "0"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: rtt_channels
           type_name:
             Struct: Channels
           value: Channels @ 0x3FCCFC6C
+          source_location:
+            line: 306
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: up
               type_name:
                 Struct: "(rtt_target::UpChannel, rtt_target::UpChannel)"
               value: "(rtt_target::UpChannel, rtt_target::UpChannel) @ 0x3FCCFC6C"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x3FCCFC6C
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x3FCCFC6C"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x3FC80DB4
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x3FC80DB4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "83"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x3FC80DB8"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "70"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DC0
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DC0
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DC4
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DC4
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DC8
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DC8
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x3FCCFC70
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x3FCCFC70"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x3FC80DCC
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x3FC80DCC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "66"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x3FC80DD0"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "0"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DD8
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DD8
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DDC
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DDC
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x3FC80DE0
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x3FC80DE0
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
   canonical_frame_address: 1070399200
 - function_name: __risc_v_rt__main
   source_location:
@@ -5306,597 +7668,1137 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tperipherals: Peripherals = Peripherals @ 0x3FCCFEFE,\n\tsystem: SystemParts = SystemParts @ 0x3FCCFEFF,\n\tclocks: Clocks = Clocks @ 0x3FCCFF00,\n\tdelay: Delay = Delay @ 0x3FCCFF18}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: peripherals
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x3FCCFEFE
+          source_location:
+            line: 18
+            column: ~
+            file: esp32c3.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: ADC1
               type_name:
                 Struct: ADC1
               value: ADC1 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: ADC2
               type_name:
                 Struct: ADC2
               value: ADC2 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: AES
               type_name:
                 Struct: AES
               value: AES @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: APB_CTRL
               type_name:
                 Struct: APB_CTRL
               value: APB_CTRL @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: ASSIST_DEBUG
               type_name:
                 Struct: ASSIST_DEBUG
               value: ASSIST_DEBUG @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: BT
               type_name:
                 Struct: BT
               value: BT @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: DMA
               type_name:
                 Struct: DMA
               value: DMA @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: DS
               type_name:
                 Struct: DS
               value: DS @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: EFUSE
               type_name:
                 Struct: EFUSE
               value: EFUSE @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: EXTMEM
               type_name:
                 Struct: EXTMEM
               value: EXTMEM @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: GPIO
               type_name:
                 Struct: GPIO
               value: GPIO @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: GPIO_SD
               type_name:
                 Struct: GPIO_SD
               value: GPIO_SD @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: HMAC
               type_name:
                 Struct: HMAC
               value: HMAC @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: I2C0
               type_name:
                 Struct: I2C0
               value: I2C0 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: I2S0
               type_name:
                 Struct: I2S0
               value: I2S0 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: INTERRUPT_CORE0
               type_name:
                 Struct: INTERRUPT_CORE0
               value: INTERRUPT_CORE0 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: IO_MUX
               type_name:
                 Struct: IO_MUX
               value: IO_MUX @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: LEDC
               type_name:
                 Struct: LEDC
               value: LEDC @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: LPWR
               type_name:
                 Struct: LPWR
               value: LPWR @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: RMT
               type_name:
                 Struct: RMT
               value: RMT @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: RNG
               type_name:
                 Struct: RNG
               value: RNG @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: RSA
               type_name:
                 Struct: RSA
               value: RSA @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: SENSITIVE
               type_name:
                 Struct: SENSITIVE
               value: SENSITIVE @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: SHA
               type_name:
                 Struct: SHA
               value: SHA @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: SPI2
               type_name:
                 Struct: SPI2
               value: SPI2 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: SYSTEM
               type_name:
                 Struct: SYSTEM
               value: SYSTEM @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: SYSTIMER
               type_name:
                 Struct: SYSTIMER
               value: SYSTIMER @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: TIMG0
               type_name:
                 Struct: TIMG0
               value: TIMG0 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: TIMG1
               type_name:
                 Struct: TIMG1
               value: TIMG1 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: TWAI0
               type_name:
                 Struct: TWAI0
               value: TWAI0 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: UART1
               type_name:
                 Struct: UART1
               value: UART1 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: UHCI0
               type_name:
                 Struct: UHCI0
               value: UHCI0 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: UHCI1
               type_name:
                 Struct: UHCI1
               value: UHCI1 @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: USB_DEVICE
               type_name:
                 Struct: USB_DEVICE
               value: USB_DEVICE @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: WIFI
               type_name:
                 Struct: WIFI
               value: WIFI @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: XTS_AES
               type_name:
                 Struct: XTS_AES
               value: XTS_AES @ 0x3FCCFEFE
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _inner
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: system
           type_name:
             Struct: SystemParts
           value: SystemParts @ 0x3FCCFEFF
+          source_location:
+            line: 19
+            column: ~
+            file: esp32c3.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: _private
               type_name:
                 Struct: "PeripheralRef<esp_hal::soc::implementation::peripherals::peripherals::SYSTEM>"
               value: "PeripheralRef<esp_hal::soc::implementation::peripherals::peripherals::SYSTEM> @ 0x3FCCFEFF"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: inner
                   type_name:
                     Struct: SYSTEM
                   value: SYSTEM @ 0x3FCCFEFF
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _inner
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: clock_control
               type_name:
                 Struct: SystemClockControl
               value: SystemClockControl @ 0x3FCCFEFF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _private
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: cpu_control
               type_name:
                 Struct: CpuControl
               value: CpuControl @ 0x3FCCFEFF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _private
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: radio_clock_control
               type_name:
                 Struct: RadioClockControl
               value: RadioClockControl @ 0x3FCCFEFF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: _private
                   type_name:
                     Base: ()
                   value: ()
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: software_interrupt_control
               type_name:
                 Struct: SoftwareInterruptControl
               value: SoftwareInterruptControl @ 0x3FCCFEFF
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: software_interrupt0
                   type_name:
                     Struct: SoftwareInterrupt<0>
                   value: SoftwareInterrupt<0> @ 0x3FCCFEFF
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: software_interrupt1
                   type_name:
                     Struct: SoftwareInterrupt<1>
                   value: SoftwareInterrupt<1> @ 0x3FCCFEFF
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: software_interrupt2
                   type_name:
                     Struct: SoftwareInterrupt<2>
                   value: SoftwareInterrupt<2> @ 0x3FCCFEFF
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: software_interrupt3
                   type_name:
                     Struct: SoftwareInterrupt<3>
                   value: SoftwareInterrupt<3> @ 0x3FCCFEFF
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: clocks
           type_name:
             Struct: Clocks
           value: Clocks @ 0x3FCCFF00
+          source_location:
+            line: 20
+            column: ~
+            file: esp32c3.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: _private
               type_name:
                 Struct: "PeripheralRef<esp_hal::system::SystemClockControl>"
               value: "PeripheralRef<esp_hal::system::SystemClockControl> @ 0x3FCCFF0C"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: inner
                   type_name:
                     Struct: SystemClockControl
                   value: SystemClockControl @ 0x3FCCFF0C
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: _private
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
             - name:
                 Named: cpu_clock
               type_name:
                 Struct: "Rate<u32, 1, 1>"
               value: "Rate<u32, 1, 1> @ 0x3FCCFF00"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: raw
                   type_name:
                     Base: u32
                   value: "80000000"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: apb_clock
               type_name:
                 Struct: "Rate<u32, 1, 1>"
               value: "Rate<u32, 1, 1> @ 0x3FCCFF04"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: raw
                   type_name:
                     Base: u32
                   value: "80000000"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: xtal_clock
               type_name:
                 Struct: "Rate<u32, 1, 1>"
               value: "Rate<u32, 1, 1> @ 0x3FCCFF08"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: raw
                   type_name:
                     Base: u32
                   value: "40000000"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: delay
           type_name:
             Struct: Delay
           value: Delay @ 0x3FCCFF18
+          source_location:
+            line: 23
+            column: ~
+            file: esp32c3.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: freq
               type_name:
                 Struct: "Rate<u64, 1, 1>"
               value: "Rate<u64, 1, 1> @ 0x3FCCFF18"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: raw
                   type_name:
                     Base: u64
                   value: "16000000"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
   canonical_frame_address: 1070399392
 - function_name: hal_main
   source_location:
@@ -6219,33 +9121,63 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\ta0: usize = 0,\n\ta1: usize = 0,\n\ta2: usize = 0,\n\tstack_chk_guard: *mut u32 = *mut u32 @ 0x3FCCFFC0}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: a0
           type_name:
             Base: usize
           value: "0"
+          source_location:
+            line: 505
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src
         - name:
             Named: a1
           type_name:
             Base: usize
           value: "0"
+          source_location:
+            line: 505
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src
         - name:
             Named: a2
           type_name:
             Base: usize
           value: "0"
+          source_location:
+            line: 505
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src
         - name:
             Named: stack_chk_guard
           type_name:
             Pointer: "*mut u32"
           value: "*mut u32 @ 0x3FCCFFC0"
+          source_location:
+            line: 516
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.17.0/src
           children:
             - name:
                 Named: "*stack_chk_guard"
               type_name:
                 Base: u32
               value: "< Probe(Other(\"The coredump does not include the memory for address 0x3fc825f4 of size 0x4\")) >"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
   canonical_frame_address: 1070399440
 - function_name: start_rust
   source_location:
@@ -6568,20 +9500,40 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\ta0: usize = 0,\n\ta1: usize = 0,\n\ta2: usize = 0}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: a0
           type_name:
             Base: usize
           value: "0"
+          source_location:
+            line: 56
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src
         - name:
             Named: a1
           type_name:
             Base: usize
           value: "0"
+          source_location:
+            line: 56
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src
         - name:
             Named: a2
           type_name:
             Base: usize
           value: "0"
+          source_location:
+            line: 56
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-riscv-rt-0.8.0/src
   canonical_frame_address: 1070399472

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_full_unwind.snap
@@ -1,6 +1,8 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1996
 expression: stack_frames
+snapshot_kind: text
 ---
 - function_name: test_deep_stack
   source_location:
@@ -213,17 +215,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 5,\n\tinternal_depth_measure: usize = 6}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "5"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "6"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 536883472
 - function_name: test_deep_stack
   source_location:
@@ -428,17 +445,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 4,\n\tinternal_depth_measure: usize = 5}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "4"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "5"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 536883616
 - function_name: test_deep_stack
   source_location:
@@ -643,17 +675,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 3,\n\tinternal_depth_measure: usize = 4}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "3"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "4"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 536883760
 - function_name: test_deep_stack
   source_location:
@@ -858,17 +905,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 2,\n\tinternal_depth_measure: usize = 3}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "2"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "3"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 536883904
 - function_name: test_deep_stack
   source_location:
@@ -1073,17 +1135,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 1,\n\tinternal_depth_measure: usize = 2}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "1"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "2"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 536884048
 - function_name: test_deep_stack
   source_location:
@@ -1288,17 +1365,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 0,\n\tinternal_depth_measure: usize = 1}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: stack_depth
           type_name:
             Base: usize
           value: "0"
+          source_location:
+            line: 331
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "1"
+          source_location:
+            line: 332
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
   canonical_frame_address: 536884192
 - function_name: setup_data_types
   source_location:
@@ -1503,316 +1595,611 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tint8_minus_twenty_three: i8 = -23,\n\tlocal_reference_to_global_const: &str = This global `const` value will only show up in the debugger in the variables where it is referenced,\n\tlocal_reference_to_global_static: &str = A 'global' static variable,\n\tlocal_reference_to_global_static_struct: *const probe_rs_debugger_test::ComplexEnum = *const probe_rs_debugger_test::ComplexEnum @ 0x20003D64,\n\tghosted_variable: usize = 0,\n\tghosted_variable: &str = New value and type for a different name,\n\tint8_twenty_six: i8 = 26,\n\tint128: i128 = -196710231994021419720322,\n\tu_int128: u128 = 340282366920938266753142613410348491134,\n\tfloat64: f64 = 1.7608695652173911,\n\tfloat64_ptr: &f64 = &f64 @ 0x20003D7C,\n\temoji: char = 💩,\n\temoji_ptr: &char = &char @ 0x20003D80,\n\ttrue_bool: bool = true,\n\tany_old_string_slice: &str = How long is a piece of String.,\n\tfunction_result: Result<(), &str> = Result<(), &str> @ 0x20003D84,\n\tglobal_types: (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) = (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x200034E8,\n\tthree_d_usize_array: Matrix<i32, 2, 3, 4> = Matrix<i32, 2, 3, 4> @ 0x20003524,\n\tthree_d_string_array: Matrix<&str, 2, 3, 6> = Matrix<&str, 2, 3, 6> @ 0x200036A4,\n\tthree: SimpleEnum = SimpleEnum::Two,\n\tsimple_enum_pointer: &probe_rs_debugger_test::SimpleEnum = &probe_rs_debugger_test::SimpleEnum @ 0x20003B28,\n\tthree_level_recursive_struct: RecursiveStruct = RecursiveStruct @ 0x20003B2C,\n\tfirst_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003B50,\n\tsecond_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003B80,\n\tstruct_with_one_variant: Option<probe_rs_debugger_test::Univariant> = Option<probe_rs_debugger_test::Univariant> @ 0x20003BA0,\n\tstuct_with_one_variant_pointer: &core::option::Option<probe_rs_debugger_test::Univariant> = &core::option::Option<probe_rs_debugger_test::Univariant> @ 0x20003D8C,\n\tlong_lived: ComplexStruct = ComplexStruct @ 0x20003C08,\n\tshort_lived: ComplexStruct = ComplexStruct @ 0x20003C18,\n\ta1: Struct<i32> = Struct<i32> @ 0x20003D90,\n\ta2: i64 = 1,\n\ta3: i64 = 2,\n\ta4: i64 = 3,\n\ta5: (i32, i64) = (i32, i64) @ 0x20003DB8,\n\ta6: Enum<i32> = Enum<i32> @ 0x20003C58,\n\ta7: Enum<i32> = Enum<i32> @ 0x20003C78,\n\t[i32; 10] = [\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55\n\t],\n\tmy_array_ptr: &[i32; 10] = &[i32; 10] @ 0x20003DC8,\n\t[i8; 10] = [\n\t\t1,\n\t\t2,\n\t\t3,\n\t\t4,\n\t\t5,\n\t\t6,\n\t\t7,\n\t\t8,\n\t\t9,\n\t\t0\n\t],\n\theapless_vec: Vec<i8, 10> = Vec<i8, 10> @ 0x20003CD0,\n\tloop_counter: Wrapping<u8> = Wrapping<u8> @ 0x20003CE3,\n\trtt_channels: Channels = Channels @ 0x20003CE4}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: int8_minus_twenty_three
           type_name:
             Base: i8
           value: "-23"
+          source_location:
+            line: 204
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: local_reference_to_global_const
           type_name:
             Struct: "&str"
           value: "This global `const` value will only show up in the debugger in the variables where it is referenced"
+          source_location:
+            line: 207
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003498"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "84"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "99"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: local_reference_to_global_static
           type_name:
             Struct: "&str"
           value: "A 'global' static variable"
+          source_location:
+            line: 208
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003D5C"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "65"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "26"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: local_reference_to_global_static_struct
           type_name:
             Pointer: "*const probe_rs_debugger_test::ComplexEnum"
           value: "*const probe_rs_debugger_test::ComplexEnum @ 0x20003D64"
+          source_location:
+            line: 209
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*local_reference_to_global_static_struct"
               type_name:
                 Struct: ComplexEnum
               value: ComplexEnum @ 0x20000048
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: Case1
                   type_name:
                     Struct: Case1
                   value: Case1 @ 0x20000048
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Base: u64
                       value: "0"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: __1
                       type_name:
                         Struct: ComplexStruct
                       value: ComplexStruct @ 0x20000058
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: x
                           type_name:
                             Base: i64
                           value: "24"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: y
                           type_name:
                             Base: i32
                           value: "25"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: z
                           type_name:
                             Base: i16
                           value: "26"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
         - name:
             Named: ghosted_variable
           type_name:
             Base: usize
           value: "0"
+          source_location:
+            line: 210
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: ghosted_variable
           type_name:
             Struct: "&str"
           value: New value and type for a different name
+          source_location:
+            line: 211
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x200034A4"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "78"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "39"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: int8_twenty_six
           type_name:
             Base: i8
           value: "26"
+          source_location:
+            line: 212
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: int128
           type_name:
             Base: i128
           value: "-196710231994021419720322"
+          source_location:
+            line: 213
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: u_int128
           type_name:
             Base: u128
           value: "340282366920938266753142613410348491134"
+          source_location:
+            line: 214
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: float64
           type_name:
             Base: f64
           value: "1.7608695652173911"
+          source_location:
+            line: 215
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: float64_ptr
           type_name:
             Pointer: "&f64"
           value: "&f64 @ 0x20003D7C"
+          source_location:
+            line: 216
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*float64_ptr"
               type_name:
                 Base: f64
               value: "1.7608695652173911"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: emoji
           type_name:
             Base: char
           value: 💩
+          source_location:
+            line: 217
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: emoji_ptr
           type_name:
             Pointer: "&char"
           value: "&char @ 0x20003D80"
+          source_location:
+            line: 218
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*emoji_ptr"
               type_name:
                 Base: char
               value: 💩
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: true_bool
           type_name:
             Base: bool
           value: "true"
+          source_location:
+            line: 219
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: any_old_string_slice
           type_name:
             Struct: "&str"
           value: How long is a piece of String.
+          source_location:
+            line: 221
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x200034C8"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "72"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "30"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: function_result
           type_name:
             Struct: "Result<(), &str>"
           value: "Result<(), &str> @ 0x20003D84"
+          source_location:
+            line: 222
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Err
               type_name:
                 Struct: Err
               value: Err @ 0x20003D84
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: "&str"
                   value: Forcing the return of an Error variant
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: data_ptr
                       type_name:
                         Pointer: u8
                       value: "*raw u8 @ 0x20003D84"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: "*data_ptr"
                           type_name:
                             Base: u8
                           value: "70"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: length
                       type_name:
                         Base: usize
                       value: "38"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
         - name:
             Named: global_types
           type_name:
             Struct: "(bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64)"
           value: "(bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x200034E8"
+          source_location:
+            line: 223
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: bool
               value: "false"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __1
               type_name:
                 Base: isize
               value: "-1"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __2
               type_name:
                 Base: char
               value: a
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "68"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __4
               type_name:
                 Base: i16
               value: "-16"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "-32"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __6
               type_name:
                 Base: i64
               value: "-64"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __7
               type_name:
                 Base: usize
               value: "1"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __8
               type_name:
                 Base: u8
               value: "100"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __9
               type_name:
                 Base: u16
               value: "16"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __10
               type_name:
                 Base: u32
               value: "32"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __11
               type_name:
                 Base: u64
               value: "64"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __12
               type_name:
                 Base: f32
               value: "2.5"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __13
               type_name:
                 Base: f64
               value: "3.5"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: three_d_usize_array
           type_name:
             Struct: "Matrix<i32, 2, 3, 4>"
           value: "Matrix<i32, 2, 3, 4> @ 0x20003524"
+          source_location:
+            line: 224
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: raw
@@ -1828,6 +2215,11 @@ expression: stack_frames
                       count: 2
                   count: 4
               value: "[[[i32; 3]; 2]; 4] = [\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t0,\n\t\t\t1,\n\t\t\t2\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t3,\n\t\t\t4,\n\t\t\t5\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t6,\n\t\t\t7,\n\t\t\t8\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t9,\n\t\t\t10,\n\t\t\t11\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t12,\n\t\t\t13,\n\t\t\t14\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t15,\n\t\t\t16,\n\t\t\t17\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t18,\n\t\t\t19,\n\t\t\t20\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t21,\n\t\t\t22,\n\t\t\t23\n\t\t]\n\t]]"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
@@ -1840,6 +2232,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t0,\n\t\t1,\n\t\t2\n\t],\n\t[i32; 3] = [\n\t\t3,\n\t\t4,\n\t\t5\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -1849,22 +2246,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t0,\n\t1,\n\t2]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "1"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "2"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -1873,22 +2290,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t3,\n\t4,\n\t5]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "3"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "4"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "5"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __1
                   type_name:
@@ -1900,6 +2337,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t6,\n\t\t7,\n\t\t8\n\t],\n\t[i32; 3] = [\n\t\t9,\n\t\t10,\n\t\t11\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -1909,22 +2351,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t6,\n\t7,\n\t8]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "6"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "7"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "8"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -1933,22 +2395,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t9,\n\t10,\n\t11]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "9"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "10"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "11"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __2
                   type_name:
@@ -1960,6 +2442,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t12,\n\t\t13,\n\t\t14\n\t],\n\t[i32; 3] = [\n\t\t15,\n\t\t16,\n\t\t17\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -1969,22 +2456,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t12,\n\t13,\n\t14]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "12"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "13"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "14"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -1993,22 +2500,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t15,\n\t16,\n\t17]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "15"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "16"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "17"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __3
                   type_name:
@@ -2020,6 +2547,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t18,\n\t\t19,\n\t\t20\n\t],\n\t[i32; 3] = [\n\t\t21,\n\t\t22,\n\t\t23\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2029,22 +2561,42 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t18,\n\t19,\n\t20]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "18"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "19"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "20"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2053,27 +2605,52 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t21,\n\t22,\n\t23]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "21"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "22"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "23"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
         - name:
             Named: three_d_string_array
           type_name:
             Struct: "Matrix<&str, 2, 3, 6>"
           value: "Matrix<&str, 2, 3, 6> @ 0x200036A4"
+          source_location:
+            line: 232
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: raw
@@ -2089,6 +2666,11 @@ expression: stack_frames
                       count: 2
                   count: 6
               value: "[[[&str; 3]; 2]; 6] = [\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tApple,\n\t\t\tBanana,\n\t\t\tCherry\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tDog,\n\t\t\tElephant,\n\t\t\tFish\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tGuitar,\n\t\t\tHorse,\n\t\t\tIce Cream\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tJaguar,\n\t\t\tKangaroo,\n\t\t\tLion\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tMoon,\n\t\t\tNewton,\n\t\t\tOwl\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tPencil,\n\t\t\tQueen,\n\t\t\tRainbow\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tSun,\n\t\t\tTree,\n\t\t\tUmbrella\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tViolin,\n\t\t\tWatch,\n\t\t\tXylophone\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tYellow,\n\t\t\tZebra,\n\t\t\tAlpha\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tBravo,\n\t\t\tCharlie,\n\t\t\tDelta\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tEcho,\n\t\t\tFoxtrot,\n\t\t\tGolf\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tHotel,\n\t\t\tIndia,\n\t\t\tJuliet\n\t\t]\n\t]]"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
@@ -2101,6 +2683,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tApple,\n\t\tBanana,\n\t\tCherry\n\t],\n\t[&str; 3] = [\n\t\tDog,\n\t\tElephant,\n\t\tFish\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2110,73 +2697,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tApple,\n\tBanana,\n\tCherry]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Apple
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036A4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Banana
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036AC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Cherry
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036B4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2185,73 +2837,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tDog,\n\tElephant,\n\tFish]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Dog
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036BC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Elephant
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036C4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Fish
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036CC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __1
                   type_name:
@@ -2263,6 +2980,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tGuitar,\n\t\tHorse,\n\t\tIce Cream\n\t],\n\t[&str; 3] = [\n\t\tJaguar,\n\t\tKangaroo,\n\t\tLion\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2272,73 +2994,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tGuitar,\n\tHorse,\n\tIce Cream]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Guitar
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036D4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Horse
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036DC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Ice Cream
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036E4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2347,73 +3134,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tJaguar,\n\tKangaroo,\n\tLion]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Jaguar
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036EC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Kangaroo
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036F4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "75"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Lion
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036FC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "76"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __2
                   type_name:
@@ -2425,6 +3277,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tMoon,\n\t\tNewton,\n\t\tOwl\n\t],\n\t[&str; 3] = [\n\t\tPencil,\n\t\tQueen,\n\t\tRainbow\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2434,73 +3291,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tMoon,\n\tNewton,\n\tOwl]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Moon
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003704"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "77"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Newton
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000370C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "78"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Owl
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003714"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "79"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2509,73 +3431,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tPencil,\n\tQueen,\n\tRainbow]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Pencil
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000371C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "80"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Queen
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003724"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "81"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Rainbow
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000372C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "82"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __3
                   type_name:
@@ -2587,6 +3574,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tSun,\n\t\tTree,\n\t\tUmbrella\n\t],\n\t[&str; 3] = [\n\t\tViolin,\n\t\tWatch,\n\t\tXylophone\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2596,73 +3588,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tSun,\n\tTree,\n\tUmbrella]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Sun
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003734"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "83"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Tree
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000373C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "84"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Umbrella
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003744"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "85"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2671,73 +3728,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tViolin,\n\tWatch,\n\tXylophone]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Violin
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000374C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "86"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Watch
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003754"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "87"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Xylophone
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000375C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "88"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __4
                   type_name:
@@ -2749,6 +3871,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tYellow,\n\t\tZebra,\n\t\tAlpha\n\t],\n\t[&str; 3] = [\n\t\tBravo,\n\t\tCharlie,\n\t\tDelta\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2758,73 +3885,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tYellow,\n\tZebra,\n\tAlpha]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Yellow
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003764"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "89"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Zebra
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000376C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "90"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Alpha
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003774"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2833,73 +4025,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tBravo,\n\tCharlie,\n\tDelta]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Bravo
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000377C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Charlie
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003784"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Delta
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000378C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                 - name:
                     Named: __5
                   type_name:
@@ -2911,6 +4168,11 @@ expression: stack_frames
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tEcho,\n\t\tFoxtrot,\n\t\tGolf\n\t],\n\t[&str; 3] = [\n\t\tHotel,\n\t\tIndia,\n\t\tJuliet\n\t]]"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
@@ -2920,73 +4182,138 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tEcho,\n\tFoxtrot,\n\tGolf]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Echo
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003794"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Foxtrot
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000379C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Golf
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200037A4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2995,505 +4322,965 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tHotel,\n\tIndia,\n\tJuliet]"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Hotel
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200037AC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: India
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200037B4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Juliet
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200037BC"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
         - name:
             Named: three
           type_name:
             Enum: SimpleEnum
           value: "SimpleEnum::Two"
+          source_location:
+            line: 249
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: simple_enum_pointer
           type_name:
             Pointer: "&probe_rs_debugger_test::SimpleEnum"
           value: "&probe_rs_debugger_test::SimpleEnum @ 0x20003B28"
+          source_location:
+            line: 250
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*simple_enum_pointer"
               type_name:
                 Enum: SimpleEnum
               value: "SimpleEnum::Two"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: three_level_recursive_struct
           type_name:
             Struct: RecursiveStruct
           value: RecursiveStruct @ 0x20003B2C
+          source_location:
+            line: 252
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: depth
               type_name:
                 Base: u32
               value: "1"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: next_self
               type_name:
                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003B30"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x20003B30
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x20003B30"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RecursiveStruct
                           value: RecursiveStruct @ 0x20003B38
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: depth
                               type_name:
                                 Base: u32
                               value: "2"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: next_self
                               type_name:
                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003B3C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: Some
                                   type_name:
                                     Struct: Some
                                   value: Some @ 0x20003B3C
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: __0
                                       type_name:
                                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x20003B3C"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                                       children:
                                         - name:
                                             Named: "*__0"
                                           type_name:
                                             Struct: RecursiveStruct
                                           value: RecursiveStruct @ 0x20003B44
+                                          source_location:
+                                            line: ~
+                                            column: ~
+                                            file: ~
+                                            directory: ~
                                           children:
                                             - name:
                                                 Named: depth
                                               type_name:
                                                 Base: u32
                                               value: "3"
+                                              source_location:
+                                                line: ~
+                                                column: ~
+                                                file: ~
+                                                directory: ~
                                             - name:
                                                 Named: next_self
                                               type_name:
                                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003B48"
+                                              source_location:
+                                                line: ~
+                                                column: ~
+                                                file: ~
+                                                directory: ~
                                               children:
                                                 - name:
                                                     Named: None
                                                   type_name:
                                                     Struct: None
                                                   value: None @ 0x20003B48
+                                                  source_location:
+                                                    line: ~
+                                                    column: ~
+                                                    file: ~
+                                                    directory: ~
         - name:
             Named: first_case_of_struct_variants
           type_name:
             Struct: ComplexEnum
           value: ComplexEnum @ 0x20003B50
+          source_location:
+            line: 263
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Case1
               type_name:
                 Struct: Case1
               value: Case1 @ 0x20003B50
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: ComplexStruct
                   value: ComplexStruct @ 0x20003B60
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: x
                       type_name:
                         Base: i64
                       value: "24"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: y
                       type_name:
                         Base: i32
                       value: "25"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: z
                       type_name:
                         Base: i16
                       value: "26"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
         - name:
             Named: second_case_of_struct_variants
           type_name:
             Struct: ComplexEnum
           value: ComplexEnum @ 0x20003B80
+          source_location:
+            line: 271
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Case2
               type_name:
                 Struct: Case2
               value: Case2 @ 0x20003B80
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: u64
                   value: "1023"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i16
                   value: "1967"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: struct_with_one_variant
           type_name:
             Struct: "Option<probe_rs_debugger_test::Univariant>"
           value: "Option<probe_rs_debugger_test::Univariant> @ 0x20003BA0"
+          source_location:
+            line: 273
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Some
               type_name:
                 Struct: Some
               value: Some @ 0x20003BA0
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: Univariant
                   value: Univariant @ 0x20003BA8
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: TupleOfComplexStruct
                       type_name:
                         Struct: TupleOfComplexStruct
                       value: TupleOfComplexStruct @ 0x20003BA8
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x20003BA8
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "24"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "25"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "26"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x20003BB8
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "-3"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "-2"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "-1"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
         - name:
             Named: stuct_with_one_variant_pointer
           type_name:
             Pointer: "&core::option::Option<probe_rs_debugger_test::Univariant>"
           value: "&core::option::Option<probe_rs_debugger_test::Univariant> @ 0x20003D8C"
+          source_location:
+            line: 285
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*stuct_with_one_variant_pointer"
               type_name:
                 Struct: "Option<probe_rs_debugger_test::Univariant>"
               value: "Option<probe_rs_debugger_test::Univariant> @ 0x20003BA0"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x20003BA0
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Struct: Univariant
                       value: Univariant @ 0x20003BA8
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: TupleOfComplexStruct
                           type_name:
                             Struct: TupleOfComplexStruct
                           value: TupleOfComplexStruct @ 0x20003BA8
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: __0
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x20003BA8
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "24"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "25"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "26"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: __1
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x20003BB8
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "-3"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "-2"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "-1"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
         - name:
             Named: long_lived
           type_name:
             Struct: ComplexStruct
           value: ComplexStruct @ 0x20003C08
+          source_location:
+            line: 287
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: x
               type_name:
                 Base: i64
               value: "10"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: short_lived
           type_name:
             Struct: ComplexStruct
           value: ComplexStruct @ 0x20003C18
+          source_location:
+            line: 289
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: x
               type_name:
                 Base: i64
               value: "20"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: a1
           type_name:
             Struct: Struct<i32>
           value: Struct<i32> @ 0x20003D90
+          source_location:
+            line: 290
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: b
               type_name:
                 Base: i32
               value: "-1"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: b1
               type_name:
                 Base: i64
               value: "0"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: a2
           type_name:
             Base: i64
           value: "1"
+          source_location:
+            line: 291
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: a3
           type_name:
             Base: i64
           value: "2"
+          source_location:
+            line: 292
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: a4
           type_name:
             Base: i64
           value: "3"
+          source_location:
+            line: 293
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: a5
           type_name:
             Struct: "(i32, i64)"
           value: "(i32, i64) @ 0x20003DB8"
+          source_location:
+            line: 294
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: i32
               value: "4"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: __1
               type_name:
                 Base: i64
               value: "5"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: a6
           type_name:
             Struct: Enum<i32>
           value: Enum<i32> @ 0x20003C58
+          source_location:
+            line: 295
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Variant2
               type_name:
                 Struct: Variant2
               value: Variant2 @ 0x20003C58
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i64
                   value: "7"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "6"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: a7
           type_name:
             Struct: Enum<i32>
           value: Enum<i32> @ 0x20003C78
+          source_location:
+            line: 296
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: Variant1
               type_name:
                 Struct: Variant1
               value: Variant1 @ 0x20003C78
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "9"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i64
                   value: "8"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: my_array
           type_name:
@@ -3502,62 +5289,122 @@ expression: stack_frames
                 Base: i32
               count: 10
           value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
+          source_location:
+            line: 298
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __1
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __2
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __3
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __4
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __6
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __7
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __8
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __9
               type_name:
                 Base: i32
               value: "55"
+              source_location:
+                line: 298
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: my_array_ptr
           type_name:
             Pointer: "&[i32; 10]"
           value: "&[i32; 10] @ 0x20003DC8"
+          source_location:
+            line: 299
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: "*my_array_ptr"
@@ -3567,57 +5414,112 @@ expression: stack_frames
                     Base: i32
                   count: 10
               value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: i32
                   value: "55"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
         - name:
             Named: my_array_of_i8
           type_name:
@@ -3626,68 +5528,133 @@ expression: stack_frames
                 Base: i8
               count: 10
           value: "[i8; 10] = [\n\t1,\n\t2,\n\t3,\n\t4,\n\t5,\n\t6,\n\t7,\n\t8,\n\t9,\n\t0]"
+          source_location:
+            line: 300
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: i8
               value: "1"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __1
               type_name:
                 Base: i8
               value: "2"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __2
               type_name:
                 Base: i8
               value: "3"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "4"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __4
               type_name:
                 Base: i8
               value: "5"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __5
               type_name:
                 Base: i8
               value: "6"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __6
               type_name:
                 Base: i8
               value: "7"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __7
               type_name:
                 Base: i8
               value: "8"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __8
               type_name:
                 Base: i8
               value: "9"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
             - name:
                 Named: __9
               type_name:
                 Base: i8
               value: "0"
+              source_location:
+                line: 300
+                column: ~
+                file: lib.rs
+                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
         - name:
             Named: heapless_vec
           type_name:
             Struct: "Vec<i8, 10>"
           value: "Vec<i8, 10> @ 0x20003CD0"
+          source_location:
+            line: 301
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: len
               type_name:
                 Base: usize
               value: "3"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: buffer
               type_name:
@@ -3696,442 +5663,837 @@ expression: stack_frames
                     Base: MaybeUninit<i8>
                   count: 10
               value: "[MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD4\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD5\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD6\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD7\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD8\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD9\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDA\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDB\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDC\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDD\n\t}]"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD4}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD4
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "1"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD5}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD5
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "2"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD6}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD6
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "3"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD7}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD7
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD8}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD8
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD9}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD9
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDA}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CDA
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDB}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CDB
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDC}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CDC
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDD}"
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CDD
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
         - name:
             Named: loop_counter
           type_name:
             Struct: Wrapping<u8>
           value: Wrapping<u8> @ 0x20003CE3
+          source_location:
+            line: 305
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: __0
               type_name:
                 Base: u8
               value: "0"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: rtt_channels
           type_name:
             Struct: Channels
           value: Channels @ 0x20003CE4
+          source_location:
+            line: 306
+            column: ~
+            file: lib.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
           children:
             - name:
                 Named: up
               type_name:
                 Struct: "(rtt_target::UpChannel, rtt_target::UpChannel)"
               value: "(rtt_target::UpChannel, rtt_target::UpChannel) @ 0x20003CE4"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x20003CE4
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x20003CE4"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x2000008C
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x2000008C"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "83"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x20000090"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "70"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x20000098
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x20000098
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x2000009C
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x2000009C
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000A0
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000A0
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x20003CE8
+                  source_location:
+                    line: ~
+                    column: ~
+                    file: ~
+                    directory: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x20003CE8"
+                      source_location:
+                        line: ~
+                        column: ~
+                        file: ~
+                        directory: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x200000A4
+                          source_location:
+                            line: ~
+                            column: ~
+                            file: ~
+                            directory: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x200000A4"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "66"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x200000A8"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "0"
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000B0
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000B0
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000B4
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000B4
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000B8
+                              source_location:
+                                line: ~
+                                column: ~
+                                file: ~
+                                directory: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000B8
+                                  source_location:
+                                    line: ~
+                                    column: ~
+                                    file: ~
+                                    directory: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
+                                      source_location:
+                                        line: ~
+                                        column: ~
+                                        file: ~
+                                        directory: ~
   canonical_frame_address: 536887136
 - function_name: __cortex_m_rt_main
   source_location:
@@ -4337,465 +6699,925 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tpac: Peripherals = Peripherals @ 0x20003F74,\n\tcore: Peripherals = Peripherals @ 0x20003F75,\n\tclocks: Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> = Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: pac
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003F74
+          source_location:
+            line: 21
+            column: ~
+            file: nRF52833_xxAA.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: FICR
               type_name:
                 Struct: FICR
               value: FICR @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UICR
               type_name:
                 Struct: UICR
               value: UICR @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CLOCK
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: POWER
               type_name:
                 Struct: POWER
               value: POWER @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: P0
               type_name:
                 Struct: P0
               value: P0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: P1
               type_name:
                 Struct: P1
               value: P1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RADIO
               type_name:
                 Struct: RADIO
               value: RADIO @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UARTE0
               type_name:
                 Struct: UARTE0
               value: UARTE0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIM0
               type_name:
                 Struct: SPIM0
               value: SPIM0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIS0
               type_name:
                 Struct: SPIS0
               value: SPIS0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWI0
               type_name:
                 Struct: TWI0
               value: TWI0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWIM0
               type_name:
                 Struct: TWIM0
               value: TWIM0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWIS0
               type_name:
                 Struct: TWIS0
               value: TWIS0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIM1
               type_name:
                 Struct: SPIM1
               value: SPIM1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIS1
               type_name:
                 Struct: SPIS1
               value: SPIS1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWI1
               type_name:
                 Struct: TWI1
               value: TWI1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWIM1
               type_name:
                 Struct: TWIM1
               value: TWIM1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWIS1
               type_name:
                 Struct: TWIS1
               value: TWIS1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: NFCT
               type_name:
                 Struct: NFCT
               value: NFCT @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: GPIOTE
               type_name:
                 Struct: GPIOTE
               value: GPIOTE @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SAADC
               type_name:
                 Struct: SAADC
               value: SAADC @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER0
               type_name:
                 Struct: TIMER0
               value: TIMER0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER1
               type_name:
                 Struct: TIMER1
               value: TIMER1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER2
               type_name:
                 Struct: TIMER2
               value: TIMER2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RTC0
               type_name:
                 Struct: RTC0
               value: RTC0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TEMP
               type_name:
                 Struct: TEMP
               value: TEMP @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RNG
               type_name:
                 Struct: RNG
               value: RNG @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ECB
               type_name:
                 Struct: ECB
               value: ECB @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: AAR
               type_name:
                 Struct: AAR
               value: AAR @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CCM
               type_name:
                 Struct: CCM
               value: CCM @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: WDT
               type_name:
                 Struct: WDT
               value: WDT @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RTC1
               type_name:
                 Struct: RTC1
               value: RTC1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: QDEC
               type_name:
                 Struct: QDEC
               value: QDEC @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: COMP
               type_name:
                 Struct: COMP
               value: COMP @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: LPCOMP
               type_name:
                 Struct: LPCOMP
               value: LPCOMP @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU0
               type_name:
                 Struct: EGU0
               value: EGU0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI0
               type_name:
                 Struct: SWI0
               value: SWI0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU1
               type_name:
                 Struct: EGU1
               value: EGU1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI1
               type_name:
                 Struct: SWI1
               value: SWI1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU2
               type_name:
                 Struct: EGU2
               value: EGU2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI2
               type_name:
                 Struct: SWI2
               value: SWI2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU3
               type_name:
                 Struct: EGU3
               value: EGU3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI3
               type_name:
                 Struct: SWI3
               value: SWI3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU4
               type_name:
                 Struct: EGU4
               value: EGU4 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI4
               type_name:
                 Struct: SWI4
               value: SWI4 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU5
               type_name:
                 Struct: EGU5
               value: EGU5 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI5
               type_name:
                 Struct: SWI5
               value: SWI5 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER3
               type_name:
                 Struct: TIMER3
               value: TIMER3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER4
               type_name:
                 Struct: TIMER4
               value: TIMER4 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PWM0
               type_name:
                 Struct: PWM0
               value: PWM0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PDM
               type_name:
                 Struct: PDM
               value: PDM @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ACL
               type_name:
                 Struct: ACL
               value: ACL @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: NVMC
               type_name:
                 Struct: NVMC
               value: NVMC @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PPI
               type_name:
                 Struct: PPI
               value: PPI @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: MWU
               type_name:
                 Struct: MWU
               value: MWU @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PWM1
               type_name:
                 Struct: PWM1
               value: PWM1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PWM2
               type_name:
                 Struct: PWM2
               value: PWM2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPI2
               type_name:
                 Struct: SPI2
               value: SPI2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIM2
               type_name:
                 Struct: SPIM2
               value: SPIM2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIS2
               type_name:
                 Struct: SPIS2
               value: SPIS2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RTC2
               type_name:
                 Struct: RTC2
               value: RTC2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: I2S
               type_name:
                 Struct: I2S
               value: I2S @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: USBD
               type_name:
                 Struct: USBD
               value: USBD @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UARTE1
               type_name:
                 Struct: UARTE1
               value: UARTE1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PWM3
               type_name:
                 Struct: PWM3
               value: PWM3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIM3
               type_name:
                 Struct: SPIM3
               value: SPIM3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: core
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003F75
+          source_location:
+            line: 22
+            column: ~
+            file: nRF52833_xxAA.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: CBP
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: clocks
           type_name:
             Struct: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped>"
           value: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76"
+          source_location:
+            line: 23
+            column: ~
+            file: nRF52833_xxAA.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: hfclk
               type_name:
                 Struct: ExternalOscillator
               value: ExternalOscillator @ 0x20003F76
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: lfclk
               type_name:
                 Struct: Internal
               value: Internal @ 0x20003F76
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: lfstat
               type_name:
                 Struct: LfOscStopped
               value: LfOscStopped @ 0x20003F76
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: periph
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F76
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
@@ -4999,4 +7821,9 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_full_unwind.snap
@@ -1,6 +1,6 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
-assertion_line: 1996
+assertion_line: 1987
 expression: stack_frames
 snapshot_kind: text
 ---
@@ -9,8 +9,7 @@ snapshot_kind: text
     line: 344
     column:
       Column: 13
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -215,7 +214,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 5,\n\tinternal_depth_measure: usize = 6}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -225,8 +223,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -235,16 +232,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883472
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -441,7 +436,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 4,\n\tinternal_depth_measure: usize = 5}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -451,8 +445,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -461,16 +454,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883616
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -667,7 +658,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 3,\n\tinternal_depth_measure: usize = 4}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -677,8 +667,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -687,16 +676,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883760
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -893,7 +880,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 2,\n\tinternal_depth_measure: usize = 3}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -903,8 +889,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -913,16 +898,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883904
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -1119,7 +1102,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 1,\n\tinternal_depth_measure: usize = 2}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1129,8 +1111,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -1139,16 +1120,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536884048
 - function_name: test_deep_stack
   source_location:
     line: 338
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -1345,7 +1324,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 0,\n\tinternal_depth_measure: usize = 1}"
-      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1355,8 +1333,7 @@ snapshot_kind: text
           source_location:
             line: 331
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
@@ -1365,16 +1342,14 @@ snapshot_kind: text
           source_location:
             line: 332
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536884192
 - function_name: setup_data_types
   source_location:
     line: 325
     column:
       Column: 5
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -1571,7 +1546,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tint8_minus_twenty_three: i8 = -23,\n\tlocal_reference_to_global_const: &str = This global `const` value will only show up in the debugger in the variables where it is referenced,\n\tlocal_reference_to_global_static: &str = A 'global' static variable,\n\tlocal_reference_to_global_static_struct: *const probe_rs_debugger_test::ComplexEnum = *const probe_rs_debugger_test::ComplexEnum @ 0x20003D64,\n\tghosted_variable: usize = 0,\n\tghosted_variable: &str = New value and type for a different name,\n\tint8_twenty_six: i8 = 26,\n\tint128: i128 = -196710231994021419720322,\n\tu_int128: u128 = 340282366920938266753142613410348491134,\n\tfloat64: f64 = 1.7608695652173911,\n\tfloat64_ptr: &f64 = &f64 @ 0x20003D7C,\n\temoji: char = 💩,\n\temoji_ptr: &char = &char @ 0x20003D80,\n\ttrue_bool: bool = true,\n\tany_old_string_slice: &str = How long is a piece of String.,\n\tfunction_result: Result<(), &str> = Result<(), &str> @ 0x20003D84,\n\tglobal_types: (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) = (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x200034E8,\n\tthree_d_usize_array: Matrix<i32, 2, 3, 4> = Matrix<i32, 2, 3, 4> @ 0x20003524,\n\tthree_d_string_array: Matrix<&str, 2, 3, 6> = Matrix<&str, 2, 3, 6> @ 0x200036A4,\n\tthree: SimpleEnum = SimpleEnum::Two,\n\tsimple_enum_pointer: &probe_rs_debugger_test::SimpleEnum = &probe_rs_debugger_test::SimpleEnum @ 0x20003B28,\n\tthree_level_recursive_struct: RecursiveStruct = RecursiveStruct @ 0x20003B2C,\n\tfirst_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003B50,\n\tsecond_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003B80,\n\tstruct_with_one_variant: Option<probe_rs_debugger_test::Univariant> = Option<probe_rs_debugger_test::Univariant> @ 0x20003BA0,\n\tstuct_with_one_variant_pointer: &core::option::Option<probe_rs_debugger_test::Univariant> = &core::option::Option<probe_rs_debugger_test::Univariant> @ 0x20003D8C,\n\tlong_lived: ComplexStruct = ComplexStruct @ 0x20003C08,\n\tshort_lived: ComplexStruct = ComplexStruct @ 0x20003C18,\n\ta1: Struct<i32> = Struct<i32> @ 0x20003D90,\n\ta2: i64 = 1,\n\ta3: i64 = 2,\n\ta4: i64 = 3,\n\ta5: (i32, i64) = (i32, i64) @ 0x20003DB8,\n\ta6: Enum<i32> = Enum<i32> @ 0x20003C58,\n\ta7: Enum<i32> = Enum<i32> @ 0x20003C78,\n\t[i32; 10] = [\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55\n\t],\n\tmy_array_ptr: &[i32; 10] = &[i32; 10] @ 0x20003DC8,\n\t[i8; 10] = [\n\t\t1,\n\t\t2,\n\t\t3,\n\t\t4,\n\t\t5,\n\t\t6,\n\t\t7,\n\t\t8,\n\t\t9,\n\t\t0\n\t],\n\theapless_vec: Vec<i8, 10> = Vec<i8, 10> @ 0x20003CD0,\n\tloop_counter: Wrapping<u8> = Wrapping<u8> @ 0x20003CE3,\n\trtt_channels: Channels = Channels @ 0x20003CE4}"
-      source_location: ~
       children:
         - name:
             Named: int8_minus_twenty_three
@@ -1581,8 +1555,7 @@ snapshot_kind: text
           source_location:
             line: 204
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: local_reference_to_global_const
           type_name:
@@ -1591,28 +1564,24 @@ snapshot_kind: text
           source_location:
             line: 207
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003498"
-              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "84"
-                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "99"
-              source_location: ~
         - name:
             Named: local_reference_to_global_static
           type_name:
@@ -1621,28 +1590,24 @@ snapshot_kind: text
           source_location:
             line: 208
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003D5C"
-              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "65"
-                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "26"
-              source_location: ~
         - name:
             Named: local_reference_to_global_static_struct
           type_name:
@@ -1651,54 +1616,46 @@ snapshot_kind: text
           source_location:
             line: 209
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*local_reference_to_global_static_struct"
               type_name:
                 Struct: ComplexEnum
               value: ComplexEnum @ 0x20000048
-              source_location: ~
               children:
                 - name:
                     Named: Case1
                   type_name:
                     Struct: Case1
                   value: Case1 @ 0x20000048
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Base: u64
                       value: "0"
-                      source_location: ~
                     - name:
                         Named: __1
                       type_name:
                         Struct: ComplexStruct
                       value: ComplexStruct @ 0x20000058
-                      source_location: ~
                       children:
                         - name:
                             Named: x
                           type_name:
                             Base: i64
                           value: "24"
-                          source_location: ~
                         - name:
                             Named: y
                           type_name:
                             Base: i32
                           value: "25"
-                          source_location: ~
                         - name:
                             Named: z
                           type_name:
                             Base: i16
                           value: "26"
-                          source_location: ~
         - name:
             Named: ghosted_variable
           type_name:
@@ -1707,8 +1664,7 @@ snapshot_kind: text
           source_location:
             line: 210
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: ghosted_variable
           type_name:
@@ -1717,28 +1673,24 @@ snapshot_kind: text
           source_location:
             line: 211
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x200034A4"
-              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "78"
-                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "39"
-              source_location: ~
         - name:
             Named: int8_twenty_six
           type_name:
@@ -1747,8 +1699,7 @@ snapshot_kind: text
           source_location:
             line: 212
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: int128
           type_name:
@@ -1757,8 +1708,7 @@ snapshot_kind: text
           source_location:
             line: 213
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: u_int128
           type_name:
@@ -1767,8 +1717,7 @@ snapshot_kind: text
           source_location:
             line: 214
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: float64
           type_name:
@@ -1777,8 +1726,7 @@ snapshot_kind: text
           source_location:
             line: 215
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: float64_ptr
           type_name:
@@ -1787,15 +1735,13 @@ snapshot_kind: text
           source_location:
             line: 216
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*float64_ptr"
               type_name:
                 Base: f64
               value: "1.7608695652173911"
-              source_location: ~
         - name:
             Named: emoji
           type_name:
@@ -1804,8 +1750,7 @@ snapshot_kind: text
           source_location:
             line: 217
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: emoji_ptr
           type_name:
@@ -1814,15 +1759,13 @@ snapshot_kind: text
           source_location:
             line: 218
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*emoji_ptr"
               type_name:
                 Base: char
               value: 💩
-              source_location: ~
         - name:
             Named: true_bool
           type_name:
@@ -1831,8 +1774,7 @@ snapshot_kind: text
           source_location:
             line: 219
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: any_old_string_slice
           type_name:
@@ -1841,28 +1783,24 @@ snapshot_kind: text
           source_location:
             line: 221
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x200034C8"
-              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "72"
-                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "30"
-              source_location: ~
         - name:
             Named: function_result
           type_name:
@@ -1871,42 +1809,36 @@ snapshot_kind: text
           source_location:
             line: 222
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Err
               type_name:
                 Struct: Err
               value: Err @ 0x20003D84
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: "&str"
                   value: Forcing the return of an Error variant
-                  source_location: ~
                   children:
                     - name:
                         Named: data_ptr
                       type_name:
                         Pointer: u8
                       value: "*raw u8 @ 0x20003D84"
-                      source_location: ~
                       children:
                         - name:
                             Named: "*data_ptr"
                           type_name:
                             Base: u8
                           value: "70"
-                          source_location: ~
                     - name:
                         Named: length
                       type_name:
                         Base: usize
                       value: "38"
-                      source_location: ~
         - name:
             Named: global_types
           type_name:
@@ -1915,93 +1847,78 @@ snapshot_kind: text
           source_location:
             line: 223
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
               type_name:
                 Base: bool
               value: "false"
-              source_location: ~
             - name:
                 Named: __1
               type_name:
                 Base: isize
               value: "-1"
-              source_location: ~
             - name:
                 Named: __2
               type_name:
                 Base: char
               value: a
-              source_location: ~
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "68"
-              source_location: ~
             - name:
                 Named: __4
               type_name:
                 Base: i16
               value: "-16"
-              source_location: ~
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "-32"
-              source_location: ~
             - name:
                 Named: __6
               type_name:
                 Base: i64
               value: "-64"
-              source_location: ~
             - name:
                 Named: __7
               type_name:
                 Base: usize
               value: "1"
-              source_location: ~
             - name:
                 Named: __8
               type_name:
                 Base: u8
               value: "100"
-              source_location: ~
             - name:
                 Named: __9
               type_name:
                 Base: u16
               value: "16"
-              source_location: ~
             - name:
                 Named: __10
               type_name:
                 Base: u32
               value: "32"
-              source_location: ~
             - name:
                 Named: __11
               type_name:
                 Base: u64
               value: "64"
-              source_location: ~
             - name:
                 Named: __12
               type_name:
                 Base: f32
               value: "2.5"
-              source_location: ~
             - name:
                 Named: __13
               type_name:
                 Base: f64
               value: "3.5"
-              source_location: ~
         - name:
             Named: three_d_usize_array
           type_name:
@@ -2010,8 +1927,7 @@ snapshot_kind: text
           source_location:
             line: 224
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: raw
@@ -2027,7 +1943,6 @@ snapshot_kind: text
                       count: 2
                   count: 4
               value: "[[[i32; 3]; 2]; 4] = [\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t0,\n\t\t\t1,\n\t\t\t2\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t3,\n\t\t\t4,\n\t\t\t5\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t6,\n\t\t\t7,\n\t\t\t8\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t9,\n\t\t\t10,\n\t\t\t11\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t12,\n\t\t\t13,\n\t\t\t14\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t15,\n\t\t\t16,\n\t\t\t17\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t18,\n\t\t\t19,\n\t\t\t20\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t21,\n\t\t\t22,\n\t\t\t23\n\t\t]\n\t]]"
-              source_location: ~
               children:
                 - name:
                     Named: __0
@@ -2040,7 +1955,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t0,\n\t\t1,\n\t\t2\n\t],\n\t[i32; 3] = [\n\t\t3,\n\t\t4,\n\t\t5\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2050,26 +1964,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t0,\n\t1,\n\t2]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "0"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "1"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "2"
-                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2078,26 +1988,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t3,\n\t4,\n\t5]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "3"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "4"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "5"
-                          source_location: ~
                 - name:
                     Named: __1
                   type_name:
@@ -2109,7 +2015,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t6,\n\t\t7,\n\t\t8\n\t],\n\t[i32; 3] = [\n\t\t9,\n\t\t10,\n\t\t11\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2119,26 +2024,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t6,\n\t7,\n\t8]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "6"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "7"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "8"
-                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2147,26 +2048,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t9,\n\t10,\n\t11]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "9"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "10"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "11"
-                          source_location: ~
                 - name:
                     Named: __2
                   type_name:
@@ -2178,7 +2075,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t12,\n\t\t13,\n\t\t14\n\t],\n\t[i32; 3] = [\n\t\t15,\n\t\t16,\n\t\t17\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2188,26 +2084,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t12,\n\t13,\n\t14]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "12"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "13"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "14"
-                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2216,26 +2108,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t15,\n\t16,\n\t17]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "15"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "16"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "17"
-                          source_location: ~
                 - name:
                     Named: __3
                   type_name:
@@ -2247,7 +2135,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t18,\n\t\t19,\n\t\t20\n\t],\n\t[i32; 3] = [\n\t\t21,\n\t\t22,\n\t\t23\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2257,26 +2144,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t18,\n\t19,\n\t20]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "18"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "19"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "20"
-                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2285,26 +2168,22 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t21,\n\t22,\n\t23]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "21"
-                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "22"
-                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "23"
-                          source_location: ~
         - name:
             Named: three_d_string_array
           type_name:
@@ -2313,8 +2192,7 @@ snapshot_kind: text
           source_location:
             line: 232
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: raw
@@ -2330,7 +2208,6 @@ snapshot_kind: text
                       count: 2
                   count: 6
               value: "[[[&str; 3]; 2]; 6] = [\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tApple,\n\t\t\tBanana,\n\t\t\tCherry\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tDog,\n\t\t\tElephant,\n\t\t\tFish\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tGuitar,\n\t\t\tHorse,\n\t\t\tIce Cream\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tJaguar,\n\t\t\tKangaroo,\n\t\t\tLion\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tMoon,\n\t\t\tNewton,\n\t\t\tOwl\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tPencil,\n\t\t\tQueen,\n\t\t\tRainbow\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tSun,\n\t\t\tTree,\n\t\t\tUmbrella\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tViolin,\n\t\t\tWatch,\n\t\t\tXylophone\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tYellow,\n\t\t\tZebra,\n\t\t\tAlpha\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tBravo,\n\t\t\tCharlie,\n\t\t\tDelta\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tEcho,\n\t\t\tFoxtrot,\n\t\t\tGolf\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tHotel,\n\t\t\tIndia,\n\t\t\tJuliet\n\t\t]\n\t]]"
-              source_location: ~
               children:
                 - name:
                     Named: __0
@@ -2343,7 +2220,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tApple,\n\t\tBanana,\n\t\tCherry\n\t],\n\t[&str; 3] = [\n\t\tDog,\n\t\tElephant,\n\t\tFish\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2353,86 +2229,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tApple,\n\tBanana,\n\tCherry]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Apple
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036A4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Banana
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036AC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Cherry
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036B4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2441,86 +2304,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tDog,\n\tElephant,\n\tFish]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Dog
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036BC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Elephant
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036C4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Fish
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036CC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                 - name:
                     Named: __1
                   type_name:
@@ -2532,7 +2382,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tGuitar,\n\t\tHorse,\n\t\tIce Cream\n\t],\n\t[&str; 3] = [\n\t\tJaguar,\n\t\tKangaroo,\n\t\tLion\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2542,86 +2391,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tGuitar,\n\tHorse,\n\tIce Cream]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Guitar
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036D4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Horse
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036DC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Ice Cream
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036E4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2630,86 +2466,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tJaguar,\n\tKangaroo,\n\tLion]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Jaguar
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036EC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Kangaroo
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036F4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "75"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Lion
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036FC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "76"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                 - name:
                     Named: __2
                   type_name:
@@ -2721,7 +2544,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tMoon,\n\t\tNewton,\n\t\tOwl\n\t],\n\t[&str; 3] = [\n\t\tPencil,\n\t\tQueen,\n\t\tRainbow\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2731,86 +2553,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tMoon,\n\tNewton,\n\tOwl]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Moon
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003704"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "77"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Newton
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000370C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "78"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Owl
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003714"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "79"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2819,86 +2628,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tPencil,\n\tQueen,\n\tRainbow]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Pencil
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000371C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "80"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Queen
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003724"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "81"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Rainbow
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000372C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "82"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location: ~
                 - name:
                     Named: __3
                   type_name:
@@ -2910,7 +2706,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tSun,\n\t\tTree,\n\t\tUmbrella\n\t],\n\t[&str; 3] = [\n\t\tViolin,\n\t\tWatch,\n\t\tXylophone\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2920,86 +2715,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tSun,\n\tTree,\n\tUmbrella]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Sun
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003734"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "83"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Tree
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000373C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "84"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Umbrella
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003744"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "85"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3008,86 +2790,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tViolin,\n\tWatch,\n\tXylophone]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Violin
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000374C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "86"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Watch
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003754"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "87"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Xylophone
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000375C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "88"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
-                              source_location: ~
                 - name:
                     Named: __4
                   type_name:
@@ -3099,7 +2868,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tYellow,\n\t\tZebra,\n\t\tAlpha\n\t],\n\t[&str; 3] = [\n\t\tBravo,\n\t\tCharlie,\n\t\tDelta\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3109,86 +2877,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tYellow,\n\tZebra,\n\tAlpha]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Yellow
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003764"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "89"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Zebra
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000376C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "90"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Alpha
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003774"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3197,86 +2952,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tBravo,\n\tCharlie,\n\tDelta]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Bravo
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000377C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Charlie
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003784"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Delta
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000378C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                 - name:
                     Named: __5
                   type_name:
@@ -3288,7 +3030,6 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tEcho,\n\t\tFoxtrot,\n\t\tGolf\n\t],\n\t[&str; 3] = [\n\t\tHotel,\n\t\tIndia,\n\t\tJuliet\n\t]]"
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3298,86 +3039,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tEcho,\n\tFoxtrot,\n\tGolf]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Echo
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003794"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Foxtrot
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000379C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Golf
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200037A4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3386,86 +3114,73 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tHotel,\n\tIndia,\n\tJuliet]"
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Hotel
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200037AC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: India
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200037B4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Juliet
-                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200037BC"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
-                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location: ~
         - name:
             Named: three
           type_name:
@@ -3474,8 +3189,7 @@ snapshot_kind: text
           source_location:
             line: 249
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: simple_enum_pointer
           type_name:
@@ -3484,15 +3198,13 @@ snapshot_kind: text
           source_location:
             line: 250
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*simple_enum_pointer"
               type_name:
                 Enum: SimpleEnum
               value: "SimpleEnum::Two"
-              source_location: ~
         - name:
             Named: three_level_recursive_struct
           type_name:
@@ -3501,96 +3213,82 @@ snapshot_kind: text
           source_location:
             line: 252
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: depth
               type_name:
                 Base: u32
               value: "1"
-              source_location: ~
             - name:
                 Named: next_self
               type_name:
                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003B30"
-              source_location: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x20003B30
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x20003B30"
-                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RecursiveStruct
                           value: RecursiveStruct @ 0x20003B38
-                          source_location: ~
                           children:
                             - name:
                                 Named: depth
                               type_name:
                                 Base: u32
                               value: "2"
-                              source_location: ~
                             - name:
                                 Named: next_self
                               type_name:
                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003B3C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: Some
                                   type_name:
                                     Struct: Some
                                   value: Some @ 0x20003B3C
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: __0
                                       type_name:
                                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x20003B3C"
-                                      source_location: ~
                                       children:
                                         - name:
                                             Named: "*__0"
                                           type_name:
                                             Struct: RecursiveStruct
                                           value: RecursiveStruct @ 0x20003B44
-                                          source_location: ~
                                           children:
                                             - name:
                                                 Named: depth
                                               type_name:
                                                 Base: u32
                                               value: "3"
-                                              source_location: ~
                                             - name:
                                                 Named: next_self
                                               type_name:
                                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003B48"
-                                              source_location: ~
                                               children:
                                                 - name:
                                                     Named: None
                                                   type_name:
                                                     Struct: None
                                                   value: None @ 0x20003B48
-                                                  source_location: ~
         - name:
             Named: first_case_of_struct_variants
           type_name:
@@ -3599,47 +3297,40 @@ snapshot_kind: text
           source_location:
             line: 263
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Case1
               type_name:
                 Struct: Case1
               value: Case1 @ 0x20003B50
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: ComplexStruct
                   value: ComplexStruct @ 0x20003B60
-                  source_location: ~
                   children:
                     - name:
                         Named: x
                       type_name:
                         Base: i64
                       value: "24"
-                      source_location: ~
                     - name:
                         Named: y
                       type_name:
                         Base: i32
                       value: "25"
-                      source_location: ~
                     - name:
                         Named: z
                       type_name:
                         Base: i16
                       value: "26"
-                      source_location: ~
         - name:
             Named: second_case_of_struct_variants
           type_name:
@@ -3648,34 +3339,29 @@ snapshot_kind: text
           source_location:
             line: 271
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Case2
               type_name:
                 Struct: Case2
               value: Case2 @ 0x20003B80
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: u64
                   value: "1023"
-                  source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i16
                   value: "1967"
-                  source_location: ~
         - name:
             Named: struct_with_one_variant
           type_name:
@@ -3684,80 +3370,68 @@ snapshot_kind: text
           source_location:
             line: 273
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Some
               type_name:
                 Struct: Some
               value: Some @ 0x20003BA0
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: Univariant
                   value: Univariant @ 0x20003BA8
-                  source_location: ~
                   children:
                     - name:
                         Named: TupleOfComplexStruct
                       type_name:
                         Struct: TupleOfComplexStruct
                       value: TupleOfComplexStruct @ 0x20003BA8
-                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x20003BA8
-                          source_location: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "24"
-                              source_location: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "25"
-                              source_location: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "26"
-                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x20003BB8
-                          source_location: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "-3"
-                              source_location: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "-2"
-                              source_location: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "-1"
-                              source_location: ~
         - name:
             Named: stuct_with_one_variant_pointer
           type_name:
@@ -3766,87 +3440,74 @@ snapshot_kind: text
           source_location:
             line: 285
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*stuct_with_one_variant_pointer"
               type_name:
                 Struct: "Option<probe_rs_debugger_test::Univariant>"
               value: "Option<probe_rs_debugger_test::Univariant> @ 0x20003BA0"
-              source_location: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x20003BA0
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Struct: Univariant
                       value: Univariant @ 0x20003BA8
-                      source_location: ~
                       children:
                         - name:
                             Named: TupleOfComplexStruct
                           type_name:
                             Struct: TupleOfComplexStruct
                           value: TupleOfComplexStruct @ 0x20003BA8
-                          source_location: ~
                           children:
                             - name:
                                 Named: __0
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x20003BA8
-                              source_location: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "24"
-                                  source_location: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "25"
-                                  source_location: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "26"
-                                  source_location: ~
                             - name:
                                 Named: __1
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x20003BB8
-                              source_location: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "-3"
-                                  source_location: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "-2"
-                                  source_location: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "-1"
-                                  source_location: ~
         - name:
             Named: long_lived
           type_name:
@@ -3855,27 +3516,23 @@ snapshot_kind: text
           source_location:
             line: 287
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: x
               type_name:
                 Base: i64
               value: "10"
-              source_location: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
-              source_location: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
-              source_location: ~
         - name:
             Named: short_lived
           type_name:
@@ -3884,27 +3541,23 @@ snapshot_kind: text
           source_location:
             line: 289
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: x
               type_name:
                 Base: i64
               value: "20"
-              source_location: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
-              source_location: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
-              source_location: ~
         - name:
             Named: a1
           type_name:
@@ -3913,21 +3566,18 @@ snapshot_kind: text
           source_location:
             line: 290
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: b
               type_name:
                 Base: i32
               value: "-1"
-              source_location: ~
             - name:
                 Named: b1
               type_name:
                 Base: i64
               value: "0"
-              source_location: ~
         - name:
             Named: a2
           type_name:
@@ -3936,8 +3586,7 @@ snapshot_kind: text
           source_location:
             line: 291
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a3
           type_name:
@@ -3946,8 +3595,7 @@ snapshot_kind: text
           source_location:
             line: 292
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a4
           type_name:
@@ -3956,8 +3604,7 @@ snapshot_kind: text
           source_location:
             line: 293
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a5
           type_name:
@@ -3966,21 +3613,18 @@ snapshot_kind: text
           source_location:
             line: 294
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
               type_name:
                 Base: i32
               value: "4"
-              source_location: ~
             - name:
                 Named: __1
               type_name:
                 Base: i64
               value: "5"
-              source_location: ~
         - name:
             Named: a6
           type_name:
@@ -3989,28 +3633,24 @@ snapshot_kind: text
           source_location:
             line: 295
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Variant2
               type_name:
                 Struct: Variant2
               value: Variant2 @ 0x20003C58
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i64
                   value: "7"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "6"
-                  source_location: ~
         - name:
             Named: a7
           type_name:
@@ -4019,28 +3659,24 @@ snapshot_kind: text
           source_location:
             line: 296
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Variant1
               type_name:
                 Struct: Variant1
               value: Variant1 @ 0x20003C78
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "9"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i64
                   value: "8"
-                  source_location: ~
         - name:
             Named: my_array
           type_name:
@@ -4052,8 +3688,7 @@ snapshot_kind: text
           source_location:
             line: 298
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -4063,8 +3698,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __1
               type_name:
@@ -4073,8 +3707,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __2
               type_name:
@@ -4083,8 +3716,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __3
               type_name:
@@ -4093,8 +3725,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __4
               type_name:
@@ -4103,8 +3734,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __5
               type_name:
@@ -4113,8 +3743,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __6
               type_name:
@@ -4123,8 +3752,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __7
               type_name:
@@ -4133,8 +3761,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __8
               type_name:
@@ -4143,8 +3770,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __9
               type_name:
@@ -4153,8 +3779,7 @@ snapshot_kind: text
               source_location:
                 line: 298
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: my_array_ptr
           type_name:
@@ -4163,8 +3788,7 @@ snapshot_kind: text
           source_location:
             line: 299
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*my_array_ptr"
@@ -4174,68 +3798,57 @@ snapshot_kind: text
                     Base: i32
                   count: 10
               value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location: ~
         - name:
             Named: my_array_of_i8
           type_name:
@@ -4247,8 +3860,7 @@ snapshot_kind: text
           source_location:
             line: 300
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -4258,8 +3870,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __1
               type_name:
@@ -4268,8 +3879,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __2
               type_name:
@@ -4278,8 +3888,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __3
               type_name:
@@ -4288,8 +3897,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __4
               type_name:
@@ -4298,8 +3906,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __5
               type_name:
@@ -4308,8 +3915,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __6
               type_name:
@@ -4318,8 +3924,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __7
               type_name:
@@ -4328,8 +3933,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __8
               type_name:
@@ -4338,8 +3942,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __9
               type_name:
@@ -4348,8 +3951,7 @@ snapshot_kind: text
               source_location:
                 line: 300
                 column: ~
-                file: lib.rs
-                directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: heapless_vec
           type_name:
@@ -4358,15 +3960,13 @@ snapshot_kind: text
           source_location:
             line: 301
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: len
               type_name:
                 Base: usize
               value: "3"
-              source_location: ~
             - name:
                 Named: buffer
               type_name:
@@ -4375,268 +3975,227 @@ snapshot_kind: text
                     Base: MaybeUninit<i8>
                   count: 10
               value: "[MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD4\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD5\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD6\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD7\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD8\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD9\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDA\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDB\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDC\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDD\n\t}]"
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD4}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD4
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "1"
-                          source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD5}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD5
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "2"
-                          source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD6}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD6
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "3"
-                          source_location: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD7}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD7
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD8}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD8
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD9}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD9
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDA}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CDA
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDB}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CDB
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDC}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CDC
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDD}"
-                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CDD
-                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location: ~
         - name:
             Named: loop_counter
           type_name:
@@ -4645,15 +4204,13 @@ snapshot_kind: text
           source_location:
             line: 305
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
               type_name:
                 Base: u8
               value: "0"
-              source_location: ~
         - name:
             Named: rtt_channels
           type_name:
@@ -4662,250 +4219,213 @@ snapshot_kind: text
           source_location:
             line: 306
             column: ~
-            file: lib.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: up
               type_name:
                 Struct: "(rtt_target::UpChannel, rtt_target::UpChannel)"
               value: "(rtt_target::UpChannel, rtt_target::UpChannel) @ 0x20003CE4"
-              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x20003CE4
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x20003CE4"
-                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x2000008C
-                          source_location: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x2000008C"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "83"
-                                  source_location: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x20000090"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
-                              source_location: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x20000098
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x20000098
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
-                                      source_location: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x2000009C
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x2000009C
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
-                                      source_location: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000A0
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000A0
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
-                                      source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x20003CE8
-                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x20003CE8"
-                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x200000A4
-                          source_location: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x200000A4"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x200000A8"
-                              source_location: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "0"
-                                  source_location: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
-                              source_location: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000B0
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000B0
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
-                                      source_location: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000B4
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000B4
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
-                                      source_location: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000B8
-                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000B8
-                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
-                                      source_location: ~
   canonical_frame_address: 536887136
 - function_name: __cortex_m_rt_main
   source_location:
     line: 38
     column:
       Column: 10
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -5103,7 +4623,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tpac: Peripherals = Peripherals @ 0x20003F74,\n\tcore: Peripherals = Peripherals @ 0x20003F75,\n\tclocks: Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> = Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76}"
-      source_location: ~
       children:
         - name:
             Named: pac
@@ -5113,423 +4632,353 @@ snapshot_kind: text
           source_location:
             line: 21
             column: ~
-            file: nRF52833_xxAA.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: FICR
               type_name:
                 Struct: FICR
               value: FICR @ 0x20003F74
-              source_location: ~
             - name:
                 Named: UICR
               type_name:
                 Struct: UICR
               value: UICR @ 0x20003F74
-              source_location: ~
             - name:
                 Named: CLOCK
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F74
-              source_location: ~
             - name:
                 Named: POWER
               type_name:
                 Struct: POWER
               value: POWER @ 0x20003F74
-              source_location: ~
             - name:
                 Named: P0
               type_name:
                 Struct: P0
               value: P0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: P1
               type_name:
                 Struct: P1
               value: P1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RADIO
               type_name:
                 Struct: RADIO
               value: RADIO @ 0x20003F74
-              source_location: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: UARTE0
               type_name:
                 Struct: UARTE0
               value: UARTE0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIM0
               type_name:
                 Struct: SPIM0
               value: SPIM0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIS0
               type_name:
                 Struct: SPIS0
               value: SPIS0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWI0
               type_name:
                 Struct: TWI0
               value: TWI0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWIM0
               type_name:
                 Struct: TWIM0
               value: TWIM0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWIS0
               type_name:
                 Struct: TWIS0
               value: TWIS0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIM1
               type_name:
                 Struct: SPIM1
               value: SPIM1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIS1
               type_name:
                 Struct: SPIS1
               value: SPIS1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWI1
               type_name:
                 Struct: TWI1
               value: TWI1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWIM1
               type_name:
                 Struct: TWIM1
               value: TWIM1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWIS1
               type_name:
                 Struct: TWIS1
               value: TWIS1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: NFCT
               type_name:
                 Struct: NFCT
               value: NFCT @ 0x20003F74
-              source_location: ~
             - name:
                 Named: GPIOTE
               type_name:
                 Struct: GPIOTE
               value: GPIOTE @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SAADC
               type_name:
                 Struct: SAADC
               value: SAADC @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER0
               type_name:
                 Struct: TIMER0
               value: TIMER0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER1
               type_name:
                 Struct: TIMER1
               value: TIMER1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER2
               type_name:
                 Struct: TIMER2
               value: TIMER2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RTC0
               type_name:
                 Struct: RTC0
               value: RTC0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TEMP
               type_name:
                 Struct: TEMP
               value: TEMP @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RNG
               type_name:
                 Struct: RNG
               value: RNG @ 0x20003F74
-              source_location: ~
             - name:
                 Named: ECB
               type_name:
                 Struct: ECB
               value: ECB @ 0x20003F74
-              source_location: ~
             - name:
                 Named: AAR
               type_name:
                 Struct: AAR
               value: AAR @ 0x20003F74
-              source_location: ~
             - name:
                 Named: CCM
               type_name:
                 Struct: CCM
               value: CCM @ 0x20003F74
-              source_location: ~
             - name:
                 Named: WDT
               type_name:
                 Struct: WDT
               value: WDT @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RTC1
               type_name:
                 Struct: RTC1
               value: RTC1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: QDEC
               type_name:
                 Struct: QDEC
               value: QDEC @ 0x20003F74
-              source_location: ~
             - name:
                 Named: COMP
               type_name:
                 Struct: COMP
               value: COMP @ 0x20003F74
-              source_location: ~
             - name:
                 Named: LPCOMP
               type_name:
                 Struct: LPCOMP
               value: LPCOMP @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU0
               type_name:
                 Struct: EGU0
               value: EGU0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI0
               type_name:
                 Struct: SWI0
               value: SWI0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU1
               type_name:
                 Struct: EGU1
               value: EGU1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI1
               type_name:
                 Struct: SWI1
               value: SWI1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU2
               type_name:
                 Struct: EGU2
               value: EGU2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI2
               type_name:
                 Struct: SWI2
               value: SWI2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU3
               type_name:
                 Struct: EGU3
               value: EGU3 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI3
               type_name:
                 Struct: SWI3
               value: SWI3 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU4
               type_name:
                 Struct: EGU4
               value: EGU4 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI4
               type_name:
                 Struct: SWI4
               value: SWI4 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU5
               type_name:
                 Struct: EGU5
               value: EGU5 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI5
               type_name:
                 Struct: SWI5
               value: SWI5 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER3
               type_name:
                 Struct: TIMER3
               value: TIMER3 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER4
               type_name:
                 Struct: TIMER4
               value: TIMER4 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PWM0
               type_name:
                 Struct: PWM0
               value: PWM0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PDM
               type_name:
                 Struct: PDM
               value: PDM @ 0x20003F74
-              source_location: ~
             - name:
                 Named: ACL
               type_name:
                 Struct: ACL
               value: ACL @ 0x20003F74
-              source_location: ~
             - name:
                 Named: NVMC
               type_name:
                 Struct: NVMC
               value: NVMC @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PPI
               type_name:
                 Struct: PPI
               value: PPI @ 0x20003F74
-              source_location: ~
             - name:
                 Named: MWU
               type_name:
                 Struct: MWU
               value: MWU @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PWM1
               type_name:
                 Struct: PWM1
               value: PWM1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PWM2
               type_name:
                 Struct: PWM2
               value: PWM2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPI2
               type_name:
                 Struct: SPI2
               value: SPI2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIM2
               type_name:
                 Struct: SPIM2
               value: SPIM2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIS2
               type_name:
                 Struct: SPIS2
               value: SPIS2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RTC2
               type_name:
                 Struct: RTC2
               value: RTC2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: I2S
               type_name:
                 Struct: I2S
               value: I2S @ 0x20003F74
-              source_location: ~
             - name:
                 Named: USBD
               type_name:
                 Struct: USBD
               value: USBD @ 0x20003F74
-              source_location: ~
             - name:
                 Named: UARTE1
               type_name:
                 Struct: UARTE1
               value: UARTE1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PWM3
               type_name:
                 Struct: PWM3
               value: PWM3 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIM3
               type_name:
                 Struct: SPIM3
               value: SPIM3 @ 0x20003F74
-              source_location: ~
         - name:
             Named: core
           type_name:
@@ -5538,99 +4987,83 @@ snapshot_kind: text
           source_location:
             line: 22
             column: ~
-            file: nRF52833_xxAA.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F75
-              source_location: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F75
-              source_location: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F75
-              source_location: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F75
-              source_location: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F75
-              source_location: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F75
-              source_location: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F75
-              source_location: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F75
-              source_location: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F75
-              source_location: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F75
-              source_location: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F75
-              source_location: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F75
-              source_location: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F75
-              source_location: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F75
-              source_location: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
-              source_location: ~
         - name:
             Named: clocks
           type_name:
@@ -5639,40 +5072,34 @@ snapshot_kind: text
           source_location:
             line: 23
             column: ~
-            file: nRF52833_xxAA.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: hfclk
               type_name:
                 Struct: ExternalOscillator
               value: ExternalOscillator @ 0x20003F76
-              source_location: ~
             - name:
                 Named: lfclk
               type_name:
                 Struct: Internal
               value: Internal @ 0x20003F76
-              source_location: ~
             - name:
                 Named: lfstat
               type_name:
                 Struct: LfOscStopped
               value: LfOscStopped @ 0x20003F76
-              source_location: ~
             - name:
                 Named: periph
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F76
-              source_location: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
     line: 19
     column: LeftEdge
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -5869,5 +5296,4 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_full_unwind.snap
@@ -6,10 +6,10 @@ snapshot_kind: text
 ---
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 344
     column:
       Column: 13
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -221,25 +221,25 @@ snapshot_kind: text
             Base: usize
           value: "5"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "6"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883472
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -443,25 +443,25 @@ snapshot_kind: text
             Base: usize
           value: "4"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "5"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883616
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -665,25 +665,25 @@ snapshot_kind: text
             Base: usize
           value: "3"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "4"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883760
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -887,25 +887,25 @@ snapshot_kind: text
             Base: usize
           value: "2"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "3"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536883904
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -1109,25 +1109,25 @@ snapshot_kind: text
             Base: usize
           value: "1"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "2"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536884048
 - function_name: test_deep_stack
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 338
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -1331,25 +1331,25 @@ snapshot_kind: text
             Base: usize
           value: "0"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 331
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: internal_depth_measure
           type_name:
             Base: usize
           value: "1"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 332
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   canonical_frame_address: 536884192
 - function_name: setup_data_types
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 325
     column:
       Column: 5
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -1553,18 +1553,18 @@ snapshot_kind: text
             Base: i8
           value: "-23"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 204
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: local_reference_to_global_const
           type_name:
             Struct: "&str"
           value: "This global `const` value will only show up in the debugger in the variables where it is referenced"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 207
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
@@ -1588,9 +1588,9 @@ snapshot_kind: text
             Struct: "&str"
           value: "A 'global' static variable"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 208
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
@@ -1614,9 +1614,9 @@ snapshot_kind: text
             Pointer: "*const probe_rs_debugger_test::ComplexEnum"
           value: "*const probe_rs_debugger_test::ComplexEnum @ 0x20003D64"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 209
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*local_reference_to_global_static_struct"
@@ -1662,18 +1662,18 @@ snapshot_kind: text
             Base: usize
           value: "0"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 210
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: ghosted_variable
           type_name:
             Struct: "&str"
           value: New value and type for a different name
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 211
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
@@ -1697,45 +1697,45 @@ snapshot_kind: text
             Base: i8
           value: "26"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 212
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: int128
           type_name:
             Base: i128
           value: "-196710231994021419720322"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 213
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: u_int128
           type_name:
             Base: u128
           value: "340282366920938266753142613410348491134"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 214
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: float64
           type_name:
             Base: f64
           value: "1.7608695652173911"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 215
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: float64_ptr
           type_name:
             Pointer: "&f64"
           value: "&f64 @ 0x20003D7C"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 216
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*float64_ptr"
@@ -1748,18 +1748,18 @@ snapshot_kind: text
             Base: char
           value: 💩
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 217
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: emoji_ptr
           type_name:
             Pointer: "&char"
           value: "&char @ 0x20003D80"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 218
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*emoji_ptr"
@@ -1772,18 +1772,18 @@ snapshot_kind: text
             Base: bool
           value: "true"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 219
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: any_old_string_slice
           type_name:
             Struct: "&str"
           value: How long is a piece of String.
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 221
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: data_ptr
@@ -1807,9 +1807,9 @@ snapshot_kind: text
             Struct: "Result<(), &str>"
           value: "Result<(), &str> @ 0x20003D84"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 222
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Err
@@ -1845,9 +1845,9 @@ snapshot_kind: text
             Struct: "(bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64)"
           value: "(bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x200034E8"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 223
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -1925,9 +1925,9 @@ snapshot_kind: text
             Struct: "Matrix<i32, 2, 3, 4>"
           value: "Matrix<i32, 2, 3, 4> @ 0x20003524"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 224
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: raw
@@ -2190,9 +2190,9 @@ snapshot_kind: text
             Struct: "Matrix<&str, 2, 3, 6>"
           value: "Matrix<&str, 2, 3, 6> @ 0x200036A4"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 232
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: raw
@@ -3187,18 +3187,18 @@ snapshot_kind: text
             Enum: SimpleEnum
           value: "SimpleEnum::Two"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 249
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: simple_enum_pointer
           type_name:
             Pointer: "&probe_rs_debugger_test::SimpleEnum"
           value: "&probe_rs_debugger_test::SimpleEnum @ 0x20003B28"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 250
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*simple_enum_pointer"
@@ -3211,9 +3211,9 @@ snapshot_kind: text
             Struct: RecursiveStruct
           value: RecursiveStruct @ 0x20003B2C
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 252
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: depth
@@ -3295,9 +3295,9 @@ snapshot_kind: text
             Struct: ComplexEnum
           value: ComplexEnum @ 0x20003B50
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 263
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Case1
@@ -3337,9 +3337,9 @@ snapshot_kind: text
             Struct: ComplexEnum
           value: ComplexEnum @ 0x20003B80
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 271
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Case2
@@ -3368,9 +3368,9 @@ snapshot_kind: text
             Struct: "Option<probe_rs_debugger_test::Univariant>"
           value: "Option<probe_rs_debugger_test::Univariant> @ 0x20003BA0"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 273
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Some
@@ -3438,9 +3438,9 @@ snapshot_kind: text
             Pointer: "&core::option::Option<probe_rs_debugger_test::Univariant>"
           value: "&core::option::Option<probe_rs_debugger_test::Univariant> @ 0x20003D8C"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 285
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*stuct_with_one_variant_pointer"
@@ -3514,9 +3514,9 @@ snapshot_kind: text
             Struct: ComplexStruct
           value: ComplexStruct @ 0x20003C08
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 287
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: x
@@ -3539,9 +3539,9 @@ snapshot_kind: text
             Struct: ComplexStruct
           value: ComplexStruct @ 0x20003C18
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 289
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: x
@@ -3564,9 +3564,9 @@ snapshot_kind: text
             Struct: Struct<i32>
           value: Struct<i32> @ 0x20003D90
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 290
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: b
@@ -3584,36 +3584,36 @@ snapshot_kind: text
             Base: i64
           value: "1"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 291
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a3
           type_name:
             Base: i64
           value: "2"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 292
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a4
           type_name:
             Base: i64
           value: "3"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 293
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: a5
           type_name:
             Struct: "(i32, i64)"
           value: "(i32, i64) @ 0x20003DB8"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 294
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -3631,9 +3631,9 @@ snapshot_kind: text
             Struct: Enum<i32>
           value: Enum<i32> @ 0x20003C58
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 295
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Variant2
@@ -3657,9 +3657,9 @@ snapshot_kind: text
             Struct: Enum<i32>
           value: Enum<i32> @ 0x20003C78
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 296
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: Variant1
@@ -3686,9 +3686,9 @@ snapshot_kind: text
               count: 10
           value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 298
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -3696,99 +3696,99 @@ snapshot_kind: text
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __1
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __2
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __3
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __4
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __6
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __7
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __8
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __9
               type_name:
                 Base: i32
               value: "55"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 298
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: my_array_ptr
           type_name:
             Pointer: "&[i32; 10]"
           value: "&[i32; 10] @ 0x20003DC8"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 299
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: "*my_array_ptr"
@@ -3858,9 +3858,9 @@ snapshot_kind: text
               count: 10
           value: "[i8; 10] = [\n\t1,\n\t2,\n\t3,\n\t4,\n\t5,\n\t6,\n\t7,\n\t8,\n\t9,\n\t0]"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 300
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -3868,99 +3868,99 @@ snapshot_kind: text
                 Base: i8
               value: "1"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __1
               type_name:
                 Base: i8
               value: "2"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __2
               type_name:
                 Base: i8
               value: "3"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "4"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __4
               type_name:
                 Base: i8
               value: "5"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __5
               type_name:
                 Base: i8
               value: "6"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __6
               type_name:
                 Base: i8
               value: "7"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __7
               type_name:
                 Base: i8
               value: "8"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __8
               type_name:
                 Base: i8
               value: "9"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             - name:
                 Named: __9
               type_name:
                 Base: i8
               value: "0"
               source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
                 line: 300
                 column: ~
-                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
         - name:
             Named: heapless_vec
           type_name:
             Struct: "Vec<i8, 10>"
           value: "Vec<i8, 10> @ 0x20003CD0"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 301
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: len
@@ -4202,9 +4202,9 @@ snapshot_kind: text
             Struct: Wrapping<u8>
           value: Wrapping<u8> @ 0x20003CE3
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 305
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: __0
@@ -4217,9 +4217,9 @@ snapshot_kind: text
             Struct: Channels
           value: Channels @ 0x20003CE4
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
             line: 306
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
           children:
             - name:
                 Named: up
@@ -4422,10 +4422,10 @@ snapshot_kind: text
   canonical_frame_address: 536887136
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 38
     column:
       Column: 10
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -4630,9 +4630,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003F74
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 21
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: FICR
@@ -4985,9 +4985,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003F75
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 22
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
@@ -5070,9 +5070,9 @@ snapshot_kind: text
             Struct: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped>"
           value: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 23
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: hfclk
@@ -5097,9 +5097,9 @@ snapshot_kind: text
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 19
     column: LeftEdge
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_full_unwind.snap
@@ -215,11 +215,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 5,\n\tinternal_depth_measure: usize = 6}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -445,11 +441,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 4,\n\tinternal_depth_measure: usize = 5}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -675,11 +667,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 3,\n\tinternal_depth_measure: usize = 4}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -905,11 +893,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 2,\n\tinternal_depth_measure: usize = 3}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1135,11 +1119,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 1,\n\tinternal_depth_measure: usize = 2}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1365,11 +1345,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tstack_depth: usize = 0,\n\tinternal_depth_measure: usize = 1}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: stack_depth
@@ -1595,11 +1571,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tint8_minus_twenty_three: i8 = -23,\n\tlocal_reference_to_global_const: &str = This global `const` value will only show up in the debugger in the variables where it is referenced,\n\tlocal_reference_to_global_static: &str = A 'global' static variable,\n\tlocal_reference_to_global_static_struct: *const probe_rs_debugger_test::ComplexEnum = *const probe_rs_debugger_test::ComplexEnum @ 0x20003D64,\n\tghosted_variable: usize = 0,\n\tghosted_variable: &str = New value and type for a different name,\n\tint8_twenty_six: i8 = 26,\n\tint128: i128 = -196710231994021419720322,\n\tu_int128: u128 = 340282366920938266753142613410348491134,\n\tfloat64: f64 = 1.7608695652173911,\n\tfloat64_ptr: &f64 = &f64 @ 0x20003D7C,\n\temoji: char = 💩,\n\temoji_ptr: &char = &char @ 0x20003D80,\n\ttrue_bool: bool = true,\n\tany_old_string_slice: &str = How long is a piece of String.,\n\tfunction_result: Result<(), &str> = Result<(), &str> @ 0x20003D84,\n\tglobal_types: (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) = (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x200034E8,\n\tthree_d_usize_array: Matrix<i32, 2, 3, 4> = Matrix<i32, 2, 3, 4> @ 0x20003524,\n\tthree_d_string_array: Matrix<&str, 2, 3, 6> = Matrix<&str, 2, 3, 6> @ 0x200036A4,\n\tthree: SimpleEnum = SimpleEnum::Two,\n\tsimple_enum_pointer: &probe_rs_debugger_test::SimpleEnum = &probe_rs_debugger_test::SimpleEnum @ 0x20003B28,\n\tthree_level_recursive_struct: RecursiveStruct = RecursiveStruct @ 0x20003B2C,\n\tfirst_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003B50,\n\tsecond_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003B80,\n\tstruct_with_one_variant: Option<probe_rs_debugger_test::Univariant> = Option<probe_rs_debugger_test::Univariant> @ 0x20003BA0,\n\tstuct_with_one_variant_pointer: &core::option::Option<probe_rs_debugger_test::Univariant> = &core::option::Option<probe_rs_debugger_test::Univariant> @ 0x20003D8C,\n\tlong_lived: ComplexStruct = ComplexStruct @ 0x20003C08,\n\tshort_lived: ComplexStruct = ComplexStruct @ 0x20003C18,\n\ta1: Struct<i32> = Struct<i32> @ 0x20003D90,\n\ta2: i64 = 1,\n\ta3: i64 = 2,\n\ta4: i64 = 3,\n\ta5: (i32, i64) = (i32, i64) @ 0x20003DB8,\n\ta6: Enum<i32> = Enum<i32> @ 0x20003C58,\n\ta7: Enum<i32> = Enum<i32> @ 0x20003C78,\n\t[i32; 10] = [\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55\n\t],\n\tmy_array_ptr: &[i32; 10] = &[i32; 10] @ 0x20003DC8,\n\t[i8; 10] = [\n\t\t1,\n\t\t2,\n\t\t3,\n\t\t4,\n\t\t5,\n\t\t6,\n\t\t7,\n\t\t8,\n\t\t9,\n\t\t0\n\t],\n\theapless_vec: Vec<i8, 10> = Vec<i8, 10> @ 0x20003CD0,\n\tloop_counter: Wrapping<u8> = Wrapping<u8> @ 0x20003CE3,\n\trtt_channels: Channels = Channels @ 0x20003CE4}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: int8_minus_twenty_three
@@ -1627,32 +1599,20 @@ snapshot_kind: text
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003498"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "84"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "99"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: local_reference_to_global_static
           type_name:
@@ -1669,32 +1629,20 @@ snapshot_kind: text
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x20003D5C"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "65"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "26"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: local_reference_to_global_static_struct
           type_name:
@@ -1711,74 +1659,46 @@ snapshot_kind: text
               type_name:
                 Struct: ComplexEnum
               value: ComplexEnum @ 0x20000048
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: Case1
                   type_name:
                     Struct: Case1
                   value: Case1 @ 0x20000048
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Base: u64
                       value: "0"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: __1
                       type_name:
                         Struct: ComplexStruct
                       value: ComplexStruct @ 0x20000058
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: x
                           type_name:
                             Base: i64
                           value: "24"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: y
                           type_name:
                             Base: i32
                           value: "25"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: z
                           type_name:
                             Base: i16
                           value: "26"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
         - name:
             Named: ghosted_variable
           type_name:
@@ -1805,32 +1725,20 @@ snapshot_kind: text
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x200034A4"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "78"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "39"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: int8_twenty_six
           type_name:
@@ -1887,11 +1795,7 @@ snapshot_kind: text
               type_name:
                 Base: f64
               value: "1.7608695652173911"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: emoji
           type_name:
@@ -1918,11 +1822,7 @@ snapshot_kind: text
               type_name:
                 Base: char
               value: 💩
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: true_bool
           type_name:
@@ -1949,32 +1849,20 @@ snapshot_kind: text
               type_name:
                 Pointer: u8
               value: "*raw u8 @ 0x200034C8"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: "*data_ptr"
                   type_name:
                     Base: u8
                   value: "72"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
             - name:
                 Named: length
               type_name:
                 Base: usize
               value: "30"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: function_result
           type_name:
@@ -1991,54 +1879,34 @@ snapshot_kind: text
               type_name:
                 Struct: Err
               value: Err @ 0x20003D84
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: "&str"
                   value: Forcing the return of an Error variant
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: data_ptr
                       type_name:
                         Pointer: u8
                       value: "*raw u8 @ 0x20003D84"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: "*data_ptr"
                           type_name:
                             Base: u8
                           value: "70"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: length
                       type_name:
                         Base: usize
                       value: "38"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
         - name:
             Named: global_types
           type_name:
@@ -2055,141 +1923,85 @@ snapshot_kind: text
               type_name:
                 Base: bool
               value: "false"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __1
               type_name:
                 Base: isize
               value: "-1"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __2
               type_name:
                 Base: char
               value: a
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __3
               type_name:
                 Base: i8
               value: "68"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __4
               type_name:
                 Base: i16
               value: "-16"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __5
               type_name:
                 Base: i32
               value: "-32"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __6
               type_name:
                 Base: i64
               value: "-64"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __7
               type_name:
                 Base: usize
               value: "1"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __8
               type_name:
                 Base: u8
               value: "100"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __9
               type_name:
                 Base: u16
               value: "16"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __10
               type_name:
                 Base: u32
               value: "32"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __11
               type_name:
                 Base: u64
               value: "64"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __12
               type_name:
                 Base: f32
               value: "2.5"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __13
               type_name:
                 Base: f64
               value: "3.5"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: three_d_usize_array
           type_name:
@@ -2215,11 +2027,7 @@ snapshot_kind: text
                       count: 2
                   count: 4
               value: "[[[i32; 3]; 2]; 4] = [\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t0,\n\t\t\t1,\n\t\t\t2\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t3,\n\t\t\t4,\n\t\t\t5\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t6,\n\t\t\t7,\n\t\t\t8\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t9,\n\t\t\t10,\n\t\t\t11\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t12,\n\t\t\t13,\n\t\t\t14\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t15,\n\t\t\t16,\n\t\t\t17\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t18,\n\t\t\t19,\n\t\t\t20\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t21,\n\t\t\t22,\n\t\t\t23\n\t\t]\n\t]]"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
@@ -2232,11 +2040,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t0,\n\t\t1,\n\t\t2\n\t],\n\t[i32; 3] = [\n\t\t3,\n\t\t4,\n\t\t5\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2246,42 +2050,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t0,\n\t1,\n\t2]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "1"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "2"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2290,42 +2078,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t3,\n\t4,\n\t5]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "3"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "4"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "5"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __1
                   type_name:
@@ -2337,11 +2109,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t6,\n\t\t7,\n\t\t8\n\t],\n\t[i32; 3] = [\n\t\t9,\n\t\t10,\n\t\t11\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2351,42 +2119,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t6,\n\t7,\n\t8]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "6"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "7"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "8"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2395,42 +2147,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t9,\n\t10,\n\t11]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "9"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "10"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "11"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __2
                   type_name:
@@ -2442,11 +2178,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t12,\n\t\t13,\n\t\t14\n\t],\n\t[i32; 3] = [\n\t\t15,\n\t\t16,\n\t\t17\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2456,42 +2188,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t12,\n\t13,\n\t14]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "12"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "13"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "14"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2500,42 +2216,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t15,\n\t16,\n\t17]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "15"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "16"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "17"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __3
                   type_name:
@@ -2547,11 +2247,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t18,\n\t\t19,\n\t\t20\n\t],\n\t[i32; 3] = [\n\t\t21,\n\t\t22,\n\t\t23\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2561,42 +2257,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t18,\n\t19,\n\t20]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "18"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "19"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "20"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2605,42 +2285,26 @@ snapshot_kind: text
                             Base: i32
                           count: 3
                       value: "[i32; 3] = [\n\t21,\n\t22,\n\t23]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Base: i32
                           value: "21"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Base: i32
                           value: "22"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Base: i32
                           value: "23"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
         - name:
             Named: three_d_string_array
           type_name:
@@ -2666,11 +2330,7 @@ snapshot_kind: text
                       count: 2
                   count: 6
               value: "[[[&str; 3]; 2]; 6] = [\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tApple,\n\t\t\tBanana,\n\t\t\tCherry\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tDog,\n\t\t\tElephant,\n\t\t\tFish\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tGuitar,\n\t\t\tHorse,\n\t\t\tIce Cream\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tJaguar,\n\t\t\tKangaroo,\n\t\t\tLion\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tMoon,\n\t\t\tNewton,\n\t\t\tOwl\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tPencil,\n\t\t\tQueen,\n\t\t\tRainbow\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tSun,\n\t\t\tTree,\n\t\t\tUmbrella\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tViolin,\n\t\t\tWatch,\n\t\t\tXylophone\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tYellow,\n\t\t\tZebra,\n\t\t\tAlpha\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tBravo,\n\t\t\tCharlie,\n\t\t\tDelta\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tEcho,\n\t\t\tFoxtrot,\n\t\t\tGolf\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tHotel,\n\t\t\tIndia,\n\t\t\tJuliet\n\t\t]\n\t]]"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
@@ -2683,11 +2343,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tApple,\n\t\tBanana,\n\t\tCherry\n\t],\n\t[&str; 3] = [\n\t\tDog,\n\t\tElephant,\n\t\tFish\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2697,138 +2353,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tApple,\n\tBanana,\n\tCherry]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Apple
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036A4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Banana
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036AC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Cherry
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036B4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -2837,138 +2441,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tDog,\n\tElephant,\n\tFish]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Dog
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036BC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Elephant
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036C4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Fish
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036CC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __1
                   type_name:
@@ -2980,11 +2532,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tGuitar,\n\t\tHorse,\n\t\tIce Cream\n\t],\n\t[&str; 3] = [\n\t\tJaguar,\n\t\tKangaroo,\n\t\tLion\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -2994,138 +2542,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tGuitar,\n\tHorse,\n\tIce Cream]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Guitar
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036D4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Horse
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036DC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Ice Cream
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036E4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3134,138 +2630,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tJaguar,\n\tKangaroo,\n\tLion]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Jaguar
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036EC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Kangaroo
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036F4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "75"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Lion
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200036FC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "76"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __2
                   type_name:
@@ -3277,11 +2721,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tMoon,\n\t\tNewton,\n\t\tOwl\n\t],\n\t[&str; 3] = [\n\t\tPencil,\n\t\tQueen,\n\t\tRainbow\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3291,138 +2731,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tMoon,\n\tNewton,\n\tOwl]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Moon
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003704"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "77"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Newton
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000370C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "78"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Owl
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003714"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "79"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3431,138 +2819,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tPencil,\n\tQueen,\n\tRainbow]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Pencil
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000371C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "80"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Queen
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003724"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "81"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Rainbow
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000372C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "82"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __3
                   type_name:
@@ -3574,11 +2910,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tSun,\n\t\tTree,\n\t\tUmbrella\n\t],\n\t[&str; 3] = [\n\t\tViolin,\n\t\tWatch,\n\t\tXylophone\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3588,138 +2920,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tSun,\n\tTree,\n\tUmbrella]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Sun
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003734"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "83"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "3"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Tree
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000373C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "84"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Umbrella
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003744"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "85"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "8"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -3728,138 +3008,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tViolin,\n\tWatch,\n\tXylophone]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Violin
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000374C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "86"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Watch
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003754"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "87"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Xylophone
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000375C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "88"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "9"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __4
                   type_name:
@@ -3871,11 +3099,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tYellow,\n\t\tZebra,\n\t\tAlpha\n\t],\n\t[&str; 3] = [\n\t\tBravo,\n\t\tCharlie,\n\t\tDelta\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -3885,138 +3109,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tYellow,\n\tZebra,\n\tAlpha]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Yellow
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003764"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "89"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Zebra
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000376C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "90"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Alpha
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003774"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "65"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -4025,138 +3197,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tBravo,\n\tCharlie,\n\tDelta]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Bravo
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000377C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Charlie
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003784"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "67"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Delta
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000378C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "68"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                 - name:
                     Named: __5
                   type_name:
@@ -4168,11 +3288,7 @@ snapshot_kind: text
                           count: 3
                       count: 2
                   value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tEcho,\n\t\tFoxtrot,\n\t\tGolf\n\t],\n\t[&str; 3] = [\n\t\tHotel,\n\t\tIndia,\n\t\tJuliet\n\t]]"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
@@ -4182,138 +3298,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tEcho,\n\tFoxtrot,\n\tGolf]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Echo
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x20003794"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "69"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: Foxtrot
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x2000379C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "7"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Golf
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200037A4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "71"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                     - name:
                         Named: __1
                       type_name:
@@ -4322,138 +3386,86 @@ snapshot_kind: text
                             Struct: "&str"
                           count: 3
                       value: "[&str; 3] = [\n\tHotel,\n\tIndia,\n\tJuliet]"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: "&str"
                           value: Hotel
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200037AC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "72"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: "&str"
                           value: India
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200037B4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "73"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "5"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __2
                           type_name:
                             Struct: "&str"
                           value: Juliet
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: data_ptr
                               type_name:
                                 Pointer: u8
                               value: "*raw u8 @ 0x200037BC"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
                                   value: "74"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "6"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
         - name:
             Named: three
           type_name:
@@ -4480,11 +3492,7 @@ snapshot_kind: text
               type_name:
                 Enum: SimpleEnum
               value: "SimpleEnum::Two"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: three_level_recursive_struct
           type_name:
@@ -4501,140 +3509,88 @@ snapshot_kind: text
               type_name:
                 Base: u32
               value: "1"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: next_self
               type_name:
                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003B30"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x20003B30
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x20003B30"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RecursiveStruct
                           value: RecursiveStruct @ 0x20003B38
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: depth
                               type_name:
                                 Base: u32
                               value: "2"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: next_self
                               type_name:
                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003B3C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: Some
                                   type_name:
                                     Struct: Some
                                   value: Some @ 0x20003B3C
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: __0
                                       type_name:
                                         Pointer: "&mut probe_rs_debugger_test::RecursiveStruct"
                                       value: "&mut probe_rs_debugger_test::RecursiveStruct @ 0x20003B3C"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                                       children:
                                         - name:
                                             Named: "*__0"
                                           type_name:
                                             Struct: RecursiveStruct
                                           value: RecursiveStruct @ 0x20003B44
-                                          source_location:
-                                            line: ~
-                                            column: ~
-                                            file: ~
-                                            directory: ~
+                                          source_location: ~
                                           children:
                                             - name:
                                                 Named: depth
                                               type_name:
                                                 Base: u32
                                               value: "3"
-                                              source_location:
-                                                line: ~
-                                                column: ~
-                                                file: ~
-                                                directory: ~
+                                              source_location: ~
                                             - name:
                                                 Named: next_self
                                               type_name:
                                                 Struct: "Option<&mut probe_rs_debugger_test::RecursiveStruct>"
                                               value: "Option<&mut probe_rs_debugger_test::RecursiveStruct> @ 0x20003B48"
-                                              source_location:
-                                                line: ~
-                                                column: ~
-                                                file: ~
-                                                directory: ~
+                                              source_location: ~
                                               children:
                                                 - name:
                                                     Named: None
                                                   type_name:
                                                     Struct: None
                                                   value: None @ 0x20003B48
-                                                  source_location:
-                                                    line: ~
-                                                    column: ~
-                                                    file: ~
-                                                    directory: ~
+                                                  source_location: ~
         - name:
             Named: first_case_of_struct_variants
           type_name:
@@ -4651,63 +3607,39 @@ snapshot_kind: text
               type_name:
                 Struct: Case1
               value: Case1 @ 0x20003B50
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: ComplexStruct
                   value: ComplexStruct @ 0x20003B60
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: x
                       type_name:
                         Base: i64
                       value: "24"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: y
                       type_name:
                         Base: i32
                       value: "25"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: z
                       type_name:
                         Base: i16
                       value: "26"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
         - name:
             Named: second_case_of_struct_variants
           type_name:
@@ -4724,42 +3656,26 @@ snapshot_kind: text
               type_name:
                 Struct: Case2
               value: Case2 @ 0x20003B80
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: u64
                   value: "0"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: u64
                   value: "1023"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i16
                   value: "1967"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: struct_with_one_variant
           type_name:
@@ -4776,116 +3692,72 @@ snapshot_kind: text
               type_name:
                 Struct: Some
               value: Some @ 0x20003BA0
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: Univariant
                   value: Univariant @ 0x20003BA8
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: TupleOfComplexStruct
                       type_name:
                         Struct: TupleOfComplexStruct
                       value: TupleOfComplexStruct @ 0x20003BA8
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: __0
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x20003BA8
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "24"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "25"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "26"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                         - name:
                             Named: __1
                           type_name:
                             Struct: ComplexStruct
                           value: ComplexStruct @ 0x20003BB8
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: x
                               type_name:
                                 Base: i64
                               value: "-3"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: y
                               type_name:
                                 Base: i32
                               value: "-2"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: z
                               type_name:
                                 Base: i16
                               value: "-1"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
         - name:
             Named: stuct_with_one_variant_pointer
           type_name:
@@ -4902,127 +3774,79 @@ snapshot_kind: text
               type_name:
                 Struct: "Option<probe_rs_debugger_test::Univariant>"
               value: "Option<probe_rs_debugger_test::Univariant> @ 0x20003BA0"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: Some
                   type_name:
                     Struct: Some
                   value: Some @ 0x20003BA0
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Struct: Univariant
                       value: Univariant @ 0x20003BA8
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: TupleOfComplexStruct
                           type_name:
                             Struct: TupleOfComplexStruct
                           value: TupleOfComplexStruct @ 0x20003BA8
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: __0
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x20003BA8
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "24"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "25"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "26"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: __1
                               type_name:
                                 Struct: ComplexStruct
                               value: ComplexStruct @ 0x20003BB8
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: x
                                   type_name:
                                     Base: i64
                                   value: "-3"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                 - name:
                                     Named: y
                                   type_name:
                                     Base: i32
                                   value: "-2"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                 - name:
                                     Named: z
                                   type_name:
                                     Base: i16
                                   value: "-1"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
         - name:
             Named: long_lived
           type_name:
@@ -5039,31 +3863,19 @@ snapshot_kind: text
               type_name:
                 Base: i64
               value: "10"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: short_lived
           type_name:
@@ -5080,31 +3892,19 @@ snapshot_kind: text
               type_name:
                 Base: i64
               value: "20"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: y
               type_name:
                 Base: i32
               value: "8"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: z
               type_name:
                 Base: i16
               value: "4"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: a1
           type_name:
@@ -5121,21 +3921,13 @@ snapshot_kind: text
               type_name:
                 Base: i32
               value: "-1"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: b1
               type_name:
                 Base: i64
               value: "0"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: a2
           type_name:
@@ -5182,21 +3974,13 @@ snapshot_kind: text
               type_name:
                 Base: i32
               value: "4"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: __1
               type_name:
                 Base: i64
               value: "5"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: a6
           type_name:
@@ -5213,32 +3997,20 @@ snapshot_kind: text
               type_name:
                 Struct: Variant2
               value: Variant2 @ 0x20003C58
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i64
                   value: "7"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "6"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: a7
           type_name:
@@ -5255,32 +4027,20 @@ snapshot_kind: text
               type_name:
                 Struct: Variant1
               value: Variant1 @ 0x20003C78
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "9"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i64
                   value: "8"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: my_array
           type_name:
@@ -5414,112 +4174,68 @@ snapshot_kind: text
                     Base: i32
                   count: 10
               value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: i32
                   value: "55"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
         - name:
             Named: my_array_of_i8
           type_name:
@@ -5650,11 +4366,7 @@ snapshot_kind: text
               type_name:
                 Base: usize
               value: "3"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: buffer
               type_name:
@@ -5663,432 +4375,268 @@ snapshot_kind: text
                     Base: MaybeUninit<i8>
                   count: 10
               value: "[MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD4\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD5\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD6\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD7\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD8\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD9\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDA\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDB\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDC\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDD\n\t}]"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD4}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD4
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "1"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD5}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD5
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "2"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __2
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD6}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD6
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "3"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __3
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD7}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD7
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __4
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD8}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD8
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __5
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CD9}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CD9
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __6
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDA}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CDA
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __7
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDB}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CDB
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __8
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDC}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CDC
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                 - name:
                     Named: __9
                   type_name:
                     Base: MaybeUninit<i8>
                   value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CDD}"
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: uninit
                       type_name:
                         Base: ()
                       value: ()
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                     - name:
                         Named: value
                       type_name:
                         Struct: ManuallyDrop<i8>
                       value: ManuallyDrop<i8> @ 0x20003CDD
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: value
                           type_name:
                             Base: i8
                           value: "0"
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
         - name:
             Named: loop_counter
           type_name:
@@ -6105,11 +4653,7 @@ snapshot_kind: text
               type_name:
                 Base: u8
               value: "0"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: rtt_channels
           type_name:
@@ -6126,374 +4670,234 @@ snapshot_kind: text
               type_name:
                 Struct: "(rtt_target::UpChannel, rtt_target::UpChannel)"
               value: "(rtt_target::UpChannel, rtt_target::UpChannel) @ 0x20003CE4"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
               children:
                 - name:
                     Named: __0
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x20003CE4
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x20003CE4"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x2000008C
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x2000008C"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "83"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x20000090"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "70"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x20000098
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x20000098
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x2000009C
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x2000009C
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "363"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000A0
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000A0
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                 - name:
                     Named: __1
                   type_name:
                     Struct: UpChannel
                   value: UpChannel @ 0x20003CE8
-                  source_location:
-                    line: ~
-                    column: ~
-                    file: ~
-                    directory: ~
+                  source_location: ~
                   children:
                     - name:
                         Named: __0
                       type_name:
                         Pointer: "*mut rtt_target::rtt::RttChannel"
                       value: "*mut rtt_target::rtt::RttChannel @ 0x20003CE8"
-                      source_location:
-                        line: ~
-                        column: ~
-                        file: ~
-                        directory: ~
+                      source_location: ~
                       children:
                         - name:
                             Named: "*__0"
                           type_name:
                             Struct: RttChannel
                           value: RttChannel @ 0x200000A4
-                          source_location:
-                            line: ~
-                            column: ~
-                            file: ~
-                            directory: ~
+                          source_location: ~
                           children:
                             - name:
                                 Named: name
                               type_name:
                                 Pointer: "*const u8"
                               value: "*const u8 @ 0x200000A4"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*name"
                                   type_name:
                                     Base: u8
                                   value: "66"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: buffer
                               type_name:
                                 Pointer: "*mut u8"
                               value: "*mut u8 @ 0x200000A8"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: "*buffer"
                                   type_name:
                                     Base: u8
                                   value: "0"
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                             - name:
                                 Named: size
                               type_name:
                                 Base: usize
                               value: "1024"
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                             - name:
                                 Named: write
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000B0
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000B0
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                             - name:
                                 Named: read
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000B4
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000B4
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "0"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
                             - name:
                                 Named: flags
                               type_name:
                                 Struct: AtomicUsize
                               value: AtomicUsize @ 0x200000B8
-                              source_location:
-                                line: ~
-                                column: ~
-                                file: ~
-                                directory: ~
+                              source_location: ~
                               children:
                                 - name:
                                     Named: v
                                   type_name:
                                     Struct: UnsafeCell<usize>
                                   value: UnsafeCell<usize> @ 0x200000B8
-                                  source_location:
-                                    line: ~
-                                    column: ~
-                                    file: ~
-                                    directory: ~
+                                  source_location: ~
                                   children:
                                     - name:
                                         Named: value
                                       type_name:
                                         Base: usize
                                       value: "1"
-                                      source_location:
-                                        line: ~
-                                        column: ~
-                                        file: ~
-                                        directory: ~
+                                      source_location: ~
   canonical_frame_address: 536887136
 - function_name: __cortex_m_rt_main
   source_location:
@@ -6699,11 +5103,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tpac: Peripherals = Peripherals @ 0x20003F74,\n\tcore: Peripherals = Peripherals @ 0x20003F75,\n\tclocks: Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> = Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: pac
@@ -6721,691 +5121,415 @@ snapshot_kind: text
               type_name:
                 Struct: FICR
               value: FICR @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UICR
               type_name:
                 Struct: UICR
               value: UICR @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CLOCK
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: POWER
               type_name:
                 Struct: POWER
               value: POWER @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: P0
               type_name:
                 Struct: P0
               value: P0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: P1
               type_name:
                 Struct: P1
               value: P1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RADIO
               type_name:
                 Struct: RADIO
               value: RADIO @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UARTE0
               type_name:
                 Struct: UARTE0
               value: UARTE0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIM0
               type_name:
                 Struct: SPIM0
               value: SPIM0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIS0
               type_name:
                 Struct: SPIS0
               value: SPIS0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWI0
               type_name:
                 Struct: TWI0
               value: TWI0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWIM0
               type_name:
                 Struct: TWIM0
               value: TWIM0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWIS0
               type_name:
                 Struct: TWIS0
               value: TWIS0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIM1
               type_name:
                 Struct: SPIM1
               value: SPIM1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIS1
               type_name:
                 Struct: SPIS1
               value: SPIS1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWI1
               type_name:
                 Struct: TWI1
               value: TWI1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWIM1
               type_name:
                 Struct: TWIM1
               value: TWIM1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWIS1
               type_name:
                 Struct: TWIS1
               value: TWIS1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: NFCT
               type_name:
                 Struct: NFCT
               value: NFCT @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: GPIOTE
               type_name:
                 Struct: GPIOTE
               value: GPIOTE @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SAADC
               type_name:
                 Struct: SAADC
               value: SAADC @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER0
               type_name:
                 Struct: TIMER0
               value: TIMER0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER1
               type_name:
                 Struct: TIMER1
               value: TIMER1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER2
               type_name:
                 Struct: TIMER2
               value: TIMER2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RTC0
               type_name:
                 Struct: RTC0
               value: RTC0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TEMP
               type_name:
                 Struct: TEMP
               value: TEMP @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RNG
               type_name:
                 Struct: RNG
               value: RNG @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ECB
               type_name:
                 Struct: ECB
               value: ECB @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: AAR
               type_name:
                 Struct: AAR
               value: AAR @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CCM
               type_name:
                 Struct: CCM
               value: CCM @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: WDT
               type_name:
                 Struct: WDT
               value: WDT @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RTC1
               type_name:
                 Struct: RTC1
               value: RTC1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: QDEC
               type_name:
                 Struct: QDEC
               value: QDEC @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: COMP
               type_name:
                 Struct: COMP
               value: COMP @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: LPCOMP
               type_name:
                 Struct: LPCOMP
               value: LPCOMP @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU0
               type_name:
                 Struct: EGU0
               value: EGU0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI0
               type_name:
                 Struct: SWI0
               value: SWI0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU1
               type_name:
                 Struct: EGU1
               value: EGU1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI1
               type_name:
                 Struct: SWI1
               value: SWI1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU2
               type_name:
                 Struct: EGU2
               value: EGU2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI2
               type_name:
                 Struct: SWI2
               value: SWI2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU3
               type_name:
                 Struct: EGU3
               value: EGU3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI3
               type_name:
                 Struct: SWI3
               value: SWI3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU4
               type_name:
                 Struct: EGU4
               value: EGU4 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI4
               type_name:
                 Struct: SWI4
               value: SWI4 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU5
               type_name:
                 Struct: EGU5
               value: EGU5 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI5
               type_name:
                 Struct: SWI5
               value: SWI5 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER3
               type_name:
                 Struct: TIMER3
               value: TIMER3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER4
               type_name:
                 Struct: TIMER4
               value: TIMER4 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PWM0
               type_name:
                 Struct: PWM0
               value: PWM0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PDM
               type_name:
                 Struct: PDM
               value: PDM @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ACL
               type_name:
                 Struct: ACL
               value: ACL @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: NVMC
               type_name:
                 Struct: NVMC
               value: NVMC @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PPI
               type_name:
                 Struct: PPI
               value: PPI @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: MWU
               type_name:
                 Struct: MWU
               value: MWU @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PWM1
               type_name:
                 Struct: PWM1
               value: PWM1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PWM2
               type_name:
                 Struct: PWM2
               value: PWM2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPI2
               type_name:
                 Struct: SPI2
               value: SPI2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIM2
               type_name:
                 Struct: SPIM2
               value: SPIM2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIS2
               type_name:
                 Struct: SPIS2
               value: SPIS2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RTC2
               type_name:
                 Struct: RTC2
               value: RTC2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: I2S
               type_name:
                 Struct: I2S
               value: I2S @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: USBD
               type_name:
                 Struct: USBD
               value: USBD @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UARTE1
               type_name:
                 Struct: UARTE1
               value: UARTE1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PWM3
               type_name:
                 Struct: PWM3
               value: PWM3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIM3
               type_name:
                 Struct: SPIM3
               value: SPIM3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: core
           type_name:
@@ -7422,151 +5546,91 @@ snapshot_kind: text
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: clocks
           type_name:
@@ -7583,41 +5647,25 @@ snapshot_kind: text
               type_name:
                 Struct: ExternalOscillator
               value: ExternalOscillator @ 0x20003F76
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: lfclk
               type_name:
                 Struct: Internal
               value: Internal @ 0x20003F76
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: lfstat
               type_name:
                 Struct: LfOscStopped
               value: LfOscStopped @ 0x20003F76
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: periph
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F76
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
@@ -7821,9 +5869,5 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_full_unwind_static_variables.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_full_unwind_static_variables.snap
@@ -1,6 +1,8 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 2023
 expression: static_variables
+snapshot_kind: text
 ---
 Child Variables:
   name: StaticScopeRoot
@@ -25,18 +27,34 @@ Child Variables:
                 Named: BUF0
               type_name: Unknown
               value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.16.1/src/pwm.rs
+                line: 1157
+                column: ~
             - name:
                 Named: BUF1
               type_name: Unknown
               value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.16.1/src/pwm.rs
+                line: 1159
+                column: ~
             - name:
                 Named: BUF2
               type_name: Unknown
               value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.16.1/src/pwm.rs
+                line: 1161
+                column: ~
             - name:
                 Named: BUF3
               type_name: Unknown
               value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.16.1/src/pwm.rs
+                line: 1163
+                column: ~
     - name:
         Named: "<usize as core::fmt::Debug>::{vtable}"
       type_name: Unknown
@@ -63,10 +81,18 @@ Child Variables:
                 Named: LOWER_FLAGS
               type_name: Unknown
               value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/fixed-1.27.0/src/debug_hex.rs
+                line: 33
+                column: ~
             - name:
                 Named: UPPER_FLAGS
               type_name: Unknown
               value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/fixed-1.27.0/src/debug_hex.rs
+                line: 35
+                column: ~
     - name:
         Named: "<core::str::error::Utf8Error as core::fmt::Debug>::{vtable}"
       type_name: Unknown
@@ -88,12 +114,20 @@ Child Variables:
                 Base: Vector
               count: 48
           value: "[Vector; 48] = [\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000040,\n\t\t_reserved: u32 = 1633\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000044,\n\t\t_reserved: u32 = 1633\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000048,\n\t\t_reserved: u32 = 1633\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000004C,\n\t\t_reserved: u32 = 1633\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000050,\n\t\t_reserved: u32 = 1633\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000054,\n\t\t_reserved: u32 = 1633\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000058,\n\t\t_reserved: u32 = 1633\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000005C,\n\t\t_reserved: u32 = 1633\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000060,\n\t\t_reserved: u32 = 1633\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000064,\n\t\t_reserved: u32 = 1633\n\t},\n\t... and 38 more]"
+          source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+            line: 88
+            column: ~
           children:
             - name:
                 Named: __0
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000040,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -115,6 +149,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000044,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -136,6 +174,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000048,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -157,6 +199,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000004C,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -178,6 +224,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000050,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -199,6 +249,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000054,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -220,6 +274,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000058,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -241,6 +299,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000005C,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -262,6 +324,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000060,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -283,6 +349,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000064,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -304,6 +374,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000068,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -325,6 +399,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000006C,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -346,6 +424,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000070,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -367,6 +449,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000074,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -388,6 +474,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000078,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -409,6 +499,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000007C,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -430,6 +524,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000080,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -451,6 +549,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000084,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -472,6 +574,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000088,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -493,6 +599,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000008C,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -514,6 +624,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000090,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -535,6 +649,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000094,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -556,6 +674,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000098,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -577,6 +699,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000009C,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -598,6 +724,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000A0,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -619,6 +749,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000A4,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -640,6 +774,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000A8,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -661,6 +799,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000AC,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -682,6 +824,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000B0,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -703,6 +849,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000B4,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -724,6 +874,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000B8,\n\t_reserved: u32 = 0}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -745,6 +899,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000BC,\n\t_reserved: u32 = 0}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -766,6 +924,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000C0,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -787,6 +949,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000C4,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -808,6 +974,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000C8,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -829,6 +999,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000CC,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -850,6 +1024,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000D0,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -871,6 +1049,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000D4,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -892,6 +1074,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000D8,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -913,6 +1099,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000DC,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -934,6 +1124,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000E0,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -955,6 +1149,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000E4,\n\t_reserved: u32 = 0}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -976,6 +1174,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000E8,\n\t_reserved: u32 = 0}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -997,6 +1199,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000EC,\n\t_reserved: u32 = 0}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -1018,6 +1224,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000F0,\n\t_reserved: u32 = 0}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -1039,6 +1249,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000F4,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -1060,6 +1274,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000F8,\n\t_reserved: u32 = 0}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -1081,6 +1299,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000FC,\n\t_reserved: u32 = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+                line: 88
+                column: ~
               children:
                 - name:
                     Named: _handler
@@ -1102,6 +1324,10 @@ Child Variables:
           type_name:
             Base: bool
           value: "true"
+          source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf52833-pac-0.12.2/src/lib.rs
+            line: 2188
+            column: ~
     - name:
         Namespace: cortex_m_rt
       type_name: Namespace
@@ -1111,11 +1337,19 @@ Child Variables:
             Named: __ONCE__
           type_name: Unknown
           value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+          source_location:
+            path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+            line: 857
+            column: ~
         - name:
             Named: __RESET_VECTOR
           type_name:
             Pointer: "unsafe extern \"C\" fn() -> !"
           value: "*raw unsafe extern \"C\" fn() -> ! @ 0x00000004"
+          source_location:
+            path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+            line: 1048
+            column: ~
           children:
             - name:
                 Named: "*__RESET_VECTOR"
@@ -1130,12 +1364,20 @@ Child Variables:
                 Base: Vector
               count: 14
           value: "[Vector; 14] = [\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000008,\n\t\treserved: usize = 1633\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000000C,\n\t\treserved: usize = 24781\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000010,\n\t\treserved: usize = 1633\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000014,\n\t\treserved: usize = 1633\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000018,\n\t\treserved: usize = 1633\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000001C,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000020,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000024,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000028,\n\t\treserved: usize = 0\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000002C,\n\t\treserved: usize = 965\n\t},\n\t... and 4 more]"
+          source_location:
+            path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+            line: 1140
+            column: ~
           children:
             - name:
                 Named: __0
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000008,\n\treserved: usize = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+                line: 1140
+                column: ~
               children:
                 - name:
                     Named: handler
@@ -1157,6 +1399,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000000C,\n\treserved: usize = 24781}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+                line: 1140
+                column: ~
               children:
                 - name:
                     Named: handler
@@ -1178,6 +1424,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000010,\n\treserved: usize = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+                line: 1140
+                column: ~
               children:
                 - name:
                     Named: handler
@@ -1199,6 +1449,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000014,\n\treserved: usize = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+                line: 1140
+                column: ~
               children:
                 - name:
                     Named: handler
@@ -1220,6 +1474,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000018,\n\treserved: usize = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+                line: 1140
+                column: ~
               children:
                 - name:
                     Named: handler
@@ -1241,6 +1499,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000001C,\n\treserved: usize = 0}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+                line: 1140
+                column: ~
               children:
                 - name:
                     Named: handler
@@ -1262,6 +1524,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000020,\n\treserved: usize = 0}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+                line: 1140
+                column: ~
               children:
                 - name:
                     Named: handler
@@ -1283,6 +1549,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000024,\n\treserved: usize = 0}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+                line: 1140
+                column: ~
               children:
                 - name:
                     Named: handler
@@ -1304,6 +1574,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000028,\n\treserved: usize = 0}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+                line: 1140
+                column: ~
               children:
                 - name:
                     Named: handler
@@ -1325,6 +1599,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000002C,\n\treserved: usize = 965}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+                line: 1140
+                column: ~
               children:
                 - name:
                     Named: handler
@@ -1346,6 +1624,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000030,\n\treserved: usize = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+                line: 1140
+                column: ~
               children:
                 - name:
                     Named: handler
@@ -1367,6 +1649,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000034,\n\treserved: usize = 0}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+                line: 1140
+                column: ~
               children:
                 - name:
                     Named: handler
@@ -1388,6 +1674,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000038,\n\treserved: usize = 1633}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+                line: 1140
+                column: ~
               children:
                 - name:
                     Named: handler
@@ -1409,6 +1699,10 @@ Child Variables:
               type_name:
                 Base: Vector
               value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000003C,\n\treserved: usize = 947}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/git/checkouts/cortex-m-6c400ec63ab46e19/d85d9c8/cortex-m-rt/src/lib.rs
+                line: 1140
+                column: ~
               children:
                 - name:
                     Named: handler
@@ -1443,11 +1737,19 @@ Child Variables:
                 Named: CORE_PERIPHERALS
               type_name: Unknown
               value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/peripheral/mod.rs
+                line: 159
+                column: ~
             - name:
                 Named: TAKEN
               type_name:
                 Base: bool
               value: "true"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/peripheral/mod.rs
+                line: 162
+                column: ~
     - name:
         Namespace: probe_rs_debugger_test
       type_name: Namespace
@@ -1458,76 +1760,136 @@ Child Variables:
           type_name:
             Base: bool
           value: "false"
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 15
+            column: ~
         - name:
             Named: I
           type_name:
             Base: isize
           value: "-1"
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 16
+            column: ~
         - name:
             Named: C
           type_name:
             Base: char
           value: a
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 17
+            column: ~
         - name:
             Named: I8
           type_name:
             Base: i8
           value: "68"
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 18
+            column: ~
         - name:
             Named: I16
           type_name:
             Base: i16
           value: "-16"
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 19
+            column: ~
         - name:
             Named: I32
           type_name:
             Base: i32
           value: "-32"
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 20
+            column: ~
         - name:
             Named: I64
           type_name:
             Base: i64
           value: "-64"
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 21
+            column: ~
         - name:
             Named: U
           type_name:
             Base: usize
           value: "1"
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 22
+            column: ~
         - name:
             Named: U8
           type_name:
             Base: u8
           value: "100"
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 23
+            column: ~
         - name:
             Named: U16
           type_name:
             Base: u16
           value: "16"
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 24
+            column: ~
         - name:
             Named: U32
           type_name:
             Base: u32
           value: "32"
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 25
+            column: ~
         - name:
             Named: U64
           type_name:
             Base: u64
           value: "64"
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 26
+            column: ~
         - name:
             Named: F32
           type_name:
             Base: f32
           value: "2.5"
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 27
+            column: ~
         - name:
             Named: F64
           type_name:
             Base: f64
           value: "3.5"
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 28
+            column: ~
         - name:
             Named: GLOBAL_STATIC
           type_name:
             Struct: "&str"
           value: "A 'global' static variable"
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 30
+            column: ~
           children:
             - name:
                 Named: data_ptr
@@ -1550,6 +1912,10 @@ Child Variables:
           type_name:
             Struct: ComplexEnum
           value: ComplexEnum @ 0x20000048
+          source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+            line: 64
+            column: ~
           children:
             - name:
                 Named: Case1
@@ -1593,6 +1959,10 @@ Child Variables:
               type_name:
                 Struct: "&str"
               value: "A 'local' to main() static variable ...will be optimized out if not used in the code."
+              source_location:
+                path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
+                line: 205
+                column: ~
               children:
                 - name:
                     Named: data_ptr
@@ -1615,6 +1985,10 @@ Child Variables:
               type_name:
                 Base: "MaybeUninit<probe_rs_debugger_test::setup_data_types::RttControlBlock>"
               value: "MaybeUninit<probe_rs_debugger_test::setup_data_types::RttControlBlock> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<probe_rs_debugger_test::setup_data_types::RttControlBlock> = ManuallyDrop<probe_rs_debugger_test::setup_data_types::RttControlBlock> @ 0x20000074}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/init.rs
+                line: 138
+                column: ~
               children:
                 - name:
                     Named: uninit
@@ -1928,6 +2302,10 @@ Child Variables:
               type_name:
                 Base: "MaybeUninit<[u8; 1024]>"
               value: "MaybeUninit<[u8; 1024]> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<[u8; 1024]> = ManuallyDrop<[u8; 1024]> @ 0x200000BC}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/init.rs
+                line: 34
+                column: ~
               children:
                 - name:
                     Named: uninit
@@ -2207,6 +2585,10 @@ Child Variables:
               type_name:
                 Base: "MaybeUninit<[u8; 1024]>"
               value: "MaybeUninit<[u8; 1024]> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<[u8; 1024]> = ManuallyDrop<[u8; 1024]> @ 0x200004BC}"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/init.rs
+                line: 34
+                column: ~
               children:
                 - name:
                     Named: uninit
@@ -2734,6 +3116,10 @@ Child Variables:
               type_name:
                 Struct: "Mutex<core::cell::RefCell<core::option::Option<rtt_target::TerminalChannel>>>"
               value: "Mutex<core::cell::RefCell<core::option::Option<rtt_target::TerminalChannel>>> @ 0x200008BC"
+              source_location:
+                path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rtt-target-0.5.0/src/print.rs
+                line: 7
+                column: ~
               children:
                 - name:
                     Named: inner

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_busfault.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_busfault.snap
@@ -1,6 +1,6 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
-assertion_line: 1996
+assertion_line: 1987
 expression: stack_frames
 snapshot_kind: text
 ---
@@ -9,8 +9,7 @@ snapshot_kind: text
     line: 371
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -215,15 +214,13 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887072
 - function_name: __cortex_m_rt_HardFault
   source_location:
     line: 93
     column:
       Column: 9
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -428,7 +425,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887072
 - function_name: "HardFault <Cause: Escalated BusFault <Cause: Precise data access error at location: 0x3ffffffc>>"
   source_location: ~
@@ -638,8 +634,7 @@ snapshot_kind: text
     line: 1678
     column:
       Column: 9
-    file: mod.rs
-    directory: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr
+    path: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr/mod.rs
   registers:
     - core_register:
         id: 0
@@ -844,7 +839,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tsrc: *const u32 = *const u32 @ 0x20003F48}"
-      source_location: ~
       children:
         - name:
             Named: src
@@ -854,23 +848,20 @@ snapshot_kind: text
           source_location:
             line: 1667
             column: ~
-            file: mod.rs
-            directory: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr
+            path: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr/mod.rs
           children:
             - name:
                 Named: "*src"
               type_name:
                 Base: u32
               value: "0"
-              source_location: ~
   canonical_frame_address: 536887128
 - function_name: trigger_hardfault_from_busfault
   source_location:
     line: 51
     column:
       Column: 2
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1067,15 +1058,13 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887136
 - function_name: __cortex_m_rt_main
   source_location:
     line: 38
     column:
       Column: 54
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1272,7 +1261,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tpac: Peripherals = Peripherals @ 0x20003F74,\n\tcore: Peripherals = Peripherals @ 0x20003F75,\n\tclocks: Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> = Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76}"
-      source_location: ~
       children:
         - name:
             Named: pac
@@ -1282,423 +1270,353 @@ snapshot_kind: text
           source_location:
             line: 21
             column: ~
-            file: nRF52833_xxAA.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: FICR
               type_name:
                 Struct: FICR
               value: FICR @ 0x20003F74
-              source_location: ~
             - name:
                 Named: UICR
               type_name:
                 Struct: UICR
               value: UICR @ 0x20003F74
-              source_location: ~
             - name:
                 Named: CLOCK
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F74
-              source_location: ~
             - name:
                 Named: POWER
               type_name:
                 Struct: POWER
               value: POWER @ 0x20003F74
-              source_location: ~
             - name:
                 Named: P0
               type_name:
                 Struct: P0
               value: P0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: P1
               type_name:
                 Struct: P1
               value: P1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RADIO
               type_name:
                 Struct: RADIO
               value: RADIO @ 0x20003F74
-              source_location: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: UARTE0
               type_name:
                 Struct: UARTE0
               value: UARTE0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIM0
               type_name:
                 Struct: SPIM0
               value: SPIM0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIS0
               type_name:
                 Struct: SPIS0
               value: SPIS0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWI0
               type_name:
                 Struct: TWI0
               value: TWI0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWIM0
               type_name:
                 Struct: TWIM0
               value: TWIM0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWIS0
               type_name:
                 Struct: TWIS0
               value: TWIS0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIM1
               type_name:
                 Struct: SPIM1
               value: SPIM1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIS1
               type_name:
                 Struct: SPIS1
               value: SPIS1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWI1
               type_name:
                 Struct: TWI1
               value: TWI1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWIM1
               type_name:
                 Struct: TWIM1
               value: TWIM1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWIS1
               type_name:
                 Struct: TWIS1
               value: TWIS1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: NFCT
               type_name:
                 Struct: NFCT
               value: NFCT @ 0x20003F74
-              source_location: ~
             - name:
                 Named: GPIOTE
               type_name:
                 Struct: GPIOTE
               value: GPIOTE @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SAADC
               type_name:
                 Struct: SAADC
               value: SAADC @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER0
               type_name:
                 Struct: TIMER0
               value: TIMER0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER1
               type_name:
                 Struct: TIMER1
               value: TIMER1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER2
               type_name:
                 Struct: TIMER2
               value: TIMER2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RTC0
               type_name:
                 Struct: RTC0
               value: RTC0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TEMP
               type_name:
                 Struct: TEMP
               value: TEMP @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RNG
               type_name:
                 Struct: RNG
               value: RNG @ 0x20003F74
-              source_location: ~
             - name:
                 Named: ECB
               type_name:
                 Struct: ECB
               value: ECB @ 0x20003F74
-              source_location: ~
             - name:
                 Named: AAR
               type_name:
                 Struct: AAR
               value: AAR @ 0x20003F74
-              source_location: ~
             - name:
                 Named: CCM
               type_name:
                 Struct: CCM
               value: CCM @ 0x20003F74
-              source_location: ~
             - name:
                 Named: WDT
               type_name:
                 Struct: WDT
               value: WDT @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RTC1
               type_name:
                 Struct: RTC1
               value: RTC1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: QDEC
               type_name:
                 Struct: QDEC
               value: QDEC @ 0x20003F74
-              source_location: ~
             - name:
                 Named: COMP
               type_name:
                 Struct: COMP
               value: COMP @ 0x20003F74
-              source_location: ~
             - name:
                 Named: LPCOMP
               type_name:
                 Struct: LPCOMP
               value: LPCOMP @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU0
               type_name:
                 Struct: EGU0
               value: EGU0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI0
               type_name:
                 Struct: SWI0
               value: SWI0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU1
               type_name:
                 Struct: EGU1
               value: EGU1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI1
               type_name:
                 Struct: SWI1
               value: SWI1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU2
               type_name:
                 Struct: EGU2
               value: EGU2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI2
               type_name:
                 Struct: SWI2
               value: SWI2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU3
               type_name:
                 Struct: EGU3
               value: EGU3 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI3
               type_name:
                 Struct: SWI3
               value: SWI3 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU4
               type_name:
                 Struct: EGU4
               value: EGU4 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI4
               type_name:
                 Struct: SWI4
               value: SWI4 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU5
               type_name:
                 Struct: EGU5
               value: EGU5 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI5
               type_name:
                 Struct: SWI5
               value: SWI5 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER3
               type_name:
                 Struct: TIMER3
               value: TIMER3 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER4
               type_name:
                 Struct: TIMER4
               value: TIMER4 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PWM0
               type_name:
                 Struct: PWM0
               value: PWM0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PDM
               type_name:
                 Struct: PDM
               value: PDM @ 0x20003F74
-              source_location: ~
             - name:
                 Named: ACL
               type_name:
                 Struct: ACL
               value: ACL @ 0x20003F74
-              source_location: ~
             - name:
                 Named: NVMC
               type_name:
                 Struct: NVMC
               value: NVMC @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PPI
               type_name:
                 Struct: PPI
               value: PPI @ 0x20003F74
-              source_location: ~
             - name:
                 Named: MWU
               type_name:
                 Struct: MWU
               value: MWU @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PWM1
               type_name:
                 Struct: PWM1
               value: PWM1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PWM2
               type_name:
                 Struct: PWM2
               value: PWM2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPI2
               type_name:
                 Struct: SPI2
               value: SPI2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIM2
               type_name:
                 Struct: SPIM2
               value: SPIM2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIS2
               type_name:
                 Struct: SPIS2
               value: SPIS2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RTC2
               type_name:
                 Struct: RTC2
               value: RTC2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: I2S
               type_name:
                 Struct: I2S
               value: I2S @ 0x20003F74
-              source_location: ~
             - name:
                 Named: USBD
               type_name:
                 Struct: USBD
               value: USBD @ 0x20003F74
-              source_location: ~
             - name:
                 Named: UARTE1
               type_name:
                 Struct: UARTE1
               value: UARTE1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PWM3
               type_name:
                 Struct: PWM3
               value: PWM3 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIM3
               type_name:
                 Struct: SPIM3
               value: SPIM3 @ 0x20003F74
-              source_location: ~
         - name:
             Named: core
           type_name:
@@ -1707,99 +1625,83 @@ snapshot_kind: text
           source_location:
             line: 22
             column: ~
-            file: nRF52833_xxAA.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F75
-              source_location: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F75
-              source_location: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F75
-              source_location: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F75
-              source_location: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F75
-              source_location: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F75
-              source_location: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F75
-              source_location: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F75
-              source_location: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F75
-              source_location: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F75
-              source_location: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F75
-              source_location: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F75
-              source_location: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F75
-              source_location: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F75
-              source_location: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
-              source_location: ~
         - name:
             Named: clocks
           type_name:
@@ -1808,40 +1710,34 @@ snapshot_kind: text
           source_location:
             line: 23
             column: ~
-            file: nRF52833_xxAA.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: hfclk
               type_name:
                 Struct: ExternalOscillator
               value: ExternalOscillator @ 0x20003F76
-              source_location: ~
             - name:
                 Named: lfclk
               type_name:
                 Struct: Internal
               value: Internal @ 0x20003F76
-              source_location: ~
             - name:
                 Named: lfstat
               type_name:
                 Struct: LfOscStopped
               value: LfOscStopped @ 0x20003F76
-              source_location: ~
             - name:
                 Named: periph
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F76
-              source_location: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
     line: 19
     column: LeftEdge
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -2038,5 +1934,4 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_busfault.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_busfault.snap
@@ -1,6 +1,8 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1996
 expression: stack_frames
+snapshot_kind: text
 ---
 - function_name: software_breakpoint
   source_location:
@@ -213,6 +215,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887072
 - function_name: __cortex_m_rt_HardFault
   source_location:
@@ -425,6 +432,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887072
 - function_name: "HardFault <Cause: Escalated BusFault <Cause: Precise data access error at location: 0x3ffffffc>>"
   source_location: ~
@@ -840,18 +852,33 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tsrc: *const u32 = *const u32 @ 0x20003F48}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: src
           type_name:
             Pointer: "*const u32"
           value: "*const u32 @ 0x20003F48"
+          source_location:
+            line: 1667
+            column: ~
+            file: mod.rs
+            directory: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr
           children:
             - name:
                 Named: "*src"
               type_name:
                 Base: u32
               value: "0"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
   canonical_frame_address: 536887128
 - function_name: trigger_hardfault_from_busfault
   source_location:
@@ -1056,6 +1083,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887136
 - function_name: __cortex_m_rt_main
   source_location:
@@ -1260,465 +1292,925 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tpac: Peripherals = Peripherals @ 0x20003F74,\n\tcore: Peripherals = Peripherals @ 0x20003F75,\n\tclocks: Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> = Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: pac
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003F74
+          source_location:
+            line: 21
+            column: ~
+            file: nRF52833_xxAA.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: FICR
               type_name:
                 Struct: FICR
               value: FICR @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UICR
               type_name:
                 Struct: UICR
               value: UICR @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CLOCK
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: POWER
               type_name:
                 Struct: POWER
               value: POWER @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: P0
               type_name:
                 Struct: P0
               value: P0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: P1
               type_name:
                 Struct: P1
               value: P1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RADIO
               type_name:
                 Struct: RADIO
               value: RADIO @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UARTE0
               type_name:
                 Struct: UARTE0
               value: UARTE0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIM0
               type_name:
                 Struct: SPIM0
               value: SPIM0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIS0
               type_name:
                 Struct: SPIS0
               value: SPIS0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWI0
               type_name:
                 Struct: TWI0
               value: TWI0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWIM0
               type_name:
                 Struct: TWIM0
               value: TWIM0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWIS0
               type_name:
                 Struct: TWIS0
               value: TWIS0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIM1
               type_name:
                 Struct: SPIM1
               value: SPIM1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIS1
               type_name:
                 Struct: SPIS1
               value: SPIS1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWI1
               type_name:
                 Struct: TWI1
               value: TWI1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWIM1
               type_name:
                 Struct: TWIM1
               value: TWIM1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWIS1
               type_name:
                 Struct: TWIS1
               value: TWIS1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: NFCT
               type_name:
                 Struct: NFCT
               value: NFCT @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: GPIOTE
               type_name:
                 Struct: GPIOTE
               value: GPIOTE @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SAADC
               type_name:
                 Struct: SAADC
               value: SAADC @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER0
               type_name:
                 Struct: TIMER0
               value: TIMER0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER1
               type_name:
                 Struct: TIMER1
               value: TIMER1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER2
               type_name:
                 Struct: TIMER2
               value: TIMER2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RTC0
               type_name:
                 Struct: RTC0
               value: RTC0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TEMP
               type_name:
                 Struct: TEMP
               value: TEMP @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RNG
               type_name:
                 Struct: RNG
               value: RNG @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ECB
               type_name:
                 Struct: ECB
               value: ECB @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: AAR
               type_name:
                 Struct: AAR
               value: AAR @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CCM
               type_name:
                 Struct: CCM
               value: CCM @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: WDT
               type_name:
                 Struct: WDT
               value: WDT @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RTC1
               type_name:
                 Struct: RTC1
               value: RTC1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: QDEC
               type_name:
                 Struct: QDEC
               value: QDEC @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: COMP
               type_name:
                 Struct: COMP
               value: COMP @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: LPCOMP
               type_name:
                 Struct: LPCOMP
               value: LPCOMP @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU0
               type_name:
                 Struct: EGU0
               value: EGU0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI0
               type_name:
                 Struct: SWI0
               value: SWI0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU1
               type_name:
                 Struct: EGU1
               value: EGU1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI1
               type_name:
                 Struct: SWI1
               value: SWI1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU2
               type_name:
                 Struct: EGU2
               value: EGU2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI2
               type_name:
                 Struct: SWI2
               value: SWI2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU3
               type_name:
                 Struct: EGU3
               value: EGU3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI3
               type_name:
                 Struct: SWI3
               value: SWI3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU4
               type_name:
                 Struct: EGU4
               value: EGU4 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI4
               type_name:
                 Struct: SWI4
               value: SWI4 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU5
               type_name:
                 Struct: EGU5
               value: EGU5 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI5
               type_name:
                 Struct: SWI5
               value: SWI5 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER3
               type_name:
                 Struct: TIMER3
               value: TIMER3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER4
               type_name:
                 Struct: TIMER4
               value: TIMER4 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PWM0
               type_name:
                 Struct: PWM0
               value: PWM0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PDM
               type_name:
                 Struct: PDM
               value: PDM @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ACL
               type_name:
                 Struct: ACL
               value: ACL @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: NVMC
               type_name:
                 Struct: NVMC
               value: NVMC @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PPI
               type_name:
                 Struct: PPI
               value: PPI @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: MWU
               type_name:
                 Struct: MWU
               value: MWU @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PWM1
               type_name:
                 Struct: PWM1
               value: PWM1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PWM2
               type_name:
                 Struct: PWM2
               value: PWM2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPI2
               type_name:
                 Struct: SPI2
               value: SPI2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIM2
               type_name:
                 Struct: SPIM2
               value: SPIM2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIS2
               type_name:
                 Struct: SPIS2
               value: SPIS2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RTC2
               type_name:
                 Struct: RTC2
               value: RTC2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: I2S
               type_name:
                 Struct: I2S
               value: I2S @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: USBD
               type_name:
                 Struct: USBD
               value: USBD @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UARTE1
               type_name:
                 Struct: UARTE1
               value: UARTE1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PWM3
               type_name:
                 Struct: PWM3
               value: PWM3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIM3
               type_name:
                 Struct: SPIM3
               value: SPIM3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: core
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003F75
+          source_location:
+            line: 22
+            column: ~
+            file: nRF52833_xxAA.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: CBP
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: clocks
           type_name:
             Struct: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped>"
           value: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76"
+          source_location:
+            line: 23
+            column: ~
+            file: nRF52833_xxAA.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: hfclk
               type_name:
                 Struct: ExternalOscillator
               value: ExternalOscillator @ 0x20003F76
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: lfclk
               type_name:
                 Struct: Internal
               value: Internal @ 0x20003F76
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: lfstat
               type_name:
                 Struct: LfOscStopped
               value: LfOscStopped @ 0x20003F76
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: periph
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F76
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
@@ -1922,4 +2414,9 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_busfault.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_busfault.snap
@@ -6,10 +6,10 @@ snapshot_kind: text
 ---
 - function_name: software_breakpoint
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 371
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -217,10 +217,10 @@ snapshot_kind: text
   canonical_frame_address: 536887072
 - function_name: __cortex_m_rt_HardFault
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 93
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -631,10 +631,10 @@ snapshot_kind: text
   canonical_frame_address: 536887072
 - function_name: read_volatile<u32>
   source_location:
+    path: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr/mod.rs
     line: 1678
     column:
       Column: 9
-    path: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr/mod.rs
   registers:
     - core_register:
         id: 0
@@ -846,9 +846,9 @@ snapshot_kind: text
             Pointer: "*const u32"
           value: "*const u32 @ 0x20003F48"
           source_location:
+            path: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr/mod.rs
             line: 1667
             column: ~
-            path: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr/mod.rs
           children:
             - name:
                 Named: "*src"
@@ -858,10 +858,10 @@ snapshot_kind: text
   canonical_frame_address: 536887128
 - function_name: trigger_hardfault_from_busfault
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 51
     column:
       Column: 2
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1061,10 +1061,10 @@ snapshot_kind: text
   canonical_frame_address: 536887136
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 38
     column:
       Column: 54
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1268,9 +1268,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003F74
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 21
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: FICR
@@ -1623,9 +1623,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003F75
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 22
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
@@ -1708,9 +1708,9 @@ snapshot_kind: text
             Struct: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped>"
           value: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 23
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: hfclk
@@ -1735,9 +1735,9 @@ snapshot_kind: text
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 19
     column: LeftEdge
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_busfault.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_busfault.snap
@@ -215,11 +215,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887072
 - function_name: __cortex_m_rt_HardFault
   source_location:
@@ -432,11 +428,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887072
 - function_name: "HardFault <Cause: Escalated BusFault <Cause: Precise data access error at location: 0x3ffffffc>>"
   source_location: ~
@@ -852,11 +844,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tsrc: *const u32 = *const u32 @ 0x20003F48}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: src
@@ -874,11 +862,7 @@ snapshot_kind: text
               type_name:
                 Base: u32
               value: "0"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
   canonical_frame_address: 536887128
 - function_name: trigger_hardfault_from_busfault
   source_location:
@@ -1083,11 +1067,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887136
 - function_name: __cortex_m_rt_main
   source_location:
@@ -1292,11 +1272,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tpac: Peripherals = Peripherals @ 0x20003F74,\n\tcore: Peripherals = Peripherals @ 0x20003F75,\n\tclocks: Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> = Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: pac
@@ -1314,691 +1290,415 @@ snapshot_kind: text
               type_name:
                 Struct: FICR
               value: FICR @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UICR
               type_name:
                 Struct: UICR
               value: UICR @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CLOCK
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: POWER
               type_name:
                 Struct: POWER
               value: POWER @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: P0
               type_name:
                 Struct: P0
               value: P0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: P1
               type_name:
                 Struct: P1
               value: P1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RADIO
               type_name:
                 Struct: RADIO
               value: RADIO @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UARTE0
               type_name:
                 Struct: UARTE0
               value: UARTE0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIM0
               type_name:
                 Struct: SPIM0
               value: SPIM0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIS0
               type_name:
                 Struct: SPIS0
               value: SPIS0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWI0
               type_name:
                 Struct: TWI0
               value: TWI0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWIM0
               type_name:
                 Struct: TWIM0
               value: TWIM0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWIS0
               type_name:
                 Struct: TWIS0
               value: TWIS0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIM1
               type_name:
                 Struct: SPIM1
               value: SPIM1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIS1
               type_name:
                 Struct: SPIS1
               value: SPIS1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWI1
               type_name:
                 Struct: TWI1
               value: TWI1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWIM1
               type_name:
                 Struct: TWIM1
               value: TWIM1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWIS1
               type_name:
                 Struct: TWIS1
               value: TWIS1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: NFCT
               type_name:
                 Struct: NFCT
               value: NFCT @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: GPIOTE
               type_name:
                 Struct: GPIOTE
               value: GPIOTE @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SAADC
               type_name:
                 Struct: SAADC
               value: SAADC @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER0
               type_name:
                 Struct: TIMER0
               value: TIMER0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER1
               type_name:
                 Struct: TIMER1
               value: TIMER1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER2
               type_name:
                 Struct: TIMER2
               value: TIMER2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RTC0
               type_name:
                 Struct: RTC0
               value: RTC0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TEMP
               type_name:
                 Struct: TEMP
               value: TEMP @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RNG
               type_name:
                 Struct: RNG
               value: RNG @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ECB
               type_name:
                 Struct: ECB
               value: ECB @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: AAR
               type_name:
                 Struct: AAR
               value: AAR @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CCM
               type_name:
                 Struct: CCM
               value: CCM @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: WDT
               type_name:
                 Struct: WDT
               value: WDT @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RTC1
               type_name:
                 Struct: RTC1
               value: RTC1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: QDEC
               type_name:
                 Struct: QDEC
               value: QDEC @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: COMP
               type_name:
                 Struct: COMP
               value: COMP @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: LPCOMP
               type_name:
                 Struct: LPCOMP
               value: LPCOMP @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU0
               type_name:
                 Struct: EGU0
               value: EGU0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI0
               type_name:
                 Struct: SWI0
               value: SWI0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU1
               type_name:
                 Struct: EGU1
               value: EGU1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI1
               type_name:
                 Struct: SWI1
               value: SWI1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU2
               type_name:
                 Struct: EGU2
               value: EGU2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI2
               type_name:
                 Struct: SWI2
               value: SWI2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU3
               type_name:
                 Struct: EGU3
               value: EGU3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI3
               type_name:
                 Struct: SWI3
               value: SWI3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU4
               type_name:
                 Struct: EGU4
               value: EGU4 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI4
               type_name:
                 Struct: SWI4
               value: SWI4 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU5
               type_name:
                 Struct: EGU5
               value: EGU5 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI5
               type_name:
                 Struct: SWI5
               value: SWI5 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER3
               type_name:
                 Struct: TIMER3
               value: TIMER3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER4
               type_name:
                 Struct: TIMER4
               value: TIMER4 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PWM0
               type_name:
                 Struct: PWM0
               value: PWM0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PDM
               type_name:
                 Struct: PDM
               value: PDM @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ACL
               type_name:
                 Struct: ACL
               value: ACL @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: NVMC
               type_name:
                 Struct: NVMC
               value: NVMC @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PPI
               type_name:
                 Struct: PPI
               value: PPI @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: MWU
               type_name:
                 Struct: MWU
               value: MWU @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PWM1
               type_name:
                 Struct: PWM1
               value: PWM1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PWM2
               type_name:
                 Struct: PWM2
               value: PWM2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPI2
               type_name:
                 Struct: SPI2
               value: SPI2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIM2
               type_name:
                 Struct: SPIM2
               value: SPIM2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIS2
               type_name:
                 Struct: SPIS2
               value: SPIS2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RTC2
               type_name:
                 Struct: RTC2
               value: RTC2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: I2S
               type_name:
                 Struct: I2S
               value: I2S @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: USBD
               type_name:
                 Struct: USBD
               value: USBD @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UARTE1
               type_name:
                 Struct: UARTE1
               value: UARTE1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PWM3
               type_name:
                 Struct: PWM3
               value: PWM3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIM3
               type_name:
                 Struct: SPIM3
               value: SPIM3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: core
           type_name:
@@ -2015,151 +1715,91 @@ snapshot_kind: text
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: clocks
           type_name:
@@ -2176,41 +1816,25 @@ snapshot_kind: text
               type_name:
                 Struct: ExternalOscillator
               value: ExternalOscillator @ 0x20003F76
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: lfclk
               type_name:
                 Struct: Internal
               value: Internal @ 0x20003F76
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: lfstat
               type_name:
                 Struct: LfOscStopped
               value: LfOscStopped @ 0x20003F76
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: periph
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F76
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
@@ -2414,9 +2038,5 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
@@ -1,6 +1,8 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1996
 expression: stack_frames
+snapshot_kind: text
 ---
 - function_name: software_breakpoint
   source_location:
@@ -213,6 +215,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887096
 - function_name: __cortex_m_rt_HardFault
   source_location:
@@ -425,6 +432,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887096
 - function_name: "HardFault <Cause: Escalated UsageFault <Cause: Undefined instruction>>"
   source_location: ~
@@ -840,6 +852,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887128
 - function_name: udf
   source_location:
@@ -1052,6 +1069,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887128
 - function_name: __cortex_m_rt_main_trampoline
   source_location:
@@ -1255,4 +1277,9 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887128

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
@@ -215,11 +215,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887096
 - function_name: __cortex_m_rt_HardFault
   source_location:
@@ -432,11 +428,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887096
 - function_name: "HardFault <Cause: Escalated UsageFault <Cause: Undefined instruction>>"
   source_location: ~
@@ -852,11 +844,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887128
 - function_name: udf
   source_location:
@@ -1069,11 +1057,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887128
 - function_name: __cortex_m_rt_main_trampoline
   source_location:
@@ -1277,9 +1261,5 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887128

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
@@ -1,6 +1,6 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
-assertion_line: 1996
+assertion_line: 1987
 expression: stack_frames
 snapshot_kind: text
 ---
@@ -9,8 +9,7 @@ snapshot_kind: text
     line: 371
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -215,15 +214,13 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887096
 - function_name: __cortex_m_rt_HardFault
   source_location:
     line: 93
     column:
       Column: 9
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -428,7 +425,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887096
 - function_name: "HardFault <Cause: Escalated UsageFault <Cause: Undefined instruction>>"
   source_location: ~
@@ -638,8 +634,7 @@ snapshot_kind: text
     line: 181
     column:
       Column: 5
-    file: inline.rs
-    directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
   registers:
     - core_register:
         id: 0
@@ -844,15 +839,13 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887128
 - function_name: udf
   source_location:
     line: 43
     column:
       Column: 5
-    file: asm.rs
-    directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
   registers:
     - core_register:
         id: 0
@@ -1057,14 +1050,12 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887128
 - function_name: __cortex_m_rt_main_trampoline
   source_location:
     line: 18
     column: LeftEdge
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1261,5 +1252,4 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887128

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
@@ -6,10 +6,10 @@ snapshot_kind: text
 ---
 - function_name: software_breakpoint
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 371
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -217,10 +217,10 @@ snapshot_kind: text
   canonical_frame_address: 536887096
 - function_name: __cortex_m_rt_HardFault
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 93
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -631,10 +631,10 @@ snapshot_kind: text
   canonical_frame_address: 536887096
 - function_name: __udf
   source_location:
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
     line: 181
     column:
       Column: 5
-    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
   registers:
     - core_register:
         id: 0
@@ -842,10 +842,10 @@ snapshot_kind: text
   canonical_frame_address: 536887128
 - function_name: udf
   source_location:
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
     line: 43
     column:
       Column: 5
-    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
   registers:
     - core_register:
         id: 0
@@ -1053,9 +1053,9 @@ snapshot_kind: text
   canonical_frame_address: 536887128
 - function_name: __cortex_m_rt_main_trampoline
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 18
     column: LeftEdge
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
@@ -6,10 +6,10 @@ snapshot_kind: text
 ---
 - function_name: software_breakpoint
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 371
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -217,10 +217,10 @@ snapshot_kind: text
   canonical_frame_address: 536886976
 - function_name: __cortex_m_rt_HardFault
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 93
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -631,10 +631,10 @@ snapshot_kind: text
   canonical_frame_address: 536886976
 - function_name: read_volatile<u32>
   source_location:
+    path: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr/mod.rs
     line: 1678
     column:
       Column: 9
-    path: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr/mod.rs
   registers:
     - core_register:
         id: 0
@@ -846,9 +846,9 @@ snapshot_kind: text
             Pointer: "*const u32"
           value: "*const u32 @ 0x20003EE8"
           source_location:
+            path: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr/mod.rs
             line: 1667
             column: ~
-            path: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr/mod.rs
           children:
             - name:
                 Named: "*src"
@@ -858,10 +858,10 @@ snapshot_kind: text
   canonical_frame_address: 536887032
 - function_name: trigger_hardfault_from_busfault
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 51
     column:
       Column: 2
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1062,10 +1062,10 @@ snapshot_kind: text
   canonical_frame_address: 536887040
 - function_name: software_breakpoint
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 371
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -1265,10 +1265,10 @@ snapshot_kind: text
   canonical_frame_address: 536887048
 - function_name: __cortex_m_rt_SysTick
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 84
     column:
       Column: 5
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1468,10 +1468,10 @@ snapshot_kind: text
   canonical_frame_address: 536887048
 - function_name: __cortex_m_rt_SysTick_trampoline
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 80
     column:
       Column: 13
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1870,10 +1870,10 @@ snapshot_kind: text
   canonical_frame_address: ~
 - function_name: __delay
   source_location:
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
     line: 62
     column:
       Column: 5
-    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
   registers:
     - core_register:
         id: 0
@@ -2081,25 +2081,25 @@ snapshot_kind: text
             Base: u32
           value: "1"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
             line: 56
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
         - name:
             Named: real_cyc
           type_name:
             Base: u32
           value: "85"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
             line: 61
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
   canonical_frame_address: 536887112
 - function_name: delay
   source_location:
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
     line: 29
     column:
       Column: 5
-    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
   registers:
     - core_register:
         id: 0
@@ -2307,16 +2307,16 @@ snapshot_kind: text
             Base: u32
           value: "500001"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
             line: 28
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
   canonical_frame_address: 536887112
 - function_name: enable_systick
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 76
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -2519,9 +2519,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003F57
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 66
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
@@ -2604,9 +2604,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003F53
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 66
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
@@ -2689,16 +2689,16 @@ snapshot_kind: text
             Struct: SYST
           value: SYST @ 0x20003F54
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 67
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   canonical_frame_address: 536887136
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 32
     column:
       Column: 5
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -2902,9 +2902,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003F74
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 21
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: FICR
@@ -3257,9 +3257,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003F75
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 22
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
@@ -3342,9 +3342,9 @@ snapshot_kind: text
             Struct: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped>"
           value: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 23
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: hfclk
@@ -3369,9 +3369,9 @@ snapshot_kind: text
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 19
     column: LeftEdge
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
@@ -1,6 +1,6 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
-assertion_line: 1996
+assertion_line: 1987
 expression: stack_frames
 snapshot_kind: text
 ---
@@ -9,8 +9,7 @@ snapshot_kind: text
     line: 371
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -215,15 +214,13 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536886976
 - function_name: __cortex_m_rt_HardFault
   source_location:
     line: 93
     column:
       Column: 9
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -428,7 +425,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536886976
 - function_name: "HardFault <Cause: Escalated BusFault <Cause: Precise data access error at location: 0x3ffffffc>>"
   source_location: ~
@@ -638,8 +634,7 @@ snapshot_kind: text
     line: 1678
     column:
       Column: 9
-    file: mod.rs
-    directory: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr
+    path: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr/mod.rs
   registers:
     - core_register:
         id: 0
@@ -844,7 +839,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tsrc: *const u32 = *const u32 @ 0x20003EE8}"
-      source_location: ~
       children:
         - name:
             Named: src
@@ -854,23 +848,20 @@ snapshot_kind: text
           source_location:
             line: 1667
             column: ~
-            file: mod.rs
-            directory: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr
+            path: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr/mod.rs
           children:
             - name:
                 Named: "*src"
               type_name:
                 Base: u32
               value: "0"
-              source_location: ~
   canonical_frame_address: 536887032
 - function_name: trigger_hardfault_from_busfault
   source_location:
     line: 51
     column:
       Column: 2
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1068,15 +1059,13 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887040
 - function_name: software_breakpoint
   source_location:
     line: 371
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -1273,15 +1262,13 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887048
 - function_name: __cortex_m_rt_SysTick
   source_location:
     line: 84
     column:
       Column: 5
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1478,15 +1465,13 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887048
 - function_name: __cortex_m_rt_SysTick_trampoline
   source_location:
     line: 80
     column:
       Column: 13
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1683,7 +1668,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887056
 - function_name: SysTick
   source_location: ~
@@ -1889,8 +1873,7 @@ snapshot_kind: text
     line: 62
     column:
       Column: 5
-    file: inline.rs
-    directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
   registers:
     - core_register:
         id: 0
@@ -2091,7 +2074,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tcyc: u32 = 1,\n\treal_cyc: u32 = 85}"
-      source_location: ~
       children:
         - name:
             Named: cyc
@@ -2101,8 +2083,7 @@ snapshot_kind: text
           source_location:
             line: 56
             column: ~
-            file: inline.rs
-            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
         - name:
             Named: real_cyc
           type_name:
@@ -2111,16 +2092,14 @@ snapshot_kind: text
           source_location:
             line: 61
             column: ~
-            file: inline.rs
-            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
   canonical_frame_address: 536887112
 - function_name: delay
   source_location:
     line: 29
     column:
       Column: 5
-    file: asm.rs
-    directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
   registers:
     - core_register:
         id: 0
@@ -2321,7 +2300,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tcycles: u32 = 500001}"
-      source_location: ~
       children:
         - name:
             Named: cycles
@@ -2331,16 +2309,14 @@ snapshot_kind: text
           source_location:
             line: 28
             column: ~
-            file: asm.rs
-            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
   canonical_frame_address: 536887112
 - function_name: enable_systick
   source_location:
     line: 76
     column:
       Column: 9
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -2537,7 +2513,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\t<unknown>: Peripherals = Peripherals @ 0x20003F57,\n\tcore: Peripherals = Peripherals @ 0x20003F53,\n\tsyst: SYST = SYST @ 0x20003F54}"
-      source_location: ~
       children:
         - name: Unknown
           type_name:
@@ -2546,99 +2521,83 @@ snapshot_kind: text
           source_location:
             line: 66
             column: ~
-            file: nRF52833_xxAA.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F57
-              source_location: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F57
-              source_location: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F57
-              source_location: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F57
-              source_location: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F57
-              source_location: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F57
-              source_location: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F57
-              source_location: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F57
-              source_location: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F57
-              source_location: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F57
-              source_location: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F57
-              source_location: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F57
-              source_location: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F57
-              source_location: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F57
-              source_location: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
-              source_location: ~
         - name:
             Named: core
           type_name:
@@ -2647,99 +2606,83 @@ snapshot_kind: text
           source_location:
             line: 66
             column: ~
-            file: nRF52833_xxAA.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F53
-              source_location: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F53
-              source_location: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F53
-              source_location: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F53
-              source_location: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F53
-              source_location: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F53
-              source_location: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F53
-              source_location: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F53
-              source_location: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F53
-              source_location: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F53
-              source_location: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F53
-              source_location: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F53
-              source_location: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F53
-              source_location: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F53
-              source_location: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
-              source_location: ~
         - name:
             Named: syst
           type_name:
@@ -2748,16 +2691,14 @@ snapshot_kind: text
           source_location:
             line: 67
             column: ~
-            file: nRF52833_xxAA.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   canonical_frame_address: 536887136
 - function_name: __cortex_m_rt_main
   source_location:
     line: 32
     column:
       Column: 5
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -2954,7 +2895,6 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tpac: Peripherals = Peripherals @ 0x20003F74,\n\tcore: Peripherals = Peripherals @ 0x20003F75,\n\tclocks: Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> = Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76}"
-      source_location: ~
       children:
         - name:
             Named: pac
@@ -2964,423 +2904,353 @@ snapshot_kind: text
           source_location:
             line: 21
             column: ~
-            file: nRF52833_xxAA.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: FICR
               type_name:
                 Struct: FICR
               value: FICR @ 0x20003F74
-              source_location: ~
             - name:
                 Named: UICR
               type_name:
                 Struct: UICR
               value: UICR @ 0x20003F74
-              source_location: ~
             - name:
                 Named: CLOCK
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F74
-              source_location: ~
             - name:
                 Named: POWER
               type_name:
                 Struct: POWER
               value: POWER @ 0x20003F74
-              source_location: ~
             - name:
                 Named: P0
               type_name:
                 Struct: P0
               value: P0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: P1
               type_name:
                 Struct: P1
               value: P1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RADIO
               type_name:
                 Struct: RADIO
               value: RADIO @ 0x20003F74
-              source_location: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: UARTE0
               type_name:
                 Struct: UARTE0
               value: UARTE0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIM0
               type_name:
                 Struct: SPIM0
               value: SPIM0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIS0
               type_name:
                 Struct: SPIS0
               value: SPIS0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWI0
               type_name:
                 Struct: TWI0
               value: TWI0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWIM0
               type_name:
                 Struct: TWIM0
               value: TWIM0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWIS0
               type_name:
                 Struct: TWIS0
               value: TWIS0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIM1
               type_name:
                 Struct: SPIM1
               value: SPIM1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIS1
               type_name:
                 Struct: SPIS1
               value: SPIS1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWI1
               type_name:
                 Struct: TWI1
               value: TWI1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWIM1
               type_name:
                 Struct: TWIM1
               value: TWIM1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TWIS1
               type_name:
                 Struct: TWIS1
               value: TWIS1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: NFCT
               type_name:
                 Struct: NFCT
               value: NFCT @ 0x20003F74
-              source_location: ~
             - name:
                 Named: GPIOTE
               type_name:
                 Struct: GPIOTE
               value: GPIOTE @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SAADC
               type_name:
                 Struct: SAADC
               value: SAADC @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER0
               type_name:
                 Struct: TIMER0
               value: TIMER0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER1
               type_name:
                 Struct: TIMER1
               value: TIMER1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER2
               type_name:
                 Struct: TIMER2
               value: TIMER2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RTC0
               type_name:
                 Struct: RTC0
               value: RTC0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TEMP
               type_name:
                 Struct: TEMP
               value: TEMP @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RNG
               type_name:
                 Struct: RNG
               value: RNG @ 0x20003F74
-              source_location: ~
             - name:
                 Named: ECB
               type_name:
                 Struct: ECB
               value: ECB @ 0x20003F74
-              source_location: ~
             - name:
                 Named: AAR
               type_name:
                 Struct: AAR
               value: AAR @ 0x20003F74
-              source_location: ~
             - name:
                 Named: CCM
               type_name:
                 Struct: CCM
               value: CCM @ 0x20003F74
-              source_location: ~
             - name:
                 Named: WDT
               type_name:
                 Struct: WDT
               value: WDT @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RTC1
               type_name:
                 Struct: RTC1
               value: RTC1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: QDEC
               type_name:
                 Struct: QDEC
               value: QDEC @ 0x20003F74
-              source_location: ~
             - name:
                 Named: COMP
               type_name:
                 Struct: COMP
               value: COMP @ 0x20003F74
-              source_location: ~
             - name:
                 Named: LPCOMP
               type_name:
                 Struct: LPCOMP
               value: LPCOMP @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU0
               type_name:
                 Struct: EGU0
               value: EGU0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI0
               type_name:
                 Struct: SWI0
               value: SWI0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU1
               type_name:
                 Struct: EGU1
               value: EGU1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI1
               type_name:
                 Struct: SWI1
               value: SWI1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU2
               type_name:
                 Struct: EGU2
               value: EGU2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI2
               type_name:
                 Struct: SWI2
               value: SWI2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU3
               type_name:
                 Struct: EGU3
               value: EGU3 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI3
               type_name:
                 Struct: SWI3
               value: SWI3 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU4
               type_name:
                 Struct: EGU4
               value: EGU4 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI4
               type_name:
                 Struct: SWI4
               value: SWI4 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: EGU5
               type_name:
                 Struct: EGU5
               value: EGU5 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SWI5
               type_name:
                 Struct: SWI5
               value: SWI5 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER3
               type_name:
                 Struct: TIMER3
               value: TIMER3 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: TIMER4
               type_name:
                 Struct: TIMER4
               value: TIMER4 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PWM0
               type_name:
                 Struct: PWM0
               value: PWM0 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PDM
               type_name:
                 Struct: PDM
               value: PDM @ 0x20003F74
-              source_location: ~
             - name:
                 Named: ACL
               type_name:
                 Struct: ACL
               value: ACL @ 0x20003F74
-              source_location: ~
             - name:
                 Named: NVMC
               type_name:
                 Struct: NVMC
               value: NVMC @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PPI
               type_name:
                 Struct: PPI
               value: PPI @ 0x20003F74
-              source_location: ~
             - name:
                 Named: MWU
               type_name:
                 Struct: MWU
               value: MWU @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PWM1
               type_name:
                 Struct: PWM1
               value: PWM1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PWM2
               type_name:
                 Struct: PWM2
               value: PWM2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPI2
               type_name:
                 Struct: SPI2
               value: SPI2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIM2
               type_name:
                 Struct: SPIM2
               value: SPIM2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIS2
               type_name:
                 Struct: SPIS2
               value: SPIS2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: RTC2
               type_name:
                 Struct: RTC2
               value: RTC2 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: I2S
               type_name:
                 Struct: I2S
               value: I2S @ 0x20003F74
-              source_location: ~
             - name:
                 Named: USBD
               type_name:
                 Struct: USBD
               value: USBD @ 0x20003F74
-              source_location: ~
             - name:
                 Named: UARTE1
               type_name:
                 Struct: UARTE1
               value: UARTE1 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: PWM3
               type_name:
                 Struct: PWM3
               value: PWM3 @ 0x20003F74
-              source_location: ~
             - name:
                 Named: SPIM3
               type_name:
                 Struct: SPIM3
               value: SPIM3 @ 0x20003F74
-              source_location: ~
         - name:
             Named: core
           type_name:
@@ -3389,99 +3259,83 @@ snapshot_kind: text
           source_location:
             line: 22
             column: ~
-            file: nRF52833_xxAA.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F75
-              source_location: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F75
-              source_location: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F75
-              source_location: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F75
-              source_location: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F75
-              source_location: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F75
-              source_location: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F75
-              source_location: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F75
-              source_location: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F75
-              source_location: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F75
-              source_location: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F75
-              source_location: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F75
-              source_location: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F75
-              source_location: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F75
-              source_location: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
-              source_location: ~
         - name:
             Named: clocks
           type_name:
@@ -3490,40 +3344,34 @@ snapshot_kind: text
           source_location:
             line: 23
             column: ~
-            file: nRF52833_xxAA.rs
-            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: hfclk
               type_name:
                 Struct: ExternalOscillator
               value: ExternalOscillator @ 0x20003F76
-              source_location: ~
             - name:
                 Named: lfclk
               type_name:
                 Struct: Internal
               value: Internal @ 0x20003F76
-              source_location: ~
             - name:
                 Named: lfstat
               type_name:
                 Struct: LfOscStopped
               value: LfOscStopped @ 0x20003F76
-              source_location: ~
             - name:
                 Named: periph
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F76
-              source_location: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
     line: 19
     column: LeftEdge
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -3720,5 +3568,4 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
@@ -1,6 +1,8 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1996
 expression: stack_frames
+snapshot_kind: text
 ---
 - function_name: software_breakpoint
   source_location:
@@ -213,6 +215,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536886976
 - function_name: __cortex_m_rt_HardFault
   source_location:
@@ -425,6 +432,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536886976
 - function_name: "HardFault <Cause: Escalated BusFault <Cause: Precise data access error at location: 0x3ffffffc>>"
   source_location: ~
@@ -840,18 +852,33 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tsrc: *const u32 = *const u32 @ 0x20003EE8}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: src
           type_name:
             Pointer: "*const u32"
           value: "*const u32 @ 0x20003EE8"
+          source_location:
+            line: 1667
+            column: ~
+            file: mod.rs
+            directory: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr
           children:
             - name:
                 Named: "*src"
               type_name:
                 Base: u32
               value: "0"
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
   canonical_frame_address: 536887032
 - function_name: trigger_hardfault_from_busfault
   source_location:
@@ -1057,6 +1084,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887040
 - function_name: software_breakpoint
   source_location:
@@ -1261,6 +1293,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887048
 - function_name: __cortex_m_rt_SysTick
   source_location:
@@ -1465,6 +1502,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887048
 - function_name: __cortex_m_rt_SysTick_trampoline
   source_location:
@@ -1669,6 +1711,11 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887056
 - function_name: SysTick
   source_location: ~
@@ -2076,17 +2123,32 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tcyc: u32 = 1,\n\treal_cyc: u32 = 85}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: cyc
           type_name:
             Base: u32
           value: "1"
+          source_location:
+            line: 56
+            column: ~
+            file: inline.rs
+            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm
         - name:
             Named: real_cyc
           type_name:
             Base: u32
           value: "85"
+          source_location:
+            line: 61
+            column: ~
+            file: inline.rs
+            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm
   canonical_frame_address: 536887112
 - function_name: delay
   source_location:
@@ -2295,12 +2357,22 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tcycles: u32 = 500001}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: cycles
           type_name:
             Base: u32
           value: "500001"
+          source_location:
+            line: 28
+            column: ~
+            file: asm.rs
+            directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src
   canonical_frame_address: 536887112
 - function_name: enable_systick
   source_location:
@@ -2505,173 +2577,343 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\t<unknown>: Peripherals = Peripherals @ 0x20003F57,\n\tcore: Peripherals = Peripherals @ 0x20003F53,\n\tsyst: SYST = SYST @ 0x20003F54}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name: Unknown
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003F57
+          source_location:
+            line: 66
+            column: ~
+            file: nRF52833_xxAA.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: CBP
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F57
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F57
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F57
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F57
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F57
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F57
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F57
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F57
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F57
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F57
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F57
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F57
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F57
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F57
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: core
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003F53
+          source_location:
+            line: 66
+            column: ~
+            file: nRF52833_xxAA.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: CBP
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F53
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F53
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F53
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F53
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F53
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F53
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F53
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F53
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F53
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F53
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F53
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F53
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F53
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F53
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: syst
           type_name:
             Struct: SYST
           value: SYST @ 0x20003F54
+          source_location:
+            line: 67
+            column: ~
+            file: nRF52833_xxAA.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
   canonical_frame_address: 536887136
 - function_name: __cortex_m_rt_main
   source_location:
@@ -2876,465 +3118,925 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tpac: Peripherals = Peripherals @ 0x20003F74,\n\tcore: Peripherals = Peripherals @ 0x20003F75,\n\tclocks: Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> = Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76}"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
       children:
         - name:
             Named: pac
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003F74
+          source_location:
+            line: 21
+            column: ~
+            file: nRF52833_xxAA.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: FICR
               type_name:
                 Struct: FICR
               value: FICR @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UICR
               type_name:
                 Struct: UICR
               value: UICR @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CLOCK
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: POWER
               type_name:
                 Struct: POWER
               value: POWER @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: P0
               type_name:
                 Struct: P0
               value: P0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: P1
               type_name:
                 Struct: P1
               value: P1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RADIO
               type_name:
                 Struct: RADIO
               value: RADIO @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UARTE0
               type_name:
                 Struct: UARTE0
               value: UARTE0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIM0
               type_name:
                 Struct: SPIM0
               value: SPIM0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIS0
               type_name:
                 Struct: SPIS0
               value: SPIS0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWI0
               type_name:
                 Struct: TWI0
               value: TWI0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWIM0
               type_name:
                 Struct: TWIM0
               value: TWIM0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWIS0
               type_name:
                 Struct: TWIS0
               value: TWIS0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIM1
               type_name:
                 Struct: SPIM1
               value: SPIM1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIS1
               type_name:
                 Struct: SPIS1
               value: SPIS1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWI1
               type_name:
                 Struct: TWI1
               value: TWI1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWIM1
               type_name:
                 Struct: TWIM1
               value: TWIM1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TWIS1
               type_name:
                 Struct: TWIS1
               value: TWIS1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: NFCT
               type_name:
                 Struct: NFCT
               value: NFCT @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: GPIOTE
               type_name:
                 Struct: GPIOTE
               value: GPIOTE @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SAADC
               type_name:
                 Struct: SAADC
               value: SAADC @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER0
               type_name:
                 Struct: TIMER0
               value: TIMER0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER1
               type_name:
                 Struct: TIMER1
               value: TIMER1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER2
               type_name:
                 Struct: TIMER2
               value: TIMER2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RTC0
               type_name:
                 Struct: RTC0
               value: RTC0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TEMP
               type_name:
                 Struct: TEMP
               value: TEMP @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RNG
               type_name:
                 Struct: RNG
               value: RNG @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ECB
               type_name:
                 Struct: ECB
               value: ECB @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: AAR
               type_name:
                 Struct: AAR
               value: AAR @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CCM
               type_name:
                 Struct: CCM
               value: CCM @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: WDT
               type_name:
                 Struct: WDT
               value: WDT @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RTC1
               type_name:
                 Struct: RTC1
               value: RTC1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: QDEC
               type_name:
                 Struct: QDEC
               value: QDEC @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: COMP
               type_name:
                 Struct: COMP
               value: COMP @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: LPCOMP
               type_name:
                 Struct: LPCOMP
               value: LPCOMP @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU0
               type_name:
                 Struct: EGU0
               value: EGU0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI0
               type_name:
                 Struct: SWI0
               value: SWI0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU1
               type_name:
                 Struct: EGU1
               value: EGU1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI1
               type_name:
                 Struct: SWI1
               value: SWI1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU2
               type_name:
                 Struct: EGU2
               value: EGU2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI2
               type_name:
                 Struct: SWI2
               value: SWI2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU3
               type_name:
                 Struct: EGU3
               value: EGU3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI3
               type_name:
                 Struct: SWI3
               value: SWI3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU4
               type_name:
                 Struct: EGU4
               value: EGU4 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI4
               type_name:
                 Struct: SWI4
               value: SWI4 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: EGU5
               type_name:
                 Struct: EGU5
               value: EGU5 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SWI5
               type_name:
                 Struct: SWI5
               value: SWI5 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER3
               type_name:
                 Struct: TIMER3
               value: TIMER3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TIMER4
               type_name:
                 Struct: TIMER4
               value: TIMER4 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PWM0
               type_name:
                 Struct: PWM0
               value: PWM0 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PDM
               type_name:
                 Struct: PDM
               value: PDM @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ACL
               type_name:
                 Struct: ACL
               value: ACL @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: NVMC
               type_name:
                 Struct: NVMC
               value: NVMC @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PPI
               type_name:
                 Struct: PPI
               value: PPI @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: MWU
               type_name:
                 Struct: MWU
               value: MWU @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PWM1
               type_name:
                 Struct: PWM1
               value: PWM1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PWM2
               type_name:
                 Struct: PWM2
               value: PWM2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPI2
               type_name:
                 Struct: SPI2
               value: SPI2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIM2
               type_name:
                 Struct: SPIM2
               value: SPIM2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIS2
               type_name:
                 Struct: SPIS2
               value: SPIS2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: RTC2
               type_name:
                 Struct: RTC2
               value: RTC2 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: I2S
               type_name:
                 Struct: I2S
               value: I2S @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: USBD
               type_name:
                 Struct: USBD
               value: USBD @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: UARTE1
               type_name:
                 Struct: UARTE1
               value: UARTE1 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: PWM3
               type_name:
                 Struct: PWM3
               value: PWM3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SPIM3
               type_name:
                 Struct: SPIM3
               value: SPIM3 @ 0x20003F74
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: core
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003F75
+          source_location:
+            line: 22
+            column: ~
+            file: nRF52833_xxAA.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: CBP
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F75
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
         - name:
             Named: clocks
           type_name:
             Struct: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped>"
           value: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76"
+          source_location:
+            line: 23
+            column: ~
+            file: nRF52833_xxAA.rs
+            directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
           children:
             - name:
                 Named: hfclk
               type_name:
                 Struct: ExternalOscillator
               value: ExternalOscillator @ 0x20003F76
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: lfclk
               type_name:
                 Struct: Internal
               value: Internal @ 0x20003F76
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: lfstat
               type_name:
                 Struct: LfOscStopped
               value: LfOscStopped @ 0x20003F76
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
             - name:
                 Named: periph
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F76
+              source_location:
+                line: ~
+                column: ~
+                file: ~
+                directory: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
@@ -3538,4 +4240,9 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
+      source_location:
+        line: ~
+        column: ~
+        file: ~
+        directory: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
@@ -215,11 +215,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536886976
 - function_name: __cortex_m_rt_HardFault
   source_location:
@@ -432,11 +428,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536886976
 - function_name: "HardFault <Cause: Escalated BusFault <Cause: Precise data access error at location: 0x3ffffffc>>"
   source_location: ~
@@ -852,11 +844,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tsrc: *const u32 = *const u32 @ 0x20003EE8}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: src
@@ -874,11 +862,7 @@ snapshot_kind: text
               type_name:
                 Base: u32
               value: "0"
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
   canonical_frame_address: 536887032
 - function_name: trigger_hardfault_from_busfault
   source_location:
@@ -1084,11 +1068,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887040
 - function_name: software_breakpoint
   source_location:
@@ -1293,11 +1273,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887048
 - function_name: __cortex_m_rt_SysTick
   source_location:
@@ -1502,11 +1478,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887048
 - function_name: __cortex_m_rt_SysTick_trampoline
   source_location:
@@ -1711,11 +1683,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887056
 - function_name: SysTick
   source_location: ~
@@ -2123,11 +2091,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tcyc: u32 = 1,\n\treal_cyc: u32 = 85}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: cyc
@@ -2357,11 +2321,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tcycles: u32 = 500001}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: cycles
@@ -2577,11 +2537,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\t<unknown>: Peripherals = Peripherals @ 0x20003F57,\n\tcore: Peripherals = Peripherals @ 0x20003F53,\n\tsyst: SYST = SYST @ 0x20003F54}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name: Unknown
           type_name:
@@ -2598,151 +2554,91 @@ snapshot_kind: text
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F57
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F57
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F57
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F57
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F57
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F57
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F57
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F57
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F57
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F57
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F57
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F57
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F57
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F57
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: core
           type_name:
@@ -2759,151 +2655,91 @@ snapshot_kind: text
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F53
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F53
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F53
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F53
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F53
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F53
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F53
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F53
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F53
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F53
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F53
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F53
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F53
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F53
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: syst
           type_name:
@@ -3118,11 +2954,7 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown> {\n\tpac: Peripherals = Peripherals @ 0x20003F74,\n\tcore: Peripherals = Peripherals @ 0x20003F75,\n\tclocks: Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> = Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76}"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
       children:
         - name:
             Named: pac
@@ -3140,691 +2972,415 @@ snapshot_kind: text
               type_name:
                 Struct: FICR
               value: FICR @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UICR
               type_name:
                 Struct: UICR
               value: UICR @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CLOCK
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: POWER
               type_name:
                 Struct: POWER
               value: POWER @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: P0
               type_name:
                 Struct: P0
               value: P0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: P1
               type_name:
                 Struct: P1
               value: P1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RADIO
               type_name:
                 Struct: RADIO
               value: RADIO @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UART0
               type_name:
                 Struct: UART0
               value: UART0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UARTE0
               type_name:
                 Struct: UARTE0
               value: UARTE0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPI0
               type_name:
                 Struct: SPI0
               value: SPI0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIM0
               type_name:
                 Struct: SPIM0
               value: SPIM0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIS0
               type_name:
                 Struct: SPIS0
               value: SPIS0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWI0
               type_name:
                 Struct: TWI0
               value: TWI0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWIM0
               type_name:
                 Struct: TWIM0
               value: TWIM0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWIS0
               type_name:
                 Struct: TWIS0
               value: TWIS0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPI1
               type_name:
                 Struct: SPI1
               value: SPI1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIM1
               type_name:
                 Struct: SPIM1
               value: SPIM1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIS1
               type_name:
                 Struct: SPIS1
               value: SPIS1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWI1
               type_name:
                 Struct: TWI1
               value: TWI1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWIM1
               type_name:
                 Struct: TWIM1
               value: TWIM1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TWIS1
               type_name:
                 Struct: TWIS1
               value: TWIS1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: NFCT
               type_name:
                 Struct: NFCT
               value: NFCT @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: GPIOTE
               type_name:
                 Struct: GPIOTE
               value: GPIOTE @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SAADC
               type_name:
                 Struct: SAADC
               value: SAADC @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER0
               type_name:
                 Struct: TIMER0
               value: TIMER0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER1
               type_name:
                 Struct: TIMER1
               value: TIMER1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER2
               type_name:
                 Struct: TIMER2
               value: TIMER2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RTC0
               type_name:
                 Struct: RTC0
               value: RTC0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TEMP
               type_name:
                 Struct: TEMP
               value: TEMP @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RNG
               type_name:
                 Struct: RNG
               value: RNG @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ECB
               type_name:
                 Struct: ECB
               value: ECB @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: AAR
               type_name:
                 Struct: AAR
               value: AAR @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CCM
               type_name:
                 Struct: CCM
               value: CCM @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: WDT
               type_name:
                 Struct: WDT
               value: WDT @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RTC1
               type_name:
                 Struct: RTC1
               value: RTC1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: QDEC
               type_name:
                 Struct: QDEC
               value: QDEC @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: COMP
               type_name:
                 Struct: COMP
               value: COMP @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: LPCOMP
               type_name:
                 Struct: LPCOMP
               value: LPCOMP @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU0
               type_name:
                 Struct: EGU0
               value: EGU0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI0
               type_name:
                 Struct: SWI0
               value: SWI0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU1
               type_name:
                 Struct: EGU1
               value: EGU1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI1
               type_name:
                 Struct: SWI1
               value: SWI1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU2
               type_name:
                 Struct: EGU2
               value: EGU2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI2
               type_name:
                 Struct: SWI2
               value: SWI2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU3
               type_name:
                 Struct: EGU3
               value: EGU3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI3
               type_name:
                 Struct: SWI3
               value: SWI3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU4
               type_name:
                 Struct: EGU4
               value: EGU4 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI4
               type_name:
                 Struct: SWI4
               value: SWI4 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: EGU5
               type_name:
                 Struct: EGU5
               value: EGU5 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SWI5
               type_name:
                 Struct: SWI5
               value: SWI5 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER3
               type_name:
                 Struct: TIMER3
               value: TIMER3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TIMER4
               type_name:
                 Struct: TIMER4
               value: TIMER4 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PWM0
               type_name:
                 Struct: PWM0
               value: PWM0 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PDM
               type_name:
                 Struct: PDM
               value: PDM @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ACL
               type_name:
                 Struct: ACL
               value: ACL @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: NVMC
               type_name:
                 Struct: NVMC
               value: NVMC @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PPI
               type_name:
                 Struct: PPI
               value: PPI @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: MWU
               type_name:
                 Struct: MWU
               value: MWU @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PWM1
               type_name:
                 Struct: PWM1
               value: PWM1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PWM2
               type_name:
                 Struct: PWM2
               value: PWM2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPI2
               type_name:
                 Struct: SPI2
               value: SPI2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIM2
               type_name:
                 Struct: SPIM2
               value: SPIM2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIS2
               type_name:
                 Struct: SPIS2
               value: SPIS2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: RTC2
               type_name:
                 Struct: RTC2
               value: RTC2 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: I2S
               type_name:
                 Struct: I2S
               value: I2S @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: USBD
               type_name:
                 Struct: USBD
               value: USBD @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: UARTE1
               type_name:
                 Struct: UARTE1
               value: UARTE1 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: PWM3
               type_name:
                 Struct: PWM3
               value: PWM3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SPIM3
               type_name:
                 Struct: SPIM3
               value: SPIM3 @ 0x20003F74
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: core
           type_name:
@@ -3841,151 +3397,91 @@ snapshot_kind: text
               type_name:
                 Struct: CBP
               value: CBP @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: CPUID
               type_name:
                 Struct: CPUID
               value: CPUID @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DCB
               type_name:
                 Struct: DCB
               value: DCB @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: DWT
               type_name:
                 Struct: DWT
               value: DWT @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: FPB
               type_name:
                 Struct: FPB
               value: FPB @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: FPU
               type_name:
                 Struct: FPU
               value: FPU @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ICB
               type_name:
                 Struct: ICB
               value: ICB @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: ITM
               type_name:
                 Struct: ITM
               value: ITM @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: MPU
               type_name:
                 Struct: MPU
               value: MPU @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: NVIC
               type_name:
                 Struct: NVIC
               value: NVIC @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SAU
               type_name:
                 Struct: SAU
               value: SAU @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SCB
               type_name:
                 Struct: SCB
               value: SCB @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: SYST
               type_name:
                 Struct: SYST
               value: SYST @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: TPIU
               type_name:
                 Struct: TPIU
               value: TPIU @ 0x20003F75
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: _priv
               type_name:
                 Base: ()
               value: ()
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
         - name:
             Named: clocks
           type_name:
@@ -4002,41 +3498,25 @@ snapshot_kind: text
               type_name:
                 Struct: ExternalOscillator
               value: ExternalOscillator @ 0x20003F76
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: lfclk
               type_name:
                 Struct: Internal
               value: Internal @ 0x20003F76
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: lfstat
               type_name:
                 Struct: LfOscStopped
               value: LfOscStopped @ 0x20003F76
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
             - name:
                 Named: periph
               type_name:
                 Struct: CLOCK
               value: CLOCK @ 0x20003F76
-              source_location:
-                line: ~
-                column: ~
-                file: ~
-                directory: ~
+              source_location: ~
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
@@ -4240,9 +3720,5 @@ snapshot_kind: text
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-      source_location:
-        line: ~
-        column: ~
-        file: ~
-        directory: ~
+      source_location: ~
   canonical_frame_address: 536887288

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_svcall.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_svcall.snap
@@ -6,10 +6,10 @@ snapshot_kind: text
 ---
 - function_name: software_breakpoint
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 371
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -217,10 +217,10 @@ snapshot_kind: text
   canonical_frame_address: 536887088
 - function_name: __cortex_m_rt_SVCall
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 99
     column:
       Column: 5
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -428,10 +428,10 @@ snapshot_kind: text
   canonical_frame_address: 536887088
 - function_name: __cortex_m_rt_SVCall_trampoline
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 97
     column:
       Column: 13
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -830,10 +830,10 @@ snapshot_kind: text
   canonical_frame_address: ~
 - function_name: trigger_supervisor_call
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 63
     column:
       Column: 2
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1037,10 +1037,10 @@ snapshot_kind: text
   canonical_frame_address: 536887136
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 38
     column:
       Column: 54
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1244,9 +1244,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003F74
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 21
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: FICR
@@ -1599,9 +1599,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003F75
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 22
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
@@ -1684,9 +1684,9 @@ snapshot_kind: text
             Struct: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped>"
           value: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 23
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: hfclk
@@ -1711,9 +1711,9 @@ snapshot_kind: text
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 19
     column: LeftEdge
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_svcall.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_svcall.snap
@@ -1,14 +1,15 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1987
 expression: stack_frames
+snapshot_kind: text
 ---
 - function_name: software_breakpoint
   source_location:
     line: 371
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -219,8 +220,7 @@ expression: stack_frames
     line: 99
     column:
       Column: 5
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -431,8 +431,7 @@ expression: stack_frames
     line: 97
     column:
       Column: 13
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -834,8 +833,7 @@ expression: stack_frames
     line: 63
     column:
       Column: 2
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1042,8 +1040,7 @@ expression: stack_frames
     line: 38
     column:
       Column: 54
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1246,6 +1243,10 @@ expression: stack_frames
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003F74
+          source_location:
+            line: 21
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: FICR
@@ -1597,6 +1598,10 @@ expression: stack_frames
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003F75
+          source_location:
+            line: 22
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
@@ -1678,6 +1683,10 @@ expression: stack_frames
           type_name:
             Struct: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped>"
           value: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76"
+          source_location:
+            line: 23
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: hfclk
@@ -1704,8 +1713,7 @@ expression: stack_frames
   source_location:
     line: 19
     column: LeftEdge
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_systick.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_systick.snap
@@ -6,10 +6,10 @@ snapshot_kind: text
 ---
 - function_name: software_breakpoint
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
     line: 371
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -217,10 +217,10 @@ snapshot_kind: text
   canonical_frame_address: 536887048
 - function_name: __cortex_m_rt_SysTick
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 84
     column:
       Column: 5
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -428,10 +428,10 @@ snapshot_kind: text
   canonical_frame_address: 536887048
 - function_name: __cortex_m_rt_SysTick_trampoline
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 80
     column:
       Column: 13
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -830,10 +830,10 @@ snapshot_kind: text
   canonical_frame_address: ~
 - function_name: __delay
   source_location:
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
     line: 62
     column:
       Column: 5
-    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
   registers:
     - core_register:
         id: 0
@@ -1041,25 +1041,25 @@ snapshot_kind: text
             Base: u32
           value: "1"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
             line: 56
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
         - name:
             Named: real_cyc
           type_name:
             Base: u32
           value: "85"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
             line: 61
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
   canonical_frame_address: 536887112
 - function_name: delay
   source_location:
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
     line: 29
     column:
       Column: 5
-    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
   registers:
     - core_register:
         id: 0
@@ -1267,16 +1267,16 @@ snapshot_kind: text
             Base: u32
           value: "500001"
           source_location:
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
             line: 28
             column: ~
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
   canonical_frame_address: 536887112
 - function_name: enable_systick
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 76
     column:
       Column: 9
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1479,9 +1479,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003F57
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 66
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
@@ -1564,9 +1564,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003F53
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 66
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
@@ -1649,16 +1649,16 @@ snapshot_kind: text
             Struct: SYST
           value: SYST @ 0x20003F54
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 67
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   canonical_frame_address: 536887136
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 38
     column:
       Column: 54
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1862,9 +1862,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003F74
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 21
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: FICR
@@ -2217,9 +2217,9 @@ snapshot_kind: text
             Struct: Peripherals
           value: Peripherals @ 0x20003F75
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 22
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
@@ -2302,9 +2302,9 @@ snapshot_kind: text
             Struct: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped>"
           value: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76"
           source_location:
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
             line: 23
             column: ~
-            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: hfclk
@@ -2329,9 +2329,9 @@ snapshot_kind: text
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main
   source_location:
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 19
     column: LeftEdge
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_systick.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA_systick.snap
@@ -1,14 +1,15 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1987
 expression: stack_frames
+snapshot_kind: text
 ---
 - function_name: software_breakpoint
   source_location:
     line: 371
     column:
       Column: 9
-    file: lib.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
   registers:
     - core_register:
         id: 0
@@ -219,8 +220,7 @@ expression: stack_frames
     line: 84
     column:
       Column: 5
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -431,8 +431,7 @@ expression: stack_frames
     line: 80
     column:
       Column: 13
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -834,8 +833,7 @@ expression: stack_frames
     line: 62
     column:
       Column: 5
-    file: inline.rs
-    directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
   registers:
     - core_register:
         id: 0
@@ -1042,19 +1040,26 @@ expression: stack_frames
           type_name:
             Base: u32
           value: "1"
+          source_location:
+            line: 56
+            column: ~
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
         - name:
             Named: real_cyc
           type_name:
             Base: u32
           value: "85"
+          source_location:
+            line: 61
+            column: ~
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
   canonical_frame_address: 536887112
 - function_name: delay
   source_location:
     line: 29
     column:
       Column: 5
-    file: asm.rs
-    directory: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src
+    path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
   registers:
     - core_register:
         id: 0
@@ -1261,14 +1266,17 @@ expression: stack_frames
           type_name:
             Base: u32
           value: "500001"
+          source_location:
+            line: 28
+            column: ~
+            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
   canonical_frame_address: 536887112
 - function_name: enable_systick
   source_location:
     line: 76
     column:
       Column: 9
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1470,6 +1478,10 @@ expression: stack_frames
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003F57
+          source_location:
+            line: 66
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
@@ -1551,6 +1563,10 @@ expression: stack_frames
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003F53
+          source_location:
+            line: 66
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
@@ -1632,14 +1648,17 @@ expression: stack_frames
           type_name:
             Struct: SYST
           value: SYST @ 0x20003F54
+          source_location:
+            line: 67
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   canonical_frame_address: 536887136
 - function_name: __cortex_m_rt_main
   source_location:
     line: 38
     column:
       Column: 54
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0
@@ -1842,6 +1861,10 @@ expression: stack_frames
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003F74
+          source_location:
+            line: 21
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: FICR
@@ -2193,6 +2216,10 @@ expression: stack_frames
           type_name:
             Struct: Peripherals
           value: Peripherals @ 0x20003F75
+          source_location:
+            line: 22
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: CBP
@@ -2274,6 +2301,10 @@ expression: stack_frames
           type_name:
             Struct: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped>"
           value: "Clocks<nrf_hal_common::clocks::ExternalOscillator, nrf_hal_common::clocks::Internal, nrf_hal_common::clocks::LfOscStopped> @ 0x20003F76"
+          source_location:
+            line: 23
+            column: ~
+            path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
           children:
             - name:
                 Named: hfclk
@@ -2300,8 +2331,7 @@ expression: stack_frames
   source_location:
     line: 19
     column: LeftEdge
-    file: nRF52833_xxAA.rs
-    directory: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin
+    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
   registers:
     - core_register:
         id: 0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__print_stacktrace.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__print_stacktrace.snap
@@ -1,76 +1,69 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1926
 expression: printed_backtrace
+snapshot_kind: text
 ---
 Frame:
  function:        read<nrf51_pac::timer0::events_compare::EVENTS_COMPARE_SPEC>
  source_location:
-  directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf51-pac-0.10.1/src
-  file: Some("generic.rs")
+  path: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf51-pac-0.10.1/src/generic.rs
   line: Some(64)
   column: Some(Column(27))
  frame_base:      Some(20003f38)
 Frame:
  function:        timer_running<nrf51_pac::TIMER0>
  source_location:
-  directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
-  file: Some("timer.rs")
+  path: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs
   line: Some(397)
   column: Some(Column(9))
  frame_base:      Some(20003f38)
 Frame:
  function:        wait<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
  source_location:
-  directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
-  file: Some("timer.rs")
+  path: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs
   line: Some(266)
   column: Some(Column(12))
  frame_base:      Some(20003f50)
 Frame:
  function:        delay<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
  source_location:
-  directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
-  file: Some("timer.rs")
+  path: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs
   line: Some(145)
   column: Some(Column(22))
  frame_base:      Some(20003f78)
 Frame:
  function:        delay_us<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
  source_location:
-  directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
-  file: Some("timer.rs")
+  path: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs
   line: Some(325)
   column: Some(Column(6))
  frame_base:      Some(20003f88)
 Frame:
  function:        delay_ms<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
  source_location:
-  directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
-  file: Some("timer.rs")
+  path: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs
   line: Some(298)
   column: Some(Column(6))
  frame_base:      Some(20003fa8)
 Frame:
  function:        delay_ms<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
  source_location:
-  directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
-  file: Some("timer.rs")
+  path: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs
   line: Some(307)
   column: Some(Column(6))
  frame_base:      Some(20003fc0)
 Frame:
  function:        __cortex_m_rt_main
  source_location:
-  directory: /Users/yatekii/repos/microbit/examples/gpio-hal-blinky/src
-  file: Some("main.rs")
+  path: /Users/yatekii/repos/microbit/examples/gpio-hal-blinky/src/main.rs
   line: Some(23)
   column: Some(Column(9))
  frame_base:      Some(20003ff0)
 Frame:
  function:        __cortex_m_rt_main_trampoline
  source_location:
-  directory: /Users/yatekii/repos/microbit/examples/gpio-hal-blinky/src
-  file: Some("main.rs")
+  path: /Users/yatekii/repos/microbit/examples/gpio-hal-blinky/src/main.rs
   line: Some(10)
   column: Some(Column(1))
  frame_base:      Some(20003ff8)

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_handler.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_handler.snap
@@ -1,20 +1,20 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1700
 expression: printed_backtrace
+snapshot_kind: text
 ---
 Frame:
  function:        __cortex_m_rt_SVCall
  source_location:
-  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
-  file: Some("main.rs")
+  path: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs
   line: Some(26)
   column: Some(Column(5))
  frame_base:      Some(2001ffc0)
 Frame:
  function:        __cortex_m_rt_SVCall_trampoline
  source_location:
-  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
-  file: Some("main.rs")
+  path: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs
   line: Some(22)
   column: Some(Column(1))
  frame_base:      Some(2001ffc8)
@@ -26,16 +26,14 @@ None
 Frame:
  function:        __cortex_m_rt_main
  source_location:
-  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
-  file: Some("main.rs")
+  path: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs
   line: Some(19)
   column: Some(Column(5))
  frame_base:      Some(2001fff0)
 Frame:
  function:        __cortex_m_rt_main_trampoline
  source_location:
-  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
-  file: Some("main.rs")
+  path: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs
   line: Some(11)
   column: Some(Column(1))
  frame_base:      Some(2001fff8)

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_trampoline.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_trampoline.snap
@@ -1,12 +1,13 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1804
 expression: printed_backtrace
+snapshot_kind: text
 ---
 Frame:
  function:        __cortex_m_rt_SVCall_trampoline
  source_location:
-  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
-  file: Some("main.rs")
+  path: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs
   line: Some(22)
   column: Some(Column(1))
  frame_base:      Some(2001ffc8)
@@ -18,16 +19,14 @@ None
 Frame:
  function:        __cortex_m_rt_main
  source_location:
-  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
-  file: Some("main.rs")
+  path: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs
   line: Some(19)
   column: Some(Column(5))
  frame_base:      Some(2001fff0)
 Frame:
  function:        __cortex_m_rt_main_trampoline
  source_location:
-  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
-  file: Some("main.rs")
+  path: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs
   line: Some(11)
   column: Some(Column(1))
  frame_base:      Some(2001fff8)

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_inlined.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_inlined.snap
@@ -1,60 +1,55 @@
 ---
 source: probe-rs/src/debug/debug_info.rs
+assertion_line: 1896
 expression: printed_backtrace
+snapshot_kind: text
 ---
 Frame:
  function:        wait<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
  source_location:
-  directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
-  file: Some("timer.rs")
+  path: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs
   line: Some(266)
   column: Some(Column(12))
  frame_base:      Some(20003ff0)
 Frame:
  function:        delay<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
  source_location:
-  directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
-  file: Some("timer.rs")
+  path: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs
   line: Some(145)
   column: Some(Column(22))
  frame_base:      Some(20003ff0)
 Frame:
  function:        delay_us<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
  source_location:
-  directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
-  file: Some("timer.rs")
+  path: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs
   line: Some(324)
   column: Some(Column(9))
  frame_base:      Some(20003ff0)
 Frame:
  function:        delay_ms<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
  source_location:
-  directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
-  file: Some("timer.rs")
+  path: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs
   line: Some(297)
   column: Some(Column(14))
  frame_base:      Some(20003ff0)
 Frame:
  function:        delay_ms<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
  source_location:
-  directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
-  file: Some("timer.rs")
+  path: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs
   line: Some(306)
   column: Some(Column(14))
  frame_base:      Some(20003ff0)
 Frame:
  function:        __cortex_m_rt_main
  source_location:
-  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/inlined-functions/src
-  file: Some("main.rs")
+  path: /home/dominik/code/probe-rs/probe-rs-repro/nrf/inlined-functions/src/main.rs
   line: Some(20)
   column: Some(Column(15))
  frame_base:      Some(20003ff0)
 Frame:
  function:        __cortex_m_rt_main_trampoline
  source_location:
-  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/inlined-functions/src
-  file: Some("main.rs")
+  path: /home/dominik/code/probe-rs/probe-rs-repro/nrf/inlined-functions/src/main.rs
   line: Some(7)
   column: Some(Column(1))
  frame_base:      Some(20003ff8)

--- a/probe-rs/src/debug/source_instructions.rs
+++ b/probe-rs/src/debug/source_instructions.rs
@@ -10,7 +10,7 @@ use std::{
     num::NonZeroU64,
     ops::Range,
 };
-use typed_path::TypedPathBuf;
+use typed_path::{TypedPath, TypedPathBuf};
 
 /// A verified breakpoint represents an instruction address, and the source location that it corresponds to it,
 /// for locations in the target binary that comply with the DWARF standard terminology for "recommended breakpoint location".
@@ -72,7 +72,7 @@ impl VerifiedBreakpoint {
     ///        on the next available line of the specified file.
     pub(crate) fn for_source_location(
         debug_info: &DebugInfo,
-        path: &TypedPathBuf,
+        path: TypedPath,
         line: u64,
         column: Option<u64>,
     ) -> Result<Self, DebugError> {
@@ -103,11 +103,11 @@ impl VerifiedBreakpoint {
                     debug_info
                         .get_path(&program_unit.unit, file_index)
                         .and_then(|combined_path: TypedPathBuf| {
-                            if canonical_path_eq(path, &combined_path) {
+                            if canonical_path_eq(path, combined_path.to_path()) {
                                 tracing::debug!(
                                     "Found matching file index: {file_index} for path: {path}",
                                     file_index = file_index,
-                                    path = path.to_path().display()
+                                    path = path.display()
                                 );
                                 Some(file_index)
                             } else {
@@ -161,7 +161,7 @@ impl VerifiedBreakpoint {
             }
         }
         // If we get here, we have not found a valid breakpoint location.
-        Err(DebugError::Other(format!("No valid breakpoint information found for file: {}, line: {line:?}, column: {column:?}", path.to_path().display())))
+        Err(DebugError::Other(format!("No valid breakpoint information found for file: {}, line: {line:?}, column: {column:?}", path.display())))
     }
 }
 
@@ -307,11 +307,6 @@ impl SourceLocation {
         self.path
             .file_name()
             .map(|name| String::from_utf8_lossy(name).to_string())
-    }
-
-    /// Get the full path of the source file
-    pub fn combined_typed_path(&self) -> Option<TypedPathBuf> {
-        Some(self.path.clone())
     }
 }
 

--- a/probe-rs/src/debug/source_instructions.rs
+++ b/probe-rs/src/debug/source_instructions.rs
@@ -270,7 +270,7 @@ pub struct SourceLocation {
     pub path: TypedPathBuf,
     /// The line number in the source file with zero based indexing.
     pub line: Option<u64>,
-    /// The column number in the source file with zero based indexing.
+    /// The column number in the source file.
     pub column: Option<ColumnType>,
 }
 

--- a/probe-rs/src/debug/source_instructions.rs
+++ b/probe-rs/src/debug/source_instructions.rs
@@ -266,7 +266,9 @@ where
 
 /// A specific location in source code.
 /// Each unique line, column, file and directory combination is a unique source location.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+///
+/// At least one of the fields must be non-None.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct SourceLocation {
     /// The line number in the source file with zero based indexing.
     pub line: Option<u64>,

--- a/probe-rs/src/debug/stack_frame.rs
+++ b/probe-rs/src/debug/stack_frame.rs
@@ -54,7 +54,7 @@ impl std::fmt::Display for StackFrame {
         // Header info for the StackFrame
         writeln!(f, "Frame: {}", self.function_name)?;
         if let Some(si) = &self.source_location {
-            write!(f, "\t{}", si.path.to_string_lossy())?;
+            write!(f, "\t{}", si.path.to_path().display())?;
 
             if let (Some(column), Some(line)) = (si.column, si.line) {
                 match column {

--- a/probe-rs/src/debug/stack_frame.rs
+++ b/probe-rs/src/debug/stack_frame.rs
@@ -54,21 +54,7 @@ impl std::fmt::Display for StackFrame {
         // Header info for the StackFrame
         writeln!(f, "Frame: {}", self.function_name)?;
         if let Some(si) = &self.source_location {
-            let separator = match &si.directory {
-                Some(path) if path.is_windows() => '\\',
-                _ => '/',
-            };
-
-            write!(
-                f,
-                "\t{}{}{}",
-                si.directory
-                    .as_ref()
-                    .map(|p| p.to_string_lossy())
-                    .unwrap_or_else(|| std::borrow::Cow::from("<unknown dir>")),
-                separator,
-                si.file.as_ref().unwrap_or(&"<unknown file>".to_owned())
-            )?;
+            write!(f, "\t{}", si.path.to_string_lossy())?;
 
             if let (Some(column), Some(line)) = (si.column, si.line) {
                 match column {
@@ -96,12 +82,7 @@ mod test {
             writeln!(f, " source_location:")?;
             match &self.0.source_location {
                 Some(location) => {
-                    write!(f, "  directory: ")?;
-                    match location.directory.as_ref() {
-                        Some(l) => writeln!(f, "{}", l.to_path().display())?,
-                        None => writeln!(f, "None")?,
-                    }
-                    writeln!(f, "  file: {:?}", location.file)?;
+                    writeln!(f, "  path: {}", location.path.to_path().display())?;
                     writeln!(f, "  line: {:?}", location.line)?;
                     writeln!(f, "  column: {:?}", location.column)?;
                 }

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -2233,7 +2233,12 @@ impl UnitInfo {
                     }
                 }
                 gimli::DW_AT_decl_column => {
-                    // Unused.
+                    if let Some(column_number) = attr.udata_value() {
+                        // According to the DWARF standard, a value of 0 means no column is specified.
+                        if column_number != 0 {
+                            source_location.column = Some(super::ColumnType::Column(column_number));
+                        }
+                    }
                 }
                 // Other attributes are not relevant for extracting source location.
                 _ => (),

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -474,7 +474,7 @@ pub struct Variable {
     /// Use `Variable::set_value()` and `Variable::get_value()` to correctly process this `value`
     pub(super) value: VariableValue,
     /// The source location of the declaration of this variable, if available.
-    pub source_location: SourceLocation,
+    pub source_location: Option<SourceLocation>,
     /// Programming language of the defining compilation unit.
     pub language: DwLang,
 
@@ -509,7 +509,7 @@ impl Variable {
             name: Default::default(),
             linkage_name: None,
             value: Default::default(),
-            source_location: Default::default(),
+            source_location: None,
             type_name: Default::default(),
             variable_node_type: Default::default(),
             memory_location: Default::default(),

--- a/probe-rs/src/debug/variable_cache.rs
+++ b/probe-rs/src/debug/variable_cache.rs
@@ -34,6 +34,7 @@ impl Serialize for VariableCache {
             /// To eliminate noise, we will only show values for base data types and strings.
             value: String,
 
+            #[serde(skip_serializing_if = "Option::is_none")]
             source_location: Option<SourceLocation>,
             /// ONLY If there are children.
             #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/probe-rs/src/debug/variable_cache.rs
+++ b/probe-rs/src/debug/variable_cache.rs
@@ -34,7 +34,7 @@ impl Serialize for VariableCache {
             /// To eliminate noise, we will only show values for base data types and strings.
             value: String,
 
-            source_location: SourceLocation,
+            source_location: Option<SourceLocation>,
             /// ONLY If there are children.
             #[serde(skip_serializing_if = "Vec::is_empty")]
             children: Vec<VariableTreeNode<'c>>,
@@ -97,7 +97,7 @@ impl Serialize for VariableCache {
                     type_name: &VariableType::Unknown,
                     value: format!("... and {} more", remaining),
                     children: Vec::new(),
-                    source_location: SourceLocation::default(),
+                    source_location: None,
                 });
             }
 
@@ -579,7 +579,7 @@ mod test {
 
         assert_eq!(cache_variable.to_string(&c), "<unknown>");
 
-        assert_eq!(cache_variable.source_location, Default::default());
+        assert_eq!(cache_variable.source_location, None);
         assert_eq!(cache_variable.memory_location, VariableLocation::Unknown);
         assert_eq!(cache_variable.byte_size, None);
         assert_eq!(cache_variable.member_index, None);

--- a/probe-rs/src/debug/variable_cache.rs
+++ b/probe-rs/src/debug/variable_cache.rs
@@ -33,6 +33,8 @@ impl Serialize for VariableCache {
             type_name: &'c VariableType,
             /// To eliminate noise, we will only show values for base data types and strings.
             value: String,
+
+            source_location: SourceLocation,
             /// ONLY If there are children.
             #[serde(skip_serializing_if = "Vec::is_empty")]
             children: Vec<VariableTreeNode<'c>>,
@@ -45,6 +47,7 @@ impl Serialize for VariableCache {
                 name: &root_node.name,
                 type_name: &root_node.type_name,
                 value: root_node.to_string(variable_cache),
+                source_location: root_node.source_location.clone(),
                 children: recurse_variables(variable_cache, root_node.variable_key, None),
             }
         }
@@ -83,6 +86,7 @@ impl Serialize for VariableCache {
                         // Limit arrays to 50(+1) elements
                         child_variable.type_name.inner().is_array().then_some(50),
                     ),
+                    source_location: child_variable.source_location.clone(),
                 });
             }
 
@@ -93,6 +97,7 @@ impl Serialize for VariableCache {
                     type_name: &VariableType::Unknown,
                     value: format!("... and {} more", remaining),
                     children: Vec::new(),
+                    source_location: SourceLocation::default(),
                 });
             }
 

--- a/probe-rs/tests/source_location.rs
+++ b/probe-rs/tests/source_location.rs
@@ -108,7 +108,7 @@ fn find_non_existing_unit_by_path() {
     let debug_info = DebugInfo::from_file("tests/probe-rs-debugger-test").unwrap();
 
     assert!(debug_info
-        .get_breakpoint_location(&unit_path, 14, None)
+        .get_breakpoint_location(unit_path.to_path(), 14, None)
         .is_err());
 }
 
@@ -117,9 +117,9 @@ fn regression_pr2324() {
     let path = "C:\\_Hobby\\probe-rs-test-c-firmware/Atmel/hpl/core/hpl_init.c";
 
     let di = DebugInfo::from_file("tests/debug-unwind-tests/atsamd51p19a.elf").unwrap();
-    let path = TypedPath::derive(path).to_path_buf();
+    let path = TypedPath::derive(path);
 
-    let addr = di.get_breakpoint_location(&path, 58, None).unwrap();
+    let addr = di.get_breakpoint_location(path, 58, None).unwrap();
 
     assert_eq!(addr.address, 0x2e4);
 }

--- a/probe-rs/tests/source_location.rs
+++ b/probe-rs/tests/source_location.rs
@@ -84,18 +84,15 @@ fn breakpoint_location_inexact() {
 fn source_location() {
     let di = DebugInfo::from_file("tests/probe-rs-debugger-test").unwrap();
 
-    let file = "main.rs";
-
-    let dir =
-        UnixPathBuf::from("/Users/jacknoppe/dev/probe-rs-debugger-test/src").to_typed_path_buf();
+    let path = UnixPathBuf::from("/Users/jacknoppe/dev/probe-rs-debugger-test/src/main.rs")
+        .to_typed_path_buf();
 
     for (addr, line, col) in TEST_DATA.iter() {
         assert_eq!(
             Some(SourceLocation {
                 line: Some(*line),
                 column: Some(*col),
-                directory: Some(dir.clone()),
-                file: Some(file.to_owned()),
+                path: path.clone(),
             }),
             di.get_source_location(*addr)
         );

--- a/probe-rs/tests/source_location.rs
+++ b/probe-rs/tests/source_location.rs
@@ -34,7 +34,7 @@ fn breakpoint_location_absolute() {
 
         assert_eq!(
             *addr,
-            di.get_breakpoint_location(&path, *line, col)
+            di.get_breakpoint_location(path.to_path(), *line, col)
                 .expect("Failed to find breakpoint location.")
                 .address,
             "Addresses do not match for data path={:?}, line={:?}, col={:?}",
@@ -69,7 +69,7 @@ fn breakpoint_location_inexact() {
 
         assert_eq!(
             *addr,
-            di.get_breakpoint_location(&path, *line, col)
+            di.get_breakpoint_location(path.to_path(), *line, col)
                 .expect("Failed to find valid breakpoint locations.")
                 .address,
             "Addresses do not match for data path={:?}, line={:?}, col={:?}",


### PR DESCRIPTION
Instead of storing file name and directory separately, this combines them into a single field, which is not optional.
Missing source locations are now represented by having the whole field be an `Option<SourceLocation>`.