### PR TITLE
Rename psel to targetsel, make it optional

### DIFF
--- a/changelog/changed-rename-psel-to-target-id.md
+++ b/changelog/changed-rename-psel-to-target-id.md
@@ -1,0 +1,2 @@
+Rename `psel` to `targetid` in the target definition for chips using the ARM debug interface,
+and make it optional. This makes it clearer what the use of this field is.

--- a/changelog/changed-rename-psel-to-target-id.md
+++ b/changelog/changed-rename-psel-to-target-id.md
@@ -1,2 +1,0 @@
-Rename `psel` to `targetid` in the target definition for chips using the ARM debug interface,
-and make it optional. This makes it clearer what the use of this field is.

--- a/changelog/changed-rename-psel-to-targetsel.md
+++ b/changelog/changed-rename-psel-to-targetsel.md
@@ -1,0 +1,2 @@
+Rename `psel` to `targetsel` in the target definition for chips using the ARM debug interface,
+and make it optional. This makes it clearer what the use of this field is.

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -1,10 +1,7 @@
 use std::collections::HashMap;
 
 use super::memory::MemoryRegion;
-use crate::{
-    serialize::{hex_option, hex_u_int},
-    CoreType,
-};
+use crate::{serialize::hex_option, CoreType};
 use serde::{Deserialize, Serialize};
 
 /// Represents a DAP scan chain element.
@@ -169,9 +166,9 @@ pub enum CoreAccessOptions {
 pub struct ArmCoreAccessOptions {
     /// The access port number to access the core
     pub ap: u8,
-    /// The port select number to access the core
-    #[serde(serialize_with = "hex_u_int")]
-    pub psel: u32,
+    /// The TARGETSEL value used to access the core
+    #[serde(serialize_with = "hex_option")]
+    pub targetsel: Option<u32>,
     /// The base address of the debug registers for the core.
     /// Required for Cortex-A, optional for Cortex-M
     #[serde(serialize_with = "hex_option")]

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -276,9 +276,9 @@ impl CoreExt for Core {
         match &self.core_access_options {
             probe_rs_target::CoreAccessOptions::Arm(options) => {
                 Some(FullyQualifiedApAddress::v1_with_dp(
-                    match options.psel {
-                        0 => DpAddress::Default,
-                        x => DpAddress::Multidrop(x),
+                    match options.targetsel {
+                        None => DpAddress::Default,
+                        Some(x) => DpAddress::Multidrop(x),
                     },
                     options.ap,
                 ))

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -256,9 +256,9 @@ impl CoreState {
             );
         };
 
-        let dp = match options.psel {
-            0 => DpAddress::Default,
-            x => DpAddress::Multidrop(x),
+        let dp = match options.targetsel {
+            None => DpAddress::Default,
+            Some(x) => DpAddress::Multidrop(x),
         };
 
         FullyQualifiedApAddress::v1_with_dp(dp, options.ap)

--- a/probe-rs/targets/ADuCM302x_Series.yaml
+++ b/probe-rs/targets/ADuCM302x_Series.yaml
@@ -11,7 +11,7 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: IROM1
@@ -45,7 +45,7 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/AIR001_Series.yaml
+++ b/probe-rs/targets/AIR001_Series.yaml
@@ -8,7 +8,7 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/AIR32F1_Series.yaml
+++ b/probe-rs/targets/AIR32F1_Series.yaml
@@ -8,7 +8,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -34,7 +33,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -60,7 +58,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -86,7 +83,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -112,7 +108,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/AT32F4_Series.yaml
+++ b/probe-rs/targets/AT32F4_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -42,7 +41,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -73,7 +71,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -104,7 +101,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -135,7 +131,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -166,7 +161,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -197,7 +191,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -228,7 +221,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -259,7 +251,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -290,7 +281,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -321,7 +311,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -352,7 +341,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -383,7 +371,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -411,7 +398,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -439,7 +425,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -467,7 +452,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -495,7 +479,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -523,7 +506,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -551,7 +533,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -579,7 +560,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -607,7 +587,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -635,7 +614,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -663,7 +641,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -691,7 +668,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -719,7 +695,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -747,7 +722,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -775,7 +749,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -803,7 +776,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -831,7 +803,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -859,7 +830,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -887,7 +857,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -915,7 +884,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -943,7 +911,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -972,7 +939,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1001,7 +967,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1030,7 +995,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1059,7 +1023,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1088,7 +1051,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1117,7 +1079,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1146,7 +1107,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1175,7 +1135,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1204,7 +1163,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1233,7 +1191,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1262,7 +1219,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1291,7 +1247,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1320,7 +1275,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1349,7 +1303,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1378,7 +1331,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1409,7 +1361,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1440,7 +1391,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1471,7 +1421,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1502,7 +1451,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1533,7 +1481,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1564,7 +1511,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1595,7 +1541,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1626,7 +1571,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1657,7 +1601,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1688,7 +1631,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1719,7 +1661,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1750,7 +1691,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1781,7 +1721,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1812,7 +1751,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1843,7 +1781,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1874,7 +1811,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1905,7 +1841,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1936,7 +1871,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1967,7 +1901,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1998,7 +1931,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2045,7 +1977,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2092,7 +2023,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2139,7 +2069,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2186,7 +2115,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2233,7 +2161,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2280,7 +2207,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2327,7 +2253,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2374,7 +2299,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2421,7 +2345,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2468,7 +2391,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2515,7 +2437,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2543,7 +2464,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2571,7 +2491,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2599,7 +2518,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2627,7 +2545,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2655,7 +2572,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2683,7 +2599,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2711,7 +2626,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2739,7 +2653,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2767,7 +2680,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2795,7 +2707,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2823,7 +2734,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2851,7 +2761,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2879,7 +2788,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2907,7 +2815,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2935,7 +2842,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2963,7 +2869,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2991,7 +2896,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3019,7 +2923,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3047,7 +2950,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3075,7 +2977,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3103,7 +3004,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3131,7 +3031,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3159,7 +3058,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3187,7 +3085,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3215,7 +3112,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3243,7 +3139,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3271,7 +3166,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3299,7 +3193,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3327,7 +3220,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3355,7 +3247,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3383,7 +3274,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3411,7 +3301,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3439,7 +3328,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3467,7 +3355,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3495,7 +3382,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3523,7 +3409,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3551,7 +3436,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3579,7 +3463,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3607,7 +3490,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3635,7 +3517,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3663,7 +3544,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3691,7 +3571,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3719,7 +3598,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3747,7 +3625,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3775,7 +3652,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3803,7 +3679,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3831,7 +3706,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3859,7 +3733,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3887,7 +3760,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3915,7 +3787,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3943,7 +3814,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3971,7 +3841,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3999,7 +3868,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4027,7 +3895,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4055,7 +3922,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4083,7 +3949,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4111,7 +3976,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4139,7 +4003,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4167,7 +4030,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4195,7 +4057,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4223,7 +4084,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4251,7 +4111,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4279,7 +4138,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4307,7 +4165,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4335,7 +4192,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4363,7 +4219,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4391,7 +4246,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4419,7 +4273,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4447,7 +4300,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4475,7 +4327,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4503,7 +4354,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4531,7 +4381,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4559,7 +4408,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4587,7 +4435,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4615,7 +4462,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4643,7 +4489,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4670,7 +4515,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4697,7 +4541,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4724,7 +4567,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4751,7 +4593,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4778,7 +4619,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4805,7 +4645,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4832,7 +4671,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4859,7 +4697,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4886,7 +4723,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4913,7 +4749,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4940,7 +4775,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4967,7 +4801,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4994,7 +4827,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5021,7 +4853,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5048,7 +4879,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5075,7 +4905,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5102,7 +4931,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5129,7 +4957,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5156,7 +4983,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5183,7 +5009,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5210,7 +5035,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5237,7 +5061,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5264,7 +5087,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5291,7 +5113,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5318,7 +5139,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5345,7 +5165,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5372,7 +5191,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5399,7 +5217,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5426,7 +5243,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5453,7 +5269,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5480,7 +5295,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5507,7 +5321,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/BCM2711.yaml
+++ b/probe-rs/targets/BCM2711.yaml
@@ -9,28 +9,24 @@ variants:
     type: armv8a
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
       debug_base: 0x80410000
       cti_base: 0x80420000
   - name: core1
     type: armv8a
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
       debug_base: 0x80510000
       cti_base: 0x80520000
   - name: core2
     type: armv8a
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
       debug_base: 0x80610000
       cti_base: 0x80620000
   - name: core3
     type: armv8a
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
       debug_base: 0x80710000
       cti_base: 0x80720000
   memory_map:

--- a/probe-rs/targets/BCM2712.yaml
+++ b/probe-rs/targets/BCM2712.yaml
@@ -9,28 +9,24 @@ variants:
     type: armv8a
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
       debug_base: 0x80010000
       cti_base: 0x80020000
   - name: core1
     type: armv8a
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
       debug_base: 0x80110000
       cti_base: 0x80120000
   - name: core2
     type: armv8a
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
       debug_base: 0x80210000
       cti_base: 0x80220000
   - name: core3
     type: armv8a
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
       debug_base: 0x80310000
       cti_base: 0x80320000
   memory_map:

--- a/probe-rs/targets/CC13XX_CC26XX_Series.yaml
+++ b/probe-rs/targets/CC13XX_CC26XX_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -39,7 +38,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -69,7 +67,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -99,7 +96,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -129,7 +125,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -159,7 +154,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -189,7 +183,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -219,7 +212,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -256,7 +248,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -293,7 +284,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -330,7 +320,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -367,7 +356,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFM32GG11B_Series.yaml
+++ b/probe-rs/targets/EFM32GG11B_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -37,7 +36,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -63,7 +61,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -89,7 +86,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -115,7 +111,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -141,7 +136,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -167,7 +161,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -193,7 +186,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -219,7 +211,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -245,7 +236,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -271,7 +261,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -297,7 +286,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -323,7 +311,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -349,7 +336,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -375,7 +361,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -401,7 +386,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -427,7 +411,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -453,7 +436,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -479,7 +461,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -505,7 +486,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -531,7 +511,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -557,7 +536,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -583,7 +561,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -609,7 +586,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -635,7 +611,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -661,7 +636,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -687,7 +661,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -713,7 +686,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -739,7 +711,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -765,7 +736,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -791,7 +761,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -817,7 +786,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -843,7 +811,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -869,7 +836,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -895,7 +861,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -921,7 +886,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -947,7 +911,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -973,7 +936,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -999,7 +961,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1025,7 +986,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1051,7 +1011,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1077,7 +1036,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1103,7 +1061,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1129,7 +1086,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1155,7 +1111,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1181,7 +1136,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1207,7 +1161,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1233,7 +1186,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1259,7 +1211,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1285,7 +1236,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1311,7 +1261,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1337,7 +1286,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1363,7 +1311,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1389,7 +1336,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1415,7 +1361,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1441,7 +1386,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1467,7 +1411,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1493,7 +1436,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1519,7 +1461,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1545,7 +1486,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/EFM32HG_Series.yaml
+++ b/probe-rs/targets/EFM32HG_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -37,7 +36,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -63,7 +61,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -89,7 +86,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -115,7 +111,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -141,7 +136,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -167,7 +161,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -193,7 +186,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -219,7 +211,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -245,7 +236,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -271,7 +261,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -297,7 +286,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -323,7 +311,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -349,7 +336,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -375,7 +361,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -401,7 +386,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -427,7 +411,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -453,7 +436,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -479,7 +461,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -505,7 +486,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/EFM32PG12B_Series.yaml
+++ b/probe-rs/targets/EFM32PG12B_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFM32PG1B_Series.yaml
+++ b/probe-rs/targets/EFM32PG1B_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -37,7 +36,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -63,7 +61,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -89,7 +86,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -115,7 +111,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -141,7 +136,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -167,7 +161,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -193,7 +186,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -219,7 +211,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -245,7 +236,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -271,7 +261,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/EFM32PG22_Series.yaml
+++ b/probe-rs/targets/EFM32PG22_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -37,7 +36,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -63,7 +61,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -89,7 +86,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -115,7 +111,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -141,7 +136,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -167,7 +161,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -193,7 +186,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/EFM32TG11B_Series.yaml
+++ b/probe-rs/targets/EFM32TG11B_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -37,7 +36,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -63,7 +61,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -89,7 +86,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -115,7 +111,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -141,7 +136,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -167,7 +161,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -193,7 +186,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -219,7 +211,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -245,7 +236,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -271,7 +261,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -297,7 +286,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -323,7 +311,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -349,7 +336,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -375,7 +361,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -401,7 +386,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -427,7 +411,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -453,7 +436,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -479,7 +461,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -505,7 +486,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -531,7 +511,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -557,7 +536,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -583,7 +561,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -609,7 +586,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -635,7 +611,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -661,7 +636,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -687,7 +661,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -713,7 +686,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -739,7 +711,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -765,7 +736,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -791,7 +761,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -817,7 +786,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -843,7 +811,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -869,7 +836,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -895,7 +861,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -921,7 +886,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -947,7 +911,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -973,7 +936,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -999,7 +961,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1025,7 +986,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1051,7 +1011,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1077,7 +1036,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1103,7 +1061,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1129,7 +1086,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1155,7 +1111,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1181,7 +1136,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1207,7 +1161,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1233,7 +1186,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1259,7 +1211,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1285,7 +1236,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1311,7 +1261,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1337,7 +1286,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/EFR32BG12P_Series.yaml
+++ b/probe-rs/targets/EFR32BG12P_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -105,7 +101,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -129,7 +124,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32BG13P_Series.yaml
+++ b/probe-rs/targets/EFR32BG13P_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32BG14P_Series.yaml
+++ b/probe-rs/targets/EFR32BG14P_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32BG1P_Series.yaml
+++ b/probe-rs/targets/EFR32BG1P_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32BG21_Series.yaml
+++ b/probe-rs/targets/EFR32BG21_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -105,7 +101,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -129,7 +124,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -153,7 +147,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -177,7 +170,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -201,7 +193,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -225,7 +216,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -249,7 +239,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -273,7 +262,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32BG22_Series.yaml
+++ b/probe-rs/targets/EFR32BG22_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32FG12P_Series.yaml
+++ b/probe-rs/targets/EFR32FG12P_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -105,7 +101,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -129,7 +124,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -153,7 +147,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32FG13P_Series.yaml
+++ b/probe-rs/targets/EFR32FG13P_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32FG14P_Series.yaml
+++ b/probe-rs/targets/EFR32FG14P_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -105,7 +101,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -129,7 +124,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32FG14V_Series.yaml
+++ b/probe-rs/targets/EFR32FG14V_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32FG1P_Series.yaml
+++ b/probe-rs/targets/EFR32FG1P_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -105,7 +101,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -129,7 +124,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -153,7 +147,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -177,7 +170,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -201,7 +193,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32FG22_Series.yaml
+++ b/probe-rs/targets/EFR32FG22_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32FG23_Series.yaml
+++ b/probe-rs/targets/EFR32FG23_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -105,7 +101,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -129,7 +124,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -153,7 +147,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -177,7 +170,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -201,7 +193,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -225,7 +216,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32MG12P_Series.yaml
+++ b/probe-rs/targets/EFR32MG12P_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -105,7 +101,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -129,7 +124,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -153,7 +147,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -177,7 +170,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -201,7 +193,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32MG13P_Series.yaml
+++ b/probe-rs/targets/EFR32MG13P_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -105,7 +101,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32MG14P_Series.yaml
+++ b/probe-rs/targets/EFR32MG14P_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32MG1P_Series.yaml
+++ b/probe-rs/targets/EFR32MG1P_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -105,7 +101,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -129,7 +124,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -153,7 +147,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -177,7 +170,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32MG21_Series.yaml
+++ b/probe-rs/targets/EFR32MG21_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -105,7 +101,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -129,7 +124,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -153,7 +147,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -177,7 +170,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -201,7 +193,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -225,7 +216,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -249,7 +239,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -273,7 +262,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -297,7 +285,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/EFR32MG22_Series.yaml
+++ b/probe-rs/targets/EFR32MG22_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/FM3_Series.yaml
+++ b/probe-rs/targets/FM3_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -44,7 +43,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -77,7 +75,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -110,7 +107,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -143,7 +139,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -176,7 +171,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -209,7 +203,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -242,7 +235,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -275,7 +267,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -316,7 +307,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -357,7 +347,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -398,7 +387,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -439,7 +427,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -480,7 +467,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -521,7 +507,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -562,7 +547,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -603,7 +587,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -636,7 +619,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -669,7 +651,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -702,7 +683,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -735,7 +715,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -768,7 +747,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -801,7 +779,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -834,7 +811,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -867,7 +843,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -900,7 +875,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -933,7 +907,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -966,7 +939,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -999,7 +971,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1032,7 +1003,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1065,7 +1035,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1098,7 +1067,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1131,7 +1099,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1164,7 +1131,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1197,7 +1163,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1238,7 +1203,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1279,7 +1243,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1320,7 +1283,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1361,7 +1323,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1402,7 +1363,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1443,7 +1403,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1484,7 +1443,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1525,7 +1483,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1558,7 +1515,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1591,7 +1547,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1624,7 +1579,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1657,7 +1611,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1690,7 +1643,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1723,7 +1675,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1756,7 +1707,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1789,7 +1739,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1822,7 +1771,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1855,7 +1803,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1888,7 +1835,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1921,7 +1867,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1962,7 +1907,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2003,7 +1947,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2044,7 +1987,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2085,7 +2027,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2126,7 +2067,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2167,7 +2107,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2208,7 +2147,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2249,7 +2187,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2282,7 +2219,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2315,7 +2251,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2348,7 +2283,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2381,7 +2315,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2414,7 +2347,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2447,7 +2379,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2480,7 +2411,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2513,7 +2443,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2546,7 +2475,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2579,7 +2507,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2612,7 +2539,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2645,7 +2571,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2678,7 +2603,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2711,7 +2635,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2752,7 +2675,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2793,7 +2715,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2834,7 +2755,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2875,7 +2795,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2916,7 +2835,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2957,7 +2875,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2998,7 +2915,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3039,7 +2955,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3072,7 +2987,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3105,7 +3019,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3138,7 +3051,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3171,7 +3083,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3204,7 +3115,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3237,7 +3147,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3270,7 +3179,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3303,7 +3211,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3336,7 +3243,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3369,7 +3275,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3402,7 +3307,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3435,7 +3339,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3468,7 +3371,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3501,7 +3403,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3534,7 +3435,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3567,7 +3467,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3600,7 +3499,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/GD32C1x3_Series.yaml
+++ b/probe-rs/targets/GD32C1x3_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -38,7 +37,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -65,7 +63,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -92,7 +89,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -119,7 +115,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -146,7 +141,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -173,7 +167,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -200,7 +193,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/GD32E10x_Series.yaml
+++ b/probe-rs/targets/GD32E10x_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -37,7 +36,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -63,7 +61,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -89,7 +86,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -115,7 +111,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -141,7 +136,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -167,7 +161,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -193,7 +186,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/GD32E50x_Series.yaml
+++ b/probe-rs/targets/GD32E50x_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -37,7 +36,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -63,7 +61,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -89,7 +86,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -115,7 +111,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -141,7 +136,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -167,7 +161,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -193,7 +186,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -219,7 +211,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -245,7 +236,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -271,7 +261,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -297,7 +286,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -323,7 +311,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -349,7 +336,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -375,7 +361,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -401,7 +386,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -427,7 +411,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -453,7 +436,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -479,7 +461,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -505,7 +486,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -531,7 +511,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -557,7 +536,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -583,7 +561,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -609,7 +586,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/GD32F10x_Series.yaml
+++ b/probe-rs/targets/GD32F10x_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -38,7 +37,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -65,7 +63,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -92,7 +89,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -119,7 +115,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -146,7 +141,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -173,7 +167,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -200,7 +193,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -227,7 +219,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -254,7 +245,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -281,7 +271,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -308,7 +297,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -335,7 +323,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -362,7 +349,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -389,7 +375,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -416,7 +401,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -443,7 +427,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -470,7 +453,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -497,7 +479,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -524,7 +505,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -551,7 +531,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -578,7 +557,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -605,7 +583,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -632,7 +609,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -659,7 +635,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -686,7 +661,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -713,7 +687,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -740,7 +713,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -767,7 +739,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -794,7 +765,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -821,7 +791,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -848,7 +817,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -875,7 +843,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -902,7 +869,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -929,7 +895,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -956,7 +921,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -983,7 +947,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1010,7 +973,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1037,7 +999,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1064,7 +1025,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1091,7 +1051,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1118,7 +1077,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1145,7 +1103,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1172,7 +1129,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1199,7 +1155,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1226,7 +1181,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1253,7 +1207,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1280,7 +1233,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1307,7 +1259,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1334,7 +1285,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1361,7 +1311,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1388,7 +1337,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1415,7 +1363,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1442,7 +1389,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1469,7 +1415,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1496,7 +1441,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1523,7 +1467,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1550,7 +1493,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1577,7 +1519,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1604,7 +1545,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1631,7 +1571,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1658,7 +1597,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1685,7 +1623,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1712,7 +1649,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1739,7 +1675,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1766,7 +1701,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1793,7 +1727,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1820,7 +1753,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1847,7 +1779,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1874,7 +1805,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1901,7 +1831,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1928,7 +1857,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1955,7 +1883,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1982,7 +1909,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2009,7 +1935,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2036,7 +1961,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2063,7 +1987,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2090,7 +2013,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2117,7 +2039,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2144,7 +2065,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2171,7 +2091,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2198,7 +2117,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2225,7 +2143,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2252,7 +2169,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2279,7 +2195,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2306,7 +2221,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2333,7 +2247,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2360,7 +2273,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2387,7 +2299,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2414,7 +2325,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2441,7 +2351,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2468,7 +2377,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2495,7 +2403,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2522,7 +2429,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2549,7 +2455,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2576,7 +2481,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2603,7 +2507,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2630,7 +2533,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2657,7 +2559,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2684,7 +2585,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2711,7 +2611,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2738,7 +2637,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2765,7 +2663,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2792,7 +2689,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2819,7 +2715,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2846,7 +2741,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/GD32F3x0_Series.yaml
+++ b/probe-rs/targets/GD32F3x0_Series.yaml
@@ -9,12 +9,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -38,12 +36,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -67,12 +63,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -96,12 +90,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -125,12 +117,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -154,12 +144,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -183,12 +171,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -212,12 +198,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -241,12 +225,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -270,12 +252,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -299,12 +279,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -328,12 +306,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -357,12 +333,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -386,12 +360,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -415,12 +387,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -444,12 +414,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -473,12 +441,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -502,12 +468,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -531,12 +495,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -560,12 +522,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -589,12 +549,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -618,12 +576,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -647,12 +603,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -676,12 +630,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -705,12 +657,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -734,12 +684,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -763,12 +711,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -792,12 +738,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -821,12 +765,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -850,12 +792,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -879,12 +819,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -908,12 +846,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -937,12 +873,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -966,12 +900,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -995,12 +927,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -1024,12 +954,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: main
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HC32F005-Series.yaml
+++ b/probe-rs/targets/HC32F005-Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HF5032x_Series.yaml
+++ b/probe-rs/targets/HF5032x_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HK32F030xMxx_Series.yaml
+++ b/probe-rs/targets/HK32F030xMxx_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -39,7 +38,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -67,7 +65,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -94,7 +91,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -122,7 +118,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -150,7 +145,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -178,7 +172,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -206,7 +199,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -234,7 +226,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -262,7 +253,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -289,7 +279,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -317,7 +306,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -345,7 +333,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -372,7 +359,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -400,7 +386,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -428,7 +413,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -455,7 +439,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -483,7 +466,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -511,7 +493,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -539,7 +520,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -567,7 +547,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -595,7 +574,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -623,7 +601,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -651,7 +628,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -679,7 +655,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -707,7 +682,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -734,7 +708,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -762,7 +735,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -790,7 +762,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -818,7 +789,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -846,7 +816,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -874,7 +843,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -902,7 +870,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -930,7 +897,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -958,7 +924,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -986,7 +951,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -1014,7 +978,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -1042,7 +1005,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -1070,7 +1032,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -1098,7 +1059,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -1126,7 +1086,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -1154,7 +1113,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -1182,7 +1140,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -1210,7 +1167,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -1238,7 +1194,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -1266,7 +1221,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -1294,7 +1248,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -1322,7 +1275,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH
@@ -1350,7 +1302,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH

--- a/probe-rs/targets/HT32F0006_Series.yaml
+++ b/probe-rs/targets/HT32F0006_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F0008_Series.yaml
+++ b/probe-rs/targets/HT32F0008_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F123xx_Series.yaml
+++ b/probe-rs/targets/HT32F123xx_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -134,7 +129,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -159,7 +153,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -184,7 +177,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -209,7 +201,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -234,7 +225,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -259,7 +249,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -284,7 +273,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -309,7 +297,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -334,7 +321,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -359,7 +345,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -384,7 +369,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -409,7 +393,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -434,7 +417,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -459,7 +441,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -484,7 +465,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -509,7 +489,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -534,7 +513,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -559,7 +537,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F12xx_Series.yaml
+++ b/probe-rs/targets/HT32F12xx_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F16xx_Series.yaml
+++ b/probe-rs/targets/HT32F16xx_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -134,7 +129,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -159,7 +153,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -184,7 +177,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -209,7 +201,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -234,7 +225,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -259,7 +249,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -284,7 +273,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -309,7 +297,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -334,7 +321,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F17xx_Series.yaml
+++ b/probe-rs/targets/HT32F17xx_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -134,7 +129,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -159,7 +153,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -184,7 +177,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -209,7 +201,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -234,7 +225,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -259,7 +249,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -284,7 +273,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -309,7 +297,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -334,7 +321,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -359,7 +345,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F502xx_Series.yaml
+++ b/probe-rs/targets/HT32F502xx_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -134,7 +129,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -159,7 +153,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -184,7 +177,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -209,7 +201,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -234,7 +225,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -259,7 +249,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -284,7 +273,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -309,7 +297,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -334,7 +321,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -359,7 +345,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -384,7 +369,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -409,7 +393,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -434,7 +417,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -459,7 +441,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -484,7 +465,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -509,7 +489,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -534,7 +513,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -559,7 +537,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -584,7 +561,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -609,7 +585,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -634,7 +609,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -659,7 +633,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -684,7 +657,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -709,7 +681,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -734,7 +705,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -759,7 +729,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -784,7 +753,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -809,7 +777,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -834,7 +801,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -859,7 +825,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -884,7 +849,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F503xx_Series.yaml
+++ b/probe-rs/targets/HT32F503xx_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F521xx_Series.yaml
+++ b/probe-rs/targets/HT32F521xx_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F522xx_Series.yaml
+++ b/probe-rs/targets/HT32F522xx_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -134,7 +129,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -159,7 +153,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -184,7 +177,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -209,7 +201,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -234,7 +225,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -259,7 +249,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -284,7 +273,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -309,7 +297,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -334,7 +321,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -359,7 +345,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -384,7 +369,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -409,7 +393,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -434,7 +417,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -459,7 +441,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -484,7 +465,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -509,7 +489,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -534,7 +513,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -559,7 +537,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -584,7 +561,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -609,7 +585,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -634,7 +609,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -659,7 +633,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -684,7 +657,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F523xx_Series.yaml
+++ b/probe-rs/targets/HT32F523xx_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -134,7 +129,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -159,7 +153,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -184,7 +177,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -209,7 +201,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -234,7 +225,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -259,7 +249,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -284,7 +273,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -309,7 +297,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -334,7 +321,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -359,7 +345,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -384,7 +369,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -409,7 +393,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -434,7 +417,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -459,7 +441,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -484,7 +465,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -509,7 +489,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -534,7 +513,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -559,7 +537,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -584,7 +561,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -609,7 +585,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -634,7 +609,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -659,7 +633,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -684,7 +657,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -709,7 +681,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -734,7 +705,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -759,7 +729,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -784,7 +753,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -809,7 +777,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -834,7 +801,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F573xx_Series.yaml
+++ b/probe-rs/targets/HT32F573xx_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -134,7 +129,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -159,7 +153,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -184,7 +177,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -209,7 +201,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -234,7 +225,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -259,7 +249,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -284,7 +273,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -309,7 +297,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -334,7 +321,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F5826_Series.yaml
+++ b/probe-rs/targets/HT32F5826_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F590xx_Series.yaml
+++ b/probe-rs/targets/HT32F590xx_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F597xx_Series.yaml
+++ b/probe-rs/targets/HT32F597xx_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F61352_Series.yaml
+++ b/probe-rs/targets/HT32F61352_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT32F652xx_Series.yaml
+++ b/probe-rs/targets/HT32F652xx_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT50F32002_Series.yaml
+++ b/probe-rs/targets/HT50F32002_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -134,7 +129,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -159,7 +153,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -184,7 +177,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -209,7 +201,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/HT50F32003_Series.yaml
+++ b/probe-rs/targets/HT50F32003_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/LM3S_Series.yaml
+++ b/probe-rs/targets/LM3S_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -37,7 +36,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -63,7 +61,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -89,7 +86,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -115,7 +111,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -141,7 +136,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -167,7 +161,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -193,7 +186,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -219,7 +211,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -245,7 +236,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -271,7 +261,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -297,7 +286,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -323,7 +311,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -349,7 +336,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -375,7 +361,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -401,7 +386,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -427,7 +411,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -453,7 +436,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -479,7 +461,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -505,7 +486,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -531,7 +511,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -557,7 +536,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -583,7 +561,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -609,7 +586,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -635,7 +611,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -661,7 +636,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -687,7 +661,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -713,7 +686,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -739,7 +711,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -765,7 +736,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -791,7 +761,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -817,7 +786,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -843,7 +811,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -869,7 +836,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -895,7 +861,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -921,7 +886,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -947,7 +911,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -973,7 +936,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -999,7 +961,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1025,7 +986,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1051,7 +1011,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1077,7 +1036,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1103,7 +1061,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1129,7 +1086,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1155,7 +1111,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1181,7 +1136,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1207,7 +1161,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1233,7 +1186,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1259,7 +1211,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1285,7 +1236,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1311,7 +1261,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1337,7 +1286,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1363,7 +1311,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1389,7 +1336,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1415,7 +1361,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1441,7 +1386,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1467,7 +1411,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1493,7 +1436,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1519,7 +1461,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1545,7 +1486,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1571,7 +1511,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1597,7 +1536,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1623,7 +1561,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1649,7 +1586,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1675,7 +1611,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1701,7 +1636,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1727,7 +1661,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1753,7 +1686,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1779,7 +1711,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1805,7 +1736,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1831,7 +1761,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1857,7 +1786,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1883,7 +1811,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1909,7 +1836,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1935,7 +1861,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1961,7 +1886,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1987,7 +1911,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2013,7 +1936,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2039,7 +1961,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2065,7 +1986,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2091,7 +2011,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2117,7 +2036,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2143,7 +2061,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2169,7 +2086,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2195,7 +2111,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2221,7 +2136,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2247,7 +2161,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2273,7 +2186,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2299,7 +2211,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2325,7 +2236,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2351,7 +2261,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2377,7 +2286,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2403,7 +2311,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2429,7 +2336,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2455,7 +2361,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2481,7 +2386,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2507,7 +2411,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2533,7 +2436,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2559,7 +2461,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2585,7 +2486,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2611,7 +2511,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2637,7 +2536,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2663,7 +2561,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2689,7 +2586,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2715,7 +2611,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2741,7 +2636,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2767,7 +2661,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2793,7 +2686,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2819,7 +2711,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2845,7 +2736,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2871,7 +2761,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2897,7 +2786,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2923,7 +2811,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2949,7 +2836,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2975,7 +2861,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3001,7 +2886,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3027,7 +2911,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3053,7 +2936,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3079,7 +2961,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3105,7 +2986,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3131,7 +3011,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3157,7 +3036,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3183,7 +3061,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3209,7 +3086,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3235,7 +3111,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3261,7 +3136,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3287,7 +3161,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3313,7 +3186,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3339,7 +3211,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3365,7 +3236,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3391,7 +3261,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3417,7 +3286,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3443,7 +3311,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3469,7 +3336,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3495,7 +3361,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3521,7 +3386,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3547,7 +3411,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3573,7 +3436,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3599,7 +3461,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3625,7 +3486,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3651,7 +3511,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3677,7 +3536,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3703,7 +3561,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3729,7 +3586,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3755,7 +3611,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3781,7 +3636,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3807,7 +3661,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3833,7 +3686,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3859,7 +3711,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3885,7 +3736,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3911,7 +3761,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3937,7 +3786,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3963,7 +3811,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3989,7 +3836,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4015,7 +3861,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4041,7 +3886,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4067,7 +3911,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4093,7 +3936,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4119,7 +3961,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4145,7 +3986,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4171,7 +4011,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4197,7 +4036,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4223,7 +4061,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4249,7 +4086,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4275,7 +4111,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4301,7 +4136,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4327,7 +4161,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4353,7 +4186,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4379,7 +4211,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4405,7 +4236,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4431,7 +4261,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4457,7 +4286,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4483,7 +4311,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4509,7 +4336,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4535,7 +4361,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4561,7 +4386,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4587,7 +4411,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4613,7 +4436,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4639,7 +4461,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4665,7 +4486,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4691,7 +4511,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4717,7 +4536,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4743,7 +4561,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4769,7 +4586,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4795,7 +4611,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4821,7 +4636,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4847,7 +4661,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4873,7 +4686,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4899,7 +4711,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4925,7 +4736,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4951,7 +4761,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -4977,7 +4786,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5003,7 +4811,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5029,7 +4836,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5055,7 +4861,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5081,7 +4886,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5107,7 +4911,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5133,7 +4936,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5159,7 +4961,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5185,7 +4986,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5211,7 +5011,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5237,7 +5036,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5263,7 +5061,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5289,7 +5086,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5315,7 +5111,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5341,7 +5136,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5367,7 +5161,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5393,7 +5186,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5419,7 +5211,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5445,7 +5236,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5471,7 +5261,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5497,7 +5286,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5523,7 +5311,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5549,7 +5336,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5575,7 +5361,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5601,7 +5386,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5627,7 +5411,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5653,7 +5436,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -5679,7 +5461,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/LPC54102.yaml
+++ b/probe-rs/targets/LPC54102.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: PROGRAM_FLASH
@@ -51,7 +50,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: PROGRAM_FLASH
@@ -91,7 +89,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: PROGRAM_FLASH
@@ -131,7 +128,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: PROGRAM_FLASH

--- a/probe-rs/targets/LPC546xx_Series.yaml
+++ b/probe-rs/targets/LPC546xx_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -134,7 +129,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -159,7 +153,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -184,7 +177,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -209,7 +201,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -234,7 +225,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -259,7 +249,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -284,7 +273,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -309,7 +297,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -334,7 +321,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -359,7 +345,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -384,7 +369,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -409,7 +393,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -434,7 +417,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -459,7 +441,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -484,7 +465,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -509,7 +489,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -534,7 +513,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -559,7 +537,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -584,7 +561,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/LPC5526.yaml
+++ b/probe-rs/targets/LPC5526.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/LPC5528.yaml
+++ b/probe-rs/targets/LPC5528.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/LPC55S16.yaml
+++ b/probe-rs/targets/LPC55S16.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/LPC55S26.yaml
+++ b/probe-rs/targets/LPC55S26.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/LPC55S28.yaml
+++ b/probe-rs/targets/LPC55S28.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/LPC55S66.yaml
+++ b/probe-rs/targets/LPC55S66.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/LPC55S69.yaml
+++ b/probe-rs/targets/LPC55S69.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: PROGRAM_FLASH
@@ -108,7 +107,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: PROGRAM_FLASH
@@ -205,7 +203,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: PROGRAM_FLASH

--- a/probe-rs/targets/LPC800_Series.yaml
+++ b/probe-rs/targets/LPC800_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -105,7 +101,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -129,7 +124,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -153,7 +147,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -177,7 +170,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -201,7 +193,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -225,7 +216,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -249,7 +239,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -273,7 +262,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -297,7 +285,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -321,7 +308,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -345,7 +331,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -369,7 +354,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -393,7 +377,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -417,7 +400,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -441,7 +423,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -465,7 +446,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -489,7 +469,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -513,7 +492,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -537,7 +515,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -561,7 +538,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -585,7 +561,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -609,7 +584,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -633,7 +607,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -657,7 +630,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -681,7 +653,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/MAX32660.yaml
+++ b/probe-rs/targets/MAX32660.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/MAX32665-66.yaml
+++ b/probe-rs/targets/MAX32665-66.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/MIMXRT1010.yaml
+++ b/probe-rs/targets/MIMXRT1010.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: OCRAM

--- a/probe-rs/targets/MIMXRT1015.yaml
+++ b/probe-rs/targets/MIMXRT1015.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: OCRAM

--- a/probe-rs/targets/MIMXRT1020.yaml
+++ b/probe-rs/targets/MIMXRT1020.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: OCRAM

--- a/probe-rs/targets/MIMXRT1050.yaml
+++ b/probe-rs/targets/MIMXRT1050.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: OCRAM
@@ -35,7 +34,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: OCRAM

--- a/probe-rs/targets/MIMXRT1060.yaml
+++ b/probe-rs/targets/MIMXRT1060.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM

--- a/probe-rs/targets/MIMXRT1064.yaml
+++ b/probe-rs/targets/MIMXRT1064.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: OCRAM2

--- a/probe-rs/targets/MIMXRT1170.yaml
+++ b/probe-rs/targets/MIMXRT1170.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: OCRAM

--- a/probe-rs/targets/MIMXRT1180.yaml
+++ b/probe-rs/targets/MIMXRT1180.yaml
@@ -11,7 +11,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: DTCM

--- a/probe-rs/targets/MIMXRT500.yaml
+++ b/probe-rs/targets/MIMXRT500.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: Shared RAM partitions 0-31 via M33 code bus
@@ -107,7 +106,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: Shared RAM partitions 0-31 via M33 code bus
@@ -203,7 +201,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: Shared RAM partitions 0-31 via M33 code bus

--- a/probe-rs/targets/MIMXRT685S.yaml
+++ b/probe-rs/targets/MIMXRT685S.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: SRAM_ROM
@@ -164,7 +163,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: SRAM_ROM
@@ -317,7 +315,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: SRAM_ROM

--- a/probe-rs/targets/MSP432E4_Series.yaml
+++ b/probe-rs/targets/MSP432E4_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -37,7 +36,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/MSP432P4XX_Series.yaml
+++ b/probe-rs/targets/MSP432P4XX_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -134,7 +129,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -159,7 +153,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -184,7 +177,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/MSPM0C_Series.yaml
+++ b/probe-rs/targets/MSPM0C_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -59,7 +58,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/MSPM0G1X0X_G3X0X_Series.yaml
+++ b/probe-rs/targets/MSPM0G1X0X_G3X0X_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -109,7 +108,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -207,7 +205,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -305,7 +302,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -403,7 +399,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -501,7 +496,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -599,7 +593,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -697,7 +690,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -795,7 +787,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -893,7 +884,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -991,7 +981,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1089,7 +1078,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/MSPM0L_Series.yaml
+++ b/probe-rs/targets/MSPM0L_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -52,7 +51,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -93,7 +91,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -133,7 +130,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -173,7 +169,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -214,7 +209,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -255,7 +249,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -295,7 +288,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -335,7 +327,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -376,7 +367,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/OL23D0.yaml
+++ b/probe-rs/targets/OL23D0.yaml
@@ -10,7 +10,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/PAC52XX_Series.yaml
+++ b/probe-rs/targets/PAC52XX_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -37,7 +36,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -63,7 +61,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -89,7 +86,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -115,7 +111,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -141,7 +136,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -167,7 +161,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -193,7 +186,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -219,7 +211,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -245,7 +236,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -271,7 +261,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/PAC55XX_Series.yaml
+++ b/probe-rs/targets/PAC55XX_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -37,7 +36,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -63,7 +61,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -89,7 +86,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -115,7 +111,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -141,7 +136,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/PY32F0_Series.yaml
+++ b/probe-rs/targets/PY32F0_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -38,7 +37,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -65,7 +63,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -92,7 +89,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -119,7 +115,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -146,7 +141,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -173,7 +167,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -200,7 +193,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -227,7 +219,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -254,7 +245,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -281,7 +271,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -308,7 +297,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -335,7 +323,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -362,7 +349,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -389,7 +375,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -416,7 +401,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -443,7 +427,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -470,7 +453,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -497,7 +479,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -524,7 +505,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -551,7 +531,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -578,7 +557,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -605,7 +583,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/RA0E1_Series.yaml
+++ b/probe-rs/targets/RA0E1_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA2A1_Series.yaml
+++ b/probe-rs/targets/RA2A1_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Generic
     name: ConfigROM

--- a/probe-rs/targets/RA2A2_Series.yaml
+++ b/probe-rs/targets/RA2A2_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA2E1_Series.yaml
+++ b/probe-rs/targets/RA2E1_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -95,7 +93,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA2E2_Series.yaml
+++ b/probe-rs/targets/RA2E2_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -95,7 +93,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA2E3_Series.yaml
+++ b/probe-rs/targets/RA2E3_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA2L1_Series.yaml
+++ b/probe-rs/targets/RA2L1_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA4E1_Series.yaml
+++ b/probe-rs/targets/RA4E1_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA4E2_Series.yaml
+++ b/probe-rs/targets/RA4E2_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA4M1.yaml
+++ b/probe-rs/targets/RA4M1.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/RA4M2_Series.yaml
+++ b/probe-rs/targets/RA4M2_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -95,7 +93,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA4M3_Series.yaml
+++ b/probe-rs/targets/RA4M3_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -95,7 +93,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA4T1_Series.yaml
+++ b/probe-rs/targets/RA4T1_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA4W1_Series.yaml
+++ b/probe-rs/targets/RA4W1_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA6E1_Series.yaml
+++ b/probe-rs/targets/RA6E1_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Generic
     name: Flash_Upper
@@ -94,7 +92,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -136,7 +133,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Generic
     name: Flash_Upper

--- a/probe-rs/targets/RA6E2_Series.yaml
+++ b/probe-rs/targets/RA6E2_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA6M1_Series.yaml
+++ b/probe-rs/targets/RA6M1_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA6M2_Series.yaml
+++ b/probe-rs/targets/RA6M2_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -60,7 +59,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA6M3_Series.yaml
+++ b/probe-rs/targets/RA6M3_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -60,7 +59,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA6M4_Series.yaml
+++ b/probe-rs/targets/RA6M4_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Generic
     name: Flash_Upper
@@ -94,7 +92,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -136,7 +133,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Generic
     name: Flash_Upper
@@ -177,7 +173,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -219,7 +214,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Generic
     name: Flash_Upper

--- a/probe-rs/targets/RA6M5_Series.yaml
+++ b/probe-rs/targets/RA6M5_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -95,7 +93,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -137,7 +134,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -179,7 +175,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA6T1_Series.yaml
+++ b/probe-rs/targets/RA6T1_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA6T2_Series.yaml
+++ b/probe-rs/targets/RA6T2_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -53,7 +52,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -95,7 +93,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -137,7 +134,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA6T3_Series.yaml
+++ b/probe-rs/targets/RA6T3_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/probe-rs/targets/RA8D1_Series.yaml
+++ b/probe-rs/targets/RA8D1_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Generic
     name: ITCM
@@ -74,7 +73,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Generic
     name: ITCM
@@ -137,7 +135,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Generic
     name: ITCM
@@ -200,7 +197,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Generic
     name: ITCM

--- a/probe-rs/targets/RA8M1_Series.yaml
+++ b/probe-rs/targets/RA8M1_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Generic
     name: ITCM
@@ -74,7 +73,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Generic
     name: ITCM

--- a/probe-rs/targets/RA8T1_Series.yaml
+++ b/probe-rs/targets/RA8T1_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Generic
     name: ITCM
@@ -74,7 +73,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Generic
     name: ITCM

--- a/probe-rs/targets/RP2040.yaml
+++ b/probe-rs/targets/RP2040.yaml
@@ -68,7 +68,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/SAM3U.yaml
+++ b/probe-rs/targets/SAM3U.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -135,7 +130,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/SAM3X.yaml
+++ b/probe-rs/targets/SAM3X.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -59,7 +58,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -107,7 +105,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -155,7 +152,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -203,7 +199,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/SAM4_Dualcore_Series.yaml
+++ b/probe-rs/targets/SAM4_Dualcore_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -58,7 +56,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -82,7 +79,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -107,7 +103,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -132,7 +127,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -156,7 +150,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -180,7 +173,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -204,7 +196,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -228,7 +219,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -252,7 +242,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -276,7 +265,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -300,7 +288,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -324,7 +311,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/SAM4_Series.yaml
+++ b/probe-rs/targets/SAM4_Series.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -105,7 +101,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -129,7 +124,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -153,7 +147,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -177,7 +170,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -201,7 +193,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -225,7 +216,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -249,7 +239,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -273,7 +262,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -297,7 +285,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -321,7 +308,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -345,7 +331,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -369,7 +354,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -393,7 +377,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -417,7 +400,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -441,7 +423,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -465,7 +446,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -489,7 +469,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -513,7 +492,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -537,7 +515,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -561,7 +538,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -585,7 +561,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -609,7 +584,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -633,7 +607,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -657,7 +630,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -682,7 +654,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -707,7 +678,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -732,7 +702,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -757,7 +726,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -782,7 +750,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -807,7 +774,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -832,7 +798,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -857,7 +822,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -882,7 +846,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -907,7 +870,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -932,7 +894,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -957,7 +918,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -982,7 +942,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -1007,7 +966,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -1032,7 +990,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -1057,7 +1014,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/SAMD10.yaml
+++ b/probe-rs/targets/SAMD10.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -105,7 +101,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -129,7 +124,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -153,7 +147,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/SAMD11.yaml
+++ b/probe-rs/targets/SAMD11.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -33,7 +32,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +55,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +78,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/SAMD21.yaml
+++ b/probe-rs/targets/SAMD21.yaml
@@ -48,7 +48,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -72,7 +71,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -96,7 +94,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -121,7 +118,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -146,7 +142,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -171,7 +166,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -196,7 +190,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -221,7 +214,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -246,7 +238,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -271,7 +262,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -296,7 +286,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -320,7 +309,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -345,7 +333,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -370,7 +357,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -395,7 +381,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -419,7 +404,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -443,7 +427,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -468,7 +451,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -493,7 +475,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -517,7 +498,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -542,7 +522,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -567,7 +546,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -591,7 +569,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -615,7 +592,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -640,7 +616,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -665,7 +640,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -689,7 +663,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -713,7 +686,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -737,7 +709,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -762,7 +733,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -786,7 +756,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -811,7 +780,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -835,7 +803,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -860,7 +827,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/SAMD51.yaml
+++ b/probe-rs/targets/SAMD51.yaml
@@ -24,7 +24,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -48,7 +47,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -72,7 +70,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -96,7 +93,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -120,7 +116,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -144,7 +139,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -168,7 +162,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -192,7 +185,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -216,7 +208,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/SAMDA1.yaml
+++ b/probe-rs/targets/SAMDA1.yaml
@@ -33,7 +33,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -57,7 +56,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -81,7 +79,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -105,7 +102,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -129,7 +125,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -153,7 +148,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -177,7 +171,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -201,7 +194,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -225,7 +217,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/SAME51.yaml
+++ b/probe-rs/targets/SAME51.yaml
@@ -21,7 +21,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -45,7 +44,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -69,7 +67,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -93,7 +90,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -117,7 +113,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -141,7 +136,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -165,7 +159,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/SAME53.yaml
+++ b/probe-rs/targets/SAME53.yaml
@@ -20,7 +20,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -44,7 +43,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -68,7 +66,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -92,7 +89,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -116,7 +112,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/SAME54.yaml
+++ b/probe-rs/targets/SAME54.yaml
@@ -19,7 +19,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -43,7 +42,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -67,7 +65,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -91,7 +88,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/SAME70.yaml
+++ b/probe-rs/targets/SAME70.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -34,7 +33,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -59,7 +57,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -84,7 +81,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -109,7 +105,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -134,7 +129,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -159,7 +153,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -184,7 +177,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -209,7 +201,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -234,7 +225,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -259,7 +249,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -284,7 +273,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -309,7 +297,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -334,7 +321,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -359,7 +345,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -384,7 +369,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -409,7 +393,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -434,7 +417,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/SAMV71.yaml
+++ b/probe-rs/targets/SAMV71.yaml
@@ -9,7 +9,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -43,7 +42,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -77,7 +75,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -111,7 +108,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -145,7 +141,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -179,7 +174,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -213,7 +207,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -247,7 +240,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -281,7 +273,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -315,7 +306,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -349,7 +339,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -383,7 +372,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -417,7 +405,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -451,7 +438,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -485,7 +471,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -519,7 +504,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -553,7 +537,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -587,7 +570,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/STM32C0_Series.yaml
+++ b/probe-rs/targets/STM32C0_Series.yaml
@@ -15,7 +15,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -45,7 +44,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -75,7 +73,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -104,7 +101,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -133,7 +129,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -163,7 +158,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -193,7 +187,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -222,7 +215,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -251,7 +243,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -280,7 +271,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -309,7 +299,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -339,7 +328,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -369,7 +357,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -401,7 +388,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -433,7 +419,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -463,7 +448,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -494,7 +478,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -524,7 +507,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -554,7 +536,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -586,7 +567,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -618,7 +598,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -650,7 +629,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -681,7 +659,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32F0_Series.yaml
+++ b/probe-rs/targets/STM32F0_Series.yaml
@@ -13,7 +13,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -43,7 +42,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -73,7 +71,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -103,7 +100,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -133,7 +129,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -163,7 +158,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -193,7 +187,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -223,7 +216,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -253,7 +245,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -283,7 +274,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -313,7 +303,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -343,7 +332,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -373,7 +361,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -403,7 +390,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -433,7 +419,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -464,7 +449,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -494,7 +478,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -524,7 +507,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -554,7 +536,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -584,7 +565,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -614,7 +594,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -645,7 +624,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -676,7 +654,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -706,7 +683,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -736,7 +712,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -766,7 +741,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -796,7 +770,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -827,7 +800,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -858,7 +830,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -888,7 +859,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -919,7 +889,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -949,7 +918,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -979,7 +947,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1010,7 +977,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1041,7 +1007,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1072,7 +1037,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1103,7 +1067,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1134,7 +1097,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1165,7 +1127,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1195,7 +1156,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1225,7 +1185,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1256,7 +1215,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1286,7 +1244,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1316,7 +1273,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1347,7 +1303,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1377,7 +1332,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1407,7 +1361,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1437,7 +1390,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1467,7 +1419,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1497,7 +1448,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1528,7 +1478,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1560,7 +1509,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1590,7 +1538,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1621,7 +1568,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1652,7 +1598,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1683,7 +1628,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1715,7 +1659,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1745,7 +1688,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1777,7 +1719,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1808,7 +1749,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1839,7 +1779,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1871,7 +1810,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1902,7 +1840,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1933,7 +1870,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1964,7 +1900,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1995,7 +1930,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2025,7 +1959,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2057,7 +1990,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2087,7 +2019,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2118,7 +2049,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2149,7 +2079,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2181,7 +2110,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2212,7 +2140,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32F1_Series.yaml
+++ b/probe-rs/targets/STM32F1_Series.yaml
@@ -13,7 +13,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -43,7 +42,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -73,7 +71,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -103,7 +100,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -134,7 +130,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -165,7 +160,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -196,7 +190,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -227,7 +220,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -257,7 +249,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -287,7 +278,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -317,7 +307,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -347,7 +336,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -377,7 +365,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -407,7 +394,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -437,7 +423,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -467,7 +452,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -497,7 +481,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -527,7 +510,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -557,7 +539,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -587,7 +568,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -617,7 +597,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -648,7 +627,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -679,7 +657,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -709,7 +686,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -739,7 +715,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -769,7 +744,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -800,7 +774,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -830,7 +803,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -860,7 +832,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -890,7 +861,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -920,7 +890,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -960,7 +929,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1000,7 +968,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1030,7 +997,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1060,7 +1026,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1090,7 +1055,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1120,7 +1084,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1150,7 +1113,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1180,7 +1142,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1210,7 +1171,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1240,7 +1200,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1270,7 +1229,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1310,7 +1268,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1350,7 +1307,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1380,7 +1336,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1410,7 +1365,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1440,7 +1394,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1480,7 +1433,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1520,7 +1472,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1550,7 +1501,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1580,7 +1530,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1610,7 +1559,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1640,7 +1588,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1670,7 +1617,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1700,7 +1646,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1730,7 +1675,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1760,7 +1704,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1791,7 +1734,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1821,7 +1763,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1852,7 +1793,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1883,7 +1823,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1914,7 +1853,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1945,7 +1883,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1976,7 +1913,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2007,7 +1943,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2038,7 +1973,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2069,7 +2003,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2099,7 +2032,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2139,7 +2071,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2179,7 +2110,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2209,7 +2139,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2239,7 +2168,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2269,7 +2197,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2300,7 +2227,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2332,7 +2258,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2363,7 +2288,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2394,7 +2318,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2425,7 +2348,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2455,7 +2377,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2495,7 +2416,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2536,7 +2456,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2567,7 +2486,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2598,7 +2516,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2629,7 +2546,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2670,7 +2586,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2710,7 +2625,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2740,7 +2654,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2770,7 +2683,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2801,7 +2713,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2832,7 +2743,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2863,7 +2773,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2893,7 +2802,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2923,7 +2831,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2954,7 +2861,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2985,7 +2891,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32F2_Series.yaml
+++ b/probe-rs/targets/STM32F2_Series.yaml
@@ -13,7 +13,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -51,7 +50,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -90,7 +88,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -128,7 +125,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -168,7 +164,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -206,7 +201,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -244,7 +238,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -282,7 +275,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -320,7 +312,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -358,7 +349,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -396,7 +386,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -434,7 +423,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -472,7 +460,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -510,7 +497,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -549,7 +535,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -588,7 +573,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -627,7 +611,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -666,7 +649,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -704,7 +686,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -742,7 +723,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -780,7 +760,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -818,7 +797,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -856,7 +834,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -894,7 +871,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -932,7 +908,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -970,7 +945,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1008,7 +982,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1046,7 +1019,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1084,7 +1056,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1122,7 +1093,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1160,7 +1130,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1198,7 +1167,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1237,7 +1205,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1276,7 +1243,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1314,7 +1280,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1352,7 +1317,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1390,7 +1354,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1428,7 +1391,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32F3_Series.yaml
+++ b/probe-rs/targets/STM32F3_Series.yaml
@@ -12,7 +12,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -43,7 +42,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -74,7 +72,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -105,7 +102,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -135,7 +131,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -165,7 +160,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -195,7 +189,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -226,7 +219,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -256,7 +248,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -286,7 +277,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -316,7 +306,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -346,7 +335,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -376,7 +364,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -406,7 +393,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -436,7 +422,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -466,7 +451,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -496,7 +480,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -526,7 +509,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -556,7 +538,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -587,7 +568,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -618,7 +598,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -649,7 +628,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -679,7 +657,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -709,7 +686,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -739,7 +715,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -777,7 +752,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -814,7 +788,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -851,7 +824,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -889,7 +861,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -927,7 +898,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -964,7 +934,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1001,7 +970,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1038,7 +1006,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1075,7 +1042,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1112,7 +1078,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1149,7 +1114,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1186,7 +1150,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1224,7 +1187,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1262,7 +1224,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1301,7 +1262,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1338,7 +1298,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1375,7 +1334,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1413,7 +1371,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1443,7 +1400,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1473,7 +1429,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1510,7 +1465,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1547,7 +1501,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1585,7 +1538,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1623,7 +1575,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1661,7 +1612,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1699,7 +1649,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1736,7 +1685,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1773,7 +1721,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1810,7 +1757,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1847,7 +1793,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1884,7 +1829,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1921,7 +1865,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1951,7 +1894,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1981,7 +1923,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2011,7 +1952,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2041,7 +1981,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2071,7 +2010,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2102,7 +2040,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2133,7 +2070,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2164,7 +2100,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2194,7 +2129,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2225,7 +2159,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2256,7 +2189,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2286,7 +2218,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32F4_Series.yaml
+++ b/probe-rs/targets/STM32F4_Series.yaml
@@ -14,7 +14,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -47,7 +46,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -79,7 +77,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -111,7 +108,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -142,7 +138,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -173,7 +168,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -204,7 +198,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -235,7 +228,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -267,7 +259,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -299,7 +290,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -331,7 +321,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -363,7 +352,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -394,7 +382,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -442,7 +429,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -489,7 +475,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -536,7 +521,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -583,7 +567,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -631,7 +614,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -679,7 +661,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -726,7 +707,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -773,7 +753,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -820,7 +799,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -867,7 +845,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -915,7 +892,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -946,7 +922,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -977,7 +952,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1008,7 +982,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1038,7 +1011,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1068,7 +1040,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1099,7 +1070,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1131,7 +1101,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1162,7 +1131,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1193,7 +1161,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1225,7 +1192,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1257,7 +1223,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1288,7 +1253,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1319,7 +1283,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1352,7 +1315,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1385,7 +1347,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1417,7 +1378,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1449,7 +1409,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1481,7 +1440,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1513,7 +1471,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1544,7 +1501,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1574,7 +1530,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1604,7 +1559,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1634,7 +1588,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1664,7 +1617,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1694,7 +1646,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1725,7 +1676,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1756,7 +1706,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1787,7 +1736,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1818,7 +1766,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1848,7 +1795,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1888,7 +1834,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1928,7 +1873,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1968,7 +1912,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2009,7 +1952,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2050,7 +1992,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2090,7 +2031,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2130,7 +2070,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2170,7 +2109,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2210,7 +2148,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2250,7 +2187,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2280,7 +2216,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2310,7 +2245,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2341,7 +2275,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2372,7 +2305,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2402,7 +2334,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2443,7 +2374,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2494,7 +2424,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2536,7 +2465,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2586,7 +2514,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2627,7 +2554,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2678,7 +2604,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2720,7 +2645,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2770,7 +2694,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2811,7 +2734,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2862,7 +2784,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2902,7 +2823,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2943,7 +2863,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2994,7 +2913,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3035,7 +2953,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3077,7 +2994,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3127,7 +3043,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3167,7 +3082,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3208,7 +3122,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3258,7 +3171,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3298,7 +3210,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3339,7 +3250,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3389,7 +3299,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3430,7 +3339,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3472,7 +3380,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3522,7 +3429,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3573,7 +3479,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3615,7 +3520,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3665,7 +3569,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3706,7 +3609,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3757,7 +3659,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3799,7 +3700,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3849,7 +3749,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3899,7 +3798,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3940,7 +3838,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3991,7 +3888,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4033,7 +3929,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4083,7 +3978,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4124,7 +4018,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4174,7 +4067,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4215,7 +4107,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4266,7 +4157,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4308,7 +4198,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4358,7 +4247,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4389,7 +4277,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4420,7 +4307,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4451,7 +4337,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4482,7 +4367,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4513,7 +4397,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4546,7 +4429,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4579,7 +4461,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4611,7 +4492,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4652,7 +4532,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4694,7 +4573,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4744,7 +4622,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4784,7 +4661,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4825,7 +4701,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4876,7 +4751,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4917,7 +4791,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4959,7 +4832,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5009,7 +4881,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5049,7 +4920,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5090,7 +4960,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5140,7 +5009,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5180,7 +5048,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5221,7 +5088,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5271,7 +5137,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5311,7 +5176,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5352,7 +5216,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5403,7 +5266,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5445,7 +5307,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5495,7 +5356,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5536,7 +5396,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5587,7 +5446,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5629,7 +5487,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5679,7 +5536,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5720,7 +5576,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5770,7 +5625,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5811,7 +5665,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5861,7 +5714,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5902,7 +5754,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32F7_Series.yaml
+++ b/probe-rs/targets/STM32F7_Series.yaml
@@ -14,7 +14,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -60,7 +59,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -105,7 +103,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -150,7 +147,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -195,7 +191,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -240,7 +235,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -285,7 +279,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -330,7 +323,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -376,7 +368,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -422,7 +413,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -468,7 +458,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -514,7 +503,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -560,7 +548,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -606,7 +593,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -651,7 +637,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -696,7 +681,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -741,7 +725,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -786,7 +769,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -832,7 +814,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -877,7 +858,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -922,7 +902,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -967,7 +946,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1013,7 +991,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1059,7 +1036,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1105,7 +1081,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1151,7 +1126,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1197,7 +1171,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1243,7 +1216,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1289,7 +1261,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1334,7 +1305,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1379,7 +1349,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1424,7 +1393,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1469,7 +1437,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1515,7 +1482,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1561,7 +1527,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1606,7 +1571,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1651,7 +1615,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1697,7 +1660,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1743,7 +1705,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1789,7 +1750,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1835,7 +1795,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1880,7 +1839,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1925,7 +1883,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1970,7 +1927,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2015,7 +1971,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2061,7 +2016,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2106,7 +2060,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2152,7 +2105,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2198,7 +2150,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2243,7 +2194,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2290,7 +2240,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2338,7 +2287,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2386,7 +2334,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2433,7 +2380,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2480,7 +2426,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2528,7 +2473,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2576,7 +2520,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2623,7 +2566,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2670,7 +2612,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2717,7 +2658,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2764,7 +2704,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2812,7 +2751,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2860,7 +2798,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2907,7 +2844,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2955,7 +2891,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3003,7 +2938,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3051,7 +2985,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3098,7 +3031,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3145,7 +3077,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3192,7 +3123,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3239,7 +3169,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3286,7 +3215,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3333,7 +3261,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3380,7 +3307,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3427,7 +3353,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3474,7 +3399,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3521,7 +3445,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3568,7 +3491,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3615,7 +3537,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3663,7 +3584,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3710,7 +3630,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3758,7 +3677,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3805,7 +3723,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3852,7 +3769,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3899,7 +3815,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3946,7 +3861,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3993,7 +3907,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4040,7 +3953,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32G0_Series.yaml
+++ b/probe-rs/targets/STM32G0_Series.yaml
@@ -13,7 +13,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -45,7 +44,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -77,7 +75,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -109,7 +106,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -141,7 +137,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -173,7 +168,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -206,7 +200,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -239,7 +232,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -272,7 +264,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -304,7 +295,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -336,7 +326,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -368,7 +357,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -400,7 +388,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -432,7 +419,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -464,7 +450,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -496,7 +481,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -528,7 +512,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -561,7 +544,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -594,7 +576,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -627,7 +608,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -659,7 +639,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -692,7 +671,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -725,7 +703,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -757,7 +734,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -789,7 +765,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -821,7 +796,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -853,7 +827,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -885,7 +858,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -918,7 +890,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -951,7 +922,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -983,7 +953,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1015,7 +984,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1047,7 +1015,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1079,7 +1046,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1111,7 +1077,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1143,7 +1108,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1176,7 +1140,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1209,7 +1172,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1241,7 +1203,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1274,7 +1235,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1306,7 +1266,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1338,7 +1297,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1371,7 +1329,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1404,7 +1361,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1437,7 +1393,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1470,7 +1425,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1502,7 +1456,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1535,7 +1488,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1567,7 +1519,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1599,7 +1550,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1632,7 +1582,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1665,7 +1614,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1697,7 +1645,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1729,7 +1676,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1761,7 +1707,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1794,7 +1739,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1827,7 +1771,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1859,7 +1802,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1892,7 +1834,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1925,7 +1866,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1960,7 +1900,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1995,7 +1934,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2028,7 +1966,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2062,7 +1999,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2095,7 +2031,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2127,7 +2062,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2160,7 +2094,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2195,7 +2128,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2228,7 +2160,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2260,7 +2191,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2302,7 +2232,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2344,7 +2273,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2386,7 +2314,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2431,7 +2358,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2466,7 +2392,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2501,7 +2426,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2546,7 +2470,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2581,7 +2504,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2616,7 +2538,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2658,7 +2579,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2690,7 +2610,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2722,7 +2641,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2764,7 +2682,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2808,7 +2725,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2842,7 +2758,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2876,7 +2791,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2919,7 +2833,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2952,7 +2865,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2985,7 +2897,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3030,7 +2941,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3065,7 +2975,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3110,7 +3019,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3145,7 +3053,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3187,7 +3094,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3219,7 +3125,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3261,7 +3166,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3305,7 +3209,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3339,7 +3242,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3382,7 +3284,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3415,7 +3316,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32G4_Series.yaml
+++ b/probe-rs/targets/STM32G4_Series.yaml
@@ -14,7 +14,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -67,7 +66,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -121,7 +119,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -174,7 +171,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -227,7 +223,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -280,7 +275,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -332,7 +326,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -384,7 +377,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -436,7 +428,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -489,7 +480,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -542,7 +532,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -595,7 +584,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -647,7 +635,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -699,7 +686,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -751,7 +737,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -805,7 +790,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -858,7 +842,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -910,7 +893,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -963,7 +945,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1015,7 +996,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1068,7 +1048,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1121,7 +1100,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1173,7 +1151,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1226,7 +1203,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1278,7 +1254,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1330,7 +1305,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1382,7 +1356,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1434,7 +1407,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1488,7 +1460,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1542,7 +1513,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1595,7 +1565,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1648,7 +1617,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1701,7 +1669,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1753,7 +1720,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1805,7 +1771,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1858,7 +1823,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1910,7 +1874,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1962,7 +1925,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2016,7 +1978,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2068,7 +2029,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2120,7 +2080,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2172,7 +2131,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2224,7 +2182,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2276,7 +2233,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2328,7 +2284,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2382,7 +2337,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2436,7 +2390,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2490,7 +2443,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2543,7 +2495,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2596,7 +2547,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2649,7 +2599,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2701,7 +2650,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2753,7 +2701,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2806,7 +2753,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2858,7 +2804,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2910,7 +2855,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2962,7 +2906,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3014,7 +2957,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3066,7 +3008,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3118,7 +3059,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3170,7 +3110,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3222,7 +3161,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3274,7 +3212,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3328,7 +3265,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3382,7 +3318,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3436,7 +3371,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3489,7 +3423,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3542,7 +3475,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3594,7 +3526,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3646,7 +3577,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3698,7 +3628,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3752,7 +3681,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3805,7 +3733,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3858,7 +3785,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3910,7 +3836,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3962,7 +3887,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4014,7 +3938,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4068,7 +3991,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4121,7 +4043,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4174,7 +4095,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4226,7 +4146,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4278,7 +4197,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4331,7 +4249,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4384,7 +4301,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4437,7 +4353,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4491,7 +4406,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4543,7 +4457,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4595,7 +4508,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4648,7 +4560,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4700,7 +4611,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4753,7 +4663,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4807,7 +4716,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4859,7 +4767,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32H5_Series.yaml
+++ b/probe-rs/targets/STM32H5_Series.yaml
@@ -14,7 +14,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -60,7 +60,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -106,7 +106,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -152,7 +152,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -199,7 +199,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -254,7 +254,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -306,7 +306,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: Flash
@@ -343,7 +343,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -397,7 +397,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -452,7 +452,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -507,7 +507,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -562,7 +562,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -617,7 +617,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -672,7 +672,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -724,7 +724,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: Flash
@@ -761,7 +761,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -816,7 +816,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -871,7 +871,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -925,7 +925,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -979,7 +979,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1034,7 +1034,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1089,7 +1089,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1144,7 +1144,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1199,7 +1199,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1253,7 +1253,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1307,7 +1307,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1361,7 +1361,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1415,7 +1415,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1469,7 +1469,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1524,7 +1524,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1579,7 +1579,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1636,7 +1636,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1690,7 +1690,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1745,7 +1745,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1800,7 +1800,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1854,7 +1854,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1909,7 +1909,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1963,7 +1963,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2018,7 +2018,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2073,7 +2073,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2130,7 +2130,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2184,7 +2184,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2239,7 +2239,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2294,7 +2294,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2349,7 +2349,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32H7RS_Series.yaml
+++ b/probe-rs/targets/STM32H7RS_Series.yaml
@@ -13,7 +13,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -95,7 +95,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -177,7 +177,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -258,7 +258,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -341,7 +341,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -423,7 +423,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -504,7 +504,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -586,7 +586,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -668,7 +668,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -749,7 +749,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -830,7 +830,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -912,7 +912,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -994,7 +994,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -1075,7 +1075,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -1158,7 +1158,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -1240,7 +1240,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -1321,7 +1321,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -1403,7 +1403,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -1485,7 +1485,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -1566,7 +1566,7 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM

--- a/probe-rs/targets/STM32H7_Series.yaml
+++ b/probe-rs/targets/STM32H7_Series.yaml
@@ -14,7 +14,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -86,7 +85,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -158,7 +156,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -230,7 +227,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -301,7 +297,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -372,7 +367,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -444,7 +438,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -516,7 +509,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -587,7 +579,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -658,7 +649,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -730,7 +720,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -803,7 +792,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -874,7 +862,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -945,7 +932,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -1016,7 +1002,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -1088,7 +1073,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -1160,7 +1144,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -1232,7 +1215,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -1304,7 +1286,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -1376,7 +1357,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -1447,7 +1427,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -1519,7 +1498,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -1590,7 +1568,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -1663,7 +1640,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -1734,7 +1710,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -1805,7 +1780,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -1893,7 +1867,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -1981,7 +1954,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -2069,7 +2041,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -2158,7 +2129,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -2247,7 +2217,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -2336,7 +2305,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -2425,7 +2393,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -2513,7 +2480,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -2601,7 +2567,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -2689,7 +2654,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -2777,7 +2741,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -2865,7 +2828,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -2946,7 +2908,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -3027,7 +2988,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -3108,7 +3068,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -3190,7 +3149,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -3272,7 +3230,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -3354,7 +3311,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -3436,7 +3392,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -3517,7 +3472,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -3598,7 +3552,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -3679,7 +3632,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -3760,7 +3712,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -3841,12 +3792,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -3934,12 +3884,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -4028,12 +3977,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -4122,12 +4070,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -4215,12 +4162,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -4308,12 +4254,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -4401,12 +4346,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -4494,12 +4438,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -4587,12 +4530,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -4680,12 +4622,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -4773,12 +4714,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -4866,12 +4806,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -4959,12 +4898,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -5052,12 +4990,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -5145,12 +5082,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -5238,12 +5174,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -5331,12 +5266,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -5425,7 +5359,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -5496,7 +5429,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -5567,7 +5499,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -5638,7 +5569,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -5709,7 +5639,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -5790,7 +5719,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -5872,7 +5800,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -5954,7 +5881,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -6035,7 +5961,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -6116,7 +6041,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -6197,12 +6121,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -6291,12 +6214,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -6384,12 +6306,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -6477,12 +6398,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -6570,12 +6490,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -6663,12 +6582,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -6756,12 +6674,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -6849,12 +6766,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -6942,12 +6858,11 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     name: ITCM
@@ -7033,7 +6948,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -7105,7 +7019,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -7182,7 +7095,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -7247,7 +7159,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -7319,7 +7230,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -7396,7 +7306,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -7461,7 +7370,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -7533,7 +7441,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -7605,7 +7512,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -7677,7 +7583,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -7752,7 +7657,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -7820,7 +7724,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -7885,7 +7788,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -7959,7 +7861,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -8026,7 +7927,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -8096,7 +7996,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -8161,7 +8060,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -8233,7 +8131,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -8310,7 +8207,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -8375,7 +8271,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -8447,7 +8342,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -8522,7 +8416,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -8587,7 +8480,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -8662,7 +8554,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -8727,7 +8618,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -8801,7 +8691,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -8856,7 +8745,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -8921,7 +8809,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -8978,7 +8865,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -9036,7 +8922,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -9093,7 +8978,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -9148,7 +9032,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -9223,7 +9106,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -9288,7 +9170,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -9360,7 +9241,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -9432,7 +9312,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -9506,7 +9385,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -9571,7 +9449,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -9645,7 +9522,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -9713,7 +9589,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -9778,7 +9653,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -9850,7 +9724,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1
@@ -9924,7 +9797,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: ITCM
@@ -9989,7 +9861,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH_Bank1

--- a/probe-rs/targets/STM32L0_Series.yaml
+++ b/probe-rs/targets/STM32L0_Series.yaml
@@ -13,7 +13,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -44,7 +43,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -75,7 +73,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -106,7 +103,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -137,7 +133,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -168,7 +163,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -199,7 +193,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -230,7 +223,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -261,7 +253,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -292,7 +283,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -324,7 +314,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -356,7 +345,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -387,7 +375,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -418,7 +405,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -450,7 +436,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -483,7 +468,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -514,7 +498,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -546,7 +529,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -577,7 +559,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -609,7 +590,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -641,7 +621,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -673,7 +652,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -704,7 +682,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -735,7 +712,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -767,7 +743,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -798,7 +773,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -829,7 +803,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -861,7 +834,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -893,7 +865,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -925,7 +896,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -957,7 +927,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -989,7 +958,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1020,7 +988,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1052,7 +1019,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1084,7 +1050,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1116,7 +1081,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1148,7 +1112,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1180,7 +1143,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1212,7 +1174,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1244,7 +1205,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1276,7 +1236,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1307,7 +1266,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1338,7 +1296,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1370,7 +1327,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1402,7 +1358,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1434,7 +1389,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1466,7 +1420,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1498,7 +1451,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1530,7 +1482,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1561,7 +1512,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1593,7 +1543,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1625,7 +1574,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1657,7 +1605,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1689,7 +1636,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1721,7 +1667,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1752,7 +1697,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1784,7 +1728,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1816,7 +1759,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1847,7 +1789,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1879,7 +1820,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1912,7 +1852,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1945,7 +1884,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1976,7 +1914,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2008,7 +1945,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2040,7 +1976,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2072,7 +2007,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2104,7 +2038,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2136,7 +2069,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2168,7 +2100,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2200,7 +2131,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2233,7 +2163,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2267,7 +2196,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2299,7 +2227,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2331,7 +2258,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2364,7 +2290,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2397,7 +2322,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2429,7 +2353,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2461,7 +2384,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2493,7 +2415,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2525,7 +2446,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2558,7 +2478,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2590,7 +2509,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2623,7 +2541,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2655,7 +2572,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2687,7 +2603,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2719,7 +2634,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2750,7 +2664,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2782,7 +2695,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2814,7 +2726,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2846,7 +2757,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2878,7 +2788,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2910,7 +2819,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2941,7 +2849,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2973,7 +2880,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3005,7 +2911,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3037,7 +2942,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3069,7 +2973,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3101,7 +3004,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3133,7 +3035,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32L1_Series.yaml
+++ b/probe-rs/targets/STM32L1_Series.yaml
@@ -14,7 +14,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -43,7 +42,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -75,7 +73,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -104,7 +101,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -136,7 +132,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -165,7 +160,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -196,7 +190,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -230,7 +223,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -259,7 +251,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -288,7 +279,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -322,7 +312,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -351,7 +340,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -380,7 +368,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -414,7 +401,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -443,7 +429,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -472,7 +457,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -504,7 +488,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -535,7 +518,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -566,7 +548,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -607,7 +588,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -651,7 +631,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -680,7 +659,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -709,7 +687,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -743,7 +720,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -772,7 +748,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -801,7 +776,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -835,7 +809,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -864,7 +837,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -893,7 +865,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -926,7 +897,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -955,7 +925,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -987,7 +956,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1028,7 +996,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1069,7 +1036,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1103,7 +1069,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1132,7 +1097,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1161,7 +1125,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1195,7 +1158,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1224,7 +1186,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1253,7 +1214,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1286,7 +1246,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1315,7 +1274,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1348,7 +1306,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1387,7 +1344,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1416,7 +1372,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1448,7 +1403,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1489,7 +1443,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1520,7 +1473,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1561,7 +1513,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1605,7 +1556,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1634,7 +1584,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1663,7 +1612,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1697,7 +1645,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1726,7 +1673,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1755,7 +1701,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1789,7 +1734,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1818,7 +1762,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1847,7 +1790,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1879,7 +1821,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1910,7 +1851,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1941,7 +1881,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1982,7 +1921,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2026,7 +1964,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2055,7 +1992,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2084,7 +2020,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2118,7 +2053,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2147,7 +2081,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2176,7 +2109,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2210,7 +2142,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2239,7 +2170,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2268,7 +2198,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2300,7 +2229,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2329,7 +2257,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2361,7 +2288,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2402,7 +2328,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2444,7 +2369,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2478,7 +2402,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2507,7 +2430,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2536,7 +2458,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2570,7 +2491,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2599,7 +2519,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2628,7 +2547,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2661,7 +2579,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2690,7 +2607,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2722,7 +2638,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2761,7 +2676,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -2793,7 +2707,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2834,7 +2747,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2865,7 +2777,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2906,7 +2817,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2948,7 +2858,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2979,7 +2888,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3021,7 +2929,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3050,7 +2957,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3082,7 +2988,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3123,7 +3028,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3166,7 +3070,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3195,7 +3098,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3227,7 +3129,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3266,7 +3167,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -3298,7 +3198,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3339,7 +3238,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3370,7 +3268,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3411,7 +3308,6 @@ variants:
     type: armv7m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32L4_Series.yaml
+++ b/probe-rs/targets/STM32L4_Series.yaml
@@ -14,7 +14,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -68,7 +67,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -120,7 +118,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -172,7 +169,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -224,7 +220,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -278,7 +273,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -329,7 +323,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -381,7 +374,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -433,7 +425,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -485,7 +476,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -538,7 +528,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -589,7 +578,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -642,7 +630,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -695,7 +682,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -746,7 +732,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -797,7 +782,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -851,7 +835,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -905,7 +888,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -958,7 +940,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1009,7 +990,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1060,7 +1040,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1113,7 +1092,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1166,7 +1144,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1220,7 +1197,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1275,7 +1251,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1328,7 +1303,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1379,7 +1353,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1433,7 +1406,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1487,7 +1459,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1540,7 +1511,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1591,7 +1561,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1643,7 +1612,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1696,7 +1664,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1749,7 +1716,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1801,7 +1767,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1853,7 +1818,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1904,7 +1868,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1957,7 +1920,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2010,7 +1972,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2065,7 +2026,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2117,7 +2077,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2169,7 +2128,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2222,7 +2180,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2275,7 +2232,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2327,7 +2283,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2378,7 +2333,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2432,7 +2386,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2486,7 +2439,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2541,7 +2493,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2595,7 +2546,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2649,7 +2599,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2704,7 +2653,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2759,7 +2707,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2813,7 +2760,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2867,7 +2813,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2921,7 +2866,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2975,7 +2919,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3029,7 +2972,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3083,7 +3025,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3137,7 +3078,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3192,7 +3132,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3246,7 +3185,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3300,7 +3238,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3354,7 +3291,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3410,7 +3346,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3464,7 +3399,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3518,7 +3452,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3572,7 +3505,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3626,7 +3558,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3680,7 +3611,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3735,7 +3665,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3789,7 +3718,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3845,7 +3773,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3899,7 +3826,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3953,7 +3879,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4007,7 +3932,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4061,7 +3985,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4115,7 +4038,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4169,7 +4091,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4231,7 +4152,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4292,7 +4212,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4355,7 +4274,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4416,7 +4334,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4478,7 +4395,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4539,7 +4455,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4603,7 +4518,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4664,7 +4578,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4725,7 +4638,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4787,7 +4699,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4849,7 +4760,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4911,7 +4821,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4973,7 +4882,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5037,7 +4945,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5099,7 +5006,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5160,7 +5066,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5197,7 +5102,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5234,7 +5138,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5273,7 +5176,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5309,7 +5211,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5347,7 +5248,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5383,7 +5283,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5420,7 +5319,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5457,7 +5355,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5496,7 +5393,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5532,7 +5428,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5569,7 +5464,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5606,7 +5500,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5645,7 +5538,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5682,7 +5574,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5719,7 +5610,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5758,7 +5648,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5795,7 +5684,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5831,7 +5719,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5870,7 +5757,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5909,7 +5795,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5948,7 +5833,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -5986,7 +5870,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6024,7 +5907,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6063,7 +5945,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6103,7 +5984,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6139,7 +6019,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Main_Flash
@@ -6191,7 +6070,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6229,7 +6107,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6267,7 +6144,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6305,7 +6181,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6343,7 +6218,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6381,7 +6255,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6419,7 +6292,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6459,7 +6331,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6500,7 +6371,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6536,7 +6406,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Main_Flash
@@ -6588,7 +6457,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6627,7 +6495,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6665,7 +6532,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6704,7 +6570,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6742,7 +6607,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6780,7 +6644,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6818,7 +6681,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6856,7 +6718,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6894,7 +6755,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -6934,7 +6794,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32L5_Series.yaml
+++ b/probe-rs/targets/STM32L5_Series.yaml
@@ -14,7 +14,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -51,7 +50,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -86,7 +84,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -120,7 +117,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -156,7 +152,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -190,7 +185,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -226,7 +220,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -260,7 +253,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -295,7 +287,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -329,7 +320,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -364,7 +354,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -401,7 +390,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -436,7 +424,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -472,7 +459,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -508,7 +494,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -543,7 +528,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -578,7 +562,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32U0_Series.yaml
+++ b/probe-rs/targets/STM32U0_Series.yaml
@@ -14,7 +14,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -44,7 +43,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -73,7 +71,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -102,7 +99,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -131,7 +127,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -158,7 +153,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -191,7 +185,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -226,7 +219,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -255,7 +247,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -285,7 +276,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -315,7 +305,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -345,7 +334,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -377,7 +365,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -408,7 +395,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -438,7 +424,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -465,7 +450,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -498,7 +482,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -531,7 +514,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -567,7 +549,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -597,7 +578,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -626,7 +606,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -658,7 +637,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -690,7 +668,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -720,7 +697,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -752,7 +728,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -784,7 +759,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -814,7 +788,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -844,7 +817,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -871,7 +843,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -906,7 +877,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -936,7 +906,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -966,7 +935,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32U5_Series.yaml
+++ b/probe-rs/targets/STM32U5_Series.yaml
@@ -16,7 +16,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -69,7 +68,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -122,7 +120,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -172,7 +169,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -222,7 +218,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -272,7 +267,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -325,7 +319,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -378,7 +371,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -431,7 +423,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -484,7 +475,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -537,7 +527,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -590,7 +579,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -640,7 +628,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -690,7 +677,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -743,7 +729,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -796,7 +781,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -847,7 +831,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -905,7 +888,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -965,7 +947,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1025,7 +1006,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1082,7 +1062,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1139,7 +1118,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1197,7 +1175,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1255,7 +1232,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1313,7 +1289,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1371,7 +1346,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1429,7 +1403,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1487,7 +1460,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1545,7 +1517,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1603,7 +1574,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1661,7 +1631,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1721,7 +1690,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1778,7 +1746,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1836,7 +1803,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1894,7 +1860,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -1952,7 +1917,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2010,7 +1974,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2068,7 +2031,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2133,7 +2095,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2198,7 +2159,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2263,7 +2223,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2330,7 +2289,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2395,7 +2353,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2460,7 +2417,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2525,7 +2481,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2591,7 +2546,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2653,7 +2607,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash
@@ -2702,7 +2655,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2766,7 +2718,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2830,7 +2781,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2894,7 +2844,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -2958,7 +2907,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3023,7 +2971,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3088,7 +3035,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3153,7 +3099,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3218,7 +3163,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3283,7 +3227,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3348,7 +3291,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3413,7 +3355,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3479,7 +3420,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3543,7 +3483,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3607,7 +3546,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3671,7 +3609,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3736,7 +3673,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3801,7 +3737,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3873,7 +3808,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -3944,7 +3878,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4015,7 +3948,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4087,7 +4019,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4158,7 +4089,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4230,7 +4160,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4302,7 +4231,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4374,7 +4302,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4445,7 +4372,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4516,7 +4442,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4587,7 +4512,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -4659,7 +4583,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32WBA_Series.yaml
+++ b/probe-rs/targets/STM32WBA_Series.yaml
@@ -15,7 +15,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -45,7 +45,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -75,7 +75,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -105,7 +105,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -135,7 +135,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -165,7 +165,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -195,7 +195,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -225,7 +225,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -255,7 +255,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -285,7 +285,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -315,7 +315,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -345,7 +345,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -375,7 +375,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -405,7 +405,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -435,7 +435,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1
@@ -465,7 +465,7 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/STM32WB_Series.yaml
+++ b/probe-rs/targets/STM32WB_Series.yaml
@@ -13,7 +13,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -44,7 +43,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -71,7 +69,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Main_Flash
@@ -106,7 +103,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -136,7 +132,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -166,7 +161,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -195,7 +189,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -224,7 +217,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -254,7 +246,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -284,7 +275,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -314,7 +304,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -344,7 +333,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -374,7 +362,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -405,7 +392,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -436,7 +422,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -467,7 +452,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -497,7 +481,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -525,7 +508,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Main_Flash

--- a/probe-rs/targets/STM32WL_Series.yaml
+++ b/probe-rs/targets/STM32WL_Series.yaml
@@ -15,12 +15,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm0p
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -60,12 +58,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm0p
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -105,12 +101,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm0p
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -150,12 +144,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm0p
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -195,12 +187,10 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: cm0p
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -240,7 +230,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -276,7 +265,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -312,7 +300,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -348,7 +335,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -384,7 +370,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -420,7 +405,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -456,7 +440,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -492,7 +475,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -528,7 +510,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -565,7 +546,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -601,7 +581,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1
@@ -637,7 +616,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: BANK_1

--- a/probe-rs/targets/SWM341.yaml
+++ b/probe-rs/targets/SWM341.yaml
@@ -6,7 +6,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/Tiva_C_Series.yaml
+++ b/probe-rs/targets/Tiva_C_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -38,7 +37,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -65,7 +63,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -92,7 +89,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -119,7 +115,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -146,7 +141,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -173,7 +167,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -200,7 +193,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -227,7 +219,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -254,7 +245,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -281,7 +271,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -308,7 +297,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -335,7 +323,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -362,7 +349,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -389,7 +375,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -416,7 +401,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -443,7 +427,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -470,7 +453,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -497,7 +479,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -524,7 +505,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -551,7 +531,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -578,7 +557,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -605,7 +583,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -632,7 +609,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -659,7 +635,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -686,7 +661,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -713,7 +687,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -740,7 +713,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -767,7 +739,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -794,7 +765,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -821,7 +791,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -848,7 +817,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -875,7 +843,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -902,7 +869,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -929,7 +895,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -956,7 +921,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -983,7 +947,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1010,7 +973,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1037,7 +999,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1064,7 +1025,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1091,7 +1051,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1118,7 +1077,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1145,7 +1103,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1172,7 +1129,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1199,7 +1155,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1226,7 +1181,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1253,7 +1207,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1280,7 +1233,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1307,7 +1259,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1334,7 +1285,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1361,7 +1311,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1388,7 +1337,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1415,7 +1363,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1442,7 +1389,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1469,7 +1415,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1496,7 +1441,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1523,7 +1467,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1550,7 +1493,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1577,7 +1519,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1604,7 +1545,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1631,7 +1571,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1658,7 +1597,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1685,7 +1623,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1712,7 +1649,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1739,7 +1675,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1766,7 +1701,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1793,7 +1727,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1820,7 +1753,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1847,7 +1779,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1874,7 +1805,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1901,7 +1831,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/VA108xx_Series.yaml
+++ b/probe-rs/targets/VA108xx_Series.yaml
@@ -8,7 +8,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
       jtag_tap: 1
   memory_map:
   - !Nvm
@@ -39,7 +38,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
       jtag_tap: 1
   memory_map:
   - !Ram

--- a/probe-rs/targets/VA416xx_Series.yaml
+++ b/probe-rs/targets/VA416xx_Series.yaml
@@ -11,7 +11,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: NVM
@@ -46,7 +45,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Ram
     name: IRAM1

--- a/probe-rs/targets/W7500.yaml
+++ b/probe-rs/targets/W7500.yaml
@@ -6,7 +6,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: FLASH

--- a/probe-rs/targets/XMC4000.yaml
+++ b/probe-rs/targets/XMC4000.yaml
@@ -55,7 +55,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -89,7 +88,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -123,7 +121,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -157,7 +154,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -191,7 +187,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -225,7 +220,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -259,7 +253,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -293,7 +286,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -327,7 +319,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -361,7 +352,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -395,7 +385,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -429,7 +418,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -463,7 +451,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -497,7 +484,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -531,7 +517,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -565,7 +550,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -599,7 +583,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -633,7 +616,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -674,7 +656,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -715,7 +696,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -756,7 +736,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -797,7 +776,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -838,7 +816,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -879,7 +856,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -920,7 +896,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -961,7 +936,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -995,7 +969,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1029,7 +1002,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1063,7 +1035,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1097,7 +1068,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1131,7 +1101,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1165,7 +1134,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1199,7 +1167,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1233,7 +1200,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1267,7 +1233,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1301,7 +1266,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1335,7 +1299,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1369,7 +1332,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1403,7 +1365,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1
@@ -1437,7 +1398,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: IROM1

--- a/probe-rs/targets/iMX7ULP.yaml
+++ b/probe-rs/targets/iMX7ULP.yaml
@@ -9,13 +9,13 @@ variants:
     type: armv7a
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
       debug_base: 0x80030000
   - name: core1
     type: armv7em
     core_access_options: !Arm
       ap: 3
-      psel: 0x0
+
   memory_map:
   - !Ram
     range:

--- a/probe-rs/targets/nRF51_Series.yaml
+++ b/probe-rs/targets/nRF51_Series.yaml
@@ -115,7 +115,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -141,7 +140,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -167,7 +165,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -193,7 +190,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -219,7 +215,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -245,7 +240,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -271,7 +265,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -297,7 +290,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -323,7 +315,6 @@ variants:
     type: armv6m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/nRF52_Series.yaml
+++ b/probe-rs/targets/nRF52_Series.yaml
@@ -96,7 +96,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -132,7 +131,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -168,7 +166,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -204,7 +201,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -240,7 +236,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -276,7 +271,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -312,7 +306,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:
@@ -348,7 +341,6 @@ variants:
     type: armv7em
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/nRF53_Series.yaml
+++ b/probe-rs/targets/nRF53_Series.yaml
@@ -17,12 +17,11 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   - name: network
     type: armv8m
     core_access_options: !Arm
       ap: 1
-      psel: 0x0
+
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/nRF54L_Series.yaml
+++ b/probe-rs/targets/nRF54L_Series.yaml
@@ -19,7 +19,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/targets/nRF91_Series.yaml
+++ b/probe-rs/targets/nRF91_Series.yaml
@@ -16,7 +16,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     range:

--- a/probe-rs/tests/scan_chain_test.yaml
+++ b/probe-rs/tests/scan_chain_test.yaml
@@ -30,7 +30,7 @@ variants:
         core_access_options:
           !Arm
             ap: 0x0
-            psel: 0x0
+
     memory_map:
       - !Ram
           range:
@@ -47,7 +47,7 @@ variants:
         core_access_options:
           !Arm
             ap: 0x0
-            psel: 0x0
+
     jtag: {}
     memory_map:
       - !Ram

--- a/target-gen/src/commands/elf.rs
+++ b/target-gen/src/commands/elf.rs
@@ -85,7 +85,7 @@ pub fn cmd_elf(
                     core_type: CoreType::Armv6m,
                     core_access_options: CoreAccessOptions::Arm(ArmCoreAccessOptions {
                         ap: 0,
-                        psel: 0,
+                        targetsel: None,
                         debug_base: None,
                         cti_base: None,
                         jtag_tap: None,

--- a/target-gen/src/commands/snapshots/target_gen__commands__elf__test__serialization_cleanup.snap
+++ b/target-gen/src/commands/snapshots/target_gen__commands__elf__test__serialization_cleanup.snap
@@ -10,7 +10,6 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: 0
-      psel: 0x0
   memory_map:
   - !Nvm
     name: Flash

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -204,7 +204,7 @@ fn create_core(processor: &Processor) -> Result<ProbeCore> {
                     AccessPort::Index(id) => id,
                     AccessPort::Address(_) => todo!(),
                 },
-                psel: 0,
+                targetsel: None,
                 debug_base: None,
                 cti_base: None,
                 jtag_tap: None,


### PR DESCRIPTION
I'm not sure where the `psel` name came from, but it only seems to be used as the `TARGETSEL` value, so this name should be clearer.

It's also only used by the RP2040 currently, so making it optional makes the target spec for all the other chips a tiny bit simpler.