### PR TITLE
bugfix: Don't try to access disabled MemoryAPs in the info command

### DIFF
--- a/changelog/fixed-memory-port-enable-check.md
+++ b/changelog/fixed-memory-port-enable-check.md
@@ -1,0 +1,1 @@
+probe-rs info: Check if memory access port is accessible before trying to use it.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -5,7 +5,7 @@ use jep106::JEP106Code;
 use probe_rs::{
     architecture::{
         arm::{
-            ap::{ApClass, MemoryAp, MemoryApType},
+            ap::{ApClass, MemoryApType},
             armv6m::Demcr,
             component::Scs,
             dp::{DebugPortId, DebugPortVersion, MinDpSupport, DLPIDR, DPIDR, TARGETID},
@@ -135,7 +135,6 @@ fn try_show_info(
                 probe = probe_moved;
                 print_err(dp_addr, e);
 
-                /*
                 if dp_addr == DpAddress::Default {
                     println!("Trying alternate multi-drop debug ports");
 
@@ -155,7 +154,6 @@ fn try_show_info(
                         }
                     }
                 }
-                */
             }
         }
     } else {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -342,20 +342,16 @@ fn handle_memory_ap(
     interface: &mut dyn ArmProbeInterface,
     access_port: &FullyQualifiedApAddress,
 ) -> Result<Tree<String>, anyhow::Error> {
-    println!("Handling memory AP {access_port:?}");
-
-    // Check if the AP is accessible
-    //
-
     let component = {
         let mut memory = interface.memory_interface(access_port)?;
 
+        // Check if the AP is accessible
         let (interface, ap) = memory.try_as_parts()?;
-
         let csw = ap.generic_status(interface)?;
-
         if !csw.DeviceEn {
-            return Ok(Tree::new("Memory AP is disabled".to_string()));
+            return Ok(Tree::new(
+                "Memory AP is not accessible, DeviceEn bit not set".to_string(),
+            ));
         }
 
         let base_address = memory.base_address()?;

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb3.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb3.rs
@@ -48,10 +48,7 @@ impl super::MemoryApType for AmbaAhb3 {
     type CSW = CSW;
 
     fn status<P: ApAccess + ?Sized>(&mut self, probe: &mut P) -> Result<CSW, ArmError> {
-        #[allow(clippy::assertions_on_constants)]
-        const {
-            assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS)
-        };
+        const { assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS) };
         self.csw = probe.read_ap_register(self)?;
         Ok(self.csw)
     }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5.rs
@@ -47,10 +47,7 @@ impl super::MemoryApType for AmbaAhb5 {
     type CSW = CSW;
 
     fn status<P: ApAccess + ?Sized>(&mut self, probe: &mut P) -> Result<CSW, ArmError> {
-        #[allow(clippy::assertions_on_constants)]
-        const {
-            assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS)
-        };
+        const { assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS) };
         self.csw = probe.read_ap_register(self)?;
         Ok(self.csw)
     }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5_hprot.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5_hprot.rs
@@ -48,10 +48,7 @@ impl super::MemoryApType for AmbaAhb5Hprot {
     type CSW = CSW;
 
     fn status<P: ApAccess + ?Sized>(&mut self, probe: &mut P) -> Result<CSW, ArmError> {
-        #[allow(clippy::assertions_on_constants)]
-        const {
-            assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS)
-        };
+        const { assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS) };
         self.csw = probe.read_ap_register(self)?;
         Ok(self.csw)
     }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_apb2_apb3.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_apb2_apb3.rs
@@ -44,10 +44,7 @@ impl super::MemoryApType for AmbaApb2Apb3 {
     type CSW = CSW;
 
     fn status<P: ApAccess + ?Sized>(&mut self, probe: &mut P) -> Result<CSW, ArmError> {
-        #[allow(clippy::assertions_on_constants)]
-        const {
-            assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS)
-        };
+        const { assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS) };
         self.csw = probe.read_ap_register(self)?;
         Ok(self.csw)
     }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_apb4_apb5.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_apb4_apb5.rs
@@ -44,10 +44,7 @@ impl super::MemoryApType for AmbaApb4Apb5 {
     type CSW = CSW;
 
     fn status<P: ApAccess + ?Sized>(&mut self, probe: &mut P) -> Result<CSW, ArmError> {
-        #[allow(clippy::assertions_on_constants)]
-        const {
-            assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS)
-        };
+        const { assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS) };
         self.csw = probe.read_ap_register(self)?;
         Ok(self.csw)
     }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_axi3_axi4.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_axi3_axi4.rs
@@ -44,10 +44,7 @@ impl super::MemoryApType for AmbaAxi3Axi4 {
     type CSW = CSW;
 
     fn status<P: ApAccess + ?Sized>(&mut self, probe: &mut P) -> Result<CSW, ArmError> {
-        #[allow(clippy::assertions_on_constants)]
-        const {
-            assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS)
-        };
+        const { assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS) };
         self.csw = probe.read_ap_register(self)?;
         Ok(self.csw)
     }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_axi5.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_axi5.rs
@@ -44,10 +44,7 @@ impl super::MemoryApType for AmbaAxi5 {
     type CSW = CSW;
 
     fn status<P: ApAccess + ?Sized>(&mut self, probe: &mut P) -> Result<CSW, ArmError> {
-        #[allow(clippy::assertions_on_constants)]
-        const {
-            assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS)
-        };
+        const { assert!(super::registers::CSW::ADDRESS == CSW::ADDRESS) };
         self.csw = probe.read_ap_register(self)?;
         Ok(self.csw)
     }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -176,7 +176,7 @@ macro_rules! memory_aps {
         })*
 
         impl MemoryAp {
-            pub fn new<I: DapAccess>(
+            pub(crate) fn new<I: DapAccess>(
                 interface: &mut I,
                 address: &FullyQualifiedApAddress,
             ) -> Result<Self, ArmError> {

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -52,14 +52,24 @@ macro_rules! attached_regs_to_mem_ap {
     };
 }
 
+/// Common trait for all memory access ports.
 pub trait MemoryApType:
     ApRegAccess<BASE> + ApRegAccess<BASE2> + ApRegAccess<TAR> + ApRegAccess<TAR2> + ApRegAccess<DRW>
 {
     /// This Memory AP’s specific CSW type.
     type CSW: Register;
 
+    /// Returns whether the Memory AP supports the large address extension.
+    ///
+    /// With the large address extension, the address is 64 bits wide.
     fn has_large_address_extension(&self) -> bool;
+
+    /// Returns whether the Memory AP supports the large data extension.
+    ///
+    /// With the large data extension, the data size can be up to 64 bits wide.
     fn has_large_data_extension(&self) -> bool;
+
+    /// Returns whether the Memory AP only supports 32 bit data size.
     fn supports_only_32bit_data_size(&self) -> bool;
 
     /// Attempts to set the requested data size.
@@ -102,6 +112,10 @@ pub trait MemoryApType:
         Ok(base_address)
     }
 
+    /// Set the target address for the next access.
+    ///
+    /// This writes the TAR register, and optionally TAR2 register if the address is larger than 32 bits,
+    /// and the large address extension is supported.
     fn set_target_address<I: ApAccess>(
         &mut self,
         interface: &mut I,
@@ -163,10 +177,19 @@ pub trait MemoryApType:
 }
 
 macro_rules! memory_aps {
-    ($($variant:ident => $type:path),*) => {
+    (
+        $(
+            $(#[$outer:meta])*
+            $variant:ident => $type:path
+        ),*
+    ) => {
+        /// Sum type for all memory access ports.
         #[derive(Debug)]
         pub enum MemoryAp {
-            $($variant($type)),*
+            $(
+                $(#[$outer])*
+                $variant($type)
+            ),*
         }
 
         $(impl From<$type> for MemoryAp {
@@ -196,12 +219,19 @@ macro_rules! memory_aps {
 }
 
 memory_aps! {
+    /// AHB3 memory access port.
     AmbaAhb3 => amba_ahb3::AmbaAhb3,
+    /// AHB5 memory access port.
     AmbaAhb5 => amba_ahb5::AmbaAhb5,
+    /// AHB5 memory access port with enhanced HPROT control.
     AmbaAhb5Hprot => amba_ahb5_hprot::AmbaAhb5Hprot,
+    /// APB2 or APB3 memory access port.
     AmbaApb2Apb3 => amba_apb2_apb3::AmbaApb2Apb3,
+    /// APB4 or APB5 memory access port.
     AmbaApb4Apb5 => amba_apb4_apb5::AmbaApb4Apb5,
+    /// AXI3 or AXI4 memory access port.
     AmbaAxi3Axi4 => amba_axi3_axi4::AmbaAxi3Axi4,
+    /// AXI5 memory access port
     AmbaAxi5 => amba_axi5::AmbaAxi5
 }
 

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -5,6 +5,9 @@ pub mod register_generation;
 pub(crate) mod generic_ap;
 pub(crate) mod memory_ap;
 
+pub use memory_ap::MemoryAp;
+pub use memory_ap::MemoryApType;
+
 use crate::architecture::arm::dp::DebugPortError;
 use crate::probe::DebugProbeError;
 
@@ -145,8 +148,9 @@ impl<T: DapAccess> ApAccess for T {
         PORT: AccessPortType + ApRegAccess<R> + ?Sized,
         R: Register,
     {
-        tracing::debug!("Writing register {}, value={:x?}", R::NAME, register);
+        tracing::debug!("Writing AP register {}, value={:x?}", R::NAME, register);
         self.write_raw_ap_register(port.ap_address(), R::ADDRESS, register.into())
+            .inspect_err(|err| tracing::warn!("Failed to write AP register {}: {}", R::NAME, err))
     }
 
     fn write_ap_register_repeated<PORT, R>(

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -872,7 +872,7 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
         dp: DpAddress,
     ) -> Result<(), ArmError> {
         // Time guard for DPIDR register to become readable after line reset
-        const RESET_RECOVERY_TIMEOUT: Duration = Duration::from_secs(1);
+        const RESET_RECOVERY_TIMEOUT: Duration = Duration::from_secs(0);
         const RESET_RECOVERY_RETRY_INTERVAL: Duration = Duration::from_millis(5);
         match interface.active_protocol() {
             Some(WireProtocol::Jtag) => {

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -872,7 +872,7 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
         dp: DpAddress,
     ) -> Result<(), ArmError> {
         // Time guard for DPIDR register to become readable after line reset
-        const RESET_RECOVERY_TIMEOUT: Duration = Duration::from_secs(0);
+        const RESET_RECOVERY_TIMEOUT: Duration = Duration::from_secs(1);
         const RESET_RECOVERY_RETRY_INTERVAL: Duration = Duration::from_millis(5);
         match interface.active_protocol() {
             Some(WireProtocol::Jtag) => {


### PR DESCRIPTION
This seems to have changed at some point, version 0.24.0 had that check.

Might be useful to have this check at a more general place, this is not only an issue for the `info` command.