### PR TITLE
Skip processing empty RTT buffers

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/processing.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/processing.rs
@@ -68,7 +68,11 @@ impl RttDecoder {
         buffer: &[u8],
         collector: &mut impl RttDataHandler,
     ) -> Result<(), Error> {
-        // FIXME: clean this up by splitting the enum variants out into separate structs
+        // Prevent the format processors generating empty strings.
+        if buffer.is_empty() {
+            return Ok(());
+        }
+
         match self {
             RttDecoder::BinaryLE => collector.on_binary_data(number, buffer),
             RttDecoder::String {


### PR DESCRIPTION
This PR prevents emitting empty strings from `RttDecoder`, fixing a cargo-embed issue where text was scrolling without anything being actually printed by the target.