### PR TITLE
Fix SvdVariable alignment when reading

### DIFF
--- a/changelog/fixed-svd-alignment.md
+++ b/changelog/fixed-svd-alignment.md
@@ -1,0 +1,1 @@
+Properly align addresses when reading registers and fields, and avoid reading out of the bounds of the registers

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/peripherals/svd_variables.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/peripherals/svd_variables.rs
@@ -178,6 +178,7 @@ pub(crate) fn variable_cache_from_svd<P: ProtocolAdapter>(
                     address: register_address,
                     restricted_read: register_has_restricted_read,
                     description: register.description.clone(),
+                    size: register.properties.size.unwrap_or(32),
                 },
             )?;
 


### PR DESCRIPTION
Some 8-bits registers in the ATSAM family are aligned to the byte and not 32-bits words, thus returning a `MemoryNotAligned` error.
This PR provides a safe way to read those smaller registers (and similarly, fields) without reading others that might be read-protected.
Since there are no mechanism to read single bit without reading at least a whole byte AFAIK, I don't think there is a safe way of reading only parts of a register if any of its field is read-protected. In this PR we don't care about this case (I'm not sure there are any examples in the SVDs I'm having right now) and still read the whole byte/bytes.

This has been tested in addition to https://github.com/probe-rs/probe-rs/pull/3040 and works in the same test conditions.