### PR TITLE
Manually set github token when running the crates release flow

### DIFF
--- a/.github/workflows/release_crates.yml
+++ b/.github/workflows/release_crates.yml
@@ -23,6 +23,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # This is a workaround for cargo-release, see https://github.com/crate-ci/cargo-release/issues/625
+          # We need to manually set a token here to ensure that we can trigger the `cargo dist` workflow.
+          #
+          # By default, pushing a tag from a workflow does not trigger other workflows, which means that the release
+          # workflow isn't triggered by pushing a tag from this workflow. Manually setting a token is a workaround for
+          # this, see https://github.com/orgs/community/discussions/57484'
+          token: ${{ secrets.GH_PAT }}
 
       - name: Install libudev (linux)
         run: |


### PR DESCRIPTION
A workaround for the behaviour described in https://github.com/probe-rs/probe-rs/pull/2964.

By default, pushing a tag from a workflow doesn't trigger a workflow, this should be a workaround.