### PR TITLE
Cleanup ArmMemoryInterface and ROM table search

### DIFF
--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb3.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb3.rs
@@ -99,7 +99,7 @@ impl AccessPortType for AmbaAhb3 {
 
 impl ApRegAccess<CSW> for AmbaAhb3 {}
 
-crate::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAhb3);
+super::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAhb3);
 
 define_ap_register!(
     /// Control and Status Word register

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5.rs
@@ -98,7 +98,7 @@ impl AccessPortType for AmbaAhb5 {
 
 impl ApRegAccess<CSW> for AmbaAhb5 {}
 
-crate::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAhb5);
+super::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAhb5);
 
 define_ap_register!(
     /// Control and Status Word register

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5_hprot.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_ahb5_hprot.rs
@@ -99,7 +99,7 @@ impl AccessPortType for AmbaAhb5Hprot {
 
 impl ApRegAccess<CSW> for AmbaAhb5Hprot {}
 
-crate::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAhb5Hprot);
+super::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAhb5Hprot);
 
 define_ap_register!(
     /// Control and Status Word register

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_apb2_apb3.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_apb2_apb3.rs
@@ -84,7 +84,7 @@ impl AccessPortType for AmbaApb2Apb3 {
 
 impl ApRegAccess<CSW> for AmbaApb2Apb3 {}
 
-crate::attached_regs_to_mem_ap!(memory_ap_regs => AmbaApb2Apb3);
+super::attached_regs_to_mem_ap!(memory_ap_regs => AmbaApb2Apb3);
 
 define_ap_register!(
     /// Control and Status Word register

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_apb4_apb5.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_apb4_apb5.rs
@@ -82,7 +82,7 @@ impl AccessPortType for AmbaApb4Apb5 {
 
 impl ApRegAccess<CSW> for AmbaApb4Apb5 {}
 
-crate::attached_regs_to_mem_ap!(memory_ap_regs => AmbaApb4Apb5);
+super::attached_regs_to_mem_ap!(memory_ap_regs => AmbaApb4Apb5);
 
 define_ap_register!(
     /// Control and Status Word register

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_axi3_axi4.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_axi3_axi4.rs
@@ -95,7 +95,7 @@ impl AccessPortType for AmbaAxi3Axi4 {
 
 impl ApRegAccess<CSW> for AmbaAxi3Axi4 {}
 
-crate::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAxi3Axi4);
+super::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAxi3Axi4);
 
 define_ap_register!(
     /// Control and Status Word register

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_axi5.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_axi5.rs
@@ -95,7 +95,7 @@ impl AccessPortType for AmbaAxi5 {
 
 impl ApRegAccess<CSW> for AmbaAxi5 {}
 
-crate::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAxi5);
+super::attached_regs_to_mem_ap!(memory_ap_regs => AmbaAxi5);
 
 define_ap_register!(
     /// Control and Status Word register

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -25,7 +25,6 @@ use crate::architecture::arm::{ArmError, DapAccess, FullyQualifiedApAddress, Reg
 /// - `mod_name` is a module name in which the impl an the required use will be expanded to.
 /// - `ApName` a type name that must be available in the current scope to which the registers will
 ///   be attached.
-#[macro_export]
 macro_rules! attached_regs_to_mem_ap {
     ($mod_name:ident => $name:ident) => {
         mod $mod_name {
@@ -51,6 +50,9 @@ macro_rules! attached_regs_to_mem_ap {
         }
     };
 }
+
+// Re-export the macro so that it can be used in this crate.
+pub(crate) use attached_regs_to_mem_ap;
 
 /// Common trait for all memory access ports.
 pub trait MemoryApType:

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -2,7 +2,7 @@ use crate::{
     architecture::arm::{
         ap::valid_access_ports_allowlist,
         dp::{
-            Abort, Ctrl, DebugPortError, DebugPortId, DebugPortVersion, DpAccess, Select, BASEPTR0,
+            Ctrl, DebugPortError, DebugPortId, DebugPortVersion, DpAccess, Select, BASEPTR0,
             BASEPTR1, DPIDR, DPIDR1,
         },
         memory::{adi_v5_memory_interface::ADIMemoryInterface, ArmMemoryInterface, Component},

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -6,7 +6,7 @@ use crate::{
             memory_ap::{DataSize, MemoryAp, MemoryApType},
             ApAccess,
         },
-        communication_interface::{FlushableArmAccess, Initialized, SwdSequence},
+        communication_interface::{FlushableArmAccess, Initialized},
         dp::DpAccess,
         memory::ArmMemoryInterface,
         ArmCommunicationInterface, ArmError, DapAccess, FullyQualifiedApAddress,
@@ -47,26 +47,6 @@ where
 }
 
 impl<APA> ADIMemoryInterface<'_, APA> where APA: ApAccess {}
-
-impl<APA> SwdSequence for ADIMemoryInterface<'_, APA>
-where
-    Self: ArmMemoryInterface,
-{
-    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError> {
-        self.get_arm_communication_interface()?
-            .swj_sequence(bit_len, bits)
-    }
-
-    fn swj_pins(
-        &mut self,
-        pin_out: u32,
-        pin_select: u32,
-        pin_wait: u32,
-    ) -> Result<u32, DebugProbeError> {
-        self.get_arm_communication_interface()?
-            .swj_pins(pin_out, pin_select, pin_wait)
-    }
-}
 
 impl<AP> MemoryInterface<ArmError> for ADIMemoryInterface<'_, AP>
 where

--- a/probe-rs/src/architecture/arm/memory/mod.rs
+++ b/probe-rs/src/architecture/arm/memory/mod.rs
@@ -6,14 +6,13 @@ pub mod romtable;
 use crate::{memory::MemoryInterface, probe::DebugProbeError, CoreStatus};
 
 use super::{
-    ap::memory_ap::MemoryAp,
-    communication_interface::{Initialized, SwdSequence},
-    ArmCommunicationInterface, ArmError,
+    ap::memory_ap::MemoryAp, communication_interface::Initialized, ArmCommunicationInterface,
+    ArmError,
 };
 pub use romtable::{Component, ComponentId, CoresightComponent, PeripheralType};
 
 /// An ArmMemoryInterface (ArmProbeInterface + MemoryAp)
-pub trait ArmMemoryInterface: SwdSequence + ArmMemoryInterfaceShim {
+pub trait ArmMemoryInterface: ArmMemoryInterfaceShim {
     /// The underlying MemoryAp.
     fn ap(&mut self) -> &mut MemoryAp;
 

--- a/probe-rs/src/probe/blackmagic/arm.rs
+++ b/probe-rs/src/probe/blackmagic/arm.rs
@@ -3,13 +3,13 @@ use crate::architecture::arm::ap::memory_ap::{DataSize, MemoryAp, MemoryApType};
 use crate::architecture::arm::ap::valid_access_ports;
 use crate::architecture::arm::communication_interface::{Initialized, SwdSequence};
 use crate::architecture::arm::dp::{Abort, Ctrl, DebugPortError, DpAccess, Select};
-use crate::architecture::arm::memory::{ArmMemoryInterface, Component};
+use crate::architecture::arm::memory::ArmMemoryInterface;
 use crate::architecture::arm::{
     communication_interface::UninitializedArmProbe, sequences::ArmDebugSequence, ArmProbeInterface,
 };
 use crate::architecture::arm::{
-    ArmChipInfo, ArmCommunicationInterface, ArmError, DapAccess, DpAddress,
-    FullyQualifiedApAddress, RawDapAccess, SwoAccess,
+    ArmCommunicationInterface, ArmError, DapAccess, DpAddress, FullyQualifiedApAddress,
+    RawDapAccess, SwoAccess,
 };
 use crate::probe::blackmagic::{Align, BlackMagicProbe, ProtocolVersion, RemoteCommand};
 use crate::probe::{DebugProbeError, Probe};
@@ -322,33 +322,6 @@ impl ArmProbeInterface for BlackMagicProbeArmDebug {
             apsel: 0,
             csw: csw.into(),
         }) as _)
-    }
-
-    fn read_chip_info_from_rom_table(
-        &mut self,
-        dp: DpAddress,
-    ) -> Result<Option<crate::architecture::arm::ArmChipInfo>, ArmError> {
-        if dp != DpAddress::Default {
-            return Err(ArmError::NotImplemented("multidrop not yet implemented"));
-        }
-
-        for ap in self.access_ports.clone() {
-            if let Ok(mut memory) = self.memory_interface(&ap) {
-                let base_address = memory.base_address()?;
-                let component = Component::try_parse(&mut *memory, base_address)?;
-
-                if let Component::Class1RomTable(component_id, _) = component {
-                    if let Some(jep106) = component_id.peripheral_id().jep106() {
-                        return Ok(Some(ArmChipInfo {
-                            manufacturer: jep106,
-                            part: component_id.peripheral_id().part(),
-                        }));
-                    }
-                }
-            }
-        }
-
-        Ok(None)
     }
 }
 

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -533,13 +533,6 @@ impl ArmProbeInterface for FakeArmInterface<Initialized> {
         Ok(BTreeSet::from([FullyQualifiedApAddress::v1_with_dp(dp, 1)]))
     }
 
-    fn read_chip_info_from_rom_table(
-        &mut self,
-        _dp: DpAddress,
-    ) -> Result<Option<crate::architecture::arm::ArmChipInfo>, ArmError> {
-        Ok(None)
-    }
-
     fn close(self: Box<Self>) -> Probe {
         Probe::from_attached_probe(self.probe)
     }

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -13,10 +13,10 @@ use crate::{
         communication_interface::{
             ArmProbeInterface, Initialized, SwdSequence, UninitializedArmProbe,
         },
-        memory::{ArmMemoryInterface, Component},
+        memory::ArmMemoryInterface,
         sequences::ArmDebugSequence,
-        valid_32bit_arm_address, ArmChipInfo, ArmError, DapAccess, DpAddress,
-        FullyQualifiedApAddress, Pins, SwoAccess, SwoConfig, SwoMode,
+        valid_32bit_arm_address, ArmError, DapAccess, DpAddress, FullyQualifiedApAddress, Pins,
+        SwoAccess, SwoConfig, SwoMode,
     },
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, Probe, ProbeError,
@@ -1435,31 +1435,6 @@ impl ArmProbeInterface for StlinkArmDebug {
         };
 
         Ok(Box::new(interface) as _)
-    }
-
-    fn read_chip_info_from_rom_table(
-        &mut self,
-        dp: DpAddress,
-    ) -> Result<Option<crate::architecture::arm::ArmChipInfo>, ArmError> {
-        self.select_dp(dp)?;
-
-        for ap in self.access_ports.clone() {
-            if let Ok(mut memory) = self.memory_interface(&ap) {
-                let base_address = memory.base_address()?;
-                let component = Component::try_parse(&mut *memory, base_address)?;
-
-                if let Component::Class1RomTable(component_id, _) = component {
-                    if let Some(jep106) = component_id.peripheral_id().jep106() {
-                        return Ok(Some(ArmChipInfo {
-                            manufacturer: jep106,
-                            part: component_id.peripheral_id().part(),
-                        }));
-                    }
-                }
-            }
-        }
-
-        Ok(None)
     }
 
     fn access_ports(

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -248,10 +248,10 @@ impl Session {
                 let reset_hardware_deassert =
                     tracing::debug_span!("reset_hardware_deassert").entered();
 
-                let mut memory_interface = interface.memory_interface(&default_memory_ap)?;
-
                 // A timeout here indicates that the reset pin is probably not properly connected.
-                if let Err(e) = sequence_handle.reset_hardware_deassert(&mut *memory_interface) {
+                if let Err(e) =
+                    sequence_handle.reset_hardware_deassert(&mut *interface, &default_memory_ap)
+                {
                     if matches!(e, ArmError::Timeout) {
                         tracing::warn!("Timeout while deasserting hardware reset pin. This indicates that the reset pin is not properly connected. Please check your hardware setup.");
                     }

--- a/probe-rs/src/vendor/mod.rs
+++ b/probe-rs/src/vendor/mod.rs
@@ -7,7 +7,10 @@ use probe_rs_target::Chip;
 
 use crate::{
     architecture::{
-        arm::{sequences::DefaultArmSequence, ArmChipInfo, ArmProbeInterface, DpAddress},
+        arm::{
+            communication_interface::read_chip_info_from_rom_table, sequences::DefaultArmSequence,
+            ArmChipInfo, ArmProbeInterface, DpAddress,
+        },
         riscv::communication_interface::RiscvCommunicationInterface,
         xtensa::communication_interface::{
             XtensaCommunicationInterface, XtensaDebugInterfaceState,
@@ -129,8 +132,7 @@ fn try_detect_arm_chip(mut probe: Probe) -> Result<(Probe, Option<Target>), Erro
                         }
                     };
 
-                let found_arm_chip = interface
-                    .read_chip_info_from_rom_table(dp_address)
+                let found_arm_chip = read_chip_info_from_rom_table(interface.as_mut(), dp_address)
                     .unwrap_or_else(|error| {
                         tracing::debug!("Error during ARM chip detection: {error}");
                         None

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
@@ -15,7 +15,8 @@ use crate::{
         dp::{Abort, Ctrl, DpAccess, Select, DPIDR},
         memory::ArmMemoryInterface,
         sequences::ArmDebugSequence,
-        ArmCommunicationInterface, ArmError, DapAccess, DpAddress, FullyQualifiedApAddress, Pins,
+        ArmCommunicationInterface, ArmError, ArmProbeInterface, DapAccess, DpAddress,
+        FullyQualifiedApAddress, Pins,
     },
     core::MemoryMappedRegister,
 };
@@ -684,7 +685,11 @@ impl ArmDebugSequence for MIMXRT5xxS {
         self.wait_for_stop_after_reset(probe)
     }
 
-    fn reset_hardware_deassert(&self, memory: &mut dyn ArmMemoryInterface) -> Result<(), ArmError> {
+    fn reset_hardware_deassert(
+        &self,
+        memory: &mut dyn ArmProbeInterface,
+        _default_ap: &FullyQualifiedApAddress,
+    ) -> Result<(), ArmError> {
         tracing::trace!("MIMXRT5xxS reset hardware deassert");
         let n_reset = Pins(0x80).0 as u32;
 


### PR DESCRIPTION
- Remove the need for `ArmMemoryInterface` to implement `SwdSequence`, the sequences using it now just create a memory interface, if they need one
- read_chip_info_from_rom_table seems to be doing the same for all the probes, so one implementation of it should be enough.