### PR TITLE
Unwind: work around an infinite loop

### DIFF
--- a/changelog/fixed-looping-unwind.md
+++ b/changelog/fixed-looping-unwind.md
@@ -1,0 +1,1 @@
+Work around a possible infinite loop in stack unwinding

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -774,6 +774,11 @@ impl DebugInfo {
                     break 'unwind;
                 };
             }
+
+            if callee_frame_registers == unwind_registers {
+                tracing::debug!("No change, preventing infinite loop");
+                break;
+            }
         }
 
         Ok(stack_frames)

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -972,7 +972,7 @@ pub fn get_unwind_info<'a>(
 ) -> Result<&'a gimli::UnwindTableRow<GimliReaderOffset>, DebugError> {
     let transform_error = |error| {
         DebugError::Other(format!(
-            "UNWIND: Error reading FrameDescriptorEntry at PC={} : {}",
+            "UNWIND: Error reading FrameDescriptorEntry at PC={:x} : {}",
             frame_program_counter, error
         ))
     };


### PR DESCRIPTION
I hit a case where unwinding ended up in an infinite loop. This PR works around that issue.