### PR TITLE
chore: Fix features for insta, update cargo-dist to 0.28.0

### DIFF
--- a/.github/workflows/v-release.yml
+++ b/.github/workflows/v-release.yml
@@ -65,7 +65,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.26.1/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.28.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -810,7 +819,7 @@ dependencies = [
  "alterable_logger",
  "anyhow",
  "byteorder",
- "colored",
+ "colored 2.2.0",
  "defmt-json-schema",
  "defmt-parser",
  "dissimilar",
@@ -2553,7 +2562,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "clap_complete",
- "colored",
+ "colored 3.0.0",
  "defmt-decoder",
  "directories",
  "docsplay",
@@ -3369,7 +3378,7 @@ name = "smoke_tester"
 version = "0.26.0"
 dependencies = [
  "clap",
- "colored",
+ "colored 3.0.0",
  "linkme",
  "log",
  "miette",
@@ -3553,7 +3562,7 @@ dependencies = [
  "anyhow",
  "clap",
  "cmsis-pack",
- "colored",
+ "colored 3.0.0",
  "futures",
  "goblin",
  "insta",
@@ -4320,7 +4329,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.26.1"
+cargo-dist-version = "0.28.0"
 # CI backends to support
 ci = "github"
 # Target platforms to build apps for (Rust target-triple syntax)

--- a/probe-rs-debug/Cargo.toml
+++ b/probe-rs-debug/Cargo.toml
@@ -28,7 +28,7 @@ typed-path = "0.10.0"
 workspace = true
 
 [dev-dependencies]
-insta = "1.41.1"
+insta = { version = "1.41.1", features = ["yaml"] }
 pretty_assertions = "1.4.1"
 probe-rs = { workspace = true, features = ["test"] }
 test-case = "3.3.1"

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -35,7 +35,7 @@ bytesize = "1"
 capstone = "0.12"
 cargo_metadata = "0.19"
 clap = { version = "4", features = ["derive", "env"] }
-colored = "2"
+colored = "3"
 defmt-decoder = "0.4"
 directories = "5"
 dunce = "1"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -93,7 +93,7 @@ pretty_assertions = "1"
 test-case = "3"
 test-log = { version = "0.2.16", features = ["trace"] }
 termtree = "0.5"
-insta = { version = "1.38", default-features = false, features = ["yaml"] }
+insta = { version = "1.38", default-features = false }
 
 [[package.metadata.release.pre-release-replacements]]
 file = "../CHANGELOG.md"

--- a/smoke-tester/Cargo.toml
+++ b/smoke-tester/Cargo.toml
@@ -16,7 +16,7 @@ toml = "0.8.12"
 pretty_env_logger = "0.5.0"
 log = "0.4.21"
 clap = { version = "4.5", features = ["derive"] }
-colored = "2.1.0"
+colored = "3"
 linkme = "0.3.25"
 miette = { version = "7.2.0", features = ["fancy"] }
 thiserror.workspace = true

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -37,7 +37,7 @@ zip = { version = "2.0.0", default-features = false, features = [
     "zstd",
 ] }
 clap = { version = "4.5", features = ["derive"] }
-colored = "2"
+colored = "3"
 anyhow.workspace = true
 reqwest = { version = "0.12.4", features = [
     "json",


### PR DESCRIPTION
- Update colored to v3
- Use correct features for insta
- Update cargo-dist to version 0.28.0