### PR TITLE
Remove debug docsrs feature

### DIFF
--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -105,7 +105,7 @@ search = "\\[unreleased\\]: https://github.com/probe-rs/probe-rs/compare/v([a-z0
 replace = "[unreleased]: https://github.com/probe-rs/probe-rs/compare/v{{version}}...master\n[{{version}}]: https://github.com/probe-rs/probe-rs/compare/v$1...v{{version}}"
 
 [package.metadata.docs.rs]
-features = ["builtin-targets", "debug", "gdb-server"]
+features = ["builtin-targets", "gdb-server"]
 
 # Define a new cfg flag for docs.rs
 rustdoc-args = ["--cfg", "probers_docsrs"]


### PR DESCRIPTION
Should fix the [docs build error](https://docs.rs/crate/probe-rs/0.27.0/builds/1731882)


```
[INFO] [stderr] error: the package 'probe-rs' does not contain this feature: debug
```