### PR TITLE
fix(c-language): added 64b values formatting

### DIFF
--- a/changelog/fixed-c-language-64bits-support.md
+++ b/changelog/fixed-c-language-64bits-support.md
@@ -1,0 +1,1 @@
+C-Language now properly supports 64bits variables (int, uint and double)

--- a/probe-rs-debug/src/language/c.rs
+++ b/probe-rs-debug/src/language/c.rs
@@ -27,11 +27,22 @@ impl ProgrammingLanguage for C {
                 "_Bool" => UnsignedInt::get_value(variable, None, memory, variable_cache).into(),
                 "char" => CChar::get_value(variable, memory, variable_cache).into(),
 
-                "unsigned char" | "unsigned int" | "short unsigned int" | "long unsigned int" => {
+                "unsigned char"
+                | "unsigned int"
+                | "short unsigned int"
+                | "long unsigned int"
+                | "long long unsigned int" => {
                     UnsignedInt::get_value(variable, None, memory, variable_cache).into()
                 }
-                "signed char" | "int" | "short int" | "long int" | "signed int"
-                | "short signed int" | "long signed int" => {
+                "signed char"
+                | "int"
+                | "short int"
+                | "long int"
+                | "long long int"
+                | "signed int"
+                | "short signed int"
+                | "long signed int"
+                | "long long signed int" => {
                     SignedInt::get_value(variable, None, memory, variable_cache).into()
                 }
 
@@ -43,7 +54,14 @@ impl ProgrammingLanguage for C {
                         VariableValue::Error(format!("Invalid byte size for float: {size}"))
                     }
                 },
-                // TODO: doubles
+                "double" => match variable.byte_size {
+                    Some(8) | None => f64::get_value(variable, memory, variable_cache)
+                        .map(|f| format_float(f as f64))
+                        .into(),
+                    Some(size) => {
+                        VariableValue::Error(format!("Invalid byte size for double: {size}"))
+                    }
+                },
                 _undetermined_value => VariableValue::Empty,
             },
 

--- a/probe-rs-debug/src/language/c.rs
+++ b/probe-rs-debug/src/language/c.rs
@@ -56,7 +56,7 @@ impl ProgrammingLanguage for C {
                 },
                 "double" => match variable.byte_size {
                     Some(8) | None => f64::get_value(variable, memory, variable_cache)
-                        .map(|f| format_float(f as f64))
+                        .map(format_float)
                         .into(),
                     Some(size) => {
                         VariableValue::Error(format!("Invalid byte size for double: {size}"))


### PR DESCRIPTION
Fixes #3046 

Added 64-bits variable formatting for the C language:

- int64_t
- uint64_t
- double

I have not been able to get a 128b variable in my 32bits MCU, apparently GCC supports the type only for 64b targets hence I did not added support to them.

NOTE: I found it weird that a `u64` comes in as `long long unsigned int, but it seems to be according to the standard: https://en.wikipedia.org/wiki/C_data_types
Based on the wiki table, I wander if `unsigned long long` (without `int`) and variants would be a valid match here?

![image](https://github.com/user-attachments/assets/34aa71c5-a481-4fc2-9ed1-af32fcc15078)
