### PR TITLE
Halt the MIMXRT11xx before changing FlexRAM

### DIFF
--- a/changelog/fixed-mimxrt-reset.md
+++ b/changelog/fixed-mimxrt-reset.md
@@ -1,0 +1,2 @@
+Fixed a problem with flaky flashing on MIMXRT when the firmware has
+changed the FlexRAM configuration from the POR fuse settings.

--- a/changelog/fixed-mimxrt10xx-flashing.md
+++ b/changelog/fixed-mimxrt10xx-flashing.md
@@ -1,2 +1,0 @@
-Fixed a problem with flaky flashing on MIMXRT10xx when the firmware has
-changed the GPR17 memory map from the POR fuse settings.

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
@@ -416,6 +416,7 @@ impl ArmDebugSequence for MIMXRT117x {
     ) -> Result<(), ArmError> {
         // OK to perform before the reset, since the configuration
         // persists beyond the reset.
+        self.halt(probe, true)?;
         self.use_boot_fuses_for_flexram(probe)?;
 
         // Cache debug system state that may be lost across the reset.


### PR DESCRIPTION
We'll need this for the same reasons we need it on the MIMXRT10xx parts (see #3014): changing the FlexRAM layout while a program is accessing FlexRAM will cause trouble. Tested on systems carrying an 1170 MCU.