### PR TITLE
Rework the RTT processing code

### DIFF
--- a/changelog/changed-defmt-default.md
+++ b/changelog/changed-defmt-default.md
@@ -1,0 +1,1 @@
+The default defmt output format is now single line. The previous default can be activated by using the "twoline" log format.

--- a/changelog/fixed-defmt.md
+++ b/changelog/fixed-defmt.md
@@ -1,0 +1,1 @@
+Fixed defmt not being able to read messages larger than the RTT buffer.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
@@ -1,3 +1,5 @@
+use time::UtcOffset;
+
 use crate::rpc::client::RpcClient;
 use crate::rpc::functions::monitor::{MonitorMode, MonitorOptions};
 use crate::util::cli::{self, rtt_client};
@@ -10,7 +12,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub async fn run(self, client: RpcClient) -> anyhow::Result<()> {
+    pub async fn run(self, client: RpcClient, utc_offset: UtcOffset) -> anyhow::Result<()> {
         let session =
             cli::attach_probe(&client, self.run.shared_options.probe_options, true).await?;
 
@@ -23,7 +25,7 @@ impl Cmd {
             },
             self.run.shared_options.log_format,
             !self.run.shared_options.no_location,
-            None,
+            Some(utc_offset),
         )
         .await?;
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
@@ -1,7 +1,6 @@
 use crate::rpc::client::RpcClient;
 use crate::rpc::functions::monitor::{MonitorMode, MonitorOptions};
-use crate::rpc::functions::rtt_client::LogOptions;
-use crate::util::cli;
+use crate::util::cli::{self, rtt_client};
 
 #[derive(clap::Parser)]
 #[group(skip)]
@@ -15,25 +14,30 @@ impl Cmd {
         let session =
             cli::attach_probe(&client, self.run.shared_options.probe_options, true).await?;
 
-        let rtt = session
-            .create_rtt_client(
-                Some(self.run.shared_options.path.clone()),
-                LogOptions {
-                    no_location: self.run.shared_options.no_location,
-                    log_format: self.run.shared_options.log_format,
-                    rtt_scan_memory: self.run.shared_options.rtt_scan_memory,
-                },
-            )
-            .await?;
+        let rtt_client = rtt_client(
+            &session,
+            &self.run.shared_options.path,
+            match self.run.shared_options.rtt_scan_memory {
+                true => crate::rpc::functions::rtt_client::ScanRegion::TargetDefault,
+                false => crate::rpc::functions::rtt_client::ScanRegion::Ranges(vec![]),
+            },
+            self.run.shared_options.log_format,
+            !self.run.shared_options.no_location,
+            None,
+        )
+        .await?;
+
+        let client_handle = rtt_client.handle();
 
         cli::monitor(
             &session,
             MonitorMode::AttachToRunning,
             &self.run.shared_options.path,
+            Some(rtt_client),
             MonitorOptions {
                 catch_reset: self.run.run_options.catch_reset,
                 catch_hardfault: self.run.run_options.catch_hardfault,
-                rtt_client: Some(rtt),
+                rtt_client: Some(client_handle),
             },
             self.run.shared_options.always_print_stacktrace,
         )

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -4,11 +4,13 @@ use figment::{
     Figment,
 };
 use probe_rs::probe::WireProtocol;
-use probe_rs::rtt::ChannelMode;
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
-use crate::util::{logging::LevelFilter, rtt::DataFormat};
+use crate::util::{
+    logging::LevelFilter,
+    rtt::{ChannelMode, DataFormat},
+};
 
 use super::rttui::tab::TabConfig;
 
@@ -76,7 +78,7 @@ pub struct General {
 
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct UpChannelConfig {
-    pub channel: usize,
+    pub channel: u32,
     #[serde(default)]
     pub mode: Option<ChannelMode>,
     #[serde(default)]
@@ -96,7 +98,7 @@ pub struct UpChannelConfig {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DownChannelConfig {
-    pub channel: usize,
+    pub channel: u32,
     #[serde(default)]
     pub mode: Option<ChannelMode>,
 }
@@ -125,7 +127,7 @@ pub struct Rtt {
 
 impl Rtt {
     /// Returns the configuration for the specified up channel number, if it exists.
-    pub fn up_channel_config(&self, channel_number: usize) -> Option<&UpChannelConfig> {
+    pub fn up_channel_config(&self, channel_number: u32) -> Option<&UpChannelConfig> {
         self.up_channels
             .iter()
             .find(|ch| ch.channel == channel_number)

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -74,8 +74,7 @@ pub struct General {
     pub connect_under_reset: bool,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-// Note: default values are defined in `RttChannelConfig`.
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct UpChannelConfig {
     pub channel: usize,
     #[serde(default)]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -131,7 +131,7 @@ impl App {
                 .any(|tab| tab.down_channel == Some(number))
             {
                 tab_config.push(TabConfig {
-                    up_channel: if up_channels.len() > number {
+                    up_channel: if up_channels.len() as u32 > number {
                         number
                     } else {
                         0
@@ -151,7 +151,7 @@ impl App {
             if tab.hide {
                 continue;
             }
-            let Some(up_channel) = up_channels.get(tab.up_channel) else {
+            let Some(up_channel) = up_channels.get(tab.up_channel as usize) else {
                 tracing::warn!(
                     "Configured up channel {} does not exist, skipping tab",
                     tab.up_channel

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
@@ -13,7 +13,7 @@ pub enum ChannelData {
 }
 
 impl RttDataHandler for (&mut Option<TcpPublisher>, &mut ChannelData) {
-    fn on_string_data(&mut self, _channel: usize, data: String) -> Result<(), Error> {
+    fn on_string_data(&mut self, _channel: u32, data: String) -> Result<(), Error> {
         if let Some(ref mut stream) = self.0 {
             stream.send(data.as_bytes());
         }
@@ -26,7 +26,7 @@ impl RttDataHandler for (&mut Option<TcpPublisher>, &mut ChannelData) {
         Ok(())
     }
 
-    fn on_binary_data(&mut self, _channel: usize, incoming: &[u8]) -> Result<(), Error> {
+    fn on_binary_data(&mut self, _channel: u32, incoming: &[u8]) -> Result<(), Error> {
         if let Some(ref mut stream) = self.0 {
             stream.send(incoming);
         }
@@ -41,7 +41,7 @@ impl RttDataHandler for (&mut Option<TcpPublisher>, &mut ChannelData) {
 }
 
 pub struct UpChannel {
-    channel_number: usize,
+    channel_number: u32,
     tcp_stream: Option<TcpPublisher>,
     channel_name: String,
     data_format: RttDecoder,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
@@ -4,7 +4,7 @@ use probe_rs::{rtt::Error, Core};
 
 use crate::{
     cmd::cargo_embed::rttui::tcp::TcpPublisher,
-    util::rtt::{client::RttClient, ChannelDataCallbacks, RttActiveUpChannel},
+    util::rtt::{client::RttClient, RttActiveUpChannel, RttDataHandler, RttDecoder},
 };
 
 pub enum ChannelData {
@@ -12,7 +12,7 @@ pub enum ChannelData {
     Binary { data: Vec<u8> },
 }
 
-impl ChannelDataCallbacks for (&mut Option<TcpPublisher>, &mut ChannelData) {
+impl RttDataHandler for (&mut Option<TcpPublisher>, &mut ChannelData) {
     fn on_string_data(&mut self, _channel: usize, data: String) -> Result<(), Error> {
         if let Some(ref mut stream) = self.0 {
             stream.send(data.as_bytes());
@@ -44,19 +44,25 @@ pub struct UpChannel {
     channel_number: usize,
     tcp_stream: Option<TcpPublisher>,
     channel_name: String,
+    data_format: RttDecoder,
     pub data: ChannelData,
 }
 
 impl UpChannel {
-    pub fn new(rtt_channel: &RttActiveUpChannel, tcp_stream: Option<SocketAddr>) -> Self {
+    pub fn new(
+        rtt_channel: &RttActiveUpChannel,
+        data_format: RttDecoder,
+        tcp_stream: Option<SocketAddr>,
+    ) -> Self {
         Self {
-            data: if rtt_channel.data_format.is_binary() {
+            data: if data_format.is_binary() {
                 ChannelData::Binary { data: Vec::new() }
             } else {
                 ChannelData::Strings {
                     messages: Vec::new(),
                 }
             },
+            data_format,
             tcp_stream: tcp_stream.map(TcpPublisher::new),
             channel_number: rtt_channel.number(),
             channel_name: rtt_channel.channel_name().to_string(),
@@ -64,11 +70,15 @@ impl UpChannel {
     }
 
     pub fn poll_rtt(&mut self, core: &mut Core<'_>, client: &mut RttClient) -> Result<(), Error> {
-        client.poll_channel(
-            core,
+        let bytes = client.poll_channel(core, self.channel_number)?;
+
+        self.data_format.process(
             self.channel_number,
+            bytes,
             &mut (&mut self.tcp_stream, &mut self.data),
-        )
+        )?;
+
+        Ok(())
     }
 
     pub(crate) fn channel_name(&self) -> &str {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/tab.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/tab.rs
@@ -13,11 +13,11 @@ use super::channel::UpChannel;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TabConfig {
     /// Which up channel to use.
-    pub up_channel: usize,
+    pub up_channel: u32,
 
     /// Which down channel to use, if any.
     #[serde(default)]
-    pub down_channel: Option<usize>,
+    pub down_channel: Option<u32>,
 
     /// The name of the tab. If not set, the name of the up channel is used.
     #[serde(default)]
@@ -30,7 +30,7 @@ pub struct TabConfig {
 
 pub struct Tab {
     up_channel: Rc<RefCell<UpChannel>>,
-    down_channel: Option<(usize, String)>,
+    down_channel: Option<(u32, String)>,
     name: String,
     scroll_offset: usize,
     messages: Vec<String>,
@@ -41,7 +41,7 @@ pub struct Tab {
 impl Tab {
     pub fn new(
         up_channel: Rc<RefCell<UpChannel>>,
-        down_channel: Option<usize>,
+        down_channel: Option<u32>,
         name: Option<String>,
     ) -> Self {
         Self {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1773,7 +1773,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
     /// Send a custom `probe-rs-rtt-channel-config` event to the MS DAP Client, to create a window for a specific RTT channel.
     pub fn rtt_window(
         &mut self,
-        channel_number: usize,
+        channel_number: u32,
         channel_name: String,
         data_format: rtt::DataFormat,
     ) -> bool {
@@ -1790,7 +1790,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
     }
 
     /// Send a custom `probe-rs-rtt-data` event to the MS DAP Client, to
-    pub fn rtt_output(&mut self, channel_number: usize, rtt_data: String) -> bool {
+    pub fn rtt_output(&mut self, channel_number: u32, rtt_data: String) -> bool {
         let Ok(event_body) = serde_json::to_value(RttDataEventBody {
             channel_number,
             data: rtt_data,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/dap_types.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/dap_types.rs
@@ -68,14 +68,14 @@ pub struct RttWindowOpened {
 #[serde(rename_all = "camelCase")]
 pub struct RttWindowOpenedArguments {
     /// The RTT channel number.
-    pub channel_number: usize,
+    pub channel_number: u32,
     pub window_is_open: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RttChannelEventBody {
-    pub channel_number: usize,
+    pub channel_number: u32,
     pub channel_name: String,
     pub data_format: rtt::DataFormat,
 }
@@ -83,7 +83,7 @@ pub struct RttChannelEventBody {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RttDataEventBody {
-    pub channel_number: usize,
+    pub channel_number: u32,
     /// RTT output
     pub data: String,
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
@@ -43,7 +43,7 @@ impl RttConnection {
 }
 
 pub(crate) struct DebuggerRttChannel {
-    pub(crate) channel_number: usize,
+    pub(crate) channel_number: u32,
     // We will not poll target RTT channels until we have confirmation from the client that the output window has been opened.
     pub(crate) has_client_window: bool,
     pub(crate) channel_data_format: RttDecoder,
@@ -91,7 +91,7 @@ struct StringCollector {
 }
 
 impl RttDataHandler for StringCollector {
-    fn on_string_data(&mut self, _channel: usize, data: String) -> Result<(), rtt::Error> {
+    fn on_string_data(&mut self, _channel: u32, data: String) -> Result<(), rtt::Error> {
         self.data = Some(data);
         Ok(())
     }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
@@ -1,13 +1,13 @@
-use crate::util::rtt::client::RttClient;
+use crate::util::rtt::{client::RttClient, RttDataHandler};
 use crate::{
     cmd::dap_server::{
         debug_adapter::{dap::adapter::*, protocol::ProtocolAdapter},
         DebuggerError,
     },
-    util::rtt::ChannelDataCallbacks,
+    util::rtt::RttDecoder,
 };
 use anyhow::anyhow;
-use probe_rs::{rtt::Error, Core};
+use probe_rs::{rtt, Core};
 
 /// Manage the active RTT target for a specific SessionData, as well as provide methods to reliably move RTT from target, through the debug_adapter, to the client.
 pub struct RttConnection {
@@ -46,6 +46,7 @@ pub(crate) struct DebuggerRttChannel {
     pub(crate) channel_number: usize,
     // We will not poll target RTT channels until we have confirmation from the client that the output window has been opened.
     pub(crate) has_client_window: bool,
+    pub(crate) channel_data_format: RttDecoder,
 }
 
 impl DebuggerRttChannel {
@@ -64,11 +65,18 @@ impl DebuggerRttChannel {
 
         let mut out = StringCollector { data: None };
 
-        if let Err(e) = client.poll_channel(core, self.channel_number, &mut out) {
-            debug_adapter
-                .show_error_message(&DebuggerError::Other(anyhow!(e)))
-                .ok();
-            return false;
+        match client.poll_channel(core, self.channel_number) {
+            Ok(bytes) => {
+                self.channel_data_format
+                    .process(self.channel_number, bytes, &mut out)
+                    .ok();
+            }
+            Err(e) => {
+                debug_adapter
+                    .show_error_message(&DebuggerError::Other(anyhow!(e)))
+                    .ok();
+                return false;
+            }
         }
 
         match out.data {
@@ -82,8 +90,8 @@ struct StringCollector {
     data: Option<String>,
 }
 
-impl ChannelDataCallbacks for StringCollector {
-    fn on_string_data(&mut self, _channel: usize, data: String) -> Result<(), Error> {
+impl RttDataHandler for StringCollector {
+    fn on_string_data(&mut self, _channel: usize, data: String) -> Result<(), rtt::Error> {
         self.data = Some(data);
         Ok(())
     }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -145,6 +145,8 @@ pub struct SharedOptions {
 
     /// The format string to use when printing defmt encoded log messages from the target.
     ///
+    /// You can also use one of two presets: oneline (default) and full.
+    ///
     /// See <https://defmt.ferrous-systems.com/custom-log-output>
     #[clap(long)]
     pub(crate) log_format: Option<String>,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -11,6 +11,7 @@ use libtest_mimic::{Arguments, FormatSetting};
 use probe_rs::flashing::FileDownloadError;
 use std::fs::File;
 use std::io::Read;
+use time::UtcOffset;
 
 /// Options only used in normal run mode
 #[derive(Debug, clap::Parser, Clone)]
@@ -157,7 +158,7 @@ pub struct SharedOptions {
 }
 
 impl Cmd {
-    pub async fn run(self, client: RpcClient) -> anyhow::Result<()> {
+    pub async fn run(self, client: RpcClient, utc_offset: UtcOffset) -> anyhow::Result<()> {
         // Detect run mode based on ELF file
         let run_mode = detect_run_mode(&self)?;
 
@@ -172,7 +173,7 @@ impl Cmd {
             },
             self.shared_options.log_format,
             !self.shared_options.no_location,
-            None,
+            Some(utc_offset),
         )
         .await?;
 

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -97,7 +97,7 @@ struct Cli {
 }
 
 impl Cli {
-    async fn run(self, client: RpcClient, _config: Config) -> Result<()> {
+    async fn run(self, client: RpcClient, _config: Config, utc_offset: UtcOffset) -> Result<()> {
         let lister = Lister::new();
         match self.subcommand {
             Subcommand::DapServer { .. } => unreachable!(),
@@ -109,8 +109,8 @@ impl Cli {
             Subcommand::Reset(cmd) => cmd.run(client).await,
             Subcommand::Debug(cmd) => cmd.run(&lister),
             Subcommand::Download(cmd) => cmd.run(client).await,
-            Subcommand::Run(cmd) => cmd.run(client).await,
-            Subcommand::Attach(cmd) => cmd.run(client).await,
+            Subcommand::Run(cmd) => cmd.run(client, utc_offset).await,
+            Subcommand::Attach(cmd) => cmd.run(client, utc_offset).await,
             Subcommand::Verify(cmd) => cmd.run(client).await,
             Subcommand::Erase(cmd) => cmd.run(client).await,
             Subcommand::Trace(cmd) => cmd.run(&lister),
@@ -465,7 +465,7 @@ async fn main() -> Result<()> {
             "The subcommand is not supported in remote mode."
         );
 
-        matches.run(client, config).await?;
+        matches.run(client, config, utc_offset).await?;
         // TODO: handle the report
         return Ok(());
     }
@@ -476,7 +476,7 @@ async fn main() -> Result<()> {
 
     // Run the command locally.
     let client = RpcClient::new_local_from_wire(tx, rx);
-    let result = matches.run(client, config).await;
+    let result = matches.run(client, config, utc_offset).await;
 
     // Wait for the server to shut down
     _ = handle.await.unwrap();

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -42,7 +42,7 @@ use crate::{
             },
             reset::ResetCoreRequest,
             resume::ResumeAllCoresRequest,
-            rtt_client::{CreateRttClientRequest, LogOptions},
+            rtt_client::{CreateRttClientRequest, RttClientData, ScanRegion},
             stack_trace::{StackTraces, TakeStackTraceRequest},
             test::{ListTestsRequest, RunTestRequest, Test, TestResult, Tests},
             AttachEndpoint, BuildEndpoint, ChipInfoEndpoint, CreateRttClientEndpoint,
@@ -552,19 +552,12 @@ impl SessionInterface {
 
     pub async fn create_rtt_client(
         &self,
-        mut path: Option<PathBuf>,
-        log_options: LogOptions,
-    ) -> anyhow::Result<Key<RttClient>> {
-        // TODO: RTT shouldn't need the firmware, we can extract location and process output locally
-        if let Some(ref mut path) = path {
-            *path = self.client.upload_file(&*path).await?;
-        }
-
+        scan_regions: ScanRegion,
+    ) -> anyhow::Result<RttClientData> {
         self.client
             .send_resp::<CreateRttClientEndpoint, _>(&CreateRttClientRequest {
                 sessid: self.sessid,
-                path: path.map(|path| path.display().to_string()),
-                log_options,
+                scan_regions,
             })
             .await
     }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -58,7 +58,7 @@ use crate::{
         transport::memory::{PostcardReceiver, PostcardSender, WireRx, WireTx},
         Key,
     },
-    util::rtt::client::RttClient,
+    util::rtt::{client::RttClient, RttChannelConfig},
     FormatOptions,
 };
 
@@ -553,11 +553,13 @@ impl SessionInterface {
     pub async fn create_rtt_client(
         &self,
         scan_regions: ScanRegion,
+        config: Vec<RttChannelConfig>,
     ) -> anyhow::Result<RttClientData> {
         self.client
             .send_resp::<CreateRttClientEndpoint, _>(&CreateRttClientRequest {
                 sessid: self.sessid,
                 scan_regions,
+                config,
             })
             .await
     }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/utils/run_loop.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/utils/run_loop.rs
@@ -125,7 +125,7 @@ impl RunLoop<'_> {
             if let Some(ref mut rtt_client) = self.rtt_client {
                 _ = rtt_client.try_attach(core);
                 for channel in 0..rtt_client.up_channels().len() {
-                    let bytes = rtt_client.poll_channel(core, channel)?;
+                    let bytes = rtt_client.poll_channel(core, channel as u32)?;
                     if !bytes.is_empty() {
                         had_rtt_data = true;
                         rtt_callback(channel as u32, bytes.to_vec())?;

--- a/probe-rs-tools/src/bin/probe-rs/rpc/utils/run_loop.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/utils/run_loop.rs
@@ -1,14 +1,12 @@
 use tokio_util::sync::CancellationToken;
 
-use std::fmt::Write;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
-use probe_rs::{rtt::Error as RttError, Core, Error, HaltReason, VectorCatchCondition};
+use probe_rs::{Core, Error, HaltReason, VectorCatchCondition};
 
 use crate::util::rtt::client::RttClient;
-use crate::util::rtt::ChannelDataCallbacks;
 
 pub struct RunLoop<'a> {
     pub core_id: usize,
@@ -40,7 +38,7 @@ impl RunLoop<'_> {
         core: &mut Core,
         catch_hardfault: bool,
         catch_reset: bool,
-        output_stream: &mut dyn Write,
+        rtt_callback: impl FnMut(u32, Vec<u8>) -> Result<()>,
         timeout: Option<Duration>,
         mut predicate: F,
     ) -> Result<ReturnReason<R>>
@@ -71,7 +69,7 @@ impl RunLoop<'_> {
         }
         let start = Instant::now();
 
-        let result = self.do_run_until(core, output_stream, timeout, start, &mut predicate);
+        let result = self.do_run_until(core, rtt_callback, timeout, start, &mut predicate);
 
         // Always clean up after RTT but don't overwrite the original result.
         if let Some(ref mut rtt_client) = self.rtt_client {
@@ -89,7 +87,7 @@ impl RunLoop<'_> {
     fn do_run_until<F, R>(
         &mut self,
         core: &mut Core,
-        output_stream: &mut dyn Write,
+        mut rtt_callback: impl FnMut(u32, Vec<u8>) -> Result<()>,
         timeout: Option<Duration>,
         start: Instant,
         predicate: &mut F,
@@ -123,11 +121,17 @@ impl RunLoop<'_> {
                 }
             }
 
-            let had_rtt_data = if let Some(ref mut rtt_client) = self.rtt_client {
-                poll_rtt(rtt_client, core, output_stream)?
-            } else {
-                false
-            };
+            let mut had_rtt_data = false;
+            if let Some(ref mut rtt_client) = self.rtt_client {
+                _ = rtt_client.try_attach(core);
+                for channel in 0..rtt_client.up_channels().len() {
+                    let bytes = rtt_client.poll_channel(core, channel)?;
+                    if !bytes.is_empty() {
+                        had_rtt_data = true;
+                        rtt_callback(channel as u32, bytes.to_vec())?;
+                    }
+                }
+            }
 
             if let Some(reason) = return_reason {
                 return reason;
@@ -155,38 +159,4 @@ impl RunLoop<'_> {
             }
         }
     }
-}
-
-/// Poll RTT and print the received buffer.
-fn poll_rtt<S: Write + ?Sized>(
-    rtt_client: &mut RttClient,
-    core: &mut Core<'_>,
-    out_stream: &mut S,
-) -> Result<bool, anyhow::Error> {
-    struct OutCollector<'a, O: Write + ?Sized> {
-        out_stream: &'a mut O,
-        had_data: bool,
-    }
-
-    impl<O: Write + ?Sized> ChannelDataCallbacks for OutCollector<'_, O> {
-        fn on_string_data(&mut self, _channel: usize, data: String) -> Result<(), RttError> {
-            if data.is_empty() {
-                return Ok(());
-            }
-            self.had_data = true;
-            self.out_stream
-                .write_str(&data)
-                .map_err(|err| anyhow!(err))?;
-            Ok(())
-        }
-    }
-
-    let mut out = OutCollector {
-        out_stream,
-        had_data: false,
-    };
-
-    rtt_client.poll(core, &mut out)?;
-
-    Ok(out.had_data)
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/utils/run_loop.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/utils/run_loop.rs
@@ -128,7 +128,13 @@ impl RunLoop<'_> {
                     let bytes = rtt_client.poll_channel(core, channel as u32)?;
                     if !bytes.is_empty() {
                         had_rtt_data = true;
-                        rtt_callback(channel as u32, bytes.to_vec())?;
+                        let res = rtt_callback(channel as u32, bytes.to_vec());
+
+                        if self.cancellation_token.is_cancelled() {
+                            return Ok(ReturnReason::Cancelled);
+                        }
+
+                        res?;
                     }
                 }
             }

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -322,7 +322,7 @@ pub async fn test(
     let rtt_handle = rtt_client.as_ref().map(|rtt| rtt.handle);
     let test = async {
         let tests = session
-            .list_tests(boot_info, rtt_handle, |msg| _ = sender.send(msg))
+            .list_tests(boot_info, rtt_handle, |msg| sender.send(msg).unwrap())
             .await?;
 
         if token.is_cancelled() {
@@ -396,7 +396,7 @@ fn create_trial(
 
             let handle = tokio::spawn(async move {
                 match session
-                    .run_test(test, rtt_client, |msg| _ = sender.send(msg))
+                    .run_test(test, rtt_client, |msg| sender.send(msg).unwrap())
                     .await
                 {
                     Ok(TestResult::Success) => Ok(()),

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -1,10 +1,12 @@
 //! CLI-specific building blocks.
 
-use std::{future::Future, path::Path, time::Instant};
+use std::{future::Future, ops::DerefMut, path::Path, time::Instant};
 
+use anyhow::Context;
 use colored::Colorize;
 use libtest_mimic::{Failed, Trial};
-use tokio::runtime::Handle;
+use time::UtcOffset;
+use tokio::{runtime::Handle, sync::mpsc::UnboundedSender};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -16,6 +18,7 @@ use crate::{
             probe::{
                 AttachRequest, AttachResult, DebugProbeEntry, DebugProbeSelector, SelectProbeResult,
             },
+            rtt_client::ScanRegion,
             stack_trace::StackTrace,
             test::{Test, TestResult},
             CancelTopic,
@@ -26,7 +29,10 @@ use crate::{
         common_options::{BinaryDownloadOptions, ProbeOptions},
         flash::CliProgressBars,
         logging,
-        rtt::client::RttClient,
+        rtt::{
+            self, client::RttClient, DefmtProcessor, DefmtState, RttDataHandler, RttDecoder,
+            RttSymbolError,
+        },
     },
     FormatOptions,
 };
@@ -111,13 +117,70 @@ pub async fn select_probe(
     }
 }
 
+pub async fn rtt_client(
+    session: &SessionInterface,
+    path: &Path,
+    mut scan_regions: ScanRegion,
+    log_format: Option<String>,
+    show_location: bool,
+    timestamp_offset: Option<UtcOffset>,
+) -> anyhow::Result<CliRttClient> {
+    let elf = tokio::fs::read(path)
+        .await
+        .with_context(|| format!("Failed to read firmware from {}", path.display()))?;
+
+    let mut load_defmt_data = false;
+    match rtt::get_rtt_symbol_from_bytes(&elf) {
+        // Do not scan the memory for the control block.
+        Ok(address) => {
+            scan_regions = ScanRegion::Exact(address);
+            load_defmt_data = true;
+        }
+        Err(RttSymbolError::RttSymbolNotFound) => {
+            load_defmt_data = true;
+        }
+        _ => {}
+    }
+
+    let defmt_data = if load_defmt_data {
+        DefmtState::try_from_bytes(&elf)?
+    } else {
+        None
+    };
+
+    let rtt_client = session.create_rtt_client(scan_regions).await?;
+    let client_handle = rtt_client.handle;
+
+    // The CLI only supports a single RTT up channel, and no down channels.
+    let data_format = if let Some(defmt_data) = defmt_data.clone() {
+        RttDecoder::Defmt {
+            processor: DefmtProcessor::new(
+                defmt_data,
+                timestamp_offset.is_some(),
+                show_location,
+                log_format.as_deref(),
+            ),
+        }
+    } else {
+        RttDecoder::String {
+            timestamp_offset,
+            last_line_done: false,
+        }
+    };
+
+    Ok(CliRttClient {
+        handle: client_handle,
+        data_format,
+    })
+}
+
 pub async fn flash(
     session: &SessionInterface,
     path: &Path,
     chip_erase: bool,
     format: FormatOptions,
     download_options: BinaryDownloadOptions,
-    rtt_client: Option<Key<RttClient>>,
+    rtt_client: Option<&mut CliRttClient>,
 ) -> anyhow::Result<BootInfo> {
     // Start timer.
     let flash_timer = Instant::now();
@@ -169,7 +232,7 @@ pub async fn flash(
             .flash(
                 options,
                 loader.loader,
-                rtt_client,
+                rtt_client.as_ref().map(|c| c.handle),
                 &mut handle_progress_events,
             )
             .await?;
@@ -204,10 +267,13 @@ pub async fn monitor(
     session: &SessionInterface,
     mode: MonitorMode,
     path: &Path,
+    mut rtt_client: Option<CliRttClient>,
     options: MonitorOptions,
     print_stack_trace: bool,
 ) -> anyhow::Result<()> {
-    let monitor = session.monitor(mode, options, print_monitor_event);
+    let monitor = session.monitor(mode, options, |msg| {
+        print_monitor_event(&mut rtt_client.as_mut(), msg)
+    });
 
     let mut cancelled = false;
 
@@ -230,14 +296,17 @@ pub async fn test(
     libtest_args: libtest_mimic::Arguments,
     print_stack_trace: bool,
     path: &Path,
-    rtt_client: Option<Key<RttClient>>,
+    mut rtt_client: Option<CliRttClient>,
 ) -> anyhow::Result<()> {
     tracing::info!("libtest args {:?}", libtest_args);
     let token = CancellationToken::new();
 
+    let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel::<MonitorEvent>();
+
+    let rtt_handle = rtt_client.as_ref().map(|rtt| rtt.handle);
     let test = async {
         let tests = session
-            .list_tests(boot_info, rtt_client, print_monitor_event)
+            .list_tests(boot_info, rtt_handle, |msg| _ = sender.send(msg))
             .await?;
 
         if token.is_cancelled() {
@@ -247,7 +316,7 @@ pub async fn test(
         let tests = tests
             .tests
             .into_iter()
-            .map(|test| create_trial(session, path, rtt_client, &token, test))
+            .map(|test| create_trial(session, path, rtt_handle, sender.clone(), &token, test))
             .collect::<Vec<_>>();
 
         tokio::task::spawn_blocking(move || {
@@ -260,7 +329,21 @@ pub async fn test(
         .await?
     };
 
-    let result = with_ctrl_c(test, async {
+    let log = async {
+        while let Some(event) = receiver.recv().await {
+            print_monitor_event(&mut rtt_client.as_mut(), event);
+        }
+        futures_util::future::pending().await
+    };
+
+    let test_and_log = async {
+        tokio::select! {
+            result = test => result,
+            _ = log => anyhow::bail!("Log task resolved unexpectedly"),
+        }
+    };
+
+    let result = with_ctrl_c(test_and_log, async {
         token.cancel();
         session.client().publish::<CancelTopic>(&()).await.unwrap();
     })
@@ -277,6 +360,7 @@ fn create_trial(
     session: &SessionInterface,
     path: &Path,
     rtt_client: Option<Key<RttClient>>,
+    sender: UnboundedSender<MonitorEvent>,
     token: &CancellationToken,
     test: Test,
 ) -> Trial {
@@ -287,35 +371,37 @@ fn create_trial(
     let session = session.clone();
     let token = token.clone();
 
-    Trial::test(name, move || {
-        if token.is_cancelled() {
-            eprintln!("Cancelled");
-            std::process::exit(0);
-        }
-
-        let handle = tokio::spawn(async move {
-            match session
-                .run_test(test, rtt_client, print_monitor_event)
-                .await
-            {
-                Ok(TestResult::Success) => Ok(()),
-                Ok(TestResult::Cancelled) => {
-                    eprintln!("Cancelled");
-                    std::process::exit(0);
-                }
-                Ok(TestResult::Failed(message)) => {
-                    display_stack_trace(&session, &path).await?;
-
-                    Err(Failed::from(message))
-                }
-                Err(e) => {
-                    eprintln!("Error: {:?}", e);
-                    std::process::exit(1);
-                }
+    Trial::test(name, {
+        move || {
+            if token.is_cancelled() {
+                eprintln!("Cancelled");
+                std::process::exit(0);
             }
-        });
 
-        Handle::current().block_on(handle).unwrap()
+            let handle = tokio::spawn(async move {
+                match session
+                    .run_test(test, rtt_client, |msg| _ = sender.send(msg))
+                    .await
+                {
+                    Ok(TestResult::Success) => Ok(()),
+                    Ok(TestResult::Cancelled) => {
+                        eprintln!("Cancelled");
+                        std::process::exit(0);
+                    }
+                    Ok(TestResult::Failed(message)) => {
+                        display_stack_trace(&session, &path).await?;
+
+                        Err(Failed::from(message))
+                    }
+                    Err(e) => {
+                        eprintln!("Error: {:?}", e);
+                        std::process::exit(1);
+                    }
+                }
+            });
+
+            Handle::current().block_on(handle).unwrap()
+        }
     })
     .with_ignored_flag(ignored)
 }
@@ -331,18 +417,6 @@ async fn display_stack_trace(session: &SessionInterface, path: &Path) -> anyhow:
     }
 
     Ok(())
-}
-
-fn print_monitor_event(event: MonitorEvent) {
-    match event {
-        MonitorEvent::RttOutput(str) => print!("{}", str),
-        MonitorEvent::SemihostingOutput(SemihostingOutput::StdOut(str)) => {
-            print!("{}", str)
-        }
-        MonitorEvent::SemihostingOutput(SemihostingOutput::StdErr(str)) => {
-            eprint!("{}", str)
-        }
-    }
 }
 
 /// Runs a future until complation, running another future when Ctrl+C is received.
@@ -365,4 +439,46 @@ where
     };
 
     r
+}
+
+pub struct CliRttClient {
+    handle: Key<RttClient>,
+    data_format: RttDecoder,
+}
+
+impl CliRttClient {
+    pub fn handle(&self) -> Key<RttClient> {
+        self.handle
+    }
+}
+
+fn print_monitor_event(
+    rtt_client: &mut Option<impl DerefMut<Target = CliRttClient>>,
+    event: MonitorEvent,
+) {
+    match event {
+        MonitorEvent::RttOutput { channel, bytes } => {
+            if let Some(client) = rtt_client {
+                _ = client
+                    .data_format
+                    .process(channel as usize, &bytes, &mut Printer);
+            }
+        }
+        MonitorEvent::SemihostingOutput(SemihostingOutput::StdOut(str)) => {
+            print!("{}", str)
+        }
+        MonitorEvent::SemihostingOutput(SemihostingOutput::StdErr(str)) => {
+            eprint!("{}", str)
+        }
+    }
+}
+
+struct Printer;
+impl RttDataHandler for Printer {
+    fn on_string_data(&mut self, channel: usize, data: String) -> Result<(), probe_rs::rtt::Error> {
+        if channel == 0 {
+            print!("{}", data);
+        }
+        Ok(())
+    }
 }

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -95,13 +95,13 @@ pub struct RttActiveUpChannel {
 }
 
 impl RttActiveUpChannel {
-    pub fn new(up_channel: UpChannel) -> Result<Self, Error> {
-        Ok(Self {
+    pub fn new(up_channel: UpChannel) -> Self {
+        Self {
             rtt_buffer: vec![0; up_channel.buffer_size().max(1)].into_boxed_slice(),
             bytes_buffered: 0,
             up_channel,
             original_mode: None,
-        })
+        }
     }
 
     pub fn change_mode(&mut self, core: &mut Core, mode: ChannelMode) -> Result<(), Error> {
@@ -200,7 +200,7 @@ impl RttConnection {
                 .cloned()
                 .unwrap_or_default();
 
-            let mut up_channel = RttActiveUpChannel::new(channel)?;
+            let mut up_channel = RttActiveUpChannel::new(channel);
             if let Some(mode) = channel_config.mode {
                 up_channel.change_mode(core, mode)?;
             }

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -1,16 +1,12 @@
-use anyhow::{anyhow, Context};
-use defmt_decoder::log::format::{Formatter, FormatterConfig, FormatterFormat};
-use defmt_decoder::DecodeError;
 pub use probe_rs::rtt::ChannelMode;
 use probe_rs::rtt::{DownChannel, Error, Rtt, UpChannel};
 use probe_rs::{Core, MemoryInterface};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::{fmt, fmt::Write, path::Path};
-use time::{macros::format_description, OffsetDateTime, UtcOffset};
 
 pub(crate) mod client;
+pub(crate) mod processing;
+
+pub use processing::*;
 
 /// Used by serde to provide defaults for `RttChannelConfig::show_timestamps`
 fn default_show_timestamps() -> bool {
@@ -86,315 +82,55 @@ impl Default for RttChannelConfig {
     }
 }
 
-pub enum ChannelDataFormat {
-    String {
-        /// UTC offset used for creating timestamps, if enabled.
-        ///
-        /// Getting the offset can fail in multi-threaded programs,
-        /// so it needs to be stored.
-        timestamp_offset: Option<UtcOffset>,
-        last_line_done: bool,
-    },
-    BinaryLE,
-    Defmt {
-        formatter: Formatter,
-        // CWD to strip from file paths in defmt output
-        cwd: PathBuf,
-        defmt_data: Option<Arc<DefmtState>>,
-    },
-}
-
-impl From<&ChannelDataFormat> for DataFormat {
-    fn from(config: &ChannelDataFormat) -> Self {
-        match config {
-            ChannelDataFormat::String { .. } => DataFormat::String,
-            ChannelDataFormat::BinaryLE => DataFormat::BinaryLE,
-            ChannelDataFormat::Defmt { .. } => DataFormat::Defmt,
-        }
-    }
-}
-
-impl fmt::Debug for ChannelDataFormat {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ChannelDataFormat::String {
-                timestamp_offset,
-                last_line_done,
-            } => f
-                .debug_struct("String")
-                .field("timestamp_offset", timestamp_offset)
-                .field("last_line_done", last_line_done)
-                .finish(),
-            ChannelDataFormat::BinaryLE => f.debug_struct("BinaryLE").finish(),
-            ChannelDataFormat::Defmt { .. } => f.debug_struct("Defmt").finish_non_exhaustive(),
-        }
-    }
-}
-
-impl ChannelDataFormat {
-    /// Returns whether the channel is expected to output binary data (`true`)
-    /// or human-readable strings (`false`).
-    pub fn is_binary(&self) -> bool {
-        matches!(self, ChannelDataFormat::BinaryLE)
-    }
-
-    fn process(
-        &mut self,
-        number: usize,
-        buffer: &[u8],
-        collector: &mut impl ChannelDataCallbacks,
-    ) -> Result<(), Error> {
-        // FIXME: clean this up by splitting the enum variants out into separate structs
-        match self {
-            ChannelDataFormat::BinaryLE => collector.on_binary_data(number, buffer),
-            ChannelDataFormat::String {
-                timestamp_offset,
-                ref mut last_line_done,
-            } => {
-                let string = Self::process_string(buffer, *timestamp_offset, last_line_done)?;
-                collector.on_string_data(number, string)
-            }
-            ChannelDataFormat::Defmt {
-                ref formatter,
-                ref cwd,
-                ref defmt_data,
-            } => {
-                let string = Self::process_defmt(buffer, defmt_data.as_deref(), formatter, cwd)?;
-                collector.on_string_data(number, string)
-            }
-        }
-    }
-
-    fn process_string(
-        buffer: &[u8],
-        offset: Option<UtcOffset>,
-        last_line_done: &mut bool,
-    ) -> Result<String, Error> {
-        let incoming = String::from_utf8_lossy(buffer);
-
-        let Some(offset) = offset else {
-            return Ok(incoming.to_string());
-        };
-
-        let timestamp = OffsetDateTime::now_utc()
-            .to_offset(offset)
-            .format(format_description!(
-                "[hour repr:24]:[minute]:[second].[subsecond digits:3]"
-            ))
-            .expect("Incorrect format string. This shouldn't happen.");
-
-        let mut formatted_data = String::new();
-        for line in incoming.split_inclusive('\n') {
-            if *last_line_done {
-                write!(formatted_data, "{timestamp}: ").expect("Writing to String cannot fail");
-            }
-            write!(formatted_data, "{line}").expect("Writing to String cannot fail");
-            *last_line_done = line.ends_with('\n');
-        }
-        Ok(formatted_data)
-    }
-
-    fn process_defmt(
-        buffer: &[u8],
-        defmt_state: Option<&DefmtState>,
-        formatter: &Formatter,
-        cwd: &Path,
-    ) -> Result<String, Error> {
-        let Some(DefmtState { table, locs }) = defmt_state else {
-            return Ok(String::from(
-                "Trying to process defmt data but table or locations could not be loaded.\n",
-            ));
-        };
-
-        let mut stream_decoder = table.new_stream_decoder();
-
-        // FIXME: this assumes we read frames atomically which is implementation-defined and we
-        // should be able to handle the case where a frame is split across two reads with a
-        // temporary buffer.
-        stream_decoder.received(buffer);
-
-        let mut formatted_data = String::new();
-        loop {
-            match stream_decoder.decode() {
-                Ok(frame) => {
-                    let loc = locs.as_ref().and_then(|locs| locs.get(&frame.index()));
-                    let (file, line, module) = if let Some(loc) = loc {
-                        let relpath = loc.file.strip_prefix(cwd).unwrap_or(&loc.file);
-                        (
-                            relpath.display().to_string(),
-                            Some(loc.line.try_into().unwrap()),
-                            Some(loc.module.as_str()),
-                        )
-                    } else {
-                        (
-                            format!(
-                                "└─ <invalid location: defmt frame-index: {}>",
-                                frame.index()
-                            ),
-                            None,
-                            None,
-                        )
-                    };
-                    let s = formatter.format_frame(frame, Some(&file), line, module);
-                    writeln!(formatted_data, "{s}").expect("Writing to String cannot fail");
-                }
-                Err(DecodeError::UnexpectedEof) => break,
-                Err(DecodeError::Malformed) if table.encoding().can_recover() => {
-                    // If recovery is possible, skip the current frame and continue with new data.
-                }
-                Err(DecodeError::Malformed) => {
-                    return Err(Error::Other(anyhow!(
-                        "Unrecoverable error while decoding Defmt \
-                        data. Some data may have been lost: {}",
-                        DecodeError::Malformed
-                    )));
-                }
-            }
-        }
-
-        Ok(formatted_data)
-    }
-}
-
-pub trait ChannelDataCallbacks {
-    fn on_binary_data(&mut self, channel: usize, data: &[u8]) -> Result<(), Error> {
-        let mut formatted_data = String::with_capacity(data.len() * 4);
-        for element in data {
-            // Width of 4 allows 0xFF to be printed.
-            write!(&mut formatted_data, "{element:#04x}").expect("Writing to String cannot fail");
-        }
-        self.on_string_data(channel, formatted_data)
-    }
-
-    fn on_string_data(&mut self, channel: usize, data: String) -> Result<(), Error>;
-}
-
 #[derive(Debug)]
 pub struct RttActiveUpChannel {
     pub up_channel: UpChannel,
-    pub data_format: ChannelDataFormat,
-    rtt_buffer: Box<[u8]>,
 
-    /// If set, the original mode of the channel before we changed it. Upon exit we should do
+    rtt_buffer: Box<[u8]>,
+    bytes_buffered: usize,
+
+    /// If set, the original mode of the channel before we first changed it. Upon exit we should do
     /// our best to restore the original mode.
     original_mode: Option<ChannelMode>,
 }
 
 impl RttActiveUpChannel {
-    pub fn new(
-        core: &mut Core,
-        up_channel: UpChannel,
-        channel_config: &RttChannelConfig,
-        timestamp_offset: UtcOffset,
-        defmt_data: Option<Arc<DefmtState>>,
-    ) -> Result<Self, Error> {
-        let is_defmt_channel = up_channel.name() == Some("defmt");
-
-        let data_format = match channel_config.data_format {
-            DataFormat::String if !is_defmt_channel => ChannelDataFormat::String {
-                timestamp_offset: channel_config.show_timestamps.then_some(timestamp_offset),
-                last_line_done: true,
-            },
-
-            DataFormat::BinaryLE if !is_defmt_channel => ChannelDataFormat::BinaryLE,
-
-            // either DataFormat::Defmt is configured, or defmt_enabled is true
-            _ => {
-                let has_timestamp = if let Some(ref defmt) = defmt_data {
-                    defmt.table.has_timestamp()
-                } else {
-                    tracing::warn!("No `Table` definition in DWARF info; compile your program with `debug = 2` to enable location info.");
-                    false
-                };
-
-                // Format options:
-                // 1. Oneline format with optional location
-                // 2. Custom format for the channel
-                // 3. Default with optional location
-                let format = match channel_config.log_format.as_deref() {
-                    Some("oneline") => FormatterFormat::OneLine {
-                        with_location: channel_config.show_location,
-                    },
-                    Some(format) => FormatterFormat::Custom(format),
-                    None => FormatterFormat::Default {
-                        with_location: channel_config.show_location,
-                    },
-                };
-
-                ChannelDataFormat::Defmt {
-                    formatter: Formatter::new(FormatterConfig {
-                        format,
-                        is_timestamp_available: has_timestamp && channel_config.show_timestamps,
-                    }),
-                    cwd: std::env::current_dir().unwrap(),
-                    defmt_data,
-                }
-            }
-        };
-
-        let mut original_mode = None;
-        if let Some(mode) = channel_config.mode.or(
-            // Try not to corrupt the byte stream if using defmt
-            if matches!(data_format, ChannelDataFormat::Defmt { .. }) {
-                Some(ChannelMode::BlockIfFull)
-            } else {
-                None
-            },
-        ) {
-            original_mode = Some(up_channel.mode(core)?);
-            up_channel.set_mode(core, mode)?;
-        }
-
+    pub fn new(up_channel: UpChannel) -> Result<Self, Error> {
         Ok(Self {
             rtt_buffer: vec![0; up_channel.buffer_size().max(1)].into_boxed_slice(),
+            bytes_buffered: 0,
             up_channel,
-            data_format,
-            original_mode,
+            original_mode: None,
         })
+    }
+
+    pub fn change_mode(&mut self, core: &mut Core, mode: ChannelMode) -> Result<(), Error> {
+        if self.original_mode.is_none() {
+            self.original_mode = Some(self.up_channel.mode(core)?);
+        }
+        self.up_channel.set_mode(core, mode)
     }
 
     pub fn channel_name(&self) -> String {
         self.up_channel
             .name()
             .map(ToString::to_string)
-            .unwrap_or_else(|| {
-                format!(
-                    "Unnamed {} RTT up channel - {}",
-                    DataFormat::from(&self.data_format),
-                    self.up_channel.number()
-                )
-            })
+            .unwrap_or_else(|| format!("Unnamed RTT up channel - {}", self.up_channel.number()))
     }
 
     pub fn number(&self) -> usize {
         self.up_channel.number()
     }
 
-    /// Polls the RTT target for new data on the channel represented by `self`.
-    /// Processes all the new data into the channel internal buffer and
-    /// returns the number of bytes that was read.
-    pub fn poll_rtt(&mut self, core: &mut Core) -> Result<Option<usize>, Error> {
-        match self.up_channel.read(core, self.rtt_buffer.as_mut())? {
-            0 => Ok(None),
-            count => Ok(Some(count)),
-        }
+    /// Reads available channel data into the internal buffer.
+    pub fn poll(&mut self, core: &mut Core) -> Result<(), Error> {
+        self.bytes_buffered = self.up_channel.read(core, self.rtt_buffer.as_mut())?;
+        Ok(())
     }
 
-    /// Retrieves available data from the channel and if available, returns `Some(channel_number:String, formatted_data:String)`.
-    /// If no data is available, or we encounter a recoverable error, it returns `None` value for `formatted_data`.
-    /// Non-recoverable errors are propagated to the caller.
-    pub fn poll_process_rtt_data(
-        &mut self,
-        core: &mut Core,
-        collector: &mut impl ChannelDataCallbacks,
-    ) -> Result<(), Error> {
-        let Some(bytes_read) = self.poll_rtt(core)? else {
-            return Ok(());
-        };
-
-        let buffer = &self.rtt_buffer[..bytes_read];
-
-        self.data_format.process(self.number(), buffer, collector)
+    /// Returns the buffered data.
+    pub fn buffered_data(&self) -> &[u8] {
+        &self.rtt_buffer[..self.bytes_buffered]
     }
 
     /// Clean up temporary changes made to the channel.
@@ -427,53 +163,8 @@ impl RttActiveDownChannel {
         self.down_channel.number()
     }
 
-    pub fn push_rtt(&mut self, core: &mut Core<'_>, data: impl AsRef<[u8]>) -> Result<(), Error> {
+    pub fn write(&mut self, core: &mut Core<'_>, data: impl AsRef<[u8]>) -> Result<(), Error> {
         self.down_channel.write(core, data.as_ref()).map(|_| ())
-    }
-}
-
-/// Once an active connection with the Target RTT control block has been established, we configure
-/// each of the active channels, and hold essential state information for successful communication.
-#[derive(Debug)]
-pub struct RttActiveTarget {
-    control_block_addr: u64,
-    pub active_up_channels: Vec<RttActiveUpChannel>,
-    pub active_down_channels: Vec<RttActiveDownChannel>,
-}
-
-/// defmt information common to all defmt channels.
-pub struct DefmtState {
-    pub table: defmt_decoder::Table,
-    pub locs: Option<defmt_decoder::Locations>,
-}
-impl DefmtState {
-    pub fn try_from_bytes(buffer: &[u8]) -> Result<Option<Self>, Error> {
-        let Some(table) =
-            defmt_decoder::Table::parse(buffer).with_context(|| "Failed to parse defmt data")?
-        else {
-            return Ok(None);
-        };
-
-        let locs = table
-            .get_locations(buffer)
-            .with_context(|| "Failed to parse defmt data")?;
-
-        let locs = if !table.is_empty() && locs.is_empty() {
-            tracing::warn!("Insufficient DWARF info; compile your program with `debug = 2` to enable location info.");
-            None
-        } else if table.indices().all(|idx| locs.contains_key(&(idx as u64))) {
-            Some(locs)
-        } else {
-            tracing::warn!("Location info is incomplete; it will be omitted from the output.");
-            None
-        };
-        Ok(Some(DefmtState { table, locs }))
-    }
-}
-
-impl fmt::Debug for DefmtState {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DefmtState").finish_non_exhaustive()
     }
 }
 
@@ -486,15 +177,18 @@ pub enum RttSymbolError {
     Goblin(#[source] goblin::error::Error),
 }
 
-impl RttActiveTarget {
+/// Once an active connection with the Target RTT control block has been established, we configure
+/// each of the active channels, and hold essential state information for successful communication.
+#[derive(Debug)]
+pub struct RttConnection {
+    control_block_addr: u64,
+    pub active_up_channels: Vec<RttActiveUpChannel>,
+    pub active_down_channels: Vec<RttActiveDownChannel>,
+}
+
+impl RttConnection {
     /// RttActiveTarget collects references to all the `RttActiveChannel`s, for latter polling/pushing of data.
-    pub fn new(
-        core: &mut Core,
-        rtt: Rtt,
-        defmt_state: Option<Arc<DefmtState>>,
-        rtt_config: &RttConfig,
-        timestamp_offset: UtcOffset,
-    ) -> Result<Self, Error> {
+    pub fn new(core: &mut Core, rtt: Rtt, rtt_config: &RttConfig) -> Result<Self, Error> {
         let control_block_addr = rtt.ptr();
         let mut active_up_channels = Vec::with_capacity(rtt.up_channels.len());
 
@@ -505,13 +199,13 @@ impl RttActiveTarget {
                 .channel_config(channel.number())
                 .cloned()
                 .unwrap_or_default();
-            active_up_channels.push(RttActiveUpChannel::new(
-                core,
-                channel,
-                &channel_config,
-                timestamp_offset,
-                defmt_state.clone(),
-            )?);
+
+            let mut up_channel = RttActiveUpChannel::new(channel)?;
+            if let Some(mode) = channel_config.mode {
+                up_channel.change_mode(core, mode)?;
+            }
+
+            active_up_channels.push(up_channel);
         }
 
         let active_down_channels = rtt
@@ -527,44 +221,19 @@ impl RttActiveTarget {
         })
     }
 
-    pub fn get_rtt_symbol_from_bytes(buffer: &[u8]) -> Result<u64, RttSymbolError> {
-        match goblin::elf::Elf::parse(buffer) {
-            Ok(binary) => {
-                for sym in &binary.syms {
-                    if binary.strtab.get_at(sym.st_name) == Some("_SEGGER_RTT") {
-                        return Ok(sym.st_value);
-                    }
-                }
-                Err(RttSymbolError::RttSymbolNotFound)
-            }
-            Err(err) => Err(RttSymbolError::Goblin(err)),
-        }
-    }
-
     /// Polls the RTT target on all channels and returns available data.
     /// An error on any channel will return an error instead of incomplete data.
-    pub fn poll_rtt_fallible(
-        &mut self,
-        core: &mut Core,
-        collector: &mut impl ChannelDataCallbacks,
-    ) -> Result<(), Error> {
-        for channel in self.active_up_channels.iter_mut() {
-            channel.poll_process_rtt_data(core, collector)?;
-        }
-        Ok(())
-    }
-
-    /// Polls the RTT target on all channels and returns available data.
-    /// An error on any channel will return an error instead of incomplete data.
-    pub fn poll_channel_fallible(
-        &mut self,
-        core: &mut Core,
-        channel: usize,
-        collector: &mut impl ChannelDataCallbacks,
-    ) -> Result<(), Error> {
+    pub fn poll_channel(&mut self, core: &mut Core, channel: usize) -> Result<(), Error> {
         if let Some(channel) = self.active_up_channels.get_mut(channel) {
-            channel.poll_process_rtt_data(core, collector)?;
-            Ok(())
+            channel.poll(core)
+        } else {
+            Err(Error::MissingChannel(channel))
+        }
+    }
+
+    pub fn channel_data(&self, channel: usize) -> Result<&[u8], Error> {
+        if let Some(channel) = self.active_up_channels.get(channel) {
+            Ok(channel.buffered_data())
         } else {
             Err(Error::MissingChannel(channel))
         }
@@ -578,7 +247,7 @@ impl RttActiveTarget {
         data: impl AsRef<[u8]>,
     ) -> Result<(), Error> {
         if let Some(channel) = self.active_down_channels.get_mut(channel) {
-            channel.push_rtt(core, data)
+            channel.write(core, data)
         } else {
             Err(Error::MissingChannel(channel))
         }
@@ -599,5 +268,19 @@ impl RttActiveTarget {
         self.active_down_channels.clear();
         self.active_up_channels.clear();
         Ok(())
+    }
+}
+
+pub fn get_rtt_symbol_from_bytes(buffer: &[u8]) -> Result<u64, RttSymbolError> {
+    match goblin::elf::Elf::parse(buffer) {
+        Ok(binary) => {
+            for sym in &binary.syms {
+                if binary.strtab.get_at(sym.st_name) == Some("_SEGGER_RTT") {
+                    return Ok(sym.st_value);
+                }
+            }
+            Err(RttSymbolError::RttSymbolNotFound)
+        }
+        Err(err) => Err(RttSymbolError::Goblin(err)),
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
@@ -68,14 +68,13 @@ impl RttClient {
                 self.last_control_block_address = None;
                 return Ok(false);
             }
+            Err(Error::ControlBlockCorrupted(_)) => return Ok(false),
             Err(error) => return Err(error),
         };
 
         match RttConnection::new(core, rtt, &self.config) {
             Ok(rtt) => self.target = Some(rtt),
-            Err(Error::ControlBlockCorrupted(error)) => {
-                tracing::debug!("RTT control block corrupted ({error})");
-            }
+            Err(Error::ControlBlockCorrupted(_)) => {}
             Err(error) => return Err(error),
         };
 

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
@@ -82,7 +82,7 @@ impl RttClient {
         Ok(self.target.is_some())
     }
 
-    pub fn poll_channel(&mut self, core: &mut Core, channel: usize) -> Result<&[u8], Error> {
+    pub fn poll_channel(&mut self, core: &mut Core, channel: u32) -> Result<&[u8], Error> {
         self.try_attach(core)?;
 
         if let Some(ref mut target) = self.target {
@@ -118,7 +118,7 @@ impl RttClient {
     pub(crate) fn write_down_channel(
         &mut self,
         core: &mut Core,
-        channel: usize,
+        channel: u32,
         input: impl AsRef<[u8]>,
     ) -> Result<(), Error> {
         self.try_attach(core)?;

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/processing.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/processing.rs
@@ -1,0 +1,283 @@
+use anyhow::{anyhow, Context};
+use defmt_decoder::{
+    log::format::{Formatter, FormatterConfig, FormatterFormat},
+    DecodeError, StreamDecoder,
+};
+use probe_rs::rtt::Error;
+use time::{macros::format_description, OffsetDateTime, UtcOffset};
+
+use std::{
+    fmt::{self, Write},
+    sync::Arc,
+};
+
+use crate::util::rtt::DataFormat;
+
+pub enum RttDecoder {
+    String {
+        /// UTC offset used for creating timestamps, if enabled.
+        ///
+        /// Getting the offset can fail in multi-threaded programs,
+        /// so it needs to be stored.
+        timestamp_offset: Option<UtcOffset>,
+        last_line_done: bool,
+    },
+    BinaryLE,
+    Defmt {
+        processor: DefmtProcessor,
+    },
+}
+
+impl From<&RttDecoder> for DataFormat {
+    fn from(config: &RttDecoder) -> Self {
+        match config {
+            RttDecoder::String { .. } => DataFormat::String,
+            RttDecoder::BinaryLE => DataFormat::BinaryLE,
+            RttDecoder::Defmt { .. } => DataFormat::Defmt,
+        }
+    }
+}
+
+impl fmt::Debug for RttDecoder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RttDecoder::String {
+                timestamp_offset,
+                last_line_done,
+            } => f
+                .debug_struct("String")
+                .field("timestamp_offset", timestamp_offset)
+                .field("last_line_done", last_line_done)
+                .finish(),
+            RttDecoder::BinaryLE => f.debug_struct("BinaryLE").finish(),
+            RttDecoder::Defmt { .. } => f.debug_struct("Defmt").finish_non_exhaustive(),
+        }
+    }
+}
+
+impl RttDecoder {
+    /// Returns whether the channel is expected to output binary data (`true`)
+    /// or human-readable strings (`false`).
+    pub fn is_binary(&self) -> bool {
+        matches!(self, RttDecoder::BinaryLE)
+    }
+
+    pub fn process(
+        &mut self,
+        number: usize,
+        buffer: &[u8],
+        collector: &mut impl RttDataHandler,
+    ) -> Result<(), Error> {
+        // FIXME: clean this up by splitting the enum variants out into separate structs
+        match self {
+            RttDecoder::BinaryLE => collector.on_binary_data(number, buffer),
+            RttDecoder::String {
+                timestamp_offset,
+                ref mut last_line_done,
+            } => {
+                let string = Self::process_string(buffer, *timestamp_offset, last_line_done)?;
+                collector.on_string_data(number, string)
+            }
+            RttDecoder::Defmt { processor } => {
+                let string = processor.process(buffer)?;
+                collector.on_string_data(number, string)
+            }
+        }
+    }
+
+    fn process_string(
+        buffer: &[u8],
+        offset: Option<UtcOffset>,
+        last_line_done: &mut bool,
+    ) -> Result<String, Error> {
+        let incoming = String::from_utf8_lossy(buffer);
+
+        let Some(offset) = offset else {
+            return Ok(incoming.to_string());
+        };
+
+        let timestamp = OffsetDateTime::now_utc()
+            .to_offset(offset)
+            .format(format_description!(
+                "[hour repr:24]:[minute]:[second].[subsecond digits:3]"
+            ))
+            .expect("Incorrect format string. This shouldn't happen.");
+
+        let mut formatted_data = String::new();
+        for line in incoming.split_inclusive('\n') {
+            if *last_line_done {
+                write!(formatted_data, "{timestamp}: ").expect("Writing to String cannot fail");
+            }
+            write!(formatted_data, "{line}").expect("Writing to String cannot fail");
+            *last_line_done = line.ends_with('\n');
+        }
+        Ok(formatted_data)
+    }
+}
+
+pub trait RttDataHandler {
+    fn on_binary_data(&mut self, channel: usize, data: &[u8]) -> Result<(), Error> {
+        let mut formatted_data = String::with_capacity(data.len() * 4);
+        for element in data {
+            // Width of 4 allows 0xFF to be printed.
+            write!(&mut formatted_data, "{element:#04x}").expect("Writing to String cannot fail");
+        }
+        self.on_string_data(channel, formatted_data)
+    }
+
+    fn on_string_data(&mut self, channel: usize, data: String) -> Result<(), Error>;
+}
+
+pub struct DefmtStateInner {
+    pub table: defmt_decoder::Table,
+    pub locs: Option<defmt_decoder::Locations>,
+}
+
+impl DefmtStateInner {
+    pub fn try_from_bytes(buffer: &[u8]) -> Result<Option<Self>, Error> {
+        let Some(table) =
+            defmt_decoder::Table::parse(buffer).with_context(|| "Failed to parse defmt data")?
+        else {
+            return Ok(None);
+        };
+
+        let locs = table
+            .get_locations(buffer)
+            .with_context(|| "Failed to parse defmt data")?;
+
+        let locs = if !table.is_empty() && locs.is_empty() {
+            tracing::warn!("Insufficient DWARF info; compile your program with `debug = 2` to enable location info.");
+            None
+        } else if table.indices().all(|idx| locs.contains_key(&(idx as u64))) {
+            Some(locs)
+        } else {
+            tracing::warn!("Location info is incomplete; it will be omitted from the output.");
+            None
+        };
+        Ok(Some(DefmtStateInner { table, locs }))
+    }
+}
+
+/// defmt information common to all defmt channels.
+#[derive(Clone)]
+pub struct DefmtState {
+    inner: Arc<DefmtStateInner>,
+}
+impl DefmtState {
+    pub fn try_from_bytes(buffer: &[u8]) -> Result<Option<Self>, Error> {
+        Ok(
+            DefmtStateInner::try_from_bytes(buffer)?.map(|inner| DefmtState {
+                inner: Arc::new(inner),
+            }),
+        )
+    }
+
+    fn as_ref(&self) -> &DefmtStateInner {
+        &self.inner
+    }
+
+    pub fn table(&self) -> &defmt_decoder::Table {
+        &self.inner.table
+    }
+}
+
+impl fmt::Debug for DefmtState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DefmtState").finish_non_exhaustive()
+    }
+}
+
+pub struct DefmtProcessor {
+    formatter: Formatter,
+    // Fields are dropped in declaration order. `decoder` is holding a reference to defmt_data's
+    // inner table, so it must be dropped first.
+    decoder: Box<dyn StreamDecoder>,
+    defmt_data: DefmtState,
+}
+
+impl DefmtProcessor {
+    pub fn new(
+        defmt_data: DefmtState,
+        show_timestamps: bool,
+        show_location: bool,
+        log_format: Option<&str>,
+    ) -> Self {
+        let has_timestamp = defmt_data.table().has_timestamp();
+
+        // Format options:
+        // 1. Oneline format with optional location
+        // 2. Custom format for the channel
+        // 3. Default with optional location
+        let format = match log_format {
+            Some("oneline") => FormatterFormat::OneLine {
+                with_location: show_location,
+            },
+            Some(format) => FormatterFormat::Custom(format),
+            None => FormatterFormat::Default {
+                with_location: show_location,
+            },
+        };
+
+        Self {
+            formatter: Formatter::new(FormatterConfig {
+                format,
+                is_timestamp_available: has_timestamp && show_timestamps,
+            }),
+            decoder: unsafe {
+                // Extend lifetime to 'static. We can do this because we hold a reference to the
+                // defmt_data's inner table for the lifetime of the processor.
+                std::mem::transmute::<Box<dyn StreamDecoder>, Box<dyn StreamDecoder + 'static>>(
+                    defmt_data.as_ref().table.new_stream_decoder(),
+                )
+            },
+            defmt_data: defmt_data.clone(),
+        }
+    }
+
+    fn process(&mut self, buffer: &[u8]) -> Result<String, Error> {
+        let DefmtStateInner { table, locs } = self.defmt_data.as_ref();
+        self.decoder.received(buffer);
+
+        let mut formatted_data = String::new();
+        loop {
+            match self.decoder.decode() {
+                Ok(frame) => {
+                    let loc = locs.as_ref().and_then(|locs| locs.get(&frame.index()));
+                    let (file, line, module) = if let Some(loc) = loc {
+                        (
+                            loc.file.display().to_string(),
+                            Some(loc.line.try_into().unwrap()),
+                            Some(loc.module.as_str()),
+                        )
+                    } else {
+                        (
+                            format!(
+                                "└─ <invalid location: defmt frame-index: {}>",
+                                frame.index()
+                            ),
+                            None,
+                            None,
+                        )
+                    };
+                    let s = self
+                        .formatter
+                        .format_frame(frame, Some(&file), line, module);
+                    writeln!(formatted_data, "{s}").expect("Writing to String cannot fail");
+                }
+                Err(DecodeError::UnexpectedEof) => break,
+                Err(DecodeError::Malformed) if table.encoding().can_recover() => {
+                    // If recovery is possible, skip the current frame and continue with new data.
+                }
+                Err(DecodeError::Malformed) => {
+                    return Err(Error::Other(anyhow!(
+                        "Unrecoverable error while decoding Defmt \
+                        data. Some data may have been lost: {}",
+                        DecodeError::Malformed
+                    )));
+                }
+            }
+        }
+
+        Ok(formatted_data)
+    }
+}

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/processing.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/processing.rs
@@ -64,7 +64,7 @@ impl RttDecoder {
 
     pub fn process(
         &mut self,
-        number: usize,
+        number: u32,
         buffer: &[u8],
         collector: &mut impl RttDataHandler,
     ) -> Result<(), Error> {
@@ -116,7 +116,7 @@ impl RttDecoder {
 }
 
 pub trait RttDataHandler {
-    fn on_binary_data(&mut self, channel: usize, data: &[u8]) -> Result<(), Error> {
+    fn on_binary_data(&mut self, channel: u32, data: &[u8]) -> Result<(), Error> {
         let mut formatted_data = String::with_capacity(data.len() * 4);
         for element in data {
             // Width of 4 allows 0xFF to be printed.
@@ -125,7 +125,7 @@ pub trait RttDataHandler {
         self.on_string_data(channel, formatted_data)
     }
 
-    fn on_string_data(&mut self, channel: usize, data: String) -> Result<(), Error>;
+    fn on_string_data(&mut self, channel: u32, data: String) -> Result<(), Error>;
 }
 
 pub struct DefmtStateInner {

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/processing.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/processing.rs
@@ -209,13 +209,13 @@ impl DefmtProcessor {
         // 2. Custom format for the channel
         // 3. Default with optional location
         let format = match log_format {
-            Some("oneline") => FormatterFormat::OneLine {
+            None | Some("oneline") => FormatterFormat::OneLine {
+                with_location: show_location,
+            },
+            Some("full") => FormatterFormat::Default {
                 with_location: show_location,
             },
             Some(format) => FormatterFormat::Custom(format),
-            None => FormatterFormat::Default {
-                with_location: show_location,
-            },
         };
 
         Self {

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -51,8 +51,8 @@ use crate::Session;
 use crate::{config::MemoryRegion, Core, MemoryInterface};
 use std::ops::Range;
 use std::thread;
+use std::time::Duration;
 use std::time::Instant;
-use std::{borrow::Cow, time::Duration};
 use zerocopy::FromBytes;
 
 /// The RTT interface.
@@ -147,7 +147,7 @@ impl RttControlBlockHeader {
         }
     }
 
-    pub fn minimal_header_size(is_64_bit: bool) -> usize {
+    pub const fn minimal_header_size(is_64_bit: bool) -> usize {
         if is_64_bit {
             std::mem::size_of::<RttControlBlockHeaderInner<u64>>()
         } else {
@@ -231,27 +231,19 @@ impl RttControlBlockHeader {
 //     RttChannel down_channels[max_down_channels]; // array of down (host to target) channels.
 // }
 impl Rtt {
-    const RTT_ID: [u8; 16] = *b"SEGGER RTT\0\0\0\0\0\0";
+    /// The magic string expected to be found at the beginning of the RTT control block.
+    pub const RTT_ID: [u8; 16] = *b"SEGGER RTT\0\0\0\0\0\0";
 
-    fn from(
+    /// Tries to attach to an RTT control block at the specified memory address.
+    pub fn attach_at(
         core: &mut Core,
         // Pointer from which to scan
         ptr: u64,
-        // Memory contents read in advance, starting from ptr
-        mem_in: Option<&[u8]>,
     ) -> Result<Rtt, Error> {
         let is_64_bit = core.is_64_bit();
 
-        let mut mem = match mem_in {
-            Some(mem) => Cow::Borrowed(mem),
-            None => {
-                // If memory wasn't passed in, read the minimum header size
-                let new_length = RttControlBlockHeader::minimal_header_size(is_64_bit);
-                let mut mem = vec![0; new_length];
-                core.read(ptr, &mut mem)?;
-                Cow::Owned(mem)
-            }
-        };
+        let mut mem = [0u8; RttControlBlockHeader::minimal_header_size(true)];
+        core.read(ptr, &mut mem)?;
 
         let rtt_header = RttControlBlockHeader::try_from_header(is_64_bit, &mem)
             .ok_or(Error::ControlBlockNotFound)?;
@@ -277,29 +269,17 @@ impl Rtt {
             )));
         }
 
-        let control_block_len = rtt_header.total_rtt_buffer_size();
-
-        if let Cow::Owned(mem) = &mut mem {
-            // If memory wasn't passed in, read the rest of the control block
-            mem.resize(control_block_len, 0);
-            core.read(
-                ptr + rtt_header.header_size() as u64,
-                &mut mem[rtt_header.header_size()..control_block_len],
-            )?;
-        }
-
-        // Validate that the entire control block fits within the region
-        if mem.len() < control_block_len {
-            tracing::debug!("Control block doesn't fit in scanned memory region.");
-            return Err(Error::ControlBlockNotFound);
-        }
+        // Read the rest of the control block
+        let channel_buffer_len = rtt_header.total_rtt_buffer_size() - rtt_header.header_size();
+        let mut mem = vec![0; channel_buffer_len];
+        core.read(ptr + rtt_header.header_size() as u64, &mut mem)?;
 
         let mut up_channels = Vec::new();
         let mut down_channels = Vec::new();
 
         let channel_buffer_size = rtt_header.channel_buffer_size();
 
-        let up_channels_start = rtt_header.header_size();
+        let up_channels_start = 0;
         let up_channels_len = max_up_channels * channel_buffer_size;
         let up_channels_raw_buffer = &mem[up_channels_start..][..up_channels_len];
         let up_channels_buffer = rtt_header.parse_channel_buffers(up_channels_raw_buffer)?;
@@ -309,11 +289,11 @@ impl Rtt {
         let down_channels_raw_buffer = &mem[down_channels_start..][..down_channels_len];
         let down_channels_buffer = rtt_header.parse_channel_buffers(down_channels_raw_buffer)?;
 
-        let mut offset = up_channels_start as u64;
+        let mut offset = ptr + rtt_header.header_size() as u64 + up_channels_start as u64;
         for (channel_index, buffer) in up_channels_buffer.into_iter().enumerate() {
             let buffer_size = buffer.size() as u64;
 
-            if let Some(chan) = Channel::from(core, channel_index, ptr + offset, buffer)? {
+            if let Some(chan) = Channel::from(core, channel_index, offset, buffer)? {
                 up_channels.push(UpChannel(chan));
             } else {
                 tracing::warn!("Buffer for up channel {channel_index} not initialized");
@@ -321,10 +301,11 @@ impl Rtt {
             offset += buffer_size;
         }
 
+        let mut offset = ptr + rtt_header.header_size() as u64 + down_channels_start as u64;
         for (channel_index, buffer) in down_channels_buffer.into_iter().enumerate() {
             let buffer_size = buffer.size() as u64;
 
-            if let Some(chan) = Channel::from(core, channel_index, ptr + offset, buffer)? {
+            if let Some(chan) = Channel::from(core, channel_index, offset, buffer)? {
                 down_channels.push(DownChannel(chan));
             } else {
                 tracing::warn!("Buffer for down channel {channel_index} not initialized");
@@ -339,24 +320,27 @@ impl Rtt {
         })
     }
 
+    /// Attempts to detect an RTT control block in the specified RAM region(s) and returns an
+    /// instance if a valid control block was found.
+    pub fn attach_region(core: &mut Core, region: &ScanRegion) -> Result<Rtt, Error> {
+        let ptr = Self::find_contol_block(core, region)?;
+        Self::attach_at(core, ptr)
+    }
+
     /// Attempts to detect an RTT control block anywhere in the target RAM and returns an instance
     /// if a valid control block was found.
-    ///
-    /// `core` can be e.g. an owned `Core` or a shared `Rc<Core>`.
     pub fn attach(core: &mut Core) -> Result<Rtt, Error> {
         Self::attach_region(core, &ScanRegion::default())
     }
 
     /// Attempts to detect an RTT control block in the specified RAM region(s) and returns an
-    /// instance if a valid control block was found.
-    ///
-    /// `core` can be e.g. an owned `Core` or a shared `Rc<Core>`.
-    pub fn attach_region(core: &mut Core, region: &ScanRegion) -> Result<Rtt, Error> {
+    /// address if a valid control block location was found.
+    pub fn find_contol_block(core: &mut Core, region: &ScanRegion) -> Result<u64, Error> {
         let ranges = match region.clone() {
             ScanRegion::Exact(addr) => {
                 tracing::debug!("Scanning at exact address: {:#010x}", addr);
 
-                return Rtt::from(core, addr, None);
+                return Ok(addr);
             }
             ScanRegion::Ram => {
                 tracing::debug!("Scanning whole RAM");
@@ -399,9 +383,9 @@ impl Rtt {
 
                 let target_ptr = range.start + offset as u64;
 
-                Some(Rtt::from(core, target_ptr, Some(&mem[offset..])))
+                Some(target_ptr)
             })
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Vec<_>>();
 
         match instances.len() {
             0 => Err(Error::ControlBlockNotFound),
@@ -484,7 +468,7 @@ pub enum Error {
     ControlBlockNotFound,
 
     /// Multiple control blocks found in target memory: {display_list(_0)}.
-    MultipleControlBlocksFound(Vec<Rtt>),
+    MultipleControlBlocksFound(Vec<u64>),
 
     /// The control block has been corrupted: {0}
     ControlBlockCorrupted(String),
@@ -508,9 +492,9 @@ pub enum Error {
     MissingChannel(usize),
 }
 
-fn display_list(list: &[Rtt]) -> String {
+fn display_list(list: &[u64]) -> String {
     list.iter()
-        .map(|rtt| format!("{:#010x}", rtt.ptr))
+        .map(|ptr| format!("{:#010x}", ptr))
         .collect::<Vec<_>>()
         .join(", ")
 }
@@ -568,15 +552,7 @@ mod test {
 
     #[test]
     fn test_how_control_block_list_looks() {
-        fn rtt(ptr: u32) -> Rtt {
-            Rtt {
-                ptr: ptr.into(),
-                up_channels: Vec::new(),
-                down_channels: Vec::new(),
-            }
-        }
-
-        let error = Error::MultipleControlBlocksFound(vec![rtt(0x2000), rtt(0x3000)]);
+        let error = Error::MultipleControlBlocksFound(vec![0x2000, 0x3000]);
         assert_eq!(
             error.to_string(),
             "Multiple control blocks found in target memory: 0x00002000, 0x00003000."

--- a/probe-rs/src/rtt/channel.rs
+++ b/probe-rs/src/rtt/channel.rs
@@ -283,7 +283,7 @@ impl Channel {
 
             if buffer_offset_larger_than_size_of_buffer {
                 return Err(Error::ControlBlockCorrupted(format!(
-                    "{which} pointer is {value} while buffer size is {} for {channel_kind}channel {} ({})",
+                    "{which} pointer is {value:#010x} while buffer size is {:#010x} for {channel_kind}channel {} ({})",
                     self.info.size_of_buffer(),
                     self.number,
                     self.name().unwrap_or("no name"),

--- a/probe-rs/src/rtt/channel.rs
+++ b/probe-rs/src/rtt/channel.rs
@@ -547,9 +547,10 @@ fn read_c_string(core: &mut Core, ptr: u64) -> Result<Option<String>, Error> {
         .filter(|r| r.is_ram() || r.is_nvm())
         .find_map(|r| r.contains(ptr).then_some(r.address_range()))
     else {
-        // If the pointer is not within any valid range, return None.
-        tracing::warn!("RTT channel name points to unrecognized memory. Bad target description?");
-        return Ok(None);
+        return Err(Error::ControlBlockCorrupted(format!(
+            "The channel name pointer is not in a valid memory region: {:#X}",
+            ptr
+        )));
     };
 
     // Read up to 128 bytes not going past the end of the region


### PR DESCRIPTION
This PR builds on top of the RPC PR and moves RTT processing from the server to the client. This mainly means the firmware doesn't need to be uploaded for monitoring operations. I'm also fixing a bug where the defmt processor couldn't deal with data arriving split into multiple reads, and I'm also changing the default log format to "oneline" because it's just so much more readable.

Closes #2981