### PR TITLE
make MIMXRT10xx reset more reliable

### DIFF
--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
@@ -116,6 +116,9 @@ impl ArmDebugSequence for MIMXRT10xx {
     ) -> Result<(), ArmError> {
         self.check_core_type(core_type)?;
 
+        // Halt the processor before messing with the memory map.
+        self.halt(interface, true)?;
+
         // OK to perform before the reset, since the configuration
         // persists beyond the reset.
         self.use_boot_fuses_for_flexram(interface)?;

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
@@ -62,8 +62,13 @@ impl MIMXRT10xx {
 
     /// Use the boot fuse configuration for FlexRAM.
     ///
-    /// If the user changed the FlexRAM configuration in software, this will undo
-    /// that configuration, preferring the system's POR FlexRAM state.
+    /// If the user changed the FlexRAM configuration in software,
+    /// this will undo that configuration, preferring the system's POR
+    /// FlexRAM state.
+    ///
+    /// This function may change the processor's memory map, which may
+    /// cause problems for any running firmware.  Halt the processor
+    /// before calling this function.
     fn use_boot_fuses_for_flexram(
         &self,
         probe: &mut dyn ArmMemoryInterface,


### PR DESCRIPTION
This makes MIMXRT10xx flashing more reliable, by halting the processor before messing with the memory map.  Without this branch `probe-rs run` does not work reliably on my MIMXRT1062 (Teensy4-equivalent).  With this branch it works flawlessly.

Thanks to tiwalun in #probe-rs:matrix.org for help in debugging this and guidance in the evolution of the patch!