### PR TITLE
Allow RTT channels without names

### DIFF
--- a/changelog/fixed-rtt-no-name.md
+++ b/changelog/fixed-rtt-no-name.md
@@ -1,0 +1,1 @@
+Fixed working with RTT when a channel has no name.

--- a/probe-rs/src/rtt/channel.rs
+++ b/probe-rs/src/rtt/channel.rs
@@ -314,19 +314,6 @@ impl Channel {
                 )));
             }
 
-            let name_in_memory_region = core
-                .target()
-                .memory_map
-                .iter()
-                .any(|mr| mr.contains(self.info.standard_name_pointer()));
-
-            if !name_in_memory_region {
-                return Err(Error::ControlBlockCorrupted(format!(
-                    "the {which} buffer name pointer doesn't point to valid memory: (pointer: {:#X})",
-                    self.info.standard_name_pointer(),
-                )));
-            }
-
             Ok(())
         };
 


### PR DESCRIPTION
This PR removes a redundant check. We don't attach if the name pointer is not valid, and we also don't read the name pointer again, so this check is doubly unnecessary, and also causes problems because the name pointer is allowed to be null.