### PR TITLE
Clear sticky error after SWD fault

### DIFF
--- a/changelog/fixed-adi-sticky-err.md
+++ b/changelog/fixed-adi-sticky-err.md
@@ -1,0 +1,1 @@
+ARM Debug interface: Clear sticky error bits after failed block transfers, so that future transfers can succeed.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -8,7 +8,7 @@ use probe_rs::{
             ap::{ApClass, MemoryApType},
             armv6m::Demcr,
             component::Scs,
-            dp::{DebugPortId, DebugPortVersion, MinDpSupport, DLPIDR, DPIDR, TARGETID},
+            dp::{Ctrl, DebugPortId, DebugPortVersion, MinDpSupport, DLPIDR, DPIDR, TARGETID},
             memory::{
                 romtable::{PeripheralID, RomTable},
                 Component, ComponentId, CoresightComponent, PeripheralType,
@@ -281,6 +281,11 @@ fn show_arm_info(interface: &mut dyn ArmProbeInterface, dp: DpAddress) -> Result
         let instance = dlpidr.tinstance();
 
         write!(dp_node, ", Instance: {:#04x}", instance)?;
+
+        // Read from the CTRL/STAT register, to ensure that the dpbanksel field is set to zero.
+        // This helps with error handling later, because it means the CTRL/AP register can be
+        // read in case of an error.
+        let _ = interface.read_raw_dp_register(dp, Ctrl::ADDRESS)?;
     } else {
         write!(
             dp_node,


### PR DESCRIPTION
We didn't clean the sticky error bit after all failing SWD transfers, which meant that the code basically got stuck in state where all future transactions failed.

This PR adds cleanup for the bit-banging code for the ARM Debug Interface.