### PR TITLE
Use custom reset sequence for EFM32xG2 devices

### DIFF
--- a/changelog/fixed-flashing-mass-erased-efm32xg2.md
+++ b/changelog/fixed-flashing-mass-erased-efm32xg2.md
@@ -1,0 +1,1 @@
+Fix flashing mass-erased EFM32xG2 devices by using a custom reset sequence

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -371,13 +371,22 @@ fn cortex_m_reset_catch_set(core: &mut dyn ArmMemoryInterface) -> Result<(), Arm
 
 /// ResetSystem for Cortex-M devices
 fn cortex_m_reset_system(interface: &mut dyn ArmMemoryInterface) -> Result<(), ArmError> {
-    use crate::architecture::arm::core::armv7m::{Aircr, Dhcsr};
+    use crate::architecture::arm::core::armv7m::Aircr;
 
     let mut aircr = Aircr(0);
     aircr.vectkey();
     aircr.set_sysresetreq(true);
 
     interface.write_word_32(Aircr::get_mmio_address(), aircr.into())?;
+
+    cortex_m_wait_for_reset(interface)
+}
+
+/// Wait for Cortex-M device to reset
+pub(crate) fn cortex_m_wait_for_reset(
+    interface: &mut dyn ArmMemoryInterface,
+) -> Result<(), ArmError> {
+    use crate::architecture::arm::core::armv7m::Dhcsr;
 
     let start = Instant::now();
 

--- a/probe-rs/src/vendor/silabs/sequences/efm32xg2.rs
+++ b/probe-rs/src/vendor/silabs/sequences/efm32xg2.rs
@@ -1,10 +1,12 @@
 //! Sequences for Silicon Labs EFM32 Series 2 chips
 
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use crate::{
     architecture::arm::{
-        core::armv8m::{Demcr, Dhcsr},
+        ap::AccessPortError,
+        core::armv8m::{Aircr, Demcr, Dhcsr},
         memory::ArmMemoryInterface,
         sequences::ArmDebugSequence,
         ArmError,
@@ -22,6 +24,30 @@ impl EFM32xG2 {
     /// Create a sequence handle for the EFM32xG2
     pub fn create() -> Arc<dyn ArmDebugSequence> {
         Arc::new(Self(()))
+    }
+
+    fn wait_for_reset(&self, interface: &mut dyn ArmMemoryInterface) -> Result<(), ArmError> {
+        let start = Instant::now();
+
+        while start.elapsed() < Duration::from_millis(500) {
+            let dhcsr = match interface.read_word_32(Dhcsr::get_mmio_address()) {
+                Ok(val) => Dhcsr(val),
+                // Some combinations of debug probe and target (in
+                // particular, hs-probe and ATSAMD21) result in
+                // register read errors while the target is
+                // resetting.
+                Err(ArmError::AccessPort {
+                    source: AccessPortError::RegisterRead { .. },
+                    ..
+                }) => continue,
+                Err(err) => return Err(err),
+            };
+            if !dhcsr.s_reset_st() {
+                return Ok(());
+            }
+        }
+
+        Err(ArmError::Timeout)
     }
 }
 
@@ -64,5 +90,57 @@ impl ArmDebugSequence for EFM32xG2 {
         let mut demcr = Demcr(core.read_word_32(Demcr::get_mmio_address())?);
         demcr.set_vc_corereset(false);
         core.write_word_32(Demcr::get_mmio_address(), demcr.into())
+    }
+
+    fn reset_system(
+        &self,
+        interface: &mut dyn ArmMemoryInterface,
+        _core_type: probe_rs_target::CoreType,
+        _debug_base: Option<u64>,
+    ) -> Result<(), ArmError> {
+        let mut aircr = Aircr(0);
+        aircr.vectkey();
+        aircr.set_sysresetreq(true);
+
+        interface.write_word_32(Aircr::get_mmio_address(), aircr.into())?;
+        self.wait_for_reset(interface)?;
+
+        let dhcsr = Dhcsr(interface.read_word_32(Dhcsr::get_mmio_address())?);
+        if dhcsr.s_lockup() {
+            // Try to resolve lockup by halting the core again with a modified version of SiLab's
+            // application note AN0062 'Programming Internal Flash Over the Serial Wire Debug
+            // Interface', section 3.1 'Halting the CPU'
+            // (https://www.silabs.com/documents/public/application-notes/an0062.pdf).
+            //
+            // Using just SYSRESETREQ did not work for mass-erased EFM32xG2/Cortex-M33 devices. But
+            // using VECTRESET instead, like OpenOCD documents as its default and as it can be seen
+            // from Simplicity Commander, does the trick.
+
+            // Request halting the core for debugging.
+            let mut value = Dhcsr(0);
+            value.set_c_halt(true);
+            value.set_c_debugen(true);
+            value.enable_write();
+            interface.write_word_32(Dhcsr::get_mmio_address(), value.into())?;
+
+            // Request halt-on-reset.
+            let mut demcr = Demcr(interface.read_word_32(Demcr::get_mmio_address())?);
+            demcr.set_vc_corereset(true);
+            interface.write_word_32(Demcr::get_mmio_address(), demcr.into())?;
+
+            // Trigger reset.
+            let mut aircr = Aircr(0);
+            aircr.vectkey();
+            aircr.set_vectreset(true);
+            aircr.set_vectclractive(true);
+            interface.write_word_32(Aircr::get_mmio_address(), aircr.into())?;
+
+            self.wait_for_reset(interface)?;
+
+            // We should no longer be in lokup state at this point. CoreInterface::status is going
+            // to chek this soon.
+        }
+
+        Ok(())
     }
 }

--- a/probe-rs/src/vendor/silabs/sequences/efm32xg2.rs
+++ b/probe-rs/src/vendor/silabs/sequences/efm32xg2.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::{
     architecture::arm::{
-        core::armv7m::{Demcr, Dhcsr},
+        core::armv8m::{Demcr, Dhcsr},
         memory::ArmMemoryInterface,
         sequences::ArmDebugSequence,
         ArmError,


### PR DESCRIPTION
The generic reset sequence from `cortex_m_reset_system` fails for flashing mass-erased devices. This custom sequence does the trick in this case.

Previously as of 999a3597:

```
$ commander-cli device masserase
Erasing chip...
Flash was erased successfully
DONE
$ cargo run --release -- download --chip EFM32PG22C200F512IM40 test.elf
    Finished `release` profile [optimized] target(s) in 0.14s
     Running `target/release/probe-rs download --chip EFM32PG22C200F512IM40 test.elf`
 WARN probe_rs::architecture::arm::core::armv8m: The core is in locked up status as a result of an unrecoverable exception
 WARN probe_rs::architecture::arm::core::armv8m: The core is in locked up status as a result of an unrecoverable exception
 WARN probe_rs::architecture::arm::core::armv8m: The core is in locked up status as a result of an unrecoverable exception
Error: The flashing procedure failed for 'test.elf'.

Caused by:
    0: Failed to reset, and then halt the CPU.
    1: An ARM specific error occurred.
    2: The core has to be halted for the operation, but was not.
```

With the changes made here:

```
$ commander-cli device masserase
Erasing chip...
Flash was erased successfully
DONE
$ cargo run --release -- download --chip EFM32PG22C200F512IM40 test.elf
   Compiling probe-rs-tools v0.26.0 (/Users/christian/Entwicklung/bauer/cable-compensation/probe-rs/probe-rs-tools)
    Finished `release` profile [optimized] target(s) in 13.53s
     Running `target/release/probe-rs download --chip EFM32PG22C200F512IM40 test.elf`
 WARN probe_rs::architecture::arm::core::armv8m: The core is in locked up status as a result of an unrecoverable exception
      Erasing ✔ 100% [####################] 168.00 KiB @ 157.44 KiB/s (took 1s)
  Programming ✔ 100% [####################] 168.00 KiB @  23.40 KiB/s (took 7s)
     Finished in 8.25s
```