### PR TITLE
Inherit access configuration from device if any

### DIFF
--- a/changelog/fixed-inherited-access.md
+++ b/changelog/fixed-inherited-access.md
@@ -1,0 +1,1 @@
+Inherit access configuration for registers and fields from device if any

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/peripherals/svd_variables.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/peripherals/svd_variables.rs
@@ -78,6 +78,8 @@ pub(crate) fn variable_cache_from_svd<P: ProtocolAdapter>(
     let mut svd_cache = SvdVariableCache::new_svd_cache();
     let device_root_variable_key = svd_cache.root_variable_key();
 
+    let device_default_access = peripheral_device.default_register_properties.access;
+
     for peripheral in &peripheral_device.peripherals {
         let current_peripheral_group_name = peripheral.group_name.as_ref();
 
@@ -140,6 +142,7 @@ pub(crate) fn variable_cache_from_svd<P: ProtocolAdapter>(
                     .properties
                     .access
                     .map(|a| !a.can_read())
+                    .or_else(|| device_default_access.map(|a| !a.can_read()))
                     .unwrap_or(true);
 
             let register_name = format!("{}.{}", &peripheral_name, register.name);
@@ -152,6 +155,7 @@ pub(crate) fn variable_cache_from_svd<P: ProtocolAdapter>(
                     || field
                         .access
                         .map(|a| !a.can_read())
+                        .or_else(|| device_default_access.map(|a| !a.can_read()))
                         .unwrap_or(register_has_restricted_read);
 
                 let field_variable = (


### PR DESCRIPTION
When working with ATSAM SVDs, most of the peripherals don't have their `access` field specified, and thus are not retrieved.
A device-wide `access` is present and the SVD spec says that register and fields should inherit from the device value: https://arm-software.github.io/CMSIS_5/SVD/html/elem_special.html#registerPropertiesGroup_gr

This PR tries to check for this device-wide value when looking for registers and fields `access` property.

I didn't take the time to explore the whole code base, so I'm not sure if there is any other place where a change would be necessary.
The way I tested that is to load an SVD when debugging an ATSAM MCU in VSCode with the `probe-rs` extension and navigate through the `peripherals` list.