### PR TITLE
Allow explicitly selecting probes without serial

### DIFF
--- a/changelog/changed-probe-selector.md
+++ b/changelog/changed-probe-selector.md
@@ -1,0 +1,1 @@
+probe-rs now allows selecting debug probes that have no serial number by using `VID:PID:`


### PR DESCRIPTION
Not all FTDI-based probes have EEPROMs to store a serial number. One such example is the ESP32 ethernet devkit. However, `esp-prog` boards use the same FTDI chip, but have the EEPROM, so they can have serial number.

This PR means that from now on, these two devices can be present in a system at the same time, and probe-rs can now work with the ethernet devkit, too.