### PR TITLE
fix: Improve detection of J-Link CMSIS-DAP

### DIFF
--- a/changelog/fixed-jlink-cmsis-dap-detection.md
+++ b/changelog/fixed-jlink-cmsis-dap-detection.md
@@ -1,0 +1,1 @@
+Fixed detection of J-Link probes configured as CMSIS-DAP compatible probes, don't recognize them as J-Links.


### PR DESCRIPTION
Improve the detection of J-Link probes configured
as CMSIS-DAP compatible probes.

Some variants of the J-Link probe can be configured to provide
a CMSIS-DAP compatible interface instead. These probes were still
detect as J-Link compatible by probe-rs. To fix this, the product
ID is now checked as well when looking for J-Links, not only the
vendor ID.
