### PR TITLE
Xtensa: try to reattach if debug domain is powered down

### DIFF
--- a/changelog/fixed-xtensa-reattach.md
+++ b/changelog/fixed-xtensa-reattach.md
@@ -1,0 +1,1 @@
+Fixed an ESP32-specific issue where sometimes `probe-rs run` reported Xtensa specific errors regarding register 44 or 45.


### PR DESCRIPTION
This PR should recognise if a core is shut down unexpectedly - it should be impossible as per Xtensa debug docs, but apparently not. We should now correctly return CoreDisabled for such cores if we can't reconnect.