### PR TITLE
Updating ADIv6 root memory interface to enumerate without BASEPTR registers

### DIFF
--- a/probe-rs/src/architecture/arm/ap_v2/root_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/ap_v2/root_memory_interface.rs
@@ -17,19 +17,10 @@ use crate::{
 pub struct RootMemoryInterface<'iface, API> {
     iface: &'iface mut API,
     dp: DpAddress,
-    base: u64,
 }
 impl<'iface, API: ArmProbeInterface> RootMemoryInterface<'iface, API> {
     pub fn new(iface: &'iface mut API, dp: DpAddress) -> Result<Self, ArmError> {
-        let base_ptr0: BASEPTR0 = iface.read_dp_register(dp)?;
-        let base_ptr1: BASEPTR1 = iface.read_dp_register(dp)?;
-        let base = base_ptr0
-            .valid()
-            .then(|| u64::from(base_ptr1.ptr()) | u64::from(base_ptr0.ptr() << 12))
-            .inspect(|base| tracing::info!("DPv3 BASE_PTR: 0x{base:x}"))
-            .ok_or_else(|| ArmError::Other("DP has no valid base address defined.".into()))?;
-
-        Ok(Self { iface, dp, base })
+        Ok(Self { iface, dp })
     }
 }
 
@@ -103,7 +94,14 @@ impl<API: ArmProbeInterface> ArmMemoryInterface for RootMemoryInterface<'_, API>
     }
 
     fn base_address(&mut self) -> Result<u64, ArmError> {
-        Ok(self.base)
+        let base_ptr0: BASEPTR0 = self.iface.read_dp_register(self.dp)?;
+        let base_ptr1: BASEPTR1 = self.iface.read_dp_register(self.dp)?;
+        let base = base_ptr0
+            .valid()
+            .then(|| u64::from(base_ptr1.ptr()) | u64::from(base_ptr0.ptr() << 12))
+            .ok_or_else(|| ArmError::Other("DP has no valid base address defined.".into()))?;
+
+        Ok(base)
     }
 
     fn get_swd_sequence(&mut self) -> Result<&mut dyn SwdSequence, DebugProbeError> {

--- a/probe-rs/src/architecture/arm/dp/mod.rs
+++ b/probe-rs/src/architecture/arm/dp/mod.rs
@@ -379,10 +379,10 @@ bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq)]
     pub struct SelectV3(u32);
     impl Debug;
-    /// Address output bits[63:4], formed by concatenating bits[31:0] of SELECT1 with bits[31:4] of SELECT.
+    /// Address output bits\[63:4\], formed by concatenating bits\[31:0\] of SELECT1 with bits\[31:4\] of SELECT.
     /// The ADDR field selects a four-word bank of system locations to access.
-    /// - Bits[3:2] of the address, that are used to select a specific register in a bank, are provided with APACC transactions.
-    /// - Bits[1:0] are always 0b00.
+    /// - Bits\[3:2\] of the address, that are used to select a specific register in a bank, are provided with APACC transactions.
+    /// - Bits\[1:0\] are always 0b00.
     ///
     /// After a powerup reset or an SWD line reset, the value of this field is UNKNOWN
     pub u32, addr, set_addr: 31, 4;
@@ -396,10 +396,10 @@ bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq)]
     pub struct Select1(u32);
     impl Debug;
-    /// Address output bits[63:4], formed by concatenating bits[31:0] of SELECT1 with bits[31:4] of SELECT.
+    /// Address output bits\[63:4\], formed by concatenating bits\[31:0\] of SELECT1 with bits\[31:4\] of SELECT.
     /// The ADDR field selects a four-word bank of system locations to access.
-    /// - Bits[3:2] of the address, that are used to select a specific register in a bank, are provided with APACC transactions.
-    /// - Bits[1:0] are always 0b00.
+    /// - Bits\[3:2\] of the address, that are used to select a specific register in a bank, are provided with APACC transactions.
+    /// - Bits\[1:0\] are always 0b00.
     ///
     /// After a powerup reset or an SWD line reset, the value of this field is UNKNOWN
     pub u32, addr, set_addr: 31, 0;


### PR DESCRIPTION
Fixes #3064 