### PR TITLE
Reset progress bar ETA and elapsed on start of that bar

### DIFF
--- a/changelog/fixed-progressbar-eta.md
+++ b/changelog/fixed-progressbar-eta.md
@@ -1,0 +1,1 @@
+the progressbars are now properly reset at the right time to improve the accuracy of the speed and ETA. (#2970) by @diondokter

--- a/probe-rs-tools/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/flash.rs
@@ -103,10 +103,15 @@ pub fn run_flash_download(
                         .map(|path| visualizer.write_svg(path));
                 }
                 ProgressEvent::StartedProgramming { length } => {
+                    progress_bars.program.mark_start_now();
                     progress_bars.program.set_length(length);
                 }
-                ProgressEvent::StartedErasing => {}
-                ProgressEvent::StartedFilling => {}
+                ProgressEvent::StartedErasing => {
+                    progress_bars.erase.mark_start_now();
+                }
+                ProgressEvent::StartedFilling => {
+                    progress_bars.fill.mark_start_now();
+                }
                 ProgressEvent::PageProgrammed { size, .. } => {
                     progress_bars.program.inc(size as u64);
                 }
@@ -264,5 +269,12 @@ impl ProgressBarGroup {
 
     pub fn append_phase(&mut self) {
         self.append_phase = true;
+    }
+
+    pub fn mark_start_now(&mut self) {
+        if let Some(bar) = self.bars.get(self.selected) {
+            bar.reset_elapsed();
+            bar.reset_eta();
+        }
     }
 }


### PR DESCRIPTION
In 0.25 there are improved progress bars, but they don't get reset properly.
This means the ETA of e.g. the programming is wrong since the bar has been started since the erasing has been started which can be a long time before.

This fixes that!