### PR TITLE
fix: nrf91 sequence on BMP

### DIFF
--- a/changelog/fixed-nrf-debug-sequence-on-bmp.md
+++ b/changelog/fixed-nrf-debug-sequence-on-bmp.md
@@ -1,0 +1,1 @@
+NRF91 and NRF52 debug sequence has been fixed for Black Magic Probe

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
@@ -2,10 +2,9 @@
 
 use crate::{
     architecture::arm::{
-        communication_interface::Initialized,
         memory::ArmMemoryInterface,
         sequences::{ArmDebugSequence, ArmDebugSequenceError},
-        ArmCommunicationInterface, ArmError, ArmProbeInterface, DapAccess, FullyQualifiedApAddress,
+        ArmError, ArmProbeInterface, DpAddress, FullyQualifiedApAddress,
     },
     session::MissingPermissions,
 };
@@ -15,13 +14,13 @@ pub trait Nrf: Sync + Send + Debug {
     /// Returns the ahb_ap and ctrl_ap of every core
     fn core_aps(
         &self,
-        interface: &mut dyn ArmMemoryInterface,
+        dp_address: &DpAddress,
     ) -> Vec<(FullyQualifiedApAddress, FullyQualifiedApAddress)>;
 
     /// Returns true when the core is unlocked and false when it is locked.
     fn is_core_unlocked(
         &self,
-        arm_interface: &mut ArmCommunicationInterface<Initialized>,
+        interface: &mut dyn ArmProbeInterface,
         ahb_ap_address: &FullyQualifiedApAddress,
         ctrl_ap_address: &FullyQualifiedApAddress,
     ) -> Result<bool, ArmError>;
@@ -43,7 +42,7 @@ const RELEASE_FORCEOFF: u32 = 0;
 /// Unlocks the core by performing an erase all procedure.
 /// The `ap_address` must be of the ctrl ap of the core.
 fn unlock_core(
-    arm_interface: &mut ArmCommunicationInterface<Initialized>,
+    arm_interface: &mut dyn ArmProbeInterface,
     ap_address: &FullyQualifiedApAddress,
     permissions: &crate::Permissions,
 ) -> Result<(), ArmError> {
@@ -84,21 +83,15 @@ impl<T: Nrf> ArmDebugSequence for T {
         default_ap: &FullyQualifiedApAddress,
         permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
-        let mut interface = interface.memory_interface(default_ap)?;
+        let aps = self.core_aps(&default_ap.dp());
 
         // TODO: Eraseprotect is not considered. If enabled, the debugger must set up the same keys as the firmware does
         // TODO: Approtect and Secure Approtect are not considered. If enabled, the debugger must set up the same keys as the firmware does
         // These keys should be queried from the user if required and once that mechanism is implemented
 
-        for (core_index, (core_ahb_ap_address, core_ctrl_ap_address)) in
-            self.core_aps(&mut *interface).iter().enumerate()
-        {
+        for (core_index, (core_ahb_ap_address, core_ctrl_ap_address)) in aps.iter().enumerate() {
             tracing::info!("Checking if core {} is unlocked", core_index);
-            if self.is_core_unlocked(
-                interface.get_arm_communication_interface()?,
-                core_ahb_ap_address,
-                core_ctrl_ap_address,
-            )? {
+            if self.is_core_unlocked(interface, core_ahb_ap_address, core_ctrl_ap_address)? {
                 tracing::info!("Core {} is already unlocked", core_index);
                 continue;
             }
@@ -107,17 +100,9 @@ impl<T: Nrf> ArmDebugSequence for T {
                 "Core {} is locked. Erase procedure will be started to unlock it.",
                 core_index
             );
-            unlock_core(
-                interface.get_arm_communication_interface()?,
-                core_ctrl_ap_address,
-                permissions,
-            )?;
+            unlock_core(interface, core_ctrl_ap_address, permissions)?;
 
-            if !self.is_core_unlocked(
-                interface.get_arm_communication_interface()?,
-                core_ahb_ap_address,
-                core_ctrl_ap_address,
-            )? {
+            if !self.is_core_unlocked(interface, core_ahb_ap_address, core_ctrl_ap_address)? {
                 return Err(ArmDebugSequenceError::custom(format!(
                     "Could not unlock core {core_index}"
                 ))
@@ -126,11 +111,12 @@ impl<T: Nrf> ArmDebugSequence for T {
         }
 
         if self.has_network_core() {
+            let mut memory_interface = interface.memory_interface(default_ap)?;
             tracing::debug!("Setting network core to running");
-            set_network_core_running(&mut *interface)?;
-        }
+            set_network_core_running(&mut *memory_interface)?;
 
-        interface.flush()?;
+            memory_interface.flush()?;
+        }
 
         Ok(())
     }

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
@@ -4,11 +4,8 @@ use std::sync::Arc;
 
 use super::nrf::Nrf;
 use crate::architecture::arm::{
-    ap::{memory_ap::registers::CSW, AccessPortType},
-    communication_interface::Initialized,
-    memory::ArmMemoryInterface,
-    sequences::ArmDebugSequence,
-    ArmCommunicationInterface, ArmError, DapAccess, FullyQualifiedApAddress,
+    ap::memory_ap::registers::CSW, sequences::ArmDebugSequence, ArmError, ArmProbeInterface,
+    DpAddress, FullyQualifiedApAddress,
 };
 
 /// The sequence handle for the nRF5340.
@@ -25,18 +22,16 @@ impl Nrf5340 {
 impl Nrf for Nrf5340 {
     fn core_aps(
         &self,
-        memory: &mut dyn ArmMemoryInterface,
+        dp_address: &DpAddress,
     ) -> Vec<(FullyQualifiedApAddress, FullyQualifiedApAddress)> {
-        let ap_address = memory.ap().ap_address();
-
         let core_aps = [(0, 2), (1, 3)];
 
         core_aps
             .into_iter()
             .map(|(core_ahb_ap, core_ctrl_ap)| {
                 (
-                    FullyQualifiedApAddress::v1_with_dp(ap_address.dp(), core_ahb_ap),
-                    FullyQualifiedApAddress::v1_with_dp(ap_address.dp(), core_ctrl_ap),
+                    FullyQualifiedApAddress::v1_with_dp(*dp_address, core_ahb_ap),
+                    FullyQualifiedApAddress::v1_with_dp(*dp_address, core_ctrl_ap),
                 )
             })
             .collect()
@@ -44,7 +39,7 @@ impl Nrf for Nrf5340 {
 
     fn is_core_unlocked(
         &self,
-        arm_interface: &mut ArmCommunicationInterface<Initialized>,
+        arm_interface: &mut dyn ArmProbeInterface,
         ahb_ap_address: &FullyQualifiedApAddress,
         _ctrl_ap_address: &FullyQualifiedApAddress,
     ) -> Result<bool, ArmError> {

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf91.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf91.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 
 use super::nrf::Nrf;
 use crate::architecture::arm::{
-    ap::AccessPortType, communication_interface::Initialized, memory::ArmMemoryInterface,
-    sequences::ArmDebugSequence, ArmCommunicationInterface, ArmError, DapAccess,
-    FullyQualifiedApAddress,
+    sequences::ArmDebugSequence, ArmError, ArmProbeInterface, DpAddress, FullyQualifiedApAddress,
 };
 
 /// The sequence handle for the nRF9160.
@@ -23,18 +21,16 @@ impl Nrf9160 {
 impl Nrf for Nrf9160 {
     fn core_aps(
         &self,
-        memory: &mut dyn ArmMemoryInterface,
+        dp_address: &DpAddress,
     ) -> Vec<(FullyQualifiedApAddress, FullyQualifiedApAddress)> {
-        let dp = memory.ap().ap_address().dp();
-
         let core_aps = [(0, 4)];
 
         core_aps
             .into_iter()
             .map(|(core_ahb_ap, core_ctrl_ap)| {
                 (
-                    FullyQualifiedApAddress::v1_with_dp(dp, core_ahb_ap),
-                    FullyQualifiedApAddress::v1_with_dp(dp, core_ctrl_ap),
+                    FullyQualifiedApAddress::v1_with_dp(*dp_address, core_ahb_ap),
+                    FullyQualifiedApAddress::v1_with_dp(*dp_address, core_ctrl_ap),
                 )
             })
             .collect()
@@ -42,7 +38,7 @@ impl Nrf for Nrf9160 {
 
     fn is_core_unlocked(
         &self,
-        arm_interface: &mut ArmCommunicationInterface<Initialized>,
+        arm_interface: &mut dyn ArmProbeInterface,
         _ahb_ap_address: &FullyQualifiedApAddress,
         ctrl_ap_address: &FullyQualifiedApAddress,
     ) -> Result<bool, ArmError> {


### PR DESCRIPTION
This fixes the nrf91 sequence for the BMP probe by removing of accessing
the memory_interface. Accessing this interface before the cores results
in a non-function debug sequence.

Fixes #2944