### PR TITLE
Work with st-links without serial

### DIFF
--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -60,6 +60,7 @@ impl std::fmt::Display for StLinkFactory {
 
 impl ProbeFactory for StLinkFactory {
     fn open(&self, selector: &DebugProbeSelector) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
+        tracing::debug!("Opening ST-Link: {selector:?}");
         let device = StLinkUsbDevice::new_from_selector(selector)?;
         let mut stlink = StLink {
             name: format!("ST-Link {}", &device.info.version_name),

--- a/probe-rs/src/probe/stlink/usb_interface.rs
+++ b/probe-rs/src/probe/stlink/usb_interface.rs
@@ -93,7 +93,13 @@ fn selector_matches(selector: &DebugProbeSelector, info: &DeviceInfo) -> bool {
         && selector
             .serial_number
             .as_ref()
-            .map(|s| read_serial_number(info).as_ref() == Some(s))
+            .map(|s| {
+                if let Some(serial) = read_serial_number(info) {
+                    serial.as_str() == s
+                } else {
+                    s.is_empty()
+                }
+            })
             .unwrap_or(true);
 
     res


### PR DESCRIPTION
For some reason I have two STM32F051 discovery kits with st-links that have empty serial numbers. (read: they show up as `[0]: STLink V2 -- 0483:3748: (ST-LINK)` - I probably broke them). These devices work with probe-rs 0.27, but not with master.