### PR TITLE
probe-rs-tools: support `--ignored` and `--include-ignored` libtest options

### DIFF
--- a/changelog/added-libtest-ignored-flags.md
+++ b/changelog/added-libtest-ignored-flags.md
@@ -1,0 +1,1 @@
+added support for `--ignored` and `--include-ignored` libtest options

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/test_run_mode.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/test_run_mode.rs
@@ -41,6 +41,10 @@ pub struct TestOptions {
     #[clap(long = "exact", help_heading = "TEST OPTIONS")]
     pub exact: bool,
 
+    /// If set, list or run only *ignored* tests.
+    #[clap(long = "ignored", help_heading = "TEST OPTIONS")]
+    pub ignored: bool,
+
     /// A list of filters. Tests whose names contain parts of any of these
     /// filters are skipped.
     #[clap(
@@ -85,6 +89,7 @@ impl TestRunMode {
                 test_threads: Some(1), // Avoid parallel execution
                 list: test_options.list,
                 exact: test_options.exact,
+                ignored: test_options.ignored,
                 format: test_options.format,
                 skip: test_options.skip_test.clone(),
                 filter: if test_options.filter.is_empty() {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/test_run_mode.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/test_run_mode.rs
@@ -41,9 +41,13 @@ pub struct TestOptions {
     #[clap(long = "exact", help_heading = "TEST OPTIONS")]
     pub exact: bool,
 
-    /// If set, list or run only *ignored* tests.
+    /// If set, run only ignored tests.
     #[clap(long = "ignored", help_heading = "TEST OPTIONS")]
     pub ignored: bool,
+
+    /// If set, run ignored and non-ignored tests.
+    #[clap(long = "include-ignored", help_heading = "TEST OPTIONS")]
+    pub include_ignored: bool,
 
     /// A list of filters. Tests whose names contain parts of any of these
     /// filters are skipped.
@@ -90,6 +94,7 @@ impl TestRunMode {
                 list: test_options.list,
                 exact: test_options.exact,
                 ignored: test_options.ignored,
+                include_ignored: test_options.include_ignored,
                 format: test_options.format,
                 skip: test_options.skip_test.clone(),
                 filter: if test_options.filter.is_empty() {


### PR DESCRIPTION
The libtest framework allows adding `#[ignore]` to a test, which a libtest compatible harness should list when getting the `--ignored` flag.

I found this when trying to wrap the runner with `nextest`.

This just needed wiring up to work (literally three lines, too bad I missed the release).

E.g., for [this test](https://github.com/kaspar030/ariel-os/blob/pr/integrate-embedded-test/examples/testing/tests/example_test.rs), the output without `--ignored` becomes this:

```
❯ probe-rs run '--protocol=swd' --chip nrf52840_xxAA --preverify /home/kaspar/src/own/rust/ariel-os/examples/testing/../../build/bin/nrf52840dk/testing/cargo/thumbv7em-none-eabi/debug/deps/example_test-9af699a2b54d0715 --list --format terse
     Finished in 1.67s
tests::trivial_async: test
tests::trivial: test
tests::trivial_ignored: test
```

... and with added `--ignored`:

```
ariel-os/examples/testing on  pr/integrate-embedded-test took 2s140ms 
❯ probe-rs run '--protocol=swd' --chip nrf52840_xxAA --preverify /home/kaspar/src/own/rust/ariel-os/examples/testing/../../build/bin/nrf52840dk/testing/cargo/thumbv7em-none-eabi/debug/deps/example_test-9af699a2b54d0715 --list --format terse --ignored
     Finished in 1.67s
tests::trivial_ignored: test
```

This corresponds to what `nextest` expects according to https://nexte.st/docs/design/custom-test-harnesses/.

Running without `--ignored`:

<details>

```
    Finished `test` profile [optimized + debuginfo] target(s) in 0.25s
     Running tests/example_test.rs (../../build/bin/nrf52840dk/testing/cargo/thumbv7em-none-eabi/debug/deps/example_test-9af699a2b54d0715)
     Finished in 1.67s

running 3 tests
test tests::trivial_async   ... ok
test tests::trivial         ... ok
test tests::trivial_ignored ... ignored

test result: ok. 2 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.54s
```
</details>

Running with `--ignored`:

<details>

```
    Finished `test` profile [optimized + debuginfo] target(s) in 0.22s                                                                                         
     Running tests/example_test.rs (../../build/bin/nrf52840dk/testing/cargo/thumbv7em-none-eabi/debug/deps/example_test-9af699a2b54d0715)                     
     Finished in 1.67s                                                                                                                                         
                                                                                                                                                               
running 1 test                                                                                                                                                 
test tests::trivial_ignored ... ok                                                                                                                             
                                                                                                                                                               
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.29s      
```

</details>

With `--include-ignored`:

<details>
```
    Finished `test` profile [optimized + debuginfo] target(s) in 0.25s
     Running tests/example_test.rs (../../build/bin/nrf52840dk/testing/cargo/thumbv7em-none-eabi/debug/deps/example_test-9af699a2b54d0715)
     Finished in 1.67s

running 3 tests
test tests::trivial_async   ... ok
test tests::trivial         ... ok
test tests::trivial_ignored ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.80s
```
</details>
