### PR TITLE
Improve exception unwinding

### DIFF
--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -707,8 +707,7 @@ impl DebugInfo {
 
             // When we unwind the registers for the current frame, we should always do the FP and SP first,
             // since many of the unwind rule calculations for the other registers depend on either one of these two.
-            let critical_unwind_registers =
-                [RegisterRole::FramePointer, RegisterRole::StackPointer];
+            let critical_unwind_registers = [RegisterRole::StackPointer];
             for register_role in &critical_unwind_registers {
                 let register = unwind_registers.get_register_mut_by_role(register_role)?;
 
@@ -730,10 +729,7 @@ impl DebugInfo {
             for debug_register in unwind_registers.0.iter_mut() {
                 if debug_register
                     .core_register
-                    .register_has_role(RegisterRole::FramePointer)
-                    || debug_register
-                        .core_register
-                        .register_has_role(RegisterRole::StackPointer)
+                    .register_has_role(RegisterRole::StackPointer)
                     || debug_register
                         .core_register
                         .register_has_role(RegisterRole::ProgramCounter)

--- a/probe-rs-debug/src/exception_handling.rs
+++ b/probe-rs-debug/src/exception_handling.rs
@@ -134,16 +134,10 @@ pub trait ExceptionInterface {
         &self,
         unwind_registers: &mut DebugRegisters,
         frame_pc: u64,
-        stack_frames: &[StackFrame],
+        _stack_frames: &[StackFrame],
         instruction_set: Option<probe_rs::InstructionSet>,
-        memory: &mut dyn MemoryInterface,
+        _memory: &mut dyn MemoryInterface,
     ) -> ControlFlow<Option<DebugError>> {
-        unwind_pc_without_debuginfo(
-            unwind_registers,
-            frame_pc,
-            stack_frames,
-            instruction_set,
-            memory,
-        )
+        unwind_pc_without_debuginfo(unwind_registers, frame_pc, instruction_set)
     }
 }

--- a/probe-rs-debug/src/exception_handling/armv7m.rs
+++ b/probe-rs-debug/src/exception_handling/armv7m.rs
@@ -336,16 +336,6 @@ impl ExceptionInterface for ArmV7MExceptionHandler {
     ) -> Result<crate::DebugRegisters, DebugError> {
         let mut updated_registers = stackframe_registers.clone();
 
-        // Identify the correct location for the exception context. This is different between Armv6-M and Armv7-M.
-        let exception_reason = ExceptionReason::from(raw_exception);
-        if exception_reason.is_precise_fault(memory_interface)? {
-            let exception_context_address = updated_registers
-                .get_register_mut_by_role(&probe_rs::RegisterRole::StackPointer)?;
-            if let Some(sp_value) = exception_context_address.value.as_mut() {
-                sp_value.increment_address(0x8)?;
-            }
-        }
-
         updated_registers = armv6m_armv7m_shared::calling_frame_registers(
             memory_interface,
             &updated_registers,

--- a/probe-rs-debug/src/exception_handling/xtensa.rs
+++ b/probe-rs-debug/src/exception_handling/xtensa.rs
@@ -50,18 +50,12 @@ impl ExceptionInterface for XtensaExceptionHandler {
         &self,
         unwind_registers: &mut DebugRegisters,
         frame_pc: u64,
-        stack_frames: &[StackFrame],
+        _stack_frames: &[StackFrame],
         instruction_set: Option<probe_rs::InstructionSet>,
         memory: &mut dyn MemoryInterface,
     ) -> ControlFlow<Option<DebugError>> {
         // Use the default method to unwind PC.
-        unwind_pc_without_debuginfo(
-            unwind_registers,
-            frame_pc,
-            stack_frames,
-            instruction_set,
-            memory,
-        )?;
+        unwind_pc_without_debuginfo(unwind_registers, frame_pc, instruction_set)?;
 
         // We can try and use FP to unwind SP and RA that allows us to continue unwinding.
 

--- a/probe-rs-debug/src/registers.rs
+++ b/probe-rs-debug/src/registers.rs
@@ -52,11 +52,6 @@ impl DebugRegister {
         Ok(None)
     }
 
-    /// Test if this is a 32-bit unsigned integer register
-    pub(crate) fn is_u32(&self) -> bool {
-        self.core_register.data_type == RegisterDataType::UnsignedInteger(32)
-    }
-
     /// A helper function to determine if the contained register value is equal to the maximum value that can be stored in that datatype.
     /// Will return false if the value is `None`
     pub(crate) fn is_max_value(&self) -> bool {
@@ -126,14 +121,15 @@ impl DebugRegisters {
 
     /// Gets the address size for this target, in bytes
     pub fn get_address_size_bytes(&self) -> usize {
-        self.get_program_counter().map_or_else(
-            || 0,
-            |debug_register| debug_register.core_register.size_in_bits().div_ceil(8),
-        )
+        self.get_program_counter()
+            .map(|debug_register| debug_register.core_register.size_in_bits().div_ceil(8))
+            .unwrap_or(0)
     }
 
     /// Get the canonical frame address, as specified in the [DWARF](https://dwarfstd.org) specification, section 6.4.
     /// [DWARF](https://dwarfstd.org)
+    ///
+    /// This is not always available
     pub fn get_frame_pointer(&self) -> Option<&DebugRegister> {
         self.0.iter().find(|debug_register| {
             debug_register

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_full_unwind.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_full_unwind.snap
@@ -1,6 +1,5 @@
 ---
 source: probe-rs-debug/src/debug_info.rs
-assertion_line: 1999
 expression: stack_frames
 ---
 - function_name: test_deep_stack

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_svcall.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_svcall.snap
@@ -1,6 +1,5 @@
 ---
 source: probe-rs-debug/src/debug_info.rs
-assertion_line: 1999
 expression: stack_frames
 ---
 - function_name: software_breakpoint

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_svcall.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_svcall.snap
@@ -785,7 +785,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268436742
+        U32: 268436741
     - core_register:
         id: 17
         roles:
@@ -824,7 +824,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268436742
+    U32: 268436741
   frame_base: ~
   is_inlined: false
   local_variables: ~
@@ -832,10 +832,10 @@ expression: stack_frames
 - function_name: trigger_supervisor_call
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
-    line: 80
+    line: 78
     column:
-      Column: 2
-    address: 268436742
+      Column: 9
+    address: 268436740
   registers:
     - core_register:
         id: 0
@@ -989,7 +989,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268436742
+        U32: 268436741
     - core_register:
         id: 17
         roles:
@@ -1028,7 +1028,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268436742
+    U32: 268436741
   frame_base: 536886960
   is_inlined: false
   local_variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_svcall.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_svcall.snap
@@ -765,7 +765,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 13
       value:
-        U32: 536886928
+        U32: 536886960
     - core_register:
         id: 14
         roles:
@@ -969,7 +969,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 13
       value:
-        U32: 536886928
+        U32: 536886960
     - core_register:
         id: 14
         roles:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_systick.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_systick.snap
@@ -765,7 +765,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 13
       value:
-        U32: 536886888
+        U32: 536886920
     - core_register:
         id: 14
         roles:
@@ -969,7 +969,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 13
       value:
-        U32: 536886888
+        U32: 536886920
     - core_register:
         id: 14
         roles:
@@ -1035,13 +1035,13 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tcyc: u32 = 858993459,\n\treal_cyc: u32 = 48000000}"
+      value: "<unknown> {\n\tcyc: u32 = 1000000,\n\treal_cyc: u32 = 500001}"
       children:
         - name:
             Named: cyc
           type_name:
             Base: u32
-          value: "858993459"
+          value: "1000000"
           source_location:
             path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
             line: 56
@@ -1051,7 +1051,7 @@ expression: stack_frames
             Named: real_cyc
           type_name:
             Base: u32
-          value: "48000000"
+          value: "500001"
           source_location:
             path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
             line: 61
@@ -1198,7 +1198,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 13
       value:
-        U32: 536886888
+        U32: 536886920
     - core_register:
         id: 14
         roles:
@@ -1264,13 +1264,13 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tcycles: u32 = 3758153744}"
+      value: "<unknown> {\n\tcycles: u32 = 1000000}"
       children:
         - name:
             Named: cycles
           type_name:
             Base: u32
-          value: "3758153744"
+          value: "1000000"
           source_location:
             path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
             line: 28

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_systick.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_systick.snap
@@ -785,7 +785,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268437366
+        U32: 268437365
     - core_register:
         id: 17
         roles:
@@ -824,7 +824,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268437366
+    U32: 268437365
   frame_base: ~
   is_inlined: false
   local_variables: ~
@@ -832,10 +832,10 @@ expression: stack_frames
 - function_name: __delay
   source_location:
     path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
-    line: 62
+    line: 61
     column:
-      Column: 5
-    address: 268437366
+      Column: 20
+    address: 268437344
   registers:
     - core_register:
         id: 0
@@ -989,7 +989,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268437366
+        U32: 268437365
     - core_register:
         id: 17
         roles:
@@ -1028,14 +1028,14 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268437366
+    U32: 268437365
   frame_base: 536886936
   is_inlined: true
   local_variables:
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tcyc: u32 = 1000000,\n\treal_cyc: u32 = 500001}"
+      value: "<unknown> {\n\tcyc: u32 = 1000000}"
       children:
         - name:
             Named: cyc
@@ -1045,16 +1045,6 @@ expression: stack_frames
           source_location:
             path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
             line: 56
-            column: ~
-            address: ~
-        - name:
-            Named: real_cyc
-          type_name:
-            Base: u32
-          value: "500001"
-          source_location:
-            path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
-            line: 61
             column: ~
             address: ~
   canonical_frame_address: 536886944
@@ -1218,7 +1208,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268437366
+        U32: 268437365
     - core_register:
         id: 17
         roles:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_systick.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_systick.snap
@@ -1,6 +1,5 @@
 ---
 source: probe-rs-debug/src/debug_info.rs
-assertion_line: 1999
 expression: stack_frames
 ---
 - function_name: software_breakpoint

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__atsamd51p19a.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__atsamd51p19a.snap
@@ -1,6 +1,5 @@
 ---
 source: probe-rs-debug/src/debug_info.rs
-assertion_line: 1999
 expression: stack_frames
 ---
 - function_name: print_const_pointers

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__atsamd51p19a.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__atsamd51p19a.snap
@@ -949,3 +949,202 @@ expression: stack_frames
                       - Base: long unsigned int
               value: "484133903"
   canonical_frame_address: 536875128
+- function_name: Reset
+  source_location: ~
+  registers:
+    - core_register:
+        id: 0
+        roles:
+          - Core: R0
+          - Argument: a1
+          - Return: r1
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 0
+      value:
+        U32: 0
+    - core_register:
+        id: 1
+        roles:
+          - Core: R1
+          - Argument: a2
+          - Return: r2
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 1
+      value:
+        U32: 0
+    - core_register:
+        id: 2
+        roles:
+          - Core: R2
+          - Argument: a3
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 2
+      value:
+        U32: 0
+    - core_register:
+        id: 3
+        roles:
+          - Core: R3
+          - Argument: a4
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 3
+      value:
+        U32: 0
+    - core_register:
+        id: 4
+        roles:
+          - Core: R4
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 4
+      value:
+        U32: 2779096485
+    - core_register:
+        id: 5
+        roles:
+          - Core: R5
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 5
+      value:
+        U32: 2779096485
+    - core_register:
+        id: 6
+        roles:
+          - Core: R6
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 6
+      value:
+        U32: 2779096485
+    - core_register:
+        id: 7
+        roles:
+          - Core: R7
+          - FramePointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 7
+      value:
+        U32: 536885816
+    - core_register:
+        id: 8
+        roles:
+          - Core: R8
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 8
+      value:
+        U32: 2779096485
+    - core_register:
+        id: 9
+        roles:
+          - Core: R9
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 9
+      value: ~
+    - core_register:
+        id: 10
+        roles:
+          - Core: R10
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 10
+      value:
+        U32: 2779096485
+    - core_register:
+        id: 11
+        roles:
+          - Core: R11
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 11
+      value:
+        U32: 2779096485
+    - core_register:
+        id: 12
+        roles:
+          - Core: R12
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 12
+      value:
+        U32: 0
+    - core_register:
+        id: 13
+        roles:
+          - Core: R13
+          - StackPointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 13
+      value:
+        U32: 536875160
+    - core_register:
+        id: 14
+        roles:
+          - Core: R14
+          - ReturnAddress
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 14
+      value:
+        U32: 0
+    - core_register:
+        id: 15
+        roles:
+          - Core: R15
+          - ProgramCounter
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 15
+      value:
+        U32: 0
+    - core_register:
+        id: 17
+        roles:
+          - Core: MSP
+          - MainStackPointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 16
+      value: ~
+    - core_register:
+        id: 18
+        roles:
+          - Core: PSP
+          - ProcessStackPointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
+    - core_register:
+        id: 16
+        roles:
+          - Core: XPSR
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 18
+      value:
+        U32: 0
+    - core_register:
+        id: 20
+        roles:
+          - Core: EXTRA
+          - Other: EXTRA
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 19
+      value: ~
+  pc:
+    U32: 0
+  frame_base: ~
+  is_inlined: false
+  local_variables: ~
+  canonical_frame_address: ~

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__atsamd51p19a.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__atsamd51p19a.snap
@@ -961,8 +961,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 0
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 1
         roles:
@@ -972,8 +971,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 1
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 2
         roles:
@@ -982,8 +980,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 2
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 3
         roles:
@@ -992,8 +989,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 3
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 4
         roles:
@@ -1001,8 +997,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 4
-      value:
-        U32: 2779096485
+      value: ~
     - core_register:
         id: 5
         roles:
@@ -1010,8 +1005,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 5
-      value:
-        U32: 2779096485
+      value: ~
     - core_register:
         id: 6
         roles:
@@ -1019,8 +1013,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 6
-      value:
-        U32: 2779096485
+      value: ~
     - core_register:
         id: 7
         roles:
@@ -1029,8 +1022,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 7
-      value:
-        U32: 536885816
+      value: ~
     - core_register:
         id: 8
         roles:
@@ -1038,8 +1030,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 8
-      value:
-        U32: 2779096485
+      value: ~
     - core_register:
         id: 9
         roles:
@@ -1055,8 +1046,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 10
-      value:
-        U32: 2779096485
+      value: ~
     - core_register:
         id: 11
         roles:
@@ -1064,8 +1054,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 11
-      value:
-        U32: 2779096485
+      value: ~
     - core_register:
         id: 12
         roles:
@@ -1073,8 +1062,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 12
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 13
         roles:
@@ -1083,8 +1071,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 13
-      value:
-        U32: 536875160
+      value: ~
     - core_register:
         id: 14
         roles:
@@ -1093,8 +1080,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 14
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 15
         roles:
@@ -1103,8 +1089,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 15
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 17
         roles:
@@ -1131,8 +1116,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 18
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 20
         roles:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_full_unwind.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_full_unwind.snap
@@ -1,6 +1,5 @@
 ---
 source: probe-rs-debug/src/debug_info.rs
-assertion_line: 1999
 expression: stack_frames
 ---
 - function_name: test_deep_stack

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_from_busfault.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_from_busfault.snap
@@ -1,6 +1,5 @@
 ---
 source: probe-rs-debug/src/debug_info.rs
-assertion_line: 1999
 expression: stack_frames
 ---
 - function_name: software_breakpoint
@@ -525,8 +524,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 9
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 10
         roles:
@@ -592,8 +590,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 16
-      value:
-        U32: 536887064
+      value: ~
     - core_register:
         id: 18
         roles:
@@ -602,8 +599,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 17
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 16
         roles:
@@ -622,14 +618,13 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 19
-      value:
-        U32: 0
+      value: ~
   pc:
     U32: 1690
-  frame_base: 536887064
+  frame_base: ~
   is_inlined: false
   local_variables: ~
-  canonical_frame_address: 536887072
+  canonical_frame_address: ~
 - function_name: read_volatile<u32>
   source_location:
     path: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr/mod.rs
@@ -733,8 +728,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 9
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 10
         roles:
@@ -800,8 +794,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 16
-      value:
-        U32: 536887064
+      value: ~
     - core_register:
         id: 18
         roles:
@@ -810,8 +803,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 17
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 16
         roles:
@@ -830,8 +822,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 19
-      value:
-        U32: 0
+      value: ~
   pc:
     U32: 1690
   frame_base: 536887120

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
@@ -1,6 +1,5 @@
 ---
 source: probe-rs-debug/src/debug_info.rs
-assertion_line: 1999
 expression: stack_frames
 ---
 - function_name: software_breakpoint

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
@@ -507,7 +507,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 7
       value:
-        U32: 536887096
+        U32: 536887128
     - core_register:
         id: 8
         roles:
@@ -524,8 +524,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 9
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 10
         roles:
@@ -591,8 +590,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 16
-      value:
-        U32: 536887088
+      value: ~
     - core_register:
         id: 18
         roles:
@@ -601,8 +599,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 17
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 16
         roles:
@@ -621,14 +618,13 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 19
-      value:
-        U32: 0
+      value: ~
   pc:
     U32: 1586
-  frame_base: 536887088
+  frame_base: ~
   is_inlined: false
   local_variables: ~
-  canonical_frame_address: 536887096
+  canonical_frame_address: ~
 - function_name: __udf
   source_location:
     path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
@@ -715,7 +711,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 7
       value:
-        U32: 536887096
+        U32: 536887128
     - core_register:
         id: 8
         roles:
@@ -732,8 +728,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 9
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 10
         roles:
@@ -799,8 +794,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 16
-      value:
-        U32: 536887088
+      value: ~
     - core_register:
         id: 18
         roles:
@@ -809,8 +803,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 17
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 16
         roles:
@@ -829,11 +822,10 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 19
-      value:
-        U32: 0
+      value: ~
   pc:
     U32: 1586
-  frame_base: 536887096
+  frame_base: 536887128
   is_inlined: true
   local_variables:
     Child Variables:
@@ -927,7 +919,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 7
       value:
-        U32: 536887096
+        U32: 536887128
     - core_register:
         id: 8
         roles:
@@ -944,8 +936,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 9
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 10
         roles:
@@ -1011,8 +1002,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 16
-      value:
-        U32: 536887088
+      value: ~
     - core_register:
         id: 18
         roles:
@@ -1021,8 +1011,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 17
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 16
         roles:
@@ -1041,11 +1030,10 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 19
-      value:
-        U32: 0
+      value: ~
   pc:
     U64: 1586
-  frame_base: 536887096
+  frame_base: 536887128
   is_inlined: false
   local_variables:
     Child Variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
@@ -1,6 +1,5 @@
 ---
 source: probe-rs-debug/src/debug_info.rs
-assertion_line: 1999
 expression: stack_frames
 ---
 - function_name: software_breakpoint
@@ -525,8 +524,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 9
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 10
         roles:
@@ -592,8 +590,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 16
-      value:
-        U32: 536886968
+      value: ~
     - core_register:
         id: 18
         roles:
@@ -602,8 +599,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 17
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 16
         roles:
@@ -622,14 +618,13 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 19
-      value:
-        U32: 0
+      value: ~
   pc:
     U32: 2166
-  frame_base: 536886968
+  frame_base: ~
   is_inlined: false
   local_variables: ~
-  canonical_frame_address: 536886976
+  canonical_frame_address: ~
 - function_name: read_volatile<u32>
   source_location:
     path: /rustc/7f2fc33da6633f5a764ddc263c769b6b2873d167/library/core/src/ptr/mod.rs
@@ -733,8 +728,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 9
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 10
         roles:
@@ -800,8 +794,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 16
-      value:
-        U32: 536886968
+      value: ~
     - core_register:
         id: 18
         roles:
@@ -810,8 +803,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 17
-      value:
-        U32: 0
+      value: ~
     - core_register:
         id: 16
         roles:
@@ -830,8 +822,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 19
-      value:
-        U32: 0
+      value: ~
   pc:
     U32: 2166
   frame_base: 536887024
@@ -1811,7 +1802,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 13
       value:
-        U32: 536887056
+        U32: 536887088
     - core_register:
         id: 14
         roles:
@@ -2015,7 +2006,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 13
       value:
-        U32: 536887056
+        U32: 536887088
     - core_register:
         id: 14
         roles:
@@ -2081,13 +2072,13 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tcyc: u32 = 1,\n\treal_cyc: u32 = 85}"
+      value: "<unknown> {\n\tcyc: u32 = 1000000,\n\treal_cyc: u32 = 500001}"
       children:
         - name:
             Named: cyc
           type_name:
             Base: u32
-          value: "1"
+          value: "1000000"
           source_location:
             path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
             line: 56
@@ -2097,7 +2088,7 @@ expression: stack_frames
             Named: real_cyc
           type_name:
             Base: u32
-          value: "85"
+          value: "500001"
           source_location:
             path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
             line: 61
@@ -2244,7 +2235,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 13
       value:
-        U32: 536887056
+        U32: 536887088
     - core_register:
         id: 14
         roles:
@@ -2310,13 +2301,13 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tcycles: u32 = 500001}"
+      value: "<unknown> {\n\tcycles: u32 = 1000000}"
       children:
         - name:
             Named: cycles
           type_name:
             Base: u32
-          value: "500001"
+          value: "1000000"
           source_location:
             path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
             line: 28

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
@@ -1822,7 +1822,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 1240
+        U32: 1239
     - core_register:
         id: 17
         roles:
@@ -1861,7 +1861,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 1240
+    U32: 1239
   frame_base: ~
   is_inlined: false
   local_variables: ~
@@ -2026,7 +2026,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 1240
+        U32: 1239
     - core_register:
         id: 17
         roles:
@@ -2065,7 +2065,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 1240
+    U32: 1239
   frame_base: 536887104
   is_inlined: true
   local_variables:
@@ -2255,7 +2255,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 1240
+        U32: 1239
     - core_register:
         id: 17
         roles:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_svcall.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_svcall.snap
@@ -1,6 +1,5 @@
 ---
 source: probe-rs-debug/src/debug_info.rs
-assertion_line: 1999
 expression: stack_frames
 ---
 - function_name: software_breakpoint

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_svcall.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_svcall.snap
@@ -785,7 +785,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 938
+        U32: 937
     - core_register:
         id: 17
         roles:
@@ -824,7 +824,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 938
+    U32: 937
   frame_base: ~
   is_inlined: false
   local_variables: ~
@@ -832,10 +832,10 @@ expression: stack_frames
 - function_name: trigger_supervisor_call
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
-    line: 63
+    line: 61
     column:
-      Column: 2
-    address: 938
+      Column: 9
+    address: 936
   registers:
     - core_register:
         id: 0
@@ -989,7 +989,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 938
+        U32: 937
     - core_register:
         id: 17
         roles:
@@ -1028,7 +1028,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 938
+    U32: 937
   frame_base: 536887128
   is_inlined: false
   local_variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_svcall.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_svcall.snap
@@ -765,7 +765,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 13
       value:
-        U32: 536887096
+        U32: 536887128
     - core_register:
         id: 14
         roles:
@@ -969,7 +969,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 13
       value:
-        U32: 536887096
+        U32: 536887128
     - core_register:
         id: 14
         roles:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_systick.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_systick.snap
@@ -1,6 +1,5 @@
 ---
 source: probe-rs-debug/src/debug_info.rs
-assertion_line: 1999
 expression: stack_frames
 ---
 - function_name: software_breakpoint

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_systick.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_systick.snap
@@ -785,7 +785,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 1398
+        U32: 1397
     - core_register:
         id: 17
         roles:
@@ -824,7 +824,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 1398
+    U32: 1397
   frame_base: ~
   is_inlined: false
   local_variables: ~
@@ -989,7 +989,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 1398
+        U32: 1397
     - core_register:
         id: 17
         roles:
@@ -1028,7 +1028,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 1398
+    U32: 1397
   frame_base: 536887104
   is_inlined: true
   local_variables:
@@ -1218,7 +1218,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 1398
+        U32: 1397
     - core_register:
         id: 17
         roles:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_systick.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_systick.snap
@@ -765,7 +765,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 13
       value:
-        U32: 536887056
+        U32: 536887088
     - core_register:
         id: 14
         roles:
@@ -969,7 +969,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 13
       value:
-        U32: 536887056
+        U32: 536887088
     - core_register:
         id: 14
         roles:
@@ -1035,13 +1035,13 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tcyc: u32 = 1,\n\treal_cyc: u32 = 85}"
+      value: "<unknown> {\n\tcyc: u32 = 1000000,\n\treal_cyc: u32 = 500001}"
       children:
         - name:
             Named: cyc
           type_name:
             Base: u32
-          value: "1"
+          value: "1000000"
           source_location:
             path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
             line: 56
@@ -1051,7 +1051,7 @@ expression: stack_frames
             Named: real_cyc
           type_name:
             Base: u32
-          value: "85"
+          value: "500001"
           source_location:
             path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/../asm/inline.rs
             line: 61
@@ -1198,7 +1198,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 13
       value:
-        U32: 536887056
+        U32: 536887088
     - core_register:
         id: 14
         roles:
@@ -1264,13 +1264,13 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tcycles: u32 = 500001}"
+      value: "<unknown> {\n\tcycles: u32 = 1000000}"
       children:
         - name:
             Named: cycles
           type_name:
             Base: u32
-          value: "500001"
+          value: "1000000"
           source_location:
             path: /Users/jacknoppe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cortex-m-0.7.7/src/asm.rs
             line: 28

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__print_stacktrace.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__print_stacktrace.snap
@@ -1,8 +1,6 @@
 ---
-source: probe-rs/src/debug/debug_info.rs
-assertion_line: 1926
+source: probe-rs-debug/src/debug_info.rs
 expression: printed_backtrace
-snapshot_kind: text
 ---
 Frame:
  function:        read<nrf51_pac::timer0::events_compare::EVENTS_COMPARE_SPEC>
@@ -68,7 +66,7 @@ Frame:
   column: Some(Column(1))
  frame_base:      Some(20003ff8)
 Frame:
- function:        <unknown function @ 0x000000ce> : ERROR: UNWIND: Tried to unwind `RegisterRule` at CFA = None.
+ function:        <unknown function @ 0x000000ce> : ERROR: UNWIND: Failed to read value for register R7/FP from address 0x0000000000000000 (4 bytes): The coredump does not include the memory for address 0x0 of size 0x4
  source_location:
 None
  frame_base:      None

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_in_exception_handler.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_in_exception_handler.snap
@@ -1,8 +1,6 @@
 ---
-source: probe-rs/src/debug/debug_info.rs
-assertion_line: 1700
+source: probe-rs-debug/src/debug_info.rs
 expression: printed_backtrace
-snapshot_kind: text
 ---
 Frame:
  function:        __cortex_m_rt_SVCall
@@ -27,7 +25,7 @@ Frame:
  function:        __cortex_m_rt_main
  source_location:
   path: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs
-  line: Some(19)
+  line: Some(17)
   column: Some(Column(5))
  frame_base:      Some(2001fff0)
 Frame:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_in_exception_trampoline.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_in_exception_trampoline.snap
@@ -1,8 +1,6 @@
 ---
-source: probe-rs/src/debug/debug_info.rs
-assertion_line: 1804
+source: probe-rs-debug/src/debug_info.rs
 expression: printed_backtrace
-snapshot_kind: text
 ---
 Frame:
  function:        __cortex_m_rt_SVCall_trampoline
@@ -20,7 +18,7 @@ Frame:
  function:        __cortex_m_rt_main
  source_location:
   path: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs
-  line: Some(19)
+  line: Some(17)
   column: Some(Column(5))
  frame_base:      Some(2001fff0)
 Frame:

--- a/probe-rs/src/architecture/arm/core/registers/cortex_m.rs
+++ b/probe-rs/src/architecture/arm/core/registers/cortex_m.rs
@@ -7,21 +7,24 @@ use crate::{
     CoreRegister, CoreRegisters, RegisterId,
 };
 
-pub(crate) const PC: CoreRegister = CoreRegister {
+/// Program counter (PC) register.
+pub const PC: CoreRegister = CoreRegister {
     roles: &[RegisterRole::Core("R15"), RegisterRole::ProgramCounter],
     id: RegisterId(15),
     data_type: RegisterDataType::UnsignedInteger(32),
     unwind_rule: UnwindRule::SpecialRule,
 };
 
-pub(crate) const FP: CoreRegister = CoreRegister {
+/// Frame pointer (FP) register.
+pub const FP: CoreRegister = CoreRegister {
     roles: &[RegisterRole::Core("R7"), RegisterRole::FramePointer],
     id: RegisterId(7),
     data_type: RegisterDataType::UnsignedInteger(32),
-    unwind_rule: UnwindRule::SpecialRule,
+    unwind_rule: UnwindRule::Preserve,
 };
 
-pub(crate) const SP: CoreRegister = CoreRegister {
+/// Stack pointer (SP) register.
+pub const SP: CoreRegister = CoreRegister {
     roles: &[RegisterRole::Core("R13"), RegisterRole::StackPointer],
     id: RegisterId(13),
     data_type: RegisterDataType::UnsignedInteger(32),
@@ -44,7 +47,7 @@ pub const XPSR: CoreRegister = CoreRegister {
     unwind_rule: UnwindRule::Preserve,
 };
 
-/// All off the Cortex-M core registers.
+/// All of the Cortex-M core registers.
 pub static CORTEX_M_CORE_REGISTERS: LazyLock<CoreRegisters> = LazyLock::new(|| {
     CoreRegisters::new(
         ARM32_COMMON_REGS_SET


### PR DESCRIPTION
This changes the general flow of unwinding to better handle exceptions. The existing code first checked for an exception, before using the unwind information from the debug information. This is wrong if we're inside an exception handler which modifies the stack pointer. In such a case, we first have to unwind to the call site of the exception handler, and only then can we check for an exception.



## Additional changes

- When unwinding an exception, ensure that we get a program counter pointing to the calling instruction, not one to the next instruction to be executed after returning from the exception. This is achieved by subtracting one from the PC. 
