### PR TITLE
Fixing AP enable checks to use the proper bit, updating the H7 DBGMCU definitions

### DIFF
--- a/changelog/fixed-ap-enable-checks.md
+++ b/changelog/fixed-ap-enable-checks.md
@@ -1,0 +1,1 @@
+Fixed an issue where `probe-rs info` and NXP sequences were looking at the wrong enable bit for memory APs.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -375,7 +375,7 @@ fn handle_memory_ap(
 
         // Check if the AP is accessible
         let csw = memory.generic_status()?;
-        if !csw.SDeviceEn {
+        if !csw.DeviceEn {
             *parent = Tree::new("Memory AP is not accessible, DeviceEn bit not set".to_string());
             return Ok(());
         }

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
@@ -244,7 +244,7 @@ impl MIMXRT117x {
 
         loop {
             match probe.generic_status() {
-                Ok(csw) if csw.SDeviceEn => {
+                Ok(csw) if csw.DeviceEn => {
                     tracing::debug!("Device enabled after {}ms with {errors} errors and {disables} invalid statuses", start.elapsed().as_millis());
                     return Ok(());
                 }

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
@@ -264,7 +264,7 @@ fn wait_for_stop_after_reset(memory: &mut dyn ArmMemoryInterface) -> Result<(), 
 
     thread::sleep(Duration::from_millis(10));
 
-    if memory.generic_status()?.SDeviceEn {
+    if memory.generic_status()?.DeviceEn {
         let dp = memory.fully_qualified_address().dp();
         enable_debug_mailbox(memory.get_dap_access()?, dp)?;
     }

--- a/probe-rs/src/vendor/st/mod.rs
+++ b/probe-rs/src/vendor/st/mod.rs
@@ -43,10 +43,10 @@ impl Vendor for St {
             DebugSequence::Arm(Stm32Armv7::create())
         } else if chip.name.starts_with("STM32H7S") || chip.name.starts_with("STM32H7R") {
             DebugSequence::Arm(Stm32h7::create(Stm32h7Line::H7S))
-        } else if chip.name.starts_with("STM32H7") {
-            DebugSequence::Arm(Stm32h7::create(Stm32h7Line::H7))
         } else if chip.name.starts_with("STM32H747") {
             DebugSequence::Arm(Stm32h7::create(Stm32h7Line::H747))
+        } else if chip.name.starts_with("STM32H7") {
+            DebugSequence::Arm(Stm32h7::create(Stm32h7Line::H7))
         } else if chip.name.starts_with("STM32H5")
             || chip.name.starts_with("STM32L5")
             || chip.name.starts_with("STM32U5")

--- a/probe-rs/src/vendor/st/mod.rs
+++ b/probe-rs/src/vendor/st/mod.rs
@@ -45,6 +45,8 @@ impl Vendor for St {
             DebugSequence::Arm(Stm32h7::create(Stm32h7Line::H7S))
         } else if chip.name.starts_with("STM32H7") {
             DebugSequence::Arm(Stm32h7::create(Stm32h7Line::H7))
+        } else if chip.name.starts_with("STM32H747") {
+            DebugSequence::Arm(Stm32h7::create(Stm32h7Line::H747))
         } else if chip.name.starts_with("STM32H5")
             || chip.name.starts_with("STM32L5")
             || chip.name.starts_with("STM32U5")

--- a/probe-rs/src/vendor/st/mod.rs
+++ b/probe-rs/src/vendor/st/mod.rs
@@ -43,8 +43,6 @@ impl Vendor for St {
             DebugSequence::Arm(Stm32Armv7::create())
         } else if chip.name.starts_with("STM32H7S") || chip.name.starts_with("STM32H7R") {
             DebugSequence::Arm(Stm32h7::create(Stm32h7Line::H7S))
-        } else if chip.name.starts_with("STM32H747") {
-            DebugSequence::Arm(Stm32h7::create(Stm32h7Line::H747))
         } else if chip.name.starts_with("STM32H7") {
             DebugSequence::Arm(Stm32h7::create(Stm32h7Line::H7))
         } else if chip.name.starts_with("STM32H5")

--- a/probe-rs/src/vendor/st/sequences/stm32h7.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32h7.rs
@@ -58,9 +58,6 @@ impl Stm32h7 {
             Stm32h7Line::H7 => 2,
             // The H7S/R lack power domain 3 and the third AP; their debug unit is on AP1.
             Stm32h7Line::H7S => 1,
-
-            // The H747 appears to utilize a debug unit on AP0.
-            Stm32h7Line::H747 => 0,
         };
         Arc::new(Self { ap })
     }
@@ -88,9 +85,12 @@ impl Stm32h7 {
         control.enable_traceck(enable);
 
         // Configure debug connection in all power modes.
-        control.enable_standby_debug(enable);
-        control.enable_sleep_debug(enable);
-        control.enable_stop_debug(enable);
+        control.enable_d1_standby_debug(enable);
+        control.enable_d1_sleep_debug(enable);
+        control.enable_d1_stop_debug(enable);
+        control.enable_d2_standby_debug(enable);
+        control.enable_d2_sleep_debug(enable);
+        control.enable_d2_stop_debug(enable);
 
         control.write(memory)?;
 
@@ -112,9 +112,12 @@ mod dbgmcu {
         pub struct Control(u32);
         impl Debug;
 
-        pub u8, dbgsleep_d1, enable_sleep_debug: 0;
-        pub u8, dbgstop_d1, enable_stop_debug: 1;
-        pub u8, dbgstby_d1, enable_standby_debug: 2;
+        pub u8, dbgsleep_d1, enable_d1_sleep_debug: 0;
+        pub u8, dbgstop_d1, enable_d1_stop_debug: 1;
+        pub u8, dbgstby_d1, enable_d1_standby_debug: 2;
+        pub u8, dbgsleep_d2, enable_d2_sleep_debug: 3;
+        pub u8, dbgstop_d2, enable_d2_stop_debug: 4;
+        pub u8, dbgstby_d2, enable_d2_standby_debug: 5;
 
         pub u8, d3dbgcken, enable_d3_clock: 22;
         pub u8, d1dbgcken, enable_d1_clock: 21;

--- a/probe-rs/src/vendor/st/sequences/stm32h7.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32h7.rs
@@ -19,6 +19,9 @@ pub enum Stm32h7Line {
 
     /// STM32H7Rx, STM32H7Sx
     H7S,
+
+    /// STM32H747
+    H747
 }
 
 // Base address of the trace funnel that directs trace data to the SWO peripheral.
@@ -55,6 +58,9 @@ impl Stm32h7 {
             Stm32h7Line::H7 => 2,
             // The H7S/R lack power domain 3 and the third AP; their debug unit is on AP1.
             Stm32h7Line::H7S => 1,
+
+            // The H747 appears to utilize a debug unit on AP0.
+            Stm32h7Line::H747 => 0,
         };
         Arc::new(Self { ap })
     }

--- a/probe-rs/src/vendor/st/sequences/stm32h7.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32h7.rs
@@ -19,9 +19,6 @@ pub enum Stm32h7Line {
 
     /// STM32H7Rx, STM32H7Sx
     H7S,
-
-    /// STM32H747
-    H747
 }
 
 // Base address of the trace funnel that directs trace data to the SWO peripheral.


### PR DESCRIPTION
Correcting some issues around checking if APs are enabled in `probe-rs info` and in NXP custom sequences that snuck in during the APv2 support (ADIv6) additions.