### PR TITLE
blackmagic: implement reinitialize()

### DIFF
--- a/changelog/added-black-magic-probe-reinitialize.md
+++ b/changelog/added-black-magic-probe-reinitialize.md
@@ -1,0 +1,1 @@
+Add a function to reinitialize the connection to the Black Magic Probe. This goes through the entire initialization process with the same sequence as it was originally started with.

--- a/probe-rs/src/probe/blackmagic/arm.rs
+++ b/probe-rs/src/probe/blackmagic/arm.rs
@@ -109,7 +109,14 @@ impl BlackMagicProbeArmDebug {
             sequence,
         };
 
-        interface.debug_port_start(dp).unwrap();
+        if let Err(e) = interface.debug_port_start(dp) {
+            return Err((
+                Box::new(UninitializedBlackMagicArmProbe {
+                    probe: interface.probe,
+                }),
+                e,
+            ));
+        }
 
         interface.access_ports = valid_access_ports(&mut interface, DpAddress::Default)
             .into_iter()
@@ -340,7 +347,7 @@ impl ArmProbeInterface for BlackMagicProbeArmDebug {
             sequence.debug_port_setup(&mut *self.probe, dp)?;
         }
 
-        self.debug_port_start(dp).unwrap();
+        self.debug_port_start(dp)?;
 
         self.access_ports = valid_access_ports(self, DpAddress::Default)
             .into_iter()

--- a/probe-rs/src/probe/blackmagic/arm.rs
+++ b/probe-rs/src/probe/blackmagic/arm.rs
@@ -113,10 +113,8 @@ impl BlackMagicProbeArmDebug {
 
         interface.access_ports = valid_access_ports(&mut interface, DpAddress::Default)
             .into_iter()
+            .inspect(|addr| tracing::debug!("AP {:#x?}", addr))
             .collect();
-        interface.access_ports.iter().for_each(|addr| {
-            tracing::debug!("AP {:#x?}", addr);
-        });
         Ok(interface)
     }
 
@@ -346,10 +344,8 @@ impl ArmProbeInterface for BlackMagicProbeArmDebug {
 
         self.access_ports = valid_access_ports(self, DpAddress::Default)
             .into_iter()
+            .inspect(|addr| tracing::debug!("AP {:#x?}", addr))
             .collect();
-        self.access_ports.iter().for_each(|addr| {
-            tracing::debug!("AP {:#x?}", addr);
-        });
 
         Ok(())
     }

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1329,10 +1329,8 @@ impl StlinkArmDebug {
 
         interface.access_ports = valid_access_ports(&mut interface, DpAddress::Default)
             .into_iter()
+            .inspect(|addr| tracing::debug!("AP {:#x?}", addr))
             .collect();
-        interface.access_ports.iter().for_each(|addr| {
-            tracing::debug!("AP {:#x?}", addr);
-        });
 
         Ok(interface)
     }


### PR DESCRIPTION
Implement `ArmProbeInterface::reinitialize()` for `BlackMagicProbeArmDebug`. This should get it working to the same level as the standard `ArmCommunicationInterface`.