### PR TITLE
Use nusb Queue API for cancel-safety

### DIFF
--- a/changelog/fixed-nusb-cancel-safe.md
+++ b/changelog/fixed-nusb-cancel-safe.md
@@ -1,0 +1,1 @@
+Fixed a problem where CMSIS-DAP probes could be slow to open.


### PR DESCRIPTION

Please refer to this issue in nusb's repo. https://github.com/kevinmehall/nusb/issues/103

CmsisDapDevice::drain() is relying on timeout of InterfaceExt::read_bulk() to function properly.

What I found is that, when read_bulk() drops the TransferFuture, the transfer in turn is canceled, but the transfer stays in-flight for some time before it is actually canceled and retired. and within that little time lag, the response to the next command can slip in to that bound to retire transfer. meaning we lose that one response entirely.

The fix uses nusb's [Queue API](https://docs.rs/nusb/latest/nusb/transfer/struct.Queue.html) to make the cancel operation to complete synchronously.