### PR TITLE
Fix regression in USB timeout handling

### DIFF
--- a/changelog/fixed-regression-usb-timeout.md
+++ b/changelog/fixed-regression-usb-timeout.md
@@ -1,0 +1,1 @@
+Fixed a regression that prevented retries of packet size query when connecting to CMSIS-DAP probes.

--- a/changelog/fixed-regression-usb-timeout.md
+++ b/changelog/fixed-regression-usb-timeout.md
@@ -1,1 +1,1 @@
-Fixed a regression that prevented retries of packet size query when connecting to CMSIS-DAP probes.
+Fixed a regression that prevented retries of the packet size query when connecting to CMSIS-DAP probes.


### PR DESCRIPTION
Fixes #2995

The regression was introduced with PR #1842, when we moved from **rusb** to **nusb**.

I have only tested it on Windows.