### PR TITLE
Update to latest serde_yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,12 +178,9 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "0.6.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
-dependencies = [
- "bytemuck",
-]
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "atomic-waker"
@@ -1135,16 +1132,16 @@ dependencies = [
 
 [[package]]
 name = "figment"
-version = "0.10.19"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+checksum = "790b4292c72618abbab50f787a477014fe15634f96291de45672ce46afe122df"
 dependencies = [
  "atomic",
  "pear",
  "serde",
  "serde_json",
- "serde_yaml",
- "toml",
+ "serde_yaml 0.8.26",
+ "toml 0.5.11",
  "uncased",
  "version_check",
 ]
@@ -1339,7 +1336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
  "fallible-iterator",
- "indexmap",
+ "indexmap 2.7.0",
  "stable_deref_trait",
 ]
 
@@ -1382,6 +1379,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1718,12 +1721,22 @@ checksum = "365a784774bb381e8c19edb91190a90d7f2625e057b55de2bc0f6b57bc779ff2"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.1",
  "serde",
 ]
 
@@ -2013,7 +2026,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.1",
 ]
 
 [[package]]
@@ -2495,7 +2508,7 @@ dependencies = [
  "scroll",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.9.34-deprecated",
  "serialport",
  "svg",
  "termtree",
@@ -2541,7 +2554,7 @@ name = "probe-rs-target"
 version = "0.26.0"
 dependencies = [
  "base64",
- "indexmap",
+ "indexmap 2.7.0",
  "jep106",
  "serde",
  "serde_with",
@@ -3252,7 +3265,7 @@ dependencies = [
  "base64",
  "chrono",
  "hex",
- "indexmap",
+ "indexmap 2.7.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3261,11 +3274,23 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.34+deprecated"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34-deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4f17ab28832fcb8e88a0e938aaa915b4f4618142bd011d4e6a3060028974c47"
+dependencies = [
+ "indexmap 2.7.0",
  "itoa",
  "ryu",
  "serde",
@@ -3386,7 +3411,7 @@ dependencies = [
  "probe-rs",
  "serde",
  "thiserror 1.0.69",
- "toml",
+ "toml 0.8.19",
 ]
 
 [[package]]
@@ -3573,7 +3598,7 @@ dependencies = [
  "probe-rs-target",
  "reqwest",
  "scroll",
- "serde_yaml",
+ "serde_yaml 0.9.34-deprecated",
  "tempfile",
  "tokio",
  "tracing-subscriber",
@@ -3846,6 +3871,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
@@ -3871,7 +3905,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -3882,7 +3916,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4591,6 +4625,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4728,7 +4771,7 @@ dependencies = [
  "deflate64",
  "displaydoc",
  "flate2",
- "indexmap",
+ "indexmap 2.7.0",
  "lzma-rs",
  "memchr",
  "thiserror 2.0.3",

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -65,7 +65,7 @@ parking_lot = "0.12.2"
 zerocopy = { version = "0.8.0", features = ["derive"] }
 
 serde = { version = "1", features = ["derive"] }
-serde_yaml = "0.9"
+serde_yaml = "=0.9.34-deprecated"
 
 # optional
 hexdump = { version = "0.1", optional = true }
@@ -80,7 +80,7 @@ dunce = "1.0.5"
 probe-rs-target = { workspace = true, optional = true }
 
 bincode = { version = "1", optional = true }
-serde_yaml = { version = "0.9", optional = true }
+serde_yaml = { version = "=0.9.34-deprecated", optional = true }
 
 [dev-dependencies]
 pretty_env_logger = "0.5"

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -27,7 +27,7 @@ goblin = { version = "0.9.0", default-features = false, features = [
     "std",
 ] }
 scroll = "0.12.0"
-serde_yaml = "0.9"
+serde_yaml = "=0.9.34-deprecated"
 log = "0.4.21"
 zip = { version = "2.0.0", default-features = false, features = [
     "deflate64",


### PR DESCRIPTION
For some reason cargo can't resolve the dependency if one tool needs 0.9, and the other =0.9.34+deprecated. Annoying...