### PR TITLE
blackmagic: support connect-under-reset

### DIFF
--- a/changelog/fixed-blackmagic-connect-under-reset.md
+++ b/changelog/fixed-blackmagic-connect-under-reset.md
@@ -1,0 +1,1 @@
+Support swj_pins() when specifying --connect-under-reset


### PR DESCRIPTION
The `--connect-under-reset` command uses the `swj_pins()` function which this platform previously didn't support. Since this platform generally cannot manually set the pins, this returned an error `CommandNotSupportedByProbe`.

However, it does support setting the reset pin directly.

Allow `swj_pins()` to succeed if and only if the only selected pin is the nRST pin.