### PR TITLE
Added extra checks for RTT control block integrity

### DIFF
--- a/changelog/added-extra-rtt-check.md
+++ b/changelog/added-extra-rtt-check.md
@@ -1,0 +1,1 @@
+added extra checks for RTT control block integrity so partially trashed blocks are now more likely to be rejected as corrupted

--- a/probe-rs/src/rtt/channel.rs
+++ b/probe-rs/src/rtt/channel.rs
@@ -309,6 +309,19 @@ impl Channel {
                 )));
             }
 
+            let name_in_memory_region = core
+                .target()
+                .memory_map
+                .iter()
+                .any(|mr| mr.contains(self.info.standard_name_pointer()));
+
+            if !name_in_memory_region {
+                return Err(Error::ControlBlockCorrupted(format!(
+                    "the {which} buffer name pointer doesn't point to valid memory: (pointer: {:#X})",
+                    self.info.standard_name_pointer(),
+                )));
+            }
+
             Ok(())
         };
 


### PR DESCRIPTION
Added extra checks for RTT control block integrity so partially trashed blocks are now more likely to be rejected as corrupted.

Fixes #2969 

This was a fun one to figure out! Learned a lot about the flashing parts of probe-rs.
It was a coincidence that 0.24 worked. Here's the rundown:

- Device had already run and so has an RTT block at 0x2000_0000
- Target yaml specifies a load_address of 0x2000_0020
- Flash header and instructions are written to RAM
  - In 0.24 arm flash header was 32 bytes and was thus put at 0x2000_0000
  - In 0.25 arm flash header is 4 bytes and was thus put at 0x2000_001C
- Flashing process is done and the chip is rebooted into its new firmware
- RTT is trying to be attached to
- The U0 is a slow chip. RTT attach is before the device has set up RTT
  - In 0.24 probe-rs couldn't find a valid RTT block since it was fully overwritten
  - In 0.25 probe-rs does find a valid RTT block since it was not fully overwritten
    - The attach proceeds, but there are a couple of checks
    - 0x2000_0000: block name is correct: `SEGGER RTT`
    - 0x2000_0010: up buffer count is 1, which is correct
    - 0x2000_0014: down buffer count is 0, which is correct
    - 0x2000_0018: Pointer to up channel 1 name is not checked (but correct)
    - 0x2000_001C: Pointer to up channel 1 buffer is not checked **and not correct!**
      - It contains 0xBE00BE00 which is the machine code for two `BKPT` instructions, placed there as the flash header
    - After attaching is complete, the buffer is read at the pointer location, but that's not a valid address so things come crashing down

This PR adds a check for the channels to see if their name pointer and buffers point to valid memory.

The explanation I have for the slower swd speed working is that the device then has just enough time to initialize the RTT block.