### PR TITLE
Mildly refactor Flasher/FlashLoader

### DIFF
--- a/probe-rs/src/flashing/erase.rs
+++ b/probe-rs/src/flashing/erase.rs
@@ -100,11 +100,11 @@ pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), F
         let algo = algo.unwrap().clone();
 
         let core_index = session.target().core_index_by_name(&core_name).unwrap();
-        let mut flasher = Flasher::new(session, core_index, &algo, progress.clone())?;
+        let mut flasher = Flasher::new(session, core_index, &algo)?;
 
         if flasher.is_chip_erase_supported(session) {
             tracing::debug!("     -- chip erase supported, doing it.");
-            flasher.run_erase_all(session)?;
+            flasher.run_erase_all(session, &progress)?;
         } else {
             tracing::debug!("     -- chip erase not supported, erasing by sector.");
 
@@ -119,7 +119,7 @@ pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), F
                 })
                 .collect::<Vec<_>>();
 
-            flasher.run_erase(session, |active| {
+            flasher.run_erase(session, &progress, |active| {
                 for info in sectors {
                     tracing::debug!(
                         "    sector: {:#010x}-{:#010x} ({} bytes)",
@@ -197,7 +197,7 @@ pub fn erase_sectors(
         let algo = algo.unwrap().clone();
 
         let core_index = session.target().core_index_by_name(&core_name).unwrap();
-        let mut flasher = Flasher::new(session, core_index, &algo, progress.clone())?;
+        let mut flasher = Flasher::new(session, core_index, &algo)?;
 
         let sectors = flasher
             .flash_algorithm()
@@ -210,7 +210,7 @@ pub fn erase_sectors(
             })
             .collect::<Vec<_>>();
 
-        flasher.run_erase(session, |active| {
+        flasher.run_erase(session, &progress, |active| {
             for info in sectors {
                 tracing::debug!(
                     "    sector: {:#010x}-{:#010x} ({} bytes)",

--- a/probe-rs/src/flashing/erase.rs
+++ b/probe-rs/src/flashing/erase.rs
@@ -43,7 +43,7 @@ pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), F
         };
 
         let target = session.target();
-        let core = target.core_index_by_name(&core_name).unwrap();
+        let core = target.core_index_by_name(core_name).unwrap();
         let algo = FlashLoader::get_flash_algorithm_for_region(&region, target)?;
 
         tracing::debug!("     -- using algorithm: {}", algo.name);
@@ -53,7 +53,7 @@ pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), F
             entry.regions.push(region);
         } else {
             algos.push(FlasherWithRegions {
-                flasher: Flasher::new(session.target(), core, &algo)?,
+                flasher: Flasher::new(session.target(), core, algo)?,
                 regions: vec![region],
             });
         }
@@ -196,7 +196,7 @@ pub fn erase_sectors(
         let algo = algo.unwrap();
 
         let core_index = session.target().core_index_by_name(&core_name).unwrap();
-        let mut flasher = Flasher::new(session.target(), core_index, &algo)?;
+        let mut flasher = Flasher::new(session.target(), core_index, algo)?;
 
         let sectors = flasher
             .flash_algorithm()

--- a/probe-rs/src/flashing/erase.rs
+++ b/probe-rs/src/flashing/erase.rs
@@ -102,9 +102,9 @@ pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), F
         let core_index = session.target().core_index_by_name(&core_name).unwrap();
         let mut flasher = Flasher::new(session, core_index, &algo, progress.clone())?;
 
-        if flasher.is_chip_erase_supported() {
+        if flasher.is_chip_erase_supported(session) {
             tracing::debug!("     -- chip erase supported, doing it.");
-            flasher.run_erase_all()?;
+            flasher.run_erase_all(session)?;
         } else {
             tracing::debug!("     -- chip erase not supported, erasing by sector.");
 
@@ -119,7 +119,7 @@ pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), F
                 })
                 .collect::<Vec<_>>();
 
-            flasher.run_erase(|active| {
+            flasher.run_erase(session, |active| {
                 for info in sectors {
                     tracing::debug!(
                         "    sector: {:#010x}-{:#010x} ({} bytes)",
@@ -210,7 +210,7 @@ pub fn erase_sectors(
             })
             .collect::<Vec<_>>();
 
-        flasher.run_erase(|active| {
+        flasher.run_erase(session, |active| {
             for info in sectors {
                 tracing::debug!(
                     "    sector: {:#010x}-{:#010x} ({} bytes)",

--- a/probe-rs/src/flashing/erase.rs
+++ b/probe-rs/src/flashing/erase.rs
@@ -97,10 +97,10 @@ pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), F
 
         // This can't fail, algo_name comes from the target.
         let algo = session.target().flash_algorithm_by_name(&algo_name);
-        let algo = algo.unwrap().clone();
+        let algo = algo.unwrap();
 
         let core_index = session.target().core_index_by_name(&core_name).unwrap();
-        let mut flasher = Flasher::new(session, core_index, &algo)?;
+        let mut flasher = Flasher::new(session.target(), core_index, &algo)?;
 
         if flasher.is_chip_erase_supported(session) {
             tracing::debug!("     -- chip erase supported, doing it.");
@@ -194,10 +194,10 @@ pub fn erase_sectors(
 
         // This can't fail, algo_name comes from the target.
         let algo = session.target().flash_algorithm_by_name(&algo_name);
-        let algo = algo.unwrap().clone();
+        let algo = algo.unwrap();
 
         let core_index = session.target().core_index_by_name(&core_name).unwrap();
-        let mut flasher = Flasher::new(session, core_index, &algo)?;
+        let mut flasher = Flasher::new(session.target(), core_index, &algo)?;
 
         let sectors = flasher
             .flash_algorithm()

--- a/probe-rs/src/flashing/erase.rs
+++ b/probe-rs/src/flashing/erase.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use probe_rs_target::{MemoryRange, MemoryRegion, NvmRegion};
 
 use crate::flashing::{flasher::Flasher, FlashError, FlashLoader};
-use crate::flashing::{FlashAlgorithm, FlashLayout, FlashSector};
+use crate::flashing::{FlashLayout, FlashSector, FlasherWithRegions};
 use crate::Session;
 
 use super::FlashProgress;
@@ -15,7 +15,9 @@ use super::FlashProgress;
 pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), FlashError> {
     tracing::debug!("Erasing all...");
 
-    let mut algos: HashMap<(String, String), Vec<NvmRegion>> = HashMap::new();
+    // TODO: this first loop is pretty much identical to FlashLoader::prepare_plan - can we simplify?
+
+    let mut algos = Vec::<FlasherWithRegions>::new();
     tracing::debug!("Regions:");
     for region in session
         .target()
@@ -33,20 +35,28 @@ pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), F
             region.range.end - region.range.start
         );
 
-        let algo = FlashLoader::get_flash_algorithm_for_region(region, session.target())?;
+        let region = region.clone();
 
         // Get the first core that can access the region
-        let core_name = region
-            .cores
-            .first()
-            .ok_or_else(|| FlashError::NoNvmCoreAccess(region.clone()))?;
+        let Some(core_name) = region.cores.first() else {
+            return Err(FlashError::NoNvmCoreAccess(region));
+        };
 
-        let entry = algos
-            .entry((algo.name.clone(), core_name.clone()))
-            .or_default();
-        entry.push(region.clone());
+        let target = session.target();
+        let core = target.core_index_by_name(&core_name).unwrap();
+        let algo = FlashLoader::get_flash_algorithm_for_region(&region, target)?;
 
         tracing::debug!("     -- using algorithm: {}", algo.name);
+        if let Some(entry) = algos.iter_mut().find(|entry| {
+            entry.flasher.flash_algorithm.name == algo.name && entry.flasher.core_index == core
+        }) {
+            entry.regions.push(region);
+        } else {
+            algos.push(FlasherWithRegions {
+                flasher: Flasher::new(session.target(), core, &algo)?,
+                regions: vec![region],
+            });
+        }
     }
 
     // No longer needs to be mutable.
@@ -57,13 +67,8 @@ pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), F
     let mut phases = vec![];
 
     // Walk through the algos to create a layout of the flash.
-    for ((algo_name, core), regions) in algos.iter() {
-        // This can't fail, algo_name comes from the target.
-        let algo = session.target().flash_algorithm_by_name(algo_name);
-        let algo = algo.unwrap().clone();
-
-        let flash_algorithm =
-            FlashAlgorithm::assemble_from_raw_with_core(&algo, core, session.target())?;
+    for el in algos.iter() {
+        let flash_algorithm = &el.flasher.flash_algorithm;
 
         let chip_erase_supported =
             session.has_sequence_erase_all() || flash_algorithm.pc_erase_all.is_some();
@@ -75,7 +80,7 @@ pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), F
 
         let mut layout = FlashLayout::default();
 
-        for region in regions {
+        for region in el.regions.iter() {
             for info in flash_algorithm.iter_sectors() {
                 let range = info.address_range();
 
@@ -92,15 +97,9 @@ pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), F
 
     progress.initialized(do_chip_erase, false, phases);
 
-    for ((algo_name, core_name), regions) in algos {
-        tracing::debug!("Erasing with algorithm: {}", algo_name);
-
-        // This can't fail, algo_name comes from the target.
-        let algo = session.target().flash_algorithm_by_name(&algo_name);
-        let algo = algo.unwrap();
-
-        let core_index = session.target().core_index_by_name(&core_name).unwrap();
-        let mut flasher = Flasher::new(session.target(), core_index, &algo)?;
+    for el in algos {
+        let mut flasher = el.flasher;
+        tracing::debug!("Erasing with algorithm: {}", flasher.flash_algorithm.name);
 
         if flasher.is_chip_erase_supported(session) {
             tracing::debug!("     -- chip erase supported, doing it.");
@@ -115,7 +114,7 @@ pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), F
                 .iter_sectors()
                 .filter(|info| {
                     let range = info.base_address..info.base_address + info.size;
-                    regions.iter().any(|r| r.range.contains_range(&range))
+                    el.regions.iter().any(|r| r.range.contains_range(&range))
                 })
                 .collect::<Vec<_>>();
 

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -8,8 +8,8 @@ use crate::flashing::encoder::FlashEncoder;
 use crate::flashing::{FlashLayout, FlashSector};
 use crate::memory::MemoryInterface;
 use crate::rtt::{self, Rtt, ScanRegion};
-use crate::CoreStatus;
 use crate::{core::CoreRegisters, session::Session, Core, InstructionSet};
+use crate::{CoreStatus, Target};
 use std::marker::PhantomData;
 use std::{
     fmt::Debug,
@@ -49,9 +49,9 @@ impl Operation for Verify {
 ///
 /// Once constructed it can be used to program date to the flash.
 pub(super) struct Flasher {
-    core_index: usize,
-    flash_algorithm: FlashAlgorithm,
-    loaded: bool,
+    pub(super) core_index: usize,
+    pub(super) flash_algorithm: FlashAlgorithm,
+    pub(super) loaded: bool,
 }
 
 /// The byte used to fill the stack when checking for stack overflows.
@@ -59,16 +59,14 @@ const STACK_FILL_BYTE: u8 = 0x56;
 
 impl Flasher {
     pub(super) fn new(
-        session: &mut Session,
+        target: &Target,
         core_index: usize,
         raw_flash_algorithm: &RawFlashAlgorithm,
     ) -> Result<Self, FlashError> {
-        let target = session.target();
-
         let flash_algorithm = FlashAlgorithm::assemble_from_raw_with_core(
             raw_flash_algorithm,
             &target.cores[core_index].name,
-            target,
+            &target,
         )?;
 
         Ok(Self {

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -66,7 +66,7 @@ impl Flasher {
         let flash_algorithm = FlashAlgorithm::assemble_from_raw_with_core(
             raw_flash_algorithm,
             &target.cores[core_index].name,
-            &target,
+            target,
         )?;
 
         Ok(Self {

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -711,7 +711,7 @@ impl FlashLoader {
             };
 
             let target = session.target();
-            let core = target.core_index_by_name(&core_name).unwrap();
+            let core = target.core_index_by_name(core_name).unwrap();
             let algo = Self::get_flash_algorithm_for_region(&region, target)?;
 
             // We don't usually have more than a handful of regions, linear search should be fine.
@@ -722,7 +722,7 @@ impl FlashLoader {
                 entry.regions.push(region);
             } else {
                 algos.push(FlasherWithRegions {
-                    flasher: Flasher::new(target, core, &algo)?,
+                    flasher: Flasher::new(target, core, algo)?,
                     regions: vec![region],
                 });
             }
@@ -752,11 +752,9 @@ impl FlashLoader {
 
             let mut phase_layout = FlashLayout::default();
             for region in el.regions.iter() {
-                let layout = el.flasher.flash_layout(
-                    &region,
-                    &self.builder,
-                    options.keep_unwritten_bytes,
-                )?;
+                let layout =
+                    el.flasher
+                        .flash_layout(region, &self.builder, options.keep_unwritten_bytes)?;
 
                 phase_layout.merge_from(layout);
             }

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -447,12 +447,12 @@ impl FlashLoader {
             let algorithm = session.target().flash_algorithm_by_name(&el.name);
             let algorithm = algorithm.unwrap().clone();
 
-            let mut flasher = Flasher::new(session, el.core, &algorithm, progress.clone())?;
+            let mut flasher = Flasher::new(session, el.core, &algorithm)?;
 
             for region in el.regions.iter() {
                 let flash_layout = flasher.flash_layout(region, &self.builder, false)?;
 
-                if !flasher.verify(session, &flash_layout, true)? {
+                if !flasher.verify(session, &progress, &flash_layout, true)? {
                     return Err(FlashError::Verify);
                 }
             }
@@ -513,11 +513,11 @@ impl FlashLoader {
             let algorithm = session.target().flash_algorithm_by_name(&el.name);
             let algorithm = algorithm.unwrap().clone();
 
-            let mut flasher = Flasher::new(session, el.core, &algorithm, progress.clone())?;
+            let mut flasher = Flasher::new(session, el.core, &algorithm)?;
 
             if do_chip_erase {
                 tracing::debug!("    Doing chip erase...");
-                flasher.run_erase_all(session)?;
+                flasher.run_erase_all(session, &progress)?;
                 do_chip_erase = false;
                 did_chip_erase = true;
             }
@@ -529,7 +529,7 @@ impl FlashLoader {
                 for region in el.regions.iter() {
                     let flash_layout = flasher.flash_layout(region, &self.builder, false)?;
 
-                    if !flasher.verify(session, &flash_layout, true)? {
+                    if !flasher.verify(session, &progress, &flash_layout, true)? {
                         contents_match = false;
                         break;
                     }
@@ -557,6 +557,7 @@ impl FlashLoader {
                 // Program the data.
                 flasher.program(
                     session,
+                    &progress,
                     &region,
                     &self.builder,
                     options.keep_unwritten_bytes,
@@ -762,7 +763,7 @@ impl FlashLoader {
             let algorithm = session.target().flash_algorithm_by_name(&el.name);
             let algorithm = algorithm.unwrap().clone();
 
-            let flasher = Flasher::new(session, el.core, &algorithm, progress.clone())?;
+            let flasher = Flasher::new(session, el.core, &algorithm)?;
             // If the first flash algo doesn't support erase all, disable chip erase.
             // TODO: we could sort by support but it's unlikely to make a difference.
             if options.do_chip_erase && !flasher.is_chip_erase_supported(session) {

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -453,7 +453,7 @@ impl FlashLoader {
             for region in regions.iter() {
                 let flash_layout = flasher.flash_layout(region, &self.builder, false)?;
 
-                if !flasher.verify(&flash_layout, true)? {
+                if !flasher.verify(session, &flash_layout, true)? {
                     return Err(FlashError::Verify);
                 }
             }
@@ -518,7 +518,7 @@ impl FlashLoader {
 
             if do_chip_erase {
                 tracing::debug!("    Doing chip erase...");
-                flasher.run_erase_all()?;
+                flasher.run_erase_all(session)?;
                 do_chip_erase = false;
                 did_chip_erase = true;
             }
@@ -530,7 +530,7 @@ impl FlashLoader {
                 for region in regions.iter() {
                     let flash_layout = flasher.flash_layout(region, &self.builder, false)?;
 
-                    if !flasher.verify(&flash_layout, true)? {
+                    if !flasher.verify(session, &flash_layout, true)? {
                         contents_match = false;
                         break;
                     }
@@ -557,6 +557,7 @@ impl FlashLoader {
 
                 // Program the data.
                 flasher.program(
+                    session,
                     &region,
                     &self.builder,
                     options.keep_unwritten_bytes,
@@ -758,7 +759,7 @@ impl FlashLoader {
             let flasher = Flasher::new(session, *core, &algo, progress.clone())?;
             // If the first flash algo doesn't support erase all, disable chip erase.
             // TODO: we could sort by support but it's unlikely to make a difference.
-            if options.do_chip_erase && !flasher.is_chip_erase_supported() {
+            if options.do_chip_erase && !flasher.is_chip_erase_supported(session) {
                 options.do_chip_erase = false;
                 tracing::warn!("Chip erase was the selected method to erase the sectors but this chip does not support chip erases (yet).");
                 tracing::warn!("A manual sector erase will be performed.");

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -706,17 +706,13 @@ impl FlashLoader {
 
             let region = region.clone();
 
-            let target = session.target();
-            let algo = Self::get_flash_algorithm_for_region(&region, target)?;
             let Some(core_name) = region.cores.first() else {
                 return Err(FlashError::NoNvmCoreAccess(region));
             };
 
-            let core = target
-                .cores
-                .iter()
-                .position(|c| c.name == *core_name)
-                .unwrap();
+            let target = session.target();
+            let core = target.core_index_by_name(&core_name).unwrap();
+            let algo = Self::get_flash_algorithm_for_region(&region, target)?;
 
             // We don't usually have more than a handful of regions, linear search should be fine.
             tracing::debug!("     -- using algorithm: {}", algo.name);
@@ -860,7 +856,7 @@ impl FlashLoader {
     }
 }
 
-struct FlasherWithRegions {
-    regions: Vec<NvmRegion>,
-    flasher: Flasher,
+pub(super) struct FlasherWithRegions {
+    pub(super) regions: Vec<NvmRegion>,
+    pub(super) flasher: Flasher,
 }


### PR DESCRIPTION
The long-term plan with this PR is to allow the RPC implementation to reuse a FlashLoader object, to not require compressing an image three times - once for preverification, once for programming and once for verification. This PR makes the inner Flasher storable, and only creates it once per program/verify call. It's not the whole story, just a step toward it.

The PR should not have user-facing changes.