### PR TITLE
Add missing description for probe-rs-debug crate

### DIFF
--- a/probe-rs-debug/Cargo.toml
+++ b/probe-rs-debug/Cargo.toml
@@ -8,6 +8,8 @@ repository.workspace = true
 readme.workspace = true
 license.workspace = true
 
+description = "Debugging functionlity built on top of the probe-rs crate"
+
 [dependencies]
 bitfield = "0.17.0"
 gimli = "0.31.1"


### PR DESCRIPTION
This caused the release of 0.26.0 to fail.