### PR TITLE
Add support for Infineon PSOC 62 family

### DIFF
--- a/changelog/added-psoc-62.md
+++ b/changelog/added-psoc-62.md
@@ -1,0 +1,1 @@
+Added support for Infineon PSOC 62 family.

--- a/probe-rs-target/src/chip_detection.rs
+++ b/probe-rs-target/src/chip_detection.rs
@@ -22,8 +22,11 @@ pub enum ChipDetectionMethod {
     /// Nordic Semiconductor FICR INFO-based chip detection information.
     NordicFicrInfo(NordicFicrDetection),
 
-    /// Infineon SCU chip detection information.
-    InfineonScu(InfinionScuDetection),
+    /// Infineon XMC4000 SCU chip detection information.
+    InfineonXmcScu(InfineonXmcScuDetection),
+
+    /// Infineon PSOC silicon ID chip detection information.
+    InfineonPsocSiid(InfineonPsocSiidDetection),
 }
 
 impl ChipDetectionMethod {
@@ -63,9 +66,18 @@ impl ChipDetectionMethod {
         }
     }
 
-    /// Returns the Infineon SCU detection information if available.
-    pub fn as_infineon_scu(&self) -> Option<&InfinionScuDetection> {
-        if let Self::InfineonScu(v) = self {
+    /// Returns the Infineon XMC SCU detection information if available.
+    pub fn as_infineon_xmc_scu(&self) -> Option<&InfineonXmcScuDetection> {
+        if let Self::InfineonXmcScu(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the Infineon PSOC silicon ID detection information if available.
+    pub fn as_infineon_psoc_siid(&self) -> Option<&InfineonPsocSiidDetection> {
+        if let Self::InfineonPsocSiid(v) = self {
             Some(v)
         } else {
             None
@@ -142,10 +154,10 @@ pub struct NordicFicrDetection {
     pub variants: IndexMap<u32, String>,
 }
 
-/// Infineon SCU chip detection information.
+/// Infineon XMC4000 SCU chip detection information.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct InfinionScuDetection {
+pub struct InfineonXmcScuDetection {
     /// Chip partid
     #[serde(serialize_with = "hex_u_int")]
     pub part: u16,
@@ -158,4 +170,14 @@ pub struct InfinionScuDetection {
     // Intentionally not hex-keyed, sizes look better in decimal.
     #[serde(deserialize_with = "maps_duplicate_key_is_error::deserialize")]
     pub variants: IndexMap<u32, String>,
+}
+
+/// Infineon PSOC SIID chip detection information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InfineonPsocSiidDetection {
+    /// Silicon ID => Target name.
+    #[serde(serialize_with = "hex_keys_indexmap")]
+    #[serde(deserialize_with = "maps_duplicate_key_is_error::deserialize")]
+    pub ids: IndexMap<u16, String>,
 }

--- a/probe-rs/targets/PSOC_62.yaml
+++ b/probe-rs/targets/PSOC_62.yaml
@@ -1,0 +1,3053 @@
+name: PS0C 62
+manufacturer:
+  id: 0x34
+  cc: 0x0
+chip_detection:
+- !InfineonPsocSiid
+  ids:
+    # Extracted from ModusToolbox:
+    # rg '^dict set MPN (\w{4}) \{([\w-]+) \w+ \d+ \d+ \"PS[Oo]C 62\" .*\}\s*$' \
+    #   -Nr '    0x$1: $2' \
+    #   ModusToolbox/tools_3.3/openocd/scripts/target/cympn.cfg
+    0xEAC0: CY8C6244AZI-S4D92
+    0xEAC1: CY8C6244LQI-S4D92
+    0xEAC2: CY8C6244AZI-S4D93
+    0xEAC3: CY8C6244AZI-S4D82
+    0xEAC4: CY8C6244LQI-S4D82
+    0xEAC5: CY8C6244AZI-S4D83
+    0xEAC6: CY8C6244AZI-S4D62
+    0xEAC7: CY8C6244LQI-S4D62
+    0xEAC8: CY8C6244AZI-S4D12
+    0xEAC9: CY8C6244LQI-S4D12
+    0xEAD4: CY8C6244AZQ-S4D92
+    0xEAD5: CY8C6244LQQ-S4D92
+    0xEAD6: CY8C6244AZQ-S4D93
+    0xEADF: CY8C6244FMI-S4D93
+    0xEADE: CY8C6244FMI-S4D73
+    0xEADD: CY8C6244FMI-S4D53
+    0xEADC: CY8C6244FMI-S4D03
+    0xEAE0: CY8C6244FMQ-S4D93
+    0xE453: CY8C624ABZI-S2D44
+    0xE454: CY8C624AAZI-S2D44
+    0xE455: CY8C624AFNI-S2D43
+    0xE450: CY8C624ABZI-S2D04
+    0xE451: CY8C624ABZI-S2D14
+    0xE452: CY8C624AAZI-S2D14
+    0xE456: CY8C6248AZI-S2D14
+    0xE457: CY8C6248BZI-S2D44
+    0xE458: CY8C6248AZI-S2D44
+    0xE459: CY8C6248FNI-S2D43
+    0xE402: CY8C624ABZI-D44
+    0xE40B: CY8C624AAZI-D44
+    0xE414: CY8C624AFNI-D43
+    0xE400: CY8C624ABZI-D04
+    0xE401: CY8C624ABZI-D14
+    0xE40A: CY8C624AAZI-D14
+    0xE40C: CY8C6248AZI-D14
+    0xE403: CY8C6248BZI-D44
+    0xE40D: CY8C6248AZI-D44
+    0xE415: CY8C6248FNI-D43
+    0xE419: CY8C624ALQI-D42
+    0xE4B0: CY8C624ALQI-S2D42
+    0xE4B1: CY8C624ALQI-S2D02
+    0xE4B2: CY8C6248LQI-S2D42
+    0xE4B3: CY8C6248LQI-S2D02
+    0xE700: CY8C6245AZI-S3D72
+    0xE701: CY8C6245LQI-S3D72
+    0xE702: CY8C6245FNI-S3D71
+    0xE703: CY8C6245AZI-S3D62
+    0xE704: CY8C6245LQI-S3D62
+    0xE705: CY8C6245AZI-S3D42
+    0xE706: CY8C6245LQI-S3D42
+    0xE707: CY8C6245FNI-S3D41
+    0xE708: CY8C6245AZI-S3D12
+    0xE709: CY8C6245LQI-S3D12
+    0xE70A: CY8C6245FNI-S3D11
+    0xE70B: CY8C6245AZI-S3D02
+    0xE70C: CY8C6245LQI-S3D02
+    0xE70E: CY8C6245WI-S3D72
+    0xE219: CY8C6246BZI-D04
+    0xE21A: CY8C6247BZI-D44
+    0xE21B: CY8C6247BZI-D34
+    0xE206: CY8C6247BZI-D54
+    0xE232: CY8C6247FDI-D02
+    0xE233: CY8C6247FDI-D32
+    0xE234: CY8C6247FDI-D52
+    0xE237: CY8C6247FTI-D52
+    0xE2A1: CY8C6247BZI-AUD54
+    0xE20A: CY8C6247BFI-D54
+    0xE250: CY8C6247WI-D54
+    0xE270: CY8C6247BTI-D54
+    0xE271: CY8C6246BTI-D54
+generated_from_pack: true
+pack_file_release: 1. x.0
+variants:
+- name: CY8C6244AZI-S4D12
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244AZI-S4D62
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244AZI-S4D82
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244AZI-S4D83
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244AZI-S4D92
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244AZI-S4D93
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244AZQ-S4D92
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244AZQ-S4D93
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244FMI-S4D03
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244FMI-S4D53
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244FMI-S4D73
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244FMI-S4D93
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244FMQ-S4D93
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244LQI-S4D12
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244LQI-S4D62
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244LQI-S4D82
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244LQI-S4D92
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6244LQQ-S4D92
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx4
+  - cy8c6xx4_sect128kb
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6245AZI-S3D02
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx5
+  - cy8c6xx5_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6245AZI-S3D12
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx5
+  - cy8c6xx5_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6245AZI-S3D42
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx5
+  - cy8c6xx5_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6245AZI-S3D62
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx5
+  - cy8c6xx5_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6245AZI-S3D72
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx5
+  - cy8c6xx5_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6245FNI-S3D11
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx5
+  - cy8c6xx5_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6245FNI-S3D41
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx5
+  - cy8c6xx5_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6245FNI-S3D71
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx5
+  - cy8c6xx5_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6245LQI-S3D02
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx5
+  - cy8c6xx5_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6245LQI-S3D12
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx5
+  - cy8c6xx5_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6245LQI-S3D42
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx5
+  - cy8c6xx5_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6245LQI-S3D62
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx5
+  - cy8c6xx5_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6245LQI-S3D72
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx5
+  - cy8c6xx5_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6246BTI-D54
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx6
+  - cy8c6xx6_sect256kb
+  - cy8c6xxx_wflash
+  - cy8c6xxx_sflash_user
+  - cy8c6xxx_sflash_nar
+  - cy8c6xxx_sflash_pkey
+  - cy8c6xxx_sflash_toc2
+  - cy8c6xxx_smif
+  - cy8c6xxx_efuse
+- name: CY8C6246BZI-D04
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx6
+  - cy8c6xx6_sect256kb
+  - cy8c6xxx_wflash
+  - cy8c6xxx_sflash_user
+  - cy8c6xxx_sflash_nar
+  - cy8c6xxx_sflash_pkey
+  - cy8c6xxx_sflash_toc2
+  - cy8c6xxx_smif
+  - cy8c6xxx_efuse
+- name: CY8C6247BFI-D54
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8048000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx7
+  - cy8c6xx7_sect256kb
+  - cy8c6xxx_wflash
+  - cy8c6xxx_sflash_user
+  - cy8c6xxx_sflash_nar
+  - cy8c6xxx_sflash_pkey
+  - cy8c6xxx_sflash_toc2
+  - cy8c6xxx_smif
+  - cy8c6xxx_efuse
+- name: CY8C6247BTI-D54
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8048000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx7
+  - cy8c6xx7_sect256kb
+  - cy8c6xxx_wflash
+  - cy8c6xxx_sflash_user
+  - cy8c6xxx_sflash_nar
+  - cy8c6xxx_sflash_pkey
+  - cy8c6xxx_sflash_toc2
+  - cy8c6xxx_smif
+  - cy8c6xxx_efuse
+- name: CY8C6247BZI-AUD54
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8048000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx7
+  - cy8c6xx7_sect256kb
+  - cy8c6xxx_wflash
+  - cy8c6xxx_sflash_user
+  - cy8c6xxx_sflash_nar
+  - cy8c6xxx_sflash_pkey
+  - cy8c6xxx_sflash_toc2
+  - cy8c6xxx_smif
+  - cy8c6xxx_efuse
+- name: CY8C6247BZI-D34
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8048000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx7
+  - cy8c6xx7_sect256kb
+  - cy8c6xxx_wflash
+  - cy8c6xxx_sflash_user
+  - cy8c6xxx_sflash_nar
+  - cy8c6xxx_sflash_pkey
+  - cy8c6xxx_sflash_toc2
+  - cy8c6xxx_smif
+  - cy8c6xxx_efuse
+- name: CY8C6247BZI-D44
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8048000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx7
+  - cy8c6xx7_sect256kb
+  - cy8c6xxx_wflash
+  - cy8c6xxx_sflash_user
+  - cy8c6xxx_sflash_nar
+  - cy8c6xxx_sflash_pkey
+  - cy8c6xxx_sflash_toc2
+  - cy8c6xxx_smif
+  - cy8c6xxx_efuse
+- name: CY8C6247BZI-D54
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8048000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx7
+  - cy8c6xx7_sect256kb
+  - cy8c6xxx_wflash
+  - cy8c6xxx_sflash_user
+  - cy8c6xxx_sflash_nar
+  - cy8c6xxx_sflash_pkey
+  - cy8c6xxx_sflash_toc2
+  - cy8c6xxx_smif
+  - cy8c6xxx_efuse
+- name: CY8C6247FDI-D02
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8048000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx7
+  - cy8c6xx7_sect256kb
+  - cy8c6xxx_wflash
+  - cy8c6xxx_sflash_user
+  - cy8c6xxx_sflash_nar
+  - cy8c6xxx_sflash_pkey
+  - cy8c6xxx_sflash_toc2
+  - cy8c6xxx_smif
+  - cy8c6xxx_efuse
+- name: CY8C6247FDI-D32
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8048000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx7
+  - cy8c6xx7_sect256kb
+  - cy8c6xxx_wflash
+  - cy8c6xxx_sflash_user
+  - cy8c6xxx_sflash_nar
+  - cy8c6xxx_sflash_pkey
+  - cy8c6xxx_sflash_toc2
+  - cy8c6xxx_smif
+  - cy8c6xxx_efuse
+- name: CY8C6247FDI-D52
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8048000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx7
+  - cy8c6xx7_sect256kb
+  - cy8c6xxx_wflash
+  - cy8c6xxx_sflash_user
+  - cy8c6xxx_sflash_nar
+  - cy8c6xxx_sflash_pkey
+  - cy8c6xxx_sflash_toc2
+  - cy8c6xxx_smif
+  - cy8c6xxx_efuse
+- name: CY8C6247FTI-D52
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8048000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx7
+  - cy8c6xx7_sect256kb
+  - cy8c6xxx_wflash
+  - cy8c6xxx_sflash_user
+  - cy8c6xxx_sflash_nar
+  - cy8c6xxx_sflash_pkey
+  - cy8c6xxx_sflash_toc2
+  - cy8c6xxx_smif
+  - cy8c6xxx_efuse
+- name: CY8C6247WI-D54
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8048000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx7
+  - cy8c6xx7_sect256kb
+  - cy8c6xxx_wflash
+  - cy8c6xxx_sflash_user
+  - cy8c6xxx_sflash_nar
+  - cy8c6xxx_sflash_pkey
+  - cy8c6xxx_sflash_toc2
+  - cy8c6xxx_smif
+  - cy8c6xxx_efuse
+- name: CY8C6248AZI-S2D14
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx8
+  - cy8c6xx8_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6248AZI-S2D44
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx8
+  - cy8c6xx8_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6248BZI-S2D44
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx8
+  - cy8c6xx8_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6248FNI-S2D43
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx8
+  - cy8c6xx8_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6248LQI-S2D02
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx8
+  - cy8c6xx8_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C6248LQI-S2D42
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xx8
+  - cy8c6xx8_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C624AAZI-S2D14
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10200000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xxa
+  - cy8c6xxa_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C624AAZI-S2D44
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10200000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xxa
+  - cy8c6xxa_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C624ABZI-D44
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10200000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xxa
+  - cy8c6xxa_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C624ABZI-S2D04
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10200000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xxa
+  - cy8c6xxa_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C624ABZI-S2D14
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10200000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xxa
+  - cy8c6xxa_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C624ABZI-S2D44
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10200000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xxa
+  - cy8c6xxa_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C624ABZI-S2D44A0
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10200000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xxa
+  - cy8c6xxa_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C624AFNI-S2D43
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10200000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xxa
+  - cy8c6xxa_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C624ALQI-S2D02
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10200000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xxa
+  - cy8c6xxa_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+- name: CY8C624ALQI-S2D42
+  cores:
+  - name: cortex-m0p
+    type: armv6m
+    core_access_options: !Arm
+      ap: !v1 1
+  - name: cortex-m4
+    type: armv7em
+    core_access_options: !Arm
+      ap: !v1 2
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x10000000
+      end: 0x10200000
+    cores:
+    - cortex-m0p
+    - cortex-m4
+    access:
+      write: false
+      boot: true
+  flash_algorithms:
+  - cy8c6xxa
+  - cy8c6xxa_sect256kb
+  - cy8c6xxa_wflash
+  - cy8c6xxa_sflash_user
+  - cy8c6xxa_sflash_nar
+  - cy8c6xxa_sflash_pkey
+  - cy8c6xxa_sflash_toc2
+  - cy8c6xxa_smif
+  - cy8c6xxa_efuse
+flash_algorithms:
+- name: cy8c6xx4
+  description: CY8C6xx4
+  instructions: gLUA8PH5APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAAIECwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwPvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwvfoA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAAACBAAUhJRghccEcFAAAAgLUA8Mv5APDh+QAggL2AtQDwzvkAIIC9gLUA8Af7gL2AtQDwEfuAvfi1DEYHRgEgAQcAII9CBNGhDALQACQA8PX6G0obSxxOtEIK2TlGMUAH0RxIJBjwGUUcOEYA8AT7GOCcQgrZOUYZQAfRFEgkGNgZRRw4RgDwB/sL4JRCE9k5RhFAENENSCQY0BlFHDhGAPDa+gdLBkoBRi9GACwF0AAgACnQ0AHgAUb35whG+L3/AQAA/w8AAP//AQAA/v//APD//wAA/v+AtQDw7fqAvbC1DEYFRgAsCdAoRgDwtPoAKAXRASBAAi0YZB7z5wAgsL3ARrC1BEYGSElGDRgBIEECKEYA8FT7IEYpRgDw4PqwvcBGRAAAALC1ACOZQgbQ1FzFXKxCAdFbHPfnGUYIGLC9ACkH0EMcSR4AeJBCGEb30AEgcEcAIHBHAACAtf/3Xv+AvYC1//df/4C9gLX/91//gL2AtRFG//eu/4C9gLX/99L/gL2Atf/32/+AvXC1FEYFRk4KKEYhRv/3nf8AKAXRASFJAmQYbRh2HvPRcL2AtVEC//dA/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8Pv6C0lgVAtIKBh9IckAAPDz+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwkfpwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8ID6KWjJAskOAPB7+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8G76C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3Cv4AKALQAPD4+QHgAPAN+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDT+eQZ9+cFSElGCFhEQyBGAPDK+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwufmAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAiQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQIkAsAAAAELX/97v9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECJALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRwAIkD4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAiQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3nv0AKAPQ//dE/QZ6A+D/9zb9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAiQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAIkAftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAWAHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEcAABC1//dx/QdIAWgHSExGIFgJCsmySRwA8EP4BElgUP/3Of0QvRAAIUAYAAAAEAAAABC1//dZ/QdIAWgHSExGIFgJCsmySRwA8Cv4BElgUP/3If0QvZAAIUAUAAAAEAAAAAHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAIgMJi0Is0wMKi0IR0wAjnEZO4ANGC0M81AAiQwiLQjHTAwmLQhzTAwqLQgHTlEY/4MMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQUMIi0IB00sAwBpSQUEaANIBRlJBEEZwR13gyg8A0ElCAxAA00BCU0CcRgAiAwmLQi3TAwqLQhLTiQH8IhK6AwqLQgzTiQGSEYtCCNOJAZIRi0IE04kBOtCSEQDgiQnDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkHZ0kMIi0IB00sAwBpSQUEaANIBRlJBEEZjRlsQAdNAQgArANVJQnBHY0ZbEADTQEIBtQVJACgC3EkcCEAA4AhGwEbARgK9AL////9/AAAAAAAA////////////AAAJPQAAEnoAAAk9AAAA0AcACT0AoA8AAAQAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x225
+  pc_program_page: 0x23d
+  pc_erase_sector: 0x235
+  pc_erase_all: 0x22d
+  pc_verify: 0x247
+  data_section_offset: 0x9fc
+  flash_properties:
+    address_range:
+      start: 0x10000000
+      end: 0x10040000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xx4_sect128kb
+  description: CY8C6xx4_sect128KB
+  default: true
+  instructions: gLUA8PH5APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAAIECwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwPvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwvfoA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAAACBAAUhJRghccEcFAAAAgLUA8Mv5APDh+QAggL2AtQDwzvkAIIC9gLUA8Af7gL2AtQDwEfuAvfi1DEYHRgEgAQcAII9CBNGhDALQACQA8PX6G0obSxxOtEIK2TlGMUAH0RxIJBjwGUUcOEYA8AT7GOCcQgrZOUYZQAfRFEgkGNgZRRw4RgDwB/sL4JRCE9k5RhFAENENSCQY0BlFHDhGAPDa+gdLBkoBRi9GACwF0AAgACnQ0AHgAUb35whG+L3/AQAA/w8AAP//AQAA/v//APD//wAA/v+AtQDw7fqAvbC1DEYFRgAsCdAoRgDwtPoAKAXRASBAAi0YZB7z5wAgsL3ARrC1BEYGSElGDRgBIEECKEYA8FT7IEYpRgDw4PqwvcBGRAAAALC1ACOZQgbQ1FzFXKxCAdFbHPfnGUYIGLC9ACkH0EMcSR4AeJBCGEb30AEgcEcAIHBHAACAtf/3Xv+AvYC1//df/4C9gLUA8IP6gL2AtRFG//eu/4C9gLX/99L/gL2Atf/32/+AvXC1FEYFRk4KKEYhRv/3nf8AKAXRASFJAmQYbRh2HvPRcL2AtVEE//dA/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8Pv6C0lgVAtIKBh9IckAAPDz+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwkfpwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8ID6KWjJAskOAPB7+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8G76C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3Cv4AKALQAPD4+QHgAPAN+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDT+eQZ9+cFSElGCFhEQyBGAPDK+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwufmAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAiQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQIkAsAAAAELX/97v9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECJALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRwAIkD4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAiQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3nv0AKAPQ//dE/QZ6A+D/9zb9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAiQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAIkAftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAWAHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEcAABC1//dx/QdIAWgHSExGIFgJCsmySRwA8EP4BElgUP/3Of0QvRAAIUAYAAAAEAAAABC1//dZ/QdIAWgHSExGIFgJCsmySRwA8Cv4BElgUP/3If0QvZAAIUAUAAAAEAAAAAHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAIgMJi0Is0wMKi0IR0wAjnEZO4ANGC0M81AAiQwiLQjHTAwmLQhzTAwqLQgHTlEY/4MMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQUMIi0IB00sAwBpSQUEaANIBRlJBEEZwR13gyg8A0ElCAxAA00BCU0CcRgAiAwmLQi3TAwqLQhLTiQH8IhK6AwqLQgzTiQGSEYtCCNOJAZIRi0IE04kBOtCSEQDgiQnDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkHZ0kMIi0IB00sAwBpSQUEaANIBRlJBEEZjRlsQAdNAQgArANVJQnBHY0ZbEADTQEIBtQVJACgC3EkcCEAA4AhGwEbARgK9AL////9/AAAAAAAA////////////AAAJPQAAEnoAAAk9AAAA0AcACT0AoA8AAAQAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x225
+  pc_program_page: 0x23d
+  pc_erase_sector: 0x235
+  pc_erase_all: 0x22d
+  pc_verify: 0x247
+  data_section_offset: 0x9fc
+  flash_properties:
+    address_range:
+      start: 0x10000000
+      end: 0x10040000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x20000
+      address: 0x0
+- name: cy8c6xxa_sflash_user
+  description: CY8C6xxA_SFLASH_USER
+  default: true
+  instructions: gLUA8AP6APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAAIECwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwUPsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwz/oA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAAACBAAUhJRghccEcFAAAAgLUA8N35APDz+QAggL2AtQDw4PkAIIC9gLUCSAQhAPAD+IC9AAgAFrC1DEYFRgAsCdAoRgDwKvgAKAXRASBAAi0YZB7z5wAgsL3ARoC1wQoKSpFCDNBBCglKkUII0AlJQRiJCgMpA9OBCgdKkUIC0QDwDPiAvQAggL3ARgHAAgANAAsAAKb/6R+ABQCwtQRGBkhJRg0YASBBAihGAPCc+yBGKUYA8Cb7sL3ARkQAAAD4tQxGBUYAICFKIkmNQgTRlEIC2QAkAPDD+h9KIE60QgzZfyHJAmkYMUIK0R9IJBhwGUccKEYA8NH6H+AXSYxCBdkTSUkZSRwUSxlCDtCUQgrZKUYRQAfREkgkGFAZRxwoRgDwq/oJ4AFGCuAOSCQYCkhAGUccKEYA8MD6BkoBRj1GACwC0AAgACnI0AhG+L3/BwAAAAgAFv8BAAD/DwAA//8DAAD+//8A8P//AAD8/4C1APDH+oC9sLUAI5lCBtDUXMVcrEIB0Vsc9+cZRggYsL0AKQfQQxxJHgB4kEIYRvfQASBwRwAgcEcAAIC1//c2/4C9gLX/9zf/gL2Atf/3Tf+AvYC1EUb/99L/gL2Atf/30v+AvYC1//fb/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8P36C0lgVAtIKBh9IckAAPD1+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwk/pwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8IL6KWjJAskOAPB9+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8HD6C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3+P0AKALQAPD6+QHgAPAP+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDV+eQZ9+cFSElGCFhEQyBGAPDM+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwu/mAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAiQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQIkAsAAAAELX/96n9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECJALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRwAIkD4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAiQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3jP0AKAPQ//cy/QZ6A+D/9yT9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAiQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAIkAftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAUAAAAAgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHAAAQtf/3b/0HSAFoB0hMRiBYCQrJskkcAPBD+ARJYFD/9zf9EL0QACFAGAAAABAAAAAQtf/3V/0HSAFoB0hMRiBYCQrJskkcAPAr+ARJYFD/9x/9EL2QACFAFAAAABAAAAAB4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nACIDCYtCLNMDCotCEdMAI5xGTuADRgtDPNQAIkMIi0Ix0wMJi0Ic0wMKi0IB05RGP+DDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkFDCItCAdNLAMAaUkFBGgDSAUZSQRBGcEdd4MoPANBJQgMQANNAQlNAnEYAIgMJi0It0wMKi0IS04kB/CISugMKi0IM04kBkhGLQgjTiQGSEYtCBNOJATrQkhEA4IkJwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJB2dJDCItCAdNLAMAaUkFBGgDSAUZSQRBGY0ZbEAHTQEIAKwDVSUJwR2NGWxAA00BCAbUFSQAoAtxJHAhAAOAIRsBGwEYCvQC/////fwAAAAAAAP///////////wAACT0AABJ6AAAJPQAAANAHAAk9AKAPAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x275
+  pc_program_page: 0x28d
+  pc_erase_sector: 0x285
+  pc_erase_all: 0x27d
+  pc_verify: 0x297
+  data_section_offset: 0xa24
+  flash_properties:
+    address_range:
+      start: 0x16000800
+      end: 0x16001000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xxa_sflash_nar
+  description: CY8C6xxA_SFLASH_NAR
+  instructions: gLUA8Cn6APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAAIECwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwdvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADw9foA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAAACBAAUhJRghccEcFAAAAgLUA8AP6APAZ+gAggL2AtQDwBvoAIIC9gLUCSAEhAPAD+IC9ABoAFrC1DEYFRgAsCdAoRgDwKvgAKAXRASBAAi0YZB7z5wAgsL3ARoC1wQoKSpFCDNBBCglKkUII0AlJQRiJCgMpA9OBCgdKkUIC0QDwDPiAvQAggL3ARgHAAgANAAsAAKb/6R+ABQCwtQRGBkhJRg0YASBBAihGAPDA+yBGKUYA8Ez7sL3ARkQAAAD4tQxGBUYAICBPIUmNQgTRvEIC2QAkAPDp+h9OtEIL2R5JaRgxQgrRH0gkGHAZRxwoRgDw+fof4BZJjEIF2QMhSQJpGBNKEUIO0LxCCtkpRjlAB9ESSCQYeBlHHChGAPDT+gngAUYK4A5IJBgJSEAZRxwoRgDw6PoBRj1GA08ALALQACAAKcnQCEb4vf8BAAAAGgAW/w8AAP//AwAA5gMAAP7//wDw//8AAPz/gLUA8O/6gL3wtRJMA0ZjQAElbgJOQB5DdUJ1QQAuC9EAJg1LAi4F0JddhF12HKdC+NAISwAtCtEAI5lCBtDUXMVcrEIB0Vsc9+cZRgsYGEbwvcBGABoAFgAcABawtQNGCUxEQAEgRQJNQCVDANECIQApBtBcHEkeG3iTQiNG99CwvQAgsL3ARgAaABaAtf/3EP+AvYC1//cR/4C9gLX/9yf/gL2AtRFG//eq/4C9gLX/96r/gL2Atf/30P+AvQAAsLUMSExGJVgLSCVQC0goGAtJAPD7+gtJYFQLSCgYfSHJAADw8/oJSWBQwAMISWBQsL3ARhAAAAAgAAAAP0IPAEBCDwAoAAAA5wMAACQAAAAcAAAAcLU4TCBoDyEBQIgANkqDGB1sByMrQATQBCsE0AErNEgP4DJIDeAQWB8iAkB9IAACESoB0ANGAeABI9sDECoA0BhGASkP0AApO9ErTSlpqmiSAJIPASoU2NIeU0JTQRlDyQcQ0S3gI00pbCpokgCSDwEqFtjSHlNCU0EZQ8kHEtEf4AMqHdEpaBxODkBqaBxJEUAA8JH6cEMpaMkByQ9JHA3gAyoN0SlofyIKQFBDKWjJBMkOAPCA+iloyQLJDgDwe/ohaIkGiQ/IQA5JTEZgUA1JCWgJDkkcAPBu+gtJYFBwvcBGgAMmQAADJkAAEnoAADZuAQAGJkCABSZA//8DAP8fAAAUAAAAEAAhQBgAAAAQtQlMSEYAXQAoC9H/99L9ACgC0ADw+PkB4ADwDfpIRgEhAVUQvcBGBAAAAPi1BEYJTQtOC0+sQgXTSEaAWQDw0/nkGffnBUhJRghYREMgRgDwyvn4vcBGAYAAACQAAAAcAAAAAID//4C1A0lKRlFcSEMA8Ln5gL0oAAAAgLX/99X/gL2Atf/37/+AvQJIAGgCSUpGUFBwRwgQIkAsAAAABEgCaARJS0ZZWJFCANABYHBHwEYIECJALAAAABC1//eD/QlJCmgJS0xG4lABIwB6ACgB0FgEAOAYBBBCANAQvRBDCGAQvcBGCBAiQCwAAAD4tQCSDUYBJGVAQAEOSUcYJkY5aAAgACkiRgDaAkYqQwEqENEAIAApAdoBRgDgASENQgjRAJiGQgTSASD/937/dhzm5wEg+L0cACJA+LUMRkABCElFGAAmL2gALwfUdhymQgTSASD/92n/AC/01fhDwA/4vQAAIkD4tRRGDUYGRgEnMWghYA8gAAcIQAUhSQeIQgbQr0IE0gEg//dP/38c7+dAGkEeiEH4vcBG8LWFsAxGBJD/92b9ACgD0P/3DP0GegPg//f+/AEmRkAcTQAuBNABLjDRApQgNQDgApR9IAOQwQAwRv/3sf8HRgAoJNEBJwSYAUY5QAGREkkB0UhGQBgMJCxDIGAIIChDB2AAIQ1KMEb/93T/ACgO0QGYACgC0UhGB0lEGAOYgQAgRgKa//ei/wdGAOABJzhGBbDwvQAAIkAwAAAAmDoAAPi1A6gCIQCRAZECkAQgBiEAIhNGAPAG+AOZSEJIQQSwgL3ARvC1h7AdRhdGAZECkAQgDJn/92T/Dp4wYAEkACgZ0Q2aBpUFlwxNA6hoYAGZQYACmQGAICAoYAQgACH/9yn/MGAAKAbRaGhBaAApAdABITFghGggRgew8L2IACJAH7UDrAKUBEwBlH0k5AAAlP/3yP8EsBC9mDoAABy1BEYBIAGp//dc/wAoANAcvQGYoHABDGFxAApgcP8gAjBpRv/3Tv8AKPHRAJkhcQoK4nAKAhIP4nEJAwkPoXEcvcBG4LUESUpGBEhQUAGp//c4/4y9wEYwAAAAAAEACuC1BUlLRgVKWlBZGEhgAakQRv/3J/+MvTAAAAAAAQAc4LUFSUtGBUpaUFkYSGABqRBG//cX/4y9MAAAAAABABTgtQVJS0YFSlpQWRhIYAGpEEb/9wf/jL0wAAAAAAEAHRy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//fz/hy9MAAAAAABAAYctQdLTEYHSuJQ4xiDJGQAXGCYYNlgAakQRv/33/4cvTAAAAAAAQAFgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHAAAQtf/3cf0HSAFoB0hMRiBYCQrJskkcAPBD+ARJYFD/9zn9EL0QACFAGAAAABAAAAAQtf/3Wf0HSAFoB0hMRiBYCQrJskkcAPAr+ARJYFD/9yH9EL2QACFAFAAAABAAAAAB4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nACIDCYtCLNMDCotCEdMAI5xGTuADRgtDPNQAIkMIi0Ix0wMJi0Ic0wMKi0IB05RGP+DDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkFDCItCAdNLAMAaUkFBGgDSAUZSQRBGcEdd4MoPANBJQgMQANNAQlNAnEYAIgMJi0It0wMKi0IS04kB/CISugMKi0IM04kBkhGLQgjTiQGSEYtCBNOJATrQkhEA4IkJwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJB2dJDCItCAdNLAMAaUkFBGgDSAUZSQRBGY0ZbEAHTQEIAKwDVSUJwR2NGWxAA00BCAbUFSQAoAtxJHAhAAOAIRsBGwEYCvQC/////fwAAAAAAAP///////////wAACT0AABJ6AAAJPQAAANAHAAk9AKAPAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x2c1
+  pc_program_page: 0x2d9
+  pc_erase_sector: 0x2d1
+  pc_erase_all: 0x2c9
+  pc_verify: 0x2e3
+  data_section_offset: 0xa6c
+  flash_properties:
+    address_range:
+      start: 0x16001a00
+      end: 0x16001c00
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xxa_sflash_pkey
+  description: CY8C6xxA_SFLASH_PKEY
+  default: true
+  instructions: gLUA8AP6APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAAIECwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwUPsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwz/oA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAAACBAAUhJRghccEcFAAAAgLUA8N35APDz+QAggL2AtQDw4PkAIIC9gLUCSAYhAPAD+IC9AFoAFrC1DEYFRgAsCdAoRgDwKvgAKAXRASBAAi0YZB7z5wAgsL3ARoC1wQoKSpFCDNBBCglKkUII0AlJQRiJCgMpA9OBCgdKkUIC0QDwDPiAvQAggL3ARgHAAgANAAsAAKb/6R+ABQCwtQRGBkhJRg0YASBBAihGAPCc+yBGKUYA8Cb7sL3ARkQAAAD4tQxGBUYAICFJjUIF0aEKAykC0wAkAPDD+h5KH0+8QgvZH0lpGDlCCtEgSCQYeBlGHChGAPDS+h/gF0mMQgXZAyFJAmkYFEsZQg7QlEIK2SlGEUAH0RNIJBhQGUYcKEYA8Kz6CeABRgrgD0gkGApIQBlGHChGAPDB+gZKAUY1RgAsAtAAIAApydAIRvi9wEYAWgAW/wEAAP8PAAD//wMAAKYDAAD+//8A8P//AAD8/4C1APDH+oC9sLUAI5lCBtDUXMVcrEIB0Vsc9+cZRggYsL0AKQfQQxxJHgB4kEIYRvfQASBwRwAgcEcAAIC1//c2/4C9gLX/9zf/gL2Atf/3Tf+AvYC1EUb/99L/gL2Atf/30v+AvYC1//fb/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8P36C0lgVAtIKBh9IckAAPD1+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwk/pwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8IL6KWjJAskOAPB9+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8HD6C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3+P0AKALQAPD6+QHgAPAP+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDV+eQZ9+cFSElGCFhEQyBGAPDM+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwu/mAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAiQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQIkAsAAAAELX/96n9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECJALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRwAIkD4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAiQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3jP0AKAPQ//cy/QZ6A+D/9yT9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAiQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAIkAftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAUAAAAAgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHAAAQtf/3b/0HSAFoB0hMRiBYCQrJskkcAPBD+ARJYFD/9zf9EL0QACFAGAAAABAAAAAQtf/3V/0HSAFoB0hMRiBYCQrJskkcAPAr+ARJYFD/9x/9EL2QACFAFAAAABAAAAAB4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nACIDCYtCLNMDCotCEdMAI5xGTuADRgtDPNQAIkMIi0Ix0wMJi0Ic0wMKi0IB05RGP+DDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkFDCItCAdNLAMAaUkFBGgDSAUZSQRBGcEdd4MoPANBJQgMQANNAQlNAnEYAIgMJi0It0wMKi0IS04kB/CISugMKi0IM04kBkhGLQgjTiQGSEYtCBNOJATrQkhEA4IkJwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJB2dJDCItCAdNLAMAaUkFBGgDSAUZSQRBGY0ZbEAHTQEIAKwDVSUJwR2NGWxAA00BCAbUFSQAoAtxJHAhAAOAIRsBGwEYCvQC/////fwAAAAAAAP///////////wAACT0AABJ6AAAJPQAAANAHAAk9AKAPAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x275
+  pc_program_page: 0x28d
+  pc_erase_sector: 0x285
+  pc_erase_all: 0x27d
+  pc_verify: 0x297
+  data_section_offset: 0xa24
+  flash_properties:
+    address_range:
+      start: 0x16005a00
+      end: 0x16006600
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xxa_sflash_toc2
+  description: CY8C6xxA_SFLASH_TOC2
+  default: true
+  instructions: gLUA8AP6APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAAIECwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwUPsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwz/oA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAAACBAAUhJRghccEcFAAAAgLUA8N35APDz+QAggL2AtQDw4PkAIIC9gLUCSAIhAPAD+IC9AHwAFrC1DEYFRgAsCdAoRgDwKvgAKAXRASBAAi0YZB7z5wAgsL3ARoC1wQoKSpFCDNBBCglKkUII0AlJQRiJCgMpA9OBCgdKkUIC0QDwDPiAvQAggL3ARgHAAgANAAsAAKb/6R+ABQCwtQRGBkhJRg0YASBBAihGAPCc+yBGKUYA8Cb7sL3ARkQAAAD4tQxGBUYAICFKIkmNQgTRlEIC2QAkAPDD+h9KIE60QgzZ4SGJAmkYMUIK0R9IJBhwGUccKEYA8NH6H+AXSYxCBdkTSUkZSRwUSxlCDtCUQgrZKUYRQAfREkgkGFAZRxwoRgDwq/oJ4AFGCuAOSCQYCkhAGUccKEYA8MD6BkoBRj1GACwC0AAgACnI0AhG+L3/AwAAAHwAFv8BAAD/DwAA//8DAAD+//8A8P//AAD8/4C1APDH+oC9sLUAI5lCBtDUXMVcrEIB0Vsc9+cZRggYsL0AKQfQQxxJHgB4kEIYRvfQASBwRwAgcEcAAIC1//c2/4C9gLX/9zf/gL2Atf/3Tf+AvYC1EUb/99L/gL2Atf/30v+AvYC1//fb/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8P36C0lgVAtIKBh9IckAAPD1+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwk/pwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8IL6KWjJAskOAPB9+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8HD6C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3+P0AKALQAPD6+QHgAPAP+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDV+eQZ9+cFSElGCFhEQyBGAPDM+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwu/mAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAiQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQIkAsAAAAELX/96n9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECJALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRwAIkD4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAiQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3jP0AKAPQ//cy/QZ6A+D/9yT9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAiQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAIkAftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAUAAAAAgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHAAAQtf/3b/0HSAFoB0hMRiBYCQrJskkcAPBD+ARJYFD/9zf9EL0QACFAGAAAABAAAAAQtf/3V/0HSAFoB0hMRiBYCQrJskkcAPAr+ARJYFD/9x/9EL2QACFAFAAAABAAAAAB4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nACIDCYtCLNMDCotCEdMAI5xGTuADRgtDPNQAIkMIi0Ix0wMJi0Ic0wMKi0IB05RGP+DDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkFDCItCAdNLAMAaUkFBGgDSAUZSQRBGcEdd4MoPANBJQgMQANNAQlNAnEYAIgMJi0It0wMKi0IS04kB/CISugMKi0IM04kBkhGLQgjTiQGSEYtCBNOJATrQkhEA4IkJwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJB2dJDCItCAdNLAMAaUkFBGgDSAUZSQRBGY0ZbEAHTQEIAKwDVSUJwR2NGWxAA00BCAbUFSQAoAtxJHAhAAOAIRsBGwEYCvQC/////fwAAAAAAAP///////////wAACT0AABJ6AAAJPQAAANAHAAk9AKAPAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x275
+  pc_program_page: 0x28d
+  pc_erase_sector: 0x285
+  pc_erase_all: 0x27d
+  pc_verify: 0x297
+  data_section_offset: 0xa24
+  flash_properties:
+    address_range:
+      start: 0x16007c00
+      end: 0x16008000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xxa_smif
+  description: CY8C6xxA_SMIF
+  instructions: ELUERgLwzvsgRgDwMfoQvQ8gAAICSQloAUBIQkhBcEcAACBAsLUtTUhGQF0AKFHRDyAAAipJCWgBQEgegUFIRkAZAXIC8Br9BEYAKD7RSEZAGUB4ASgt0UhGQRnIeIl4ACkF0eIoA9FIRkAZACEg4AIpBdHkKAPRSEZAGQIhGOAFKQXR5ygD0UhGQBkFIRDgDikF0eooA9FIRkAZDiEI4BUpB9HtKAXRSEZAGQEhwXIVIUFySEZAGQB6ACgC0ALwj/wA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARkQKAAAAACBAAUhJRghccEdECgAAELUuSElGDBgtSAFoYWBBbCFhgWxhYcFsoWEBbOFggWmhYABt4GEnSAFoIWJBaGFiJUkKaKJiSmxiY4psomPKbOJjCmwiY4pp4mIJbSFkAW9hZEBvoGQdSAFo4WRBbKFlgWzhZcFsIWYBbGFlgWkhZQBtYGYWSAFooWZBaOFmFUkKaCJnSmziZyJGcDKLbBNhy2xTYQtso2eLaWNnCW2RYQFp0WFAaRBi//dE/8B6gAAJSUBYlCFgUBC9wEYMDAAAgAAxQBAAMEAABDFAgAUxQLAAMEAABjFAgAMmQPi1//cp/8B6hQAZSChYGUxJRgkZlCfJWYhCENBIRgYZ//ca//JZgHoAKAXQAyAGIQAjAvAv/ALgDUgoGAJgTkY0GSEdDEgQT39EuEchRigxCki4RyFGTDEJTShGuEdwNIA1KEYhRrhHBkgAITFU+L2AAyZADAwAAIAAMUAABDFAgAUxQAQAAADtIwAA8LWnsDZJSEZAXAAkAChj0QKUNEhJRggYlCFAWAEk5QcFQ4VCFdD/99H+xnr/987+gHotTwAoBtADIAYhACMqRgLw4vsB4LAAPVCwADhYqEJC0R6tKB0gIQGRAvDW/yNIJZBoICGQAyAekCFIJkx8RClGoEcVrzgdGCUpRgLwxf8cSB2QHJAcSBiQ/yAVkBtOMEY5RqBHDK84HSlGAvC1/xEgFJATSBOQFUgPkB8gDJCANjBGOUagRwOtKB0BmQLwpP8LIAaQASYDlg5IKUagR0hGA0lGVAKcIEYnsPC9wEYEAAAADAwAAIADJkASEgAAAAQxQBERERFm5u5ugAUxQO7uBgCAADFAOyMAAPi1GU9IRsBdACYAKAHQNEYN4BZIBWgBJAAtCNAoDw4oBdgoaAAoAtARSYhCAdkgRvi9KEYC8NL7ACgN0ChGAvDt+wAo89AKSYhC8NgAaAAo7dCIQuvYAOAoaElGASLKVQRKiFDT58BGCAAAAAx8ABb////vdAoAAPC1E0pLRppYE2gAJOWyq0IY2a0AVmh1WQAtEdAuDw4uDtguebYHC9Uuaa9pf2i+QgDTPkbvaIdCAti+GYZCA9hkHOPnASDwvQ1gACDwvcBGdAoAAHC1DkpLRppYE2gAJOWyq0IP2a0AVmh1WQAtCNAuDw4uBdguebYHAtVuaY5CA9BkHOznASBwvQVgACBwvXQKAAActQRG//c8/v/37v4AKADQHL3/92//ACgG0QdISUYIGADwDPgAKAHQASAcvQGpIEb/95z/HL3ARmAKAAD4tQVGK0pIRoBYACgG0AEPDikD2KhCAdEAJkngSEYAJIRQJU/DGX0gwgAkSClGAPAx+wEmACg70QCUSEbBGR9POEYA8F/9KGgBKAPRACE4RgDwWfsaTEhGAVkXSoIYOEYA8Lr+ACgj0UhGEklFUChoASgD0QEhOEYA8EX7SEYAWQWIAJ4MT65CEdJIRgBZQGixAEFYACkI0IhpwGsAKATQSEbCGQVIAfDP+3Yc6+cAnjBG+L1wCgAAeAoAAAAAQkB0CgAAELUJTEhGAFkAKAjQAA8OKAXYBkgA8P76SEYAIQFR//cd/gAgEL3ARnAKAAAAAEJA/rUjTEhGAFkGaAAnApcBl/iyhkI62UlGCVlJaIAADVgALTHQKA8OKC7YaGiBByvVaWkAKQjQACIEKgXQAqubXFIcmUL40R/gSh6RQSppykBABwPVqGlBaJFCANMRRuhoAPAY+AAoEtFoaQAoDNADIclDACkI0AKqUhgSeUkcACr30AKqURjIcH8cwecBmP69dAoAAPC1jbAMRgZGACUMlQuVDKn/98r+B0YAKALQOEYNsPC9DJgIkEFpACkF0Auo//fm/gdGACjx0V1ISUYIGP/3HP8AKAHQASfo51lJCJgA8Lj4B0YAKOHRCJmIaYBpBpDIaAqVMBoHkAuYApBSTgAsANGa4DBGBJUlRktGT0qaGAxGAfCu+gEnACjH0WBpACgiRixGBJ0J0EhGR0lCGDBGApkB8J76CJoAKLfRcGgAKPzUACADkAmQCakQRgeaAfDq+wNGPkiDQgWUAdAAKx/RAZMJmAAoBp8A0MdoCJiAaQJoCqwHmCFGAPCZ+AWYuEIA0zhGBpBIRjBJQxgwRgifOUYiRgHwi/sAKAbQACQQ4AMkASUoRgaaDeB4aQAkAChA0EhGJUlDGAqqMEYCmQHwdvsGmgGbIUmLQgaSAdAAKxzRAScAKADQaOcInCBGAPBs+GFpACkD0AKYAPBm+AicIEYTSQDwLfgImQAoBZwA0FTnBpucQgXRIEYE4CBGBZwImQrg2BhKaQAqANEYRiQaB5gYGAeQA5gFRgAoL0YA0WXnO+cGmiBGxOcvRjbnUAoAAMAnCQAAAEJAeAoAAAYAsgD+tQ1GBkYAIAGQApABJBJPSEbCGQ9IMUYB8Dr6cWkAKQrQACgI0QKo//cI/khGwhkCmQhIAfAs+gAoBtCsQgbSZCAB8On/ZBzi5wGY/r0BIP69wEYAAEJAeAoAAEkeiFQAClIe+9FwR/C1hbAERhNNE05oaAAo/NRIRhJJQBihaYlqCXgjeAAiAJIBkgKTA5IEkChGE0YA8L/5ASDABChlMGgAKPzQ92hkIAHwtf+gaYBrOELd0QAgBbDwvQAAQkDEAEJAeAoAAPC1k7AeRhVGACQSlBGUDxgSqThG//eE/QAoAdATsPC9EpgPkEFpACkE0BGo//ei/QAo89FLSElGCBj/99n9ASgB0QEg6udISQ+Y//d1/wAo5NEPmYhpQmrIaBCUOBoOkBGYBpBBSEJPBZQALnbQDJINlklGP0qKGA+eMUYB8Gz5ASEHkQAoa9FwaQAoM0Y3TgnQSEY3SUIYMEYGmQHwXPkPmwAoXNFwaAAo/NSYaQJoEKkLkQ6YHkb/92z/SEYtSUAYCpCzaRhqAXkJkQF4CJEbaEJ5MXgAIACTAZICkQOQCpgEkCFICJkJmgubAPAw+Q2ZDJqRQgDTEUYAKDDRDJE4aAAH/NFIRhpJQBgPmYlpC2pKaht9AJAAJhRIMUYA8Gn5ACgc0Q+ZiGlDaghGnkIJ0DEZaVz5YDloDyIKQAQq+th2HPPn//cr/w6YDJqAGA6QpBgNnrYaBEiG5wWYB5AHmFvnUAoAAFDDAAAAAEJAhABCQHgKAAD4tRxGF0YNRgZGGGANSElGCBj/9zH9ACgA0Pi9aUYwRv/3wvwAKAPQqBkgYAAg+L04RjFGKkYC8K/7ACj00AEg+L3ARmAKAAD+tRdGDUYERh1ISUYIGP/3D/0AKADQ/r0AIACQApAZTn5DYBlHHiVGAZS9QiXYAqkgRv/3lfwAKAHQLR315wKYwmgDaZkYgGlEaKAYo0IKRgDTAkZSHodCOEYA0xBGj0IBnAXTEEYD4ClojkID0S0dhUL52dnnASD+vQCY/r3ARmAKAAABAQEBgLX/9zP9gL2Atf/3R/2AvYC1ASGJBP/3i/2AvYC1C0YAIf/3yf6AveC1Aav/94D/AZiMvYC1//ef/4C9cLUPTAAoGdAAKRfQACsV0Pkk5AAFWQMmtUMFUVpiHMkJaAElFUCiB5IMUhlbB1sL0hjJB8kJURgBYAAkIEZwvQQAsgADIQkCAWCAIgAhgVACRoAyEWT5ItIAgVABItICgBgEIgAqA9ABYIAwUh7553BHSh6RQQJoASOaQ1EYAWBwRwFoASAIQHBHwEZJHgcpG9jARnlECXlJAI9EAwYWCBYWFgsBIckCBuARIQPgCSEJAgHgEyHJAUAYAyEJBANoi0ORB4kLWRgBYHBH8LWFsAOTBUYNmMADgLIKnwAmAC8AkADQMEaSB5ILURgIGAyZCQcJDQKRQBgoZQ6YQGoEkAuYgAeACwGQD0wwRvGyuUIX0qBCFdBobEAHDtRIHLhCAdMAmADgACABmhBDA5pRXAFDApgBQylldhwEqADwBvjk5wWw8L3ARgIAsgAQtQRGAGgAKAbQASAB8Lj9IGhAHiBgAdAAIBC9AEgQvQIAsgDwtYmwVE0AKgDRnuAERkBsQAcA1ZvgmAeAC1Mem7IYGAEjmwTAGCBlACkA0ZHg+SDAACAYAZCENA6YQGoIkAeRBpIAIASQAiECkQWRASEDkQWZAikA0H3gaRyIQgDReeAGnweeIGgPIQFACCVoGrhCANM4RggoDNh4RAB5QACHRE8EExojKjM/CAAweOBgA51D4DBGA5kA8I/6YGEwHQOZAPCK+mBhOOAweHF4CQIIGCBhAp0x4DB4cXgJAggYIGGweOBgAyUo4DBGA5kA8HT6YGEEJSHgMEYDmQDwbfpgYTB54GAFJRjgMEYDmQDwZPpgYTB5cXkJAggYIGEGJQzgMEYDmQDwWPpgYTB5cXkJAggYIGGweeBgByV/G3YZoecHlgaXAC8L0QGaEGgBIYhDEGAFkQSYACgC0ASZASCIRwio//dL/wRNgufoHALgKEYA4AAgCbDwvQEAsgDwtYewW08AKgDRq+AERkBsQAcA1ajgmAeAC1Mem7IYGAEm8wTAGCBlACkA0Z7g+SDAACAYAZDENAyYQGoGkAWRBJIAIAKQBCUDlQOZBCkA0I3geRyIQgDRieAEnwWYImgPIRFAuUIA0zlGCCkN2MBGeUQJeUkAj0ReBBogKDI+TAgA4WgBcDFGUuBhaQFwCg7CcAoMgnAJCkFwYWkBcQoOwnEKDIJxCQpBcQghQOAhaQFwCQpBcAIhOuAhaQFwCQpBcOFogXADITLgYWkBcAoOwnAKDIJwCQpBcClGKOBhaQFwCg7CcAoMgnAJCkFw4WgBcQUhHOBhaQFwCg7CcAoMgnAJCkFwIWkBcQkKQXEGIQ7gYWkBcAoOwnAKDIJwCQpBcCFpAXEJCkFx4WiBcQchfxpAGJPnBZAElwAvDNEBmhBoAiGIQxBgAyADkAKYACgC0AKZAyCIRwSXBqj/95D+BE9y5/gcAuA4RgDgACAHsPC9wEYBALIAAkYISAApCtBTbFsHBtQDIIAESR6JsggYEGUAIHBHwBxwR8BGAQCyAIhpcEcAIgpgimDKYEphimFKYAphASHJBwJoCkMCYHBH8LWJsAVGDphAagiQLE6wHAAqUtAURg8iCkBO0QKRASABkEACLRgYCQOQACAHRgOZj0JC0DkBApqJGCliKWgBmpFDKWAqYCloyQcF0LBCA9AIqP/3Nf7257BCLdAqbgSpCnATDstwEwyLcBIKSnBqbgpxEw7LcRMMi3ESCkpxqm4KchMOy3ITDItyEgpKcupuCnMTDstzEwyLcxIKSnMAIRApBtAEqlJcY1xTQGNUSRz25xA0fxy65zBGCbDwvcBGAgCyABC1ASQiAoMYAyLSAYIY4AcDKQbQAikH0AEpGkYE0AVIEL0ZaAFDGWARaAFDEWAAIBC9wEYEALIAASISAoMYAyLSAYIYCUgDKQbQAikH0AEpGkYE0ARIcEcZaAFAGWARaAFAEWAAIHBHBACyAP///38QtQEkIgKDGAMi0gGCGKAHAykG0AIpB9ABKRpGBNAFSBC9GWgBQxlgEWgBQxFgACAQvcBGBACyAAEiEgKDGAMi0gGCGAlIAykG0AIpB9ABKRpGBNAESHBHGWgBQBlgEWgBQBFgACBwRwQAsgD///+/ISLSAIIYMSPbAMAYAykG0AIpCNABKRBGBdAGSHBHEWgBIwtDE2ABaAEiCkMCYAAgcEfARgQAsgAQtUseByse2AJGQGiRaAAke0QbeVsAn0QGAxYeFhYWA//38v4X4IlpybIKH1FCUUFCaAAqAdQAIgDgASIDaBNDC0PZBwHQBUwF4AEhyQcCaIpDAmAAJCBGEL3ARv8AQgAQtUseByse2AJGQGiRaAAke0QbeVsAn0QGAxYeFhYWA//3wv4X4IlpybIKH1FCUUFCaAAqAdQAIgDgASIDaBNDC0PZBwHQBUwF4AEhyQcCaIpDAmAAJCBGEL3ARv8AQgACRgB4U3gbAhgYACkF0JF4CQTSeBIGURgIGHBH8LWRsAyQACgA0fXgACkA0fLgACoA0e/gS2gAKwDR6+AIaA+QACgA0ebgB5IBIMECDJpRGA2RESHJAVEYBJEJIQkCURgDkRMhyQFRGAKRAQIKkQMhBZEPBMAHDpAAIAVGAZAJkAuXD5ioQgDRx+AeaAAuANG94DJ4UB4HKADZx+AQk4AAAqEIWAkYDZxhSI9GKgAAACAAAABwAQAAJAAAAHABAABwAQAAcAEAACgAAAAEnALgA5wA4AKcIGi4QzN6GQQ5QAgYIGBwaEEHDtWxaQeYAJAMmADwn/gAKAXQCCCoQAmZAUMJkQLgcGiBBwHUEJt+4AiV/yHJQ/JoCkCiYDJpUkIKQOJgcmkAKgqZANERRrJpE2hbHgWfO0ALQyNiFWqSaAAqLNAGlRFoACdLHDtGC50G0BN5GwQrQMmyyxgOmQtDI2RReQkEKUBhZJFoSxwG0BN7GwQrQMmyzxgOmQ9Dp2QTaQArBNBZHh8jC0AOmQtD42QRfQkEC5oRQCFlBp0ALQufKNApaAAiSxwTRgbQK3kbBDtAybLLGA6ZC0MjZml5CQQ5QGFmqWhLHAbQKnsSBDpAybKKGA6ZCkOiZippACoE0FEeHyIKQA6ZCkPiZil9CQQ5QCFnCplJHAhAMXoJBDlAQBgOmQhDIGAQmwidGx1tHDbnBkgRsPC9AZgJmQAp+dADSAAfAUMIRvTnAEj15wQAsgDwtdmwHUYWRg9GEpA+qQAgiHAIgD2piHAIgDypiHAIgHlrEZE/qSgxDpFenGQoBNA/qQAiClRAHPjnE5QSnCBGMUYMlSpG//dz++dNEZkAKShGCtATmAKQP6gBkDggAJA+qiBGM0YA8Kn9D5Y/qYl5BikpRgDYAUYAKBOcANABRgApWNE/qAF4UykA0JDiQXhGKdVKTtGBeEQpS9HBeFApSNEBeQYpRdNAeQEoQtEAJi+W/yAIkAUCKEaEMA2XP689qi+rOUYA8KX9LpYoRoEwPKouqzlGDZ8A8Jz9wkl7MQmRiEIC0QAg+GQ4ZS2WP6k+qi2rKEYA8I39AUYAKBrRLZgClD+vAZcAkD6qEpgRmQ+bAPBT/R03MC4P0Dp4MKmKVYsZeR4JeAEiikBaYAw2vxzx5xFGCEZZsPC9CpA/qIB4QAeBDwAmAyk1RgLQiAD2oQ1YDpgDeA2YwWhAnw5xBiIKYAJpFnEEIQaREWCCahZxBSEHkRFgAmsWcQVgASELkYFjAC8C1H4c9ggD4OpOvxn2HD5DDZ9+YBsJC56eQH5iDpiDfFsGWw8FKwrYmwDipvZYFmDnotJY+mProtJY+2oaYPppYCMTYAAnF3FJmpMEAdVAIwDgCCPWBPYOdhxeQxMH2w6bHHNDDZmLZNMODCAQkANA46bzWEieNgf2DrYc0gDSDlIcckNaQ0pk/SIMmBBAi2j+Qz+qkngBKAvR0AYU1NAHPtGeYAAimoADIBhgASUQRlvgMUYeRpMGG9RSBjNGQtQoRv8lDkZU4D+pynsBIB1GAwKrgCtGKmCJeyApMUYB0xhz/yGZYD+piXsfIgpAAyU74D+oRXoLmlICM0aygDVgAHogKA5GCEYC0wIgGHMImJhgP6gAeh8iAkACIAedJOA/qUp7ACCYgBpgCXsgKTFGAdMYc/8hmWA/qAB7HyICQAIlASAR4D+ownqfgBpggHogKA5GCEYB0x9z/yCYYD+ogHofIgJAAiAGnRh1GmENmABoBChC0QeVDpgAfUEGCZoA1QAiwQcSnDDQgAcW1Q2YwGgAKBLQAnkBeAEg/yQdRgAjAJMBlA+cApQSnAOQE5gEkCBG//cZ+itGAkYAKgPQ90iCQgDQMuEBIP8hACIAkgGRD5kCkQOQE5gEkLchIEYdRhNG//cB+itGAkYBJQAqANGv4BFGE5woRg3gDZgCahd1F2EXc5Zgl4ACIRFgP6kwqgDwbvwKmQAoDZov0AqRP6kOkEAYQB4AeAuZgUCRYTCoCDBImQoH0g6SHNmjEJ0cLxDQDEb8QOYJLkCeWeQF5A5kHFRDdEMEYBOc/x0MMO7nBQCyAA6YGzhACBCZSEMwqUAYAB8AaA2aEGQKmRBtACgA0ZTmLp0ClD+oAZAAlTyqEpgRmQ+bAPDN+wFGACgA0IXmACQUlLxIQRw/qMccDJQOlT+oAF2ABwDVreBYqQAgCHACIiJDP6mKXJMJAysNmgLQmgC2o5oYE2gDIiJDilwRkgEiIkOJXDpGg0IF0NVcFK41VFIeQBz35wAiAJMBkg+YApADkhOdBJUUqxKeMEb/92r5ACgJ0QCVWKkBIgAlMEYrRv/3YPoAKAbQAUYOnQg3CDSsQrzZjeBYqAB4EZkIQEEeiEEMmUkACBgMkClG7ecOky+YE5sCkxSpAZEAkD2qIEYcRhGZD5sA8GP7AUYAKChGANBO5weYQh4UmQQqANnd4JAAAqMYWBgYh0bARnwAAACWAQAAdAEAAH4BAACKAQAAAwAAAAQAAAAEAAAA/f//f/////8BAAAAAQAAAD4AAAABAAAAAQAAAP////8CAAAAQAAAAIAAAAACAAAAAgAAAP////81AAAABQAAAD8AAAA1AAAANQAAABAAAAAAAQAAoA8AAAD6AACIBxCYDp0A1IrgkeAAKQvQXkhAHIFCDZgh0MLlW0nA5QEgEUYTnPDmC5sCICBDP6kIXCJGGkOJXAya0rKKQgfQgAAkGAg0rELv2VBIgRyo5UAcwbINmMFkEZEBKQPYACHBZAFlneUAbQ+QC5gGAgAnOUYTlzpGEZiHQsnQCpETmBAYE5AkHT+oAF0PIQFAACALmgpCC9EzRv4zUgAaQEMcBCgYRvXTOUiAHAqQBSA/qQ1ZEpe6AA+bn1gTmjpgEJpQQzCqE1y7YBAYQWiAaDhh/yCFQ6oZikIC0gEgFUYF4BBGDpINRgHwp/sOmnhg/WASn38cCpm+5wgHDp0Q1bwgFuDIBg6dDtQNmABqHeCIBg6dCtQNmABqFeBIBw6dBtQNmABqE+BsIALg7CAA4DwgKGAUmQ2YAGoDKgjTB50ELQPQBS0S0coFHNQKBhXUSQYB1AIhAOASIQFgACEKRgJ1ACICYQFzhmBBcQJxFKkwqg2YAPC3+gAhR+Y0IQFgAiIAIeznPiEBYAIh5+cFALIAgACyAAEAAAAQAAAAgAAAAOgDAAAAAAAAAwAAAAQAAAABIckCQBgEIQApEdAAIgJggmDCYAJiAmRCZIJkwmQCZQJmQmaCZsJmAmeAMEke6+dwR8BG8LWFsItp22gAKw/QHXkceAl4ASb/JwAjAJMBlwKRA5YEkiFGKkb+9+f/AOABSAWw8L3ARoAAsgDwtYWwi2kbaQArD9AdeRx4CXgBJv8nACMAkwGXApEDlgSSIUYqRv73y/8A4AFIBbDwvcBGgACyALy1BEYBqwEgGHCNaatqACsP0Bt4AJIBqiBGAPAN+AAoAtABqAB4BOA4IClcAagAeAhAQR6IQby9cLWGsBRGBUYIeAqeACL/IQCSAZECqUXBKEYZRhNG/veX/wAoBtEAlgEiACMoRiFG//eO+AawcL3wtYewFkYMRgaqACERgKVp62oyTwArXdApawApWtCqagAqV9ASaAWSCWgCkRloAJbLsgaqIUYElgOQHkb/98T/AChI0QWZAZYEmuhrAigJ0IAoI9BAKDzRQCAGmQFDBq85cC3gFkYAksuyBqoDnShGIUb/96n/ACgBmyzRAJYGqEIcKEYhRv/3n/8AKCPRBq94eAIhAUN5cDJGEeAVRgCSBqhHHAOYIUY6RgGb//eM/wAoENEGqEF4gCIKQ0JwKkYCmACSw7IDmCFGOkYA8Aj4AeB9PzhGB7DwvcBGgACyAPC1h7AGkxVGDEYGRgyfOkb/9xb/ACgS0QWVoGnAayN4ASEAIgGSApMDkQSXAigA0QFGAJEwRgaZBZv+9/3+B7DwvcBG8LWFsItp22kAKw/QHXkceAl4ASb/JwAjAJMBlwKRA5YEkiFGKkb+9+X+AOABSAWw8L3ARoAAsgDwtYmwD0YbSQAqL9AURgaQB5O9aW5pACIIkihoEUaIQgTQY1wSAtIYSRz45wipOEYA8CL4AUYPSHwwAC4X0DJ5/yoU0AtLmUIR0AApAdEIngg2MXgoaDt4ASUAri3GB5gEkAaYI0b+96n+AOAIRgmw8L3ARgQAsgD4tYRpY2gOSJNCF9mAHCNtACsT0ACR5GwALA/QHWguaJZCBdhpaO9oT0O5GZFCAtgbHWQe8OcAmAVgACD4vcBGBACyAPC1ibAVRgJGJ0iPaT5qAC4P0AAtI9AIkg6cemoGlKJCHdMQmAeQSGkAKAWTA9DDsgLgfDAT4At4MnkxeDhodHkAJwCQAZQcRgKTA5cHmASQCJgrRv73VP4AKAWdAdAJsPC9sGhBHA3QMnv/IQCXAauSwweZBJHBsgiYO0b+90D+ACjs0TFpACkE0AiY/vf0/wAo5NEzfQeYAJAImClGBpr+94D+2+fARgQAsgDwtYmwCJAlSI5pt2gALwrQFUYAKh3QEJgHkEhpACgGkwPQw7IC4HwwE+ALeDp5OXgwaHx5ACYAkAGUHEYCkwOWB5gEkAiYK0b+9wT+ACgGnQHQCbDwvbhoQRwN0Dp7/yEAlgGrUsMHmQSRwbIImDNG/vfw/QAo7NE5aQApBNAImP73pP8AKOTRDpo7fQeYAJAImClG/vfe/tvnwEYEALIA8LWHsB5GBpINRgJGCHkFkAt4SHkOmQAnAyQAlBRGAZAClgOXD0YEkRBGGUYFmgab/vfA/QAoDNEpaSBG/vd2/wAoBtENmQyaK30AlyBG/vex/gew8L3ARvy1AZMAkop51AAINAgmACLAshVGpkIQ2Itdg0IL0YsZ33n/LwfRX3i9QgTYm3gBKwHRMkY9Rgg27OcAKg3QUBgBeQCakXBBeVFwgXkRcMB4gAABmQhgACD8vQFI/L3ARoAAsgBwtQNGAGgEKBDRW2kAJOBDGGBIeMAGBQ8dIAUsHdAuRuZA9gcN0YAcZBz25x0gClz/KgPRIigP2IAc+OdbaRpgEeADLAnYCR0AJQQtCdBOXRZwDDJtHPjnW2n/IBhxACBwvQldGWAAIZmAcL3+tQKTFkYBkQCQlAgTSIRCANMERgAsANEBJH0gxwAgRjlGAfBh+AVGR0PgG4eyKEYA8Db7OEYA8Df7AKoHyv/3Yf0xGwDSACEAKALQpkIORu3YACgA0AJI/r3ARkBCDwACALIA/rUURgKqACcXcI1p7mvtai14AJMrRv/3X/0ncAAoAND+vQKpCXj/IkpAFkBxQnFBIXD+vfi1HEYVRg5GB0YaRv/39vwAKADQ+L04RjFGIkb/9179ACj30ThGMUYqRiNG//ec//i9wEbwtY+wBpAAIAmQDpAUnjJIAC5e0B1GF0ayGIxpY2iaQlfYCJGkaBWYDZA4RgeUDJYLlQietWkqaA6vCpA5RgDwTfgieSF4KGhjeTV4DJ4ArCnECZgDkA2YBJAGnShGO0b+9678ASEJBI5CN0YA0w9GACgu0QecoGhBHBHQInsImQl4/yQJmwCTAZQHnAKRA5MNmQSRwbIoRv73kvwAKBjRIWkAKQTQKEb+90b+ACgQ0SN9DZgAkChGC50pRjpG/vd//QAoBdHtGQqYwBn2G67RCZgPsPC9wEYEALIASR6IVAAKUh770XBH8LWRsA+RBpAAIAyQEJAWnD9IACx50B9GFUaiGA+ZiWlLaJpCcdgIagWQSGoHkBeeDZYoRgeeMUYA8Hz/CBmwQgmUDpQC0weYQBoOkAacIEYPmQ2a//dE/AAoVtEKlw+YhmkyaChGEK0IkClG//fC/wWfOHkLkDp4MGgNnnt5D5kJeACQAZMCkQyYA5AEliBGEUYLmitG/vcf/AAoNdG4aEEcDtA6ew+ZCXj/JQybAJMBlQKtSsXBsiBG/vcN/AAoI9E5aQApBNAgRv73wf0AKBvRO30AliBGCp85Rg6a/vdN/AAoEdEPmYhpgmwgRjNG//es/gAoCNEJnA6YJBoInUUZPxgALJTRDJgRsPC9wEYEALIA8LWNsB5GFUYKRgAhDJEKkQuR6RgJkUselGlhaFhPAZOLQgDTqeAGkCBsAJAFlKRpC6kHkhBGKkb/9yL9ACgH0LRCANmZ4CFGuEIKnAvRlOALmtFosUIA2Y/gFGhSaEpDohhSHgqSA5EIkCgbAPDY/gApANCB4ASUA5wBmgqYgkIS2QupB5j/9/v8PUmIQnPQCJAAKCFGCZoEmwjRC5jBaANoACAIkALgIUYJmgSb0BoDkQDwtf4AKQeaXtESnAifApQALlnQC6kQRipG//fY/AAoAZwIlA3RC5nPaAzJA5d7Q9IYUh4IOZRCCJQA0wiSCWkAkX0hygAAmUpDBJIHmgiZjUIy0gqVCZYGnShGEUYWRgKcIkb/91n7ACgh0QWYAmgMrwqYOUb/99r+KEYxRjpGI0b/92j8ACgS0ShGMUYEmiNG//f4/QdGCZ4DmIZCDtk2GgqdLRgAIAAvB5rP0K/nB0YyRgmeCp2q5wdGqOcAJgeaCp2k5wdGOEYNsPC9BACyAHC1FEYNRgZG//ce+wAoANBwvTBGKUYiRv/3GPwAKPfRfSDAAKlpSmxCQzBGKUYjRv/3wP1wvQAACmgCYMpoQmQKaYJkSmnCZIpoAmRKaIJhimkCZQVKgBjACQABymkES8JQwBgJakFgcEfARgAAz78AADBAsLUMSExGJVgLSCVQC0goGAtJAPAJ/gtJYFQLSCgYfSHJAADwAf4JSWBQwAMISWBQsL3ARqAKAACwCgAAP0IPAEBCDwC4CgAA5wMAALQKAACsCgAAcLU4TCBoDyEBQIgANkqDGB1sByMrQATQBCsE0AErNEgP4DJIDeAQWB8iAkB9IAACESoB0ANGAeABI9sDECoA0BhGASkP0AApO9ErTSlpqmiSAJIPASoU2NIeU0JTQRlDyQcQ0S3gI00pbCpokgCSDwEqFtjSHlNCU0EZQ8kHEtEf4AMqHdEpaBxODkBqaBxJEUAA8J/9cEMpaMkByQ9JHA3gAyoN0SlofyIKQFBDKWjJBMkOAPCO/SloyQLJDgDwif0haIkGiQ/IQA5JTEZgUA1JCWgJDkkcAPB8/QtJYFBwvcBGgAMmQAADJkAAEnoAADZuAQAGJkCABSZA//8DAP8fAACkCgAAEAAhQKgKAAAQtQlMSEYAXQAoC9H99y78ACgC0ADwkvkB4ADwp/lIRgEhAVUQvcBGCQAAAPi1BEYJTQtOC0+sQgXTSEaAWQDwbfnkGffnBUhJRghYREMgRgDwZPn4vcBGAYAAALQKAACsCgAAAID//4C1A0lKRlFcSEMA8FP5gL24CgAAgLX/99X/gL2Atf/37/+AvQJIAGgCSUpGUFBwRwgQIkAMDAAABEgCaARJS0ZZWJFCANABYHBHwEYIECJADAwAABC1/fff+wlJCmgJS0xG4lABIwB6ACgB0FgEAOAYBBBCANAQvRBDCGAQvcBGCBAiQAwMAAD4tQCSDUYBJGVAQAEOSUcYJkY5aAAgACkiRgDaAkYqQwEqENEAIAApAdoBRgDgASENQgjRAJiGQgTSASD/937/dhzm5wEg+L0cACJA+LUMRkABCElFGAAmL2gALwfUdhymQgTSASD/92n/AC/01fhDwA/4vQAAIkD4tRRGDUYGRgEnMWghYA8gAAcIQAUhSQeIQgbQr0IE0gEg//dP/38c7+dAGkEeiEH4vcBG8LWFsAxGBJD998z7ACgD0P33aPsGegPg/fda+wEmRkAcTQAuBNABLjDRApQgNQDgApR9IAOQwQAwRv/3sf8HRgAoJNEBJwSYAUY5QAGREkkB0UhGQBgMJCxDIGAIIChDB2AAIQ1KMEb/93T/ACgO0QGYACgC0UhGB0lEGAOYgQAgRgKa//ei/wdGAOABJzhGBbDwvQAAIkDcDAAAmDoAAPi1A6gCIQCRAZECkAQgBiEAIhNGAPAG+AOZSEJIQQSwgL3ARvC1h7AdRhdGAZECkAQgDJn/92T/Dp4wYAEkACgZ0Q2aBpUFlwxNA6hoYAGZQYACmQGAICAoYAQgACH/9yn/MGAAKAbRaGhBaAApAdABITFghGggRgew8L2IACJAH7UDrAKUBEwBlH0k5AAAlP/3yP8EsBC9mDoAABy1BEYBIAGp//dc/wAoANAcvQGYoHABDGFxAApgcP8gAjBpRv/3Tv8AKPHRAJkhcQoK4nAKAhIP4nEJAwkPoXEcvQAAgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHAAAQtf/31/0HSAFoB0hMRiBYCQrJskkcAPC3+wRJYFD/95/9EL0QACFAqAoAAKAKAAAQtf/3v/0HSAFoB0hMRiBYCQrJskkcAPCf+wRJYFD/94f9EL2QACFApAoAAKAKAAAQtQFoiGjKaGQjQ0OYGAtKS0aYUJYoAdIBIBC9CGhAHAAiQB4G0BMdTGiiWBJ5UgcaRvbVQR6IQRC9wEYMAAAA8LWHsAWQ90hJRgoYA5L2SApQ9kvOGPZLzlD2TA0Z9kwNUcgYBpBQYPRNTRm1YfROjhnuYvNOjhnzT88Z72EuYvJOjhnyT88Z8kqKGPJICBgrRggzhcNuYfBICBhoY/BICBioYgwZLGXuSAgYKGPuSAgYBJDtSAgY7UqKGO1OjhntT88Z7UvLGO1NTRllYqNi52ImY2JjoGMEmOBj/EgIGASQ/EgIGAKQ+0gIGPtKihj7S8sY+0/PGftNTRn7To4ZZmClYOdgI2FiYaBhApjgYQSYIGL2SAgY9kwIUfZICBj2So0YhWEGmlBg9UgIGOhi9EgIGPRKihjqYShi80gIGPNKihjzS8sY806OGa5g62AqYWhh8UgIGKhi8UgIGGhj8EgIGChjDBksZe9ICBgEkO5KiBgCkO5LyBgBkO1NTRntTo4Z7U/PGe1ICBjtSooYBJtjYAKbo2ABm+NgJWFmYadh4GEiYuhICBgEkOdKiBgCkOdLyxjnTU0Z506OGedPzxnnSAgYBJpiYgKaomLjYiVjZmOnY+Bj4kgIGAaakGDhSo0YhWHhSAgY6GLgSAgY4EqKGOphKGLfSAgY30qKGN9LyxjfTAwZrGDrYCphaGHdSAgYaGPdSAgYqGLcSAwYLGXcSooYKmPbSooYClDbSAgYBJDaSAgY2kqKGNpLyxjaTo4Z2k/PGdpNTRllYqdi5mIjY2JjoGMEmOBj1kgIGASQ1kgIGAKQ1UgIGNVKihjVS8sY1U/PGdVNTRnVTo4ZZmClYOdgI2FiYaBhApjgYQSYIGLQSAgYBprQYM9KjBiEYc9ICBjgYs5ICBjOSooY4mEgYs1ICBjNSooYzUvLGM1NTRmlYONgImFgYctICBhgY8tICBigYspICxgjZcpKihgiY8lKihgKUMlICBgGkMhICBjISooYyE1NGchOjhnIT88ZyEwMGVxin2LeYh1jWmOYYwaY2GPESAgYBpDESAgYBJDDSAgYw0qKGMNOjhnDT88Zw0wMGcNNTRldYJxg32AeYVphmGEEmNhhBpgYYgWYBWgoaFxKiFCoaAOakGDoaNBguUgIWAaQASADkAACApAAJCNGBJUoaINCANOd4GhoAFlBaEoHA9QGmpUqANmR4AWTSkZMS9IYUmgSWVFgAXgRcAF6EXLBaNFgAWkRYUFpUWGXaQaZlSlj2IZpMGg4YHBoeGC4aLFook19RKhH8Wj4aKhHMWk4aahHcWl4aahHsGm4Yfhp8WmoRzFqOGqoR3BqeGK4arFqqEfxavhqqEcxazhrqEdxa3hrqEcEnbBruGPwa/hjMGw4ZHBseGSwbETgvAwAABAAAAAUAAAAzAwAABgBAADYAAAAvAoAAKgAAABgAAAAMAAAAEgAAABYAgAAcAIAAHgAAACQAAAAwAAAAIgCAACkAQAAkAEAAHwBAABoAQAAVAEAAEABAABEAgAAApl5YgMgA8cDnjADOGFIRm5JQRj4agg/APDc+BAgACG5Y/ljPmR4ZAggACG4ZPlkBZskHVscXedIRgNJQBgHsPC9wEa8DAAAEAAAADACAAAcAgAACAIAAPQBAADgAQAAzAEAALgBAAAsAQAApAMAAGQDAACgAgAAEAsAADQDAADsAgAAvAIAANQCAADkBAAA/AQAAAQDAABMAwAAHAMAABQFAAC4AwAARAQAAFgEAABsBAAAgAQAAJQEAACoBAAAvAQAANAEAADMAwAA4AMAAPQDAAAIBAAAHAQAADAEAAAsBQAAZAsAAMAFAAB4BQAASAUAAGAFAABwBwAAiAcAAJAFAACoBQAA2AUAAPAFAACgBwAAMAYAALwGAACoBgAAlAYAAIAGAABsBgAAWAYAAFwHAABIBwAANAcAACAHAAAMBwAA+AYAAOQGAADQBgAARAYAALgHAAC4CwAATAgAAAQIAADUBwAA7AcAAPwJAAAUCgAAHAgAADQIAABkCAAAfAgAACwKAAC8CAAASAkAADQJAAAgCQAADAkAAPgIAADkCAAA6AkAANQJAADACQAArAkAAJgJAACECQAAcAkAAFwJAADQCAAADAAAAKQMAACJAgAAACkL0ApoAmCKiIKAimiCYAp7AnMKaQJhCX0BdXBHwEYCSElGCBgCSohQcEe8DAAAEAAAAANGELULQ5sHD9EEKg3TCMgQyRIfo0L40Bi6IbqIQgHZASAQvQAgwEMQvQAqA9DTBwPQUhwH4AAgEL0DeAx4QBxJHBsbB9EDeAx4QBxJHBsbAdGSHvHRGEYQvQHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAAAAiAwmLQizTAwqLQhHTACOcRk7gA0YLQzzUACJDCItCMdMDCYtCHNMDCotCAdOURj/gwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJBQwiLQgHTSwDAGlJBQRoA0gFGUkEQRnBHXeDKDwDQSUIDEADTQEJTQJxGACIDCYtCLdMDCotCEtOJAfwiEroDCotCDNOJAZIRi0II04kBkhGLQgTTiQE60JIRAOCJCcMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQdnSQwiLQgHTSwDAGlJBQRoA0gFGUkEQRmNGWxAB00BCACsA1UlCcEdjRlsQANNAQgG1BUkAKALcSRwIQADgCEbARsBGAr0Av////39wtQZMfEQGTX1EBOAgRgFoCBiARyQdrEL40XC9HAAAABwAAADB/f//AAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABwAAAAAAAAAAAAAYAAAAAgAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAWgAAAAAAAAD/////AAAAAAgAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAA/////////////////////////////////////////////////////////////////////////////////////wAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAgAAAAcAAAAAAAAAAAAAGgAAAAIAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAFoAAAAAAAAA/////wAAAAAIAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAP////////////////////////////////////////////////////////////////////////////////////8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAQAAAAHAAAAAAAAAAAAABwAAAACAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAABaAAAAAAAAAP////8AAAAACAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAD/////////////////////////////////////////////////////////////////////////////////////AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAIAAAABwAAAAAAAAAAAAAeAAAAAgAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAWgAAAAAAAAD/////AAAAAAgAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAA/////////////////////////////////////////////////////////////////////////////////////wAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAP///////////wACAAAAAAcAAAABAAAAAAAAAAEAAAAHAAAAAQAAAAAAAAD//////////wAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACT0AABJ6AAAJPQAAANAHAAk9AKAPAAAEAAAAAwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAABaAAAAAAAAAP////8AAAAACAAAAAAAAAAEAAAAAAAAAAIAAAAUAAAA/////////////////////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0xb05
+  pc_program_page: 0xb21
+  pc_erase_sector: 0xb15
+  pc_erase_all: 0xb0d
+  pc_verify: 0xb2d
+  data_section_offset: 0x33fc
+  flash_properties:
+    address_range:
+      start: 0x18000000
+      end: 0x20000000
+    page_size: 0x1000
+    erased_byte_value: 0xff
+    program_page_timeout: 50000
+    erase_sector_timeout: 600000
+    sectors:
+    - size: 0x40000
+      address: 0x0
+- name: cy8c6xxa_efuse
+  description: CY8C6xxA_EFUSE
+  instructions: gLUA8I/7APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAAIECwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDw3PwERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwW/wA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAAACBAAUhJRghccEcFAAAAgLUA8Gn7APB/+wAggL2AtQDwbPsAIIC9/rUWRgVGAZHICClGACoE0AAjC3BJHFIe+OcHJAGaEUahQ5FCF0Ye0sCyAqkA8JD8ACgA0P69AZgEQAggABuwQgDTMEYBGQKqEngrRoxCCNIXRudA/wcB0AEnH3BbHGQc9OcBmocYsRgIJBZGAJG5Qh/ZOEYIMIhCANnMG/gIwLICqQDwZfwAKNTRuBsCqQ54ACLTspxCCNkxRtlAyQcC0MEYASNrVFIc8+fnGQGeAJnd5wAg/r3ARvi1FUYERgAghUIG0CFcAikB0/8pM9FAHPbnACa1QirQp13/LyXQMEYA8DD4ACgg0bAKFUmIQgHQMEYB4BFIMBgHIQFAwAgALwXQwLIA8Fj4ACgO0BTgakYAIxNwwLIA8D/4AUYBIAApCtFpRgl4ASkG0HYc0ucgRgDwZfj4vQEg+L3ARgAAkG8AHCQAAUbCCAEgKyoI0AVKiRgKRhAyECoC0w8pANkAIHBHwEa4/v//sLUISwNACEwITatCANEAGcUI7bINYAchAUARcBkZSEJIQbC9APz//wAAkG8AAHCQvLUURg1GAakA8Nb7ACgA0Ly9AakJeOlAASIKQCJwvL18tQxGBUYBqv/36v8AKADQfL0BqAB4ASgB0QAgfL0oRiFGAPDX+wAo8tEBrihGIUYyRv/31f8BRjJ4ASBQQAhDQR6IQXy9sLUERgDwF/gAKA7QBUb/95D+wHkBKArR/iEpQAIpBtEoRiFGAPAj+LC9ACCwvUAbQR6IQbC9ELUERishAPAB+QAoC9ArISBGAPAI+QEHB9RBBwfUgQcH1QIgEL0AIBC9BCAQvQMgEL0BIQhAEL3+tQ1GBEb/913+QHoFKA7Q//dY/kB6DigJ0P/3U/5AegIoEtH/907+QHkSKA3TASbwsgQoCdg8IIAbwLIAIf/3hf92HAAo89D+vQAgApABkCchAqoCJihGM0YA8A34Ap8pIQGqKEYzRgDwBvgBmSBGOkYA8JP7/r3wtckAQBjZAAAjDU2ZQhTQxlwBLg/RngquQgHQHkYB4AZMHhkHJzdAASS8QPYI9rKXXSdDl1VbHOjn8L0AAJBvABwkAP61FkYMRhJJAZBAGACQACWsQhnQcF3/KBPQAZhAGYEKDEqRQgHRAJhAGQchAUDACMCyAq86Rv/3G/9wXTl4gUIB0W0c5OcsRgGYIBj+vcBGAACQbwAcJAD4tRRGDUYGRhNPAC0d0LAKuEIB0DBGAeAOSDAYByEBQMAIwLJqRv/39/7/LAHQACwE0WhGAHgAKATQCOBoRgB4oEIE0XYcbR7f5wAg+L0BIPi9wEYAAJBvABwkAPi1DEYAJsWyN0YILwvQIEb4QMAHBdD5sihG//ff/gAoAtF/HPHnMEb4vcBGgAoCSUEYSEJIQXBHAOTb/xC1BkoCQAZLBkyiQgHRwBjACAhg0RhIQkhBEL0A/P//AACQbwAAcJDJAApGCDKRQgXSQ1xJHP8r+dABIHBHACBwR7C1yQBAGApGCDIAIxxGzRiVQgnSxVwBLQHQACUB4AElnUAsQ1sc8ufgsrC9AACAtf/3tP2AvQAgcEcAIHBHgLULRgFGEEYaRv/3Cf6AvYC1//c9/4C9gLX/92X/gL2AtQtGAUYQRhpG//ed/QAoAdAAIMBDgL2wtQxITEYlWAtIJVALSCgYC0kA8O36C0lgVAtIKBh9IckAAPDl+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwg/pwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8HL6KWjJAskOAPBt+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8GD6C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3bPwAKALQAPAK+gHgAPAf+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDl+eQZ9+cFSElGCFhEQyBGAPDc+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwy/mAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAiQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQIkAsAAAAELX/9x38CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECJALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRwAIkD4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAiQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3APwAKAPQ//em+wZ6A+D/95j7ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAiQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAIkAftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEYctQxGaUb/91/9AJgABAAKBUlAGAGp//cz/wAoANAcvQGZIXAcvcBGAQAAA+C1AkgBqf/3Jf+MvQEAACfgtcIG0gpACQADgBhJB0kNQBgDSUAYAan/9xT/jL3ARgEAAAF8tRApAdIBIHy9FEYFRg8gQAYQTklGiFEBqf/3Af8AKADQfL0AIBAoDdBJRokZCRhJaClUKhgLDtNwCwyTcAkKUXAAHe/nSEaAGUBpIHAAIHy9wEYwAAAAvLUDRgEgxEMdH6VCDtMCKwLQLyAABgDgBUgGS0xG4FDjGFlgmmABqf/3zv68vcBGAAEALzAAAACAHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEcAABC1//df/QdIAWgHSExGIFgJCsmySRwA8CP4BElgUP/3J/0QvRAAIUAYAAAAEAAAABC1//dH/QdIAWgHSExGIFgJCsmySRwA8Av4BElgUP/3D/0QvZAAIUAUAAAAEAAAAAAiAwmLQizTAwqLQhHTACOcRk7gA0YLQzzUACJDCItCMdMDCYtCHNMDCotCAdOURj/gwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJBQwiLQgHTSwDAGlJBQRoA0gFGUkEQRnBHXeDKDwDQSUIDEADTQEJTQJxGACIDCYtCLdMDCotCEtOJAfwiEroDCotCDNOJAZIRi0II04kBkhGLQgTTiQE60JIRAOCJCcMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQdnSQwiLQgHTSwDAGlJBQRoA0gFGUkEQRmNGWxAB00BCACsA1UlCcEdjRlsQANNAQgG1BUkAKALcSRwIQADgCEbARsBGAr0Av////38AAAAAAAD///////////8AAAk9AAASegAACT0AAADQBwAJPQCgDwAABAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x579
+  pc_program_page: 0x589
+  pc_erase_sector: 0x585
+  pc_erase_all: 0x581
+  pc_verify: 0x599
+  data_section_offset: 0xd1c
+  flash_properties:
+    address_range:
+      start: 0x90700000
+      end: 0x90700400
+    page_size: 0x400
+    erased_byte_value: 0xff
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x400
+      address: 0x0
+- name: cy8c6xx5
+  description: CY8C6xx5
+  instructions: gLUA8PH5APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAAIECwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwPvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwvfoA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAAACBAAUhJRghccEcFAAAAgLUA8Mv5APDh+QAggL2AtQDwzvkAIIC9gLUA8Af7gL2AtQDwEfuAvfi1DEYHRgEgAQcAII9CBNHhDALQACQA8PX6G0obSxxOtEIK2TlGMUAH0RxIJBjwGUUcOEYA8AT7GOCcQgrZOUYZQAfRFEgkGNgZRRw4RgDwB/sL4JRCE9k5RhFAENENSCQY0BlFHDhGAPDa+gdLBkoBRi9GACwF0AAgACnQ0AHgAUb35whG+L3/AQAA/w8AAP//AwAA/v//APD//wAA/P+AtQDw7fqAvbC1DEYFRgAsCdAoRgDwtPoAKAXRASBAAi0YZB7z5wAgsL3ARrC1BEYGSElGDRgBIEECKEYA8FT7IEYpRgDw4PqwvcBGRAAAALC1ACOZQgbQ1FzFXKxCAdFbHPfnGUYIGLC9ACkH0EMcSR4AeJBCGEb30AEgcEcAIHBHAACAtf/3Xv+AvYC1//df/4C9gLX/91//gL2AtRFG//eu/4C9gLX/99L/gL2Atf/32/+AvXC1FEYFRk4KKEYhRv/3nf8AKAXRASFJAmQYbRh2HvPRcL2AtVEC//dA/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8Pv6C0lgVAtIKBh9IckAAPDz+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwkfpwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8ID6KWjJAskOAPB7+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8G76C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3Cv4AKALQAPD4+QHgAPAN+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDT+eQZ9+cFSElGCFhEQyBGAPDK+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwufmAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAiQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQIkAsAAAAELX/97v9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECJALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRwAIkD4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAiQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3nv0AKAPQ//dE/QZ6A+D/9zb9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAiQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAIkAftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAWAHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEcAABC1//dx/QdIAWgHSExGIFgJCsmySRwA8EP4BElgUP/3Of0QvRAAIUAYAAAAEAAAABC1//dZ/QdIAWgHSExGIFgJCsmySRwA8Cv4BElgUP/3If0QvZAAIUAUAAAAEAAAAAHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAIgMJi0Is0wMKi0IR0wAjnEZO4ANGC0M81AAiQwiLQjHTAwmLQhzTAwqLQgHTlEY/4MMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQUMIi0IB00sAwBpSQUEaANIBRlJBEEZwR13gyg8A0ElCAxAA00BCU0CcRgAiAwmLQi3TAwqLQhLTiQH8IhK6AwqLQgzTiQGSEYtCCNOJAZIRi0IE04kBOtCSEQDgiQnDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkHZ0kMIi0IB00sAwBpSQUEaANIBRlJBEEZjRlsQAdNAQgArANVJQnBHY0ZbEADTQEIBtQVJACgC3EkcCEAA4AhGwEbARgK9AL////9/AAAAAAAA////////////AAAJPQAAEnoAAAk9AAAA0AcACT0AoA8AAAQAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x225
+  pc_program_page: 0x23d
+  pc_erase_sector: 0x235
+  pc_erase_all: 0x22d
+  pc_verify: 0x247
+  data_section_offset: 0x9fc
+  flash_properties:
+    address_range:
+      start: 0x10000000
+      end: 0x10080000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xx5_sect256kb
+  description: CY8C6xx5_sect256KB
+  default: true
+  instructions: gLUA8PH5APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAAIECwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwPvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwvfoA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAAACBAAUhJRghccEcFAAAAgLUA8Mv5APDh+QAggL2AtQDwzvkAIIC9gLUA8Af7gL2AtQDwEfuAvfi1DEYHRgEgAQcAII9CBNHhDALQACQA8PX6G0obSxxOtEIK2TlGMUAH0RxIJBjwGUUcOEYA8AT7GOCcQgrZOUYZQAfRFEgkGNgZRRw4RgDwB/sL4JRCE9k5RhFAENENSCQY0BlFHDhGAPDa+gdLBkoBRi9GACwF0AAgACnQ0AHgAUb35whG+L3/AQAA/w8AAP//AwAA/v//APD//wAA/P+AtQDw7fqAvbC1DEYFRgAsCdAoRgDwtPoAKAXRASBAAi0YZB7z5wAgsL3ARrC1BEYGSElGDRgBIEECKEYA8FT7IEYpRgDw4PqwvcBGRAAAALC1ACOZQgbQ1FzFXKxCAdFbHPfnGUYIGLC9ACkH0EMcSR4AeJBCGEb30AEgcEcAIHBHAACAtf/3Xv+AvYC1//df/4C9gLUA8IP6gL2AtRFG//eu/4C9gLX/99L/gL2Atf/32/+AvXC1FEYFRk4KKEYhRv/3nf8AKAXRASFJAmQYbRh2HvPRcL2AtZEE//dA/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8Pv6C0lgVAtIKBh9IckAAPDz+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwkfpwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8ID6KWjJAskOAPB7+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8G76C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3Cv4AKALQAPD4+QHgAPAN+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDT+eQZ9+cFSElGCFhEQyBGAPDK+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwufmAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAiQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQIkAsAAAAELX/97v9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECJALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRwAIkD4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAiQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3nv0AKAPQ//dE/QZ6A+D/9zb9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAiQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAIkAftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAWAHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEcAABC1//dx/QdIAWgHSExGIFgJCsmySRwA8EP4BElgUP/3Of0QvRAAIUAYAAAAEAAAABC1//dZ/QdIAWgHSExGIFgJCsmySRwA8Cv4BElgUP/3If0QvZAAIUAUAAAAEAAAAAHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAIgMJi0Is0wMKi0IR0wAjnEZO4ANGC0M81AAiQwiLQjHTAwmLQhzTAwqLQgHTlEY/4MMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQUMIi0IB00sAwBpSQUEaANIBRlJBEEZwR13gyg8A0ElCAxAA00BCU0CcRgAiAwmLQi3TAwqLQhLTiQH8IhK6AwqLQgzTiQGSEYtCCNOJAZIRi0IE04kBOtCSEQDgiQnDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkHZ0kMIi0IB00sAwBpSQUEaANIBRlJBEEZjRlsQAdNAQgArANVJQnBHY0ZbEADTQEIBtQVJACgC3EkcCEAA4AhGwEbARgK9AL////9/AAAAAAAA////////////AAAJPQAAEnoAAAk9AAAA0AcACT0AoA8AAAQAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x225
+  pc_program_page: 0x23d
+  pc_erase_sector: 0x235
+  pc_erase_all: 0x22d
+  pc_verify: 0x247
+  data_section_offset: 0x9fc
+  flash_properties:
+    address_range:
+      start: 0x10000000
+      end: 0x10080000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x40000
+      address: 0x0
+- name: cy8c6xxa_wflash
+  description: CY8C6xxA_WFLASH
+  default: true
+  instructions: gLUA8N35APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAAIECwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwKvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwqfoA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAAACBAAUhJRghccEcFAAAAgLUA8Lf5APDN+QAggL2AtQDwuvkAIIC9gLUFIIAGQCEA8AH4gL2wtQxGBUYALAnQKEYA8PX6ACgF0QEgQAItGGQe8+cAILC9gLUA8On6gL34tQxGB0YFIIEGACCPQgTR4QsC0AAkAPDN+htKG0scTrRCCtk5RjFAB9EcSCQY8BlFHDhGAPDc+hjgnEIK2TlGGUAH0RRIJBjYGUUcOEYA8N/6C+CUQhPZOUYRQBDRDUgkGNAZRRw4RgDwsvoHSwZKAUYvRgAsBdAAIAAp0NAB4AFG9+cIRvi9/wEAAP8PAAD//wMAAP7//wDw//8AAPz/gLUA8MX6gL2wtQRGBkhJRg0YASBBAihGAPA++yBGKUYA8Mr6sL3ARkQAAACwtQAjmUIG0NRcxVysQgHRWxz35xlGCBiwvQApB9BDHEkeAHiQQhhG99ABIHBHACBwRwAAgLX/91z/gL2Atf/3Xf+AvYC1//dx/4C9gLURRv/3wP+AvYC1//fS/4C9gLX/99v/gL0AALC1DEhMRiVYC0glUAtIKBgLSQDw+/oLSWBUC0goGH0hyQAA8PP6CUlgUMADCElgULC9wEYQAAAAIAAAAD9CDwBAQg8AKAAAAOcDAAAkAAAAHAAAAHC1OEwgaA8hAUCIADZKgxgdbAcjK0AE0AQrBNABKzRID+AySA3gEFgfIgJAfSAAAhEqAdADRgHgASPbAxAqANAYRgEpD9AAKTvRK00paapokgCSDwEqFNjSHlNCU0EZQ8kHENEt4CNNKWwqaJIAkg8BKhbY0h5TQlNBGUPJBxLRH+ADKh3RKWgcTg5AamgcSRFAAPCR+nBDKWjJAckPSRwN4AMqDdEpaH8iCkBQQyloyQTJDgDwgPopaMkCyQ4A8Hv6IWiJBokPyEAOSUxGYFANSQloCQ5JHADwbvoLSWBQcL3ARoADJkAAAyZAABJ6AAA2bgEABiZAgAUmQP//AwD/HwAAFAAAABAAIUAYAAAAELUJTEhGAF0AKAvR//ce/gAoAtAA8Pj5AeAA8A36SEYBIQFVEL3ARgQAAAD4tQRGCU0LTgtPrEIF00hGgFkA8NP55Bn35wVISUYIWERDIEYA8Mr5+L3ARgGAAAAkAAAAHAAAAACA//+AtQNJSkZRXEhDAPC5+YC9KAAAAIC1//fV/4C9gLX/9+//gL0CSABoAklKRlBQcEcIECJALAAAAARIAmgESUtGWViRQgDQAWBwR8BGCBAiQCwAAAAQtf/3z/0JSQpoCUtMRuJQASMAegAoAdBYBADgGAQQQgDQEL0QQwhgEL3ARggQIkAsAAAA+LUAkg1GASRlQEABDklHGCZGOWgAIAApIkYA2gJGKkMBKhDRACAAKQHaAUYA4AEhDUII0QCYhkIE0gEg//d+/3Yc5ucBIPi9HAAiQPi1DEZAAQhJRRgAJi9oAC8H1HYcpkIE0gEg//dp/wAv9NX4Q8AP+L0AACJA+LUURg1GBkYBJzFoIWAPIAAHCEAFIUkHiEIG0K9CBNIBIP/3T/9/HO/nQBpBHohB+L3ARvC1hbAMRgSQ//ey/QAoA9D/91j9BnoD4P/3Sv0BJkZAHE0ALgTQAS4w0QKUIDUA4AKUfSADkMEAMEb/97H/B0YAKCTRAScEmAFGOUABkRJJAdFIRkAYDCQsQyBgCCAoQwdgACENSjBG//d0/wAoDtEBmAAoAtFIRgdJRBgDmIEAIEYCmv/3ov8HRgDgASc4RgWw8L0AACJAMAAAAJg6AAD4tQOoAiEAkQGRApAEIAYhACITRgDwBvgDmUhCSEEEsIC9wEbwtYewHUYXRgGRApAEIAyZ//dk/w6eMGABJAAoGdENmgaVBZcMTQOoaGABmUGAApkBgCAgKGAEIAAh//cp/zBgACgG0WhoQWgAKQHQASExYIRoIEYHsPC9iAAiQB+1A6wClARMAZR9JOQAAJT/98j/BLAQvZg6AAActQRGASABqf/3XP8AKADQHL0BmKBwAQxhcQAKYHD/IAIwaUb/907/ACjx0QCZIXEKCuJwCgISD+JxCQMJD6FxHL3ARuC1BElKRgRIUFABqf/3OP+MvcBGMAAAAAABAArgtQVJS0YFSlpQWRhIYAGpEEb/9yf/jL0wAAAAAAEAHOC1BUlLRgVKWlBZGEhgAakQRv/3F/+MvTAAAAAAAQAU4LUFSUtGBUpaUFkYSGABqRBG//cH/4y9MAAAAAABAB0ctQdLTEYHSuJQ4xiDJGQAXGCYYNlgAakQRv/38/4cvTAAAAAAAQAGHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/99/+HL0wAAAAAAEABYAcgAgD0EAcgB780QC/cEfv8xCAcrZwR4DzEIhwRwAAELX/93H9B0gBaAdITEYgWAkKybJJHADwQ/gESWBQ//c5/RC9EAAhQBgAAAAQAAAAELX/91n9B0gBaAdITEYgWAkKybJJHADwK/gESWBQ//ch/RC9kAAhQBQAAAAQAAAAAeAEwAkfBCn70osHAdUCgIAcyQcA0AJwcEcAKQvQwwcC0AJwQBxJHgIpBNODBwLVAoCAHIke4+cAIu7nACLf5wAiAwmLQizTAwqLQhHTACOcRk7gA0YLQzzUACJDCItCMdMDCYtCHNMDCotCAdOURj/gwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJBQwiLQgHTSwDAGlJBQRoA0gFGUkEQRnBHXeDKDwDQSUIDEADTQEJTQJxGACIDCYtCLdMDCotCEtOJAfwiEroDCotCDNOJAZIRi0II04kBkhGLQgTTiQE60JIRAOCJCcMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQdnSQwiLQgHTSwDAGlJBQRoA0gFGUkEQRmNGWxAB00BCACsA1UlCcEdjRlsQANNAQgG1BUkAKALcSRwIQADgCEbARsBGAr0Av////38AAAAAAAD///////////8AAAk9AAASegAACT0AAADQBwAJPQCgDwAABAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x229
+  pc_program_page: 0x241
+  pc_erase_sector: 0x239
+  pc_erase_all: 0x231
+  pc_verify: 0x24b
+  data_section_offset: 0x9d4
+  flash_properties:
+    address_range:
+      start: 0x14000000
+      end: 0x14008000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xx6
+  description: CY8C6xx6
+  instructions: gLUA8PH5APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAEIUCwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwPvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwvfoA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAABCFAAUhJRghccEcFAAAAgLUA8Mv5APDh+QAggL2AtQDwzvkAIIC9gLUA8Af7gL2AtQDwEfuAvfi1DEYHRgEgAQcAII9CBNHhDALQACQA8PX6G0obSxxOtEIK2TlGMUAH0RxIJBjwGUUcOEYA8AT7GOCcQgrZOUYZQAfRFEgkGNgZRRw4RgDwB/sL4JRCE9k5RhFAENENSCQY0BlFHDhGAPDa+gdLBkoBRi9GACwF0AAgACnQ0AHgAUb35whG+L3/AQAA/w8AAP//AwAA/v//APD//wAA/P+AtQDw7fqAvbC1DEYFRgAsCdAoRgDwtPoAKAXRASBAAi0YZB7z5wAgsL3ARrC1BEYGSElGDRgBIEECKEYA8FT7IEYpRgDw4PqwvcBGRAAAALC1ACOZQgbQ1FzFXKxCAdFbHPfnGUYIGLC9ACkH0EMcSR4AeJBCGEb30AEgcEcAIHBHAACAtf/3Xv+AvYC1//df/4C9gLX/91//gL2AtRFG//eu/4C9gLX/99L/gL2Atf/32/+AvXC1FEYFRk4KKEYhRv/3nf8AKAXRASFJAmQYbRh2HvPRcL2AtVEC//dA/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8Pv6C0lgVAtIKBh9IckAAPDz+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwkfpwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8ID6KWjJAskOAPB7+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8G76C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3Cv4AKALQAPD4+QHgAPAN+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDT+eQZ9+cFSElGCFhEQyBGAPDK+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwufmAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAjQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQI0AsAAAAELX/97v9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECNALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRAAI0D4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAjQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3nv0AKAPQ//dE/QZ6A+D/9zb9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAjQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAI0AftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAWAHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEcAABC1//dx/QdIAWgHSExGIFgJCsmySRwA8EP4BElgUP/3Of0QvRAAIUAYAAAAEAAAABC1//dZ/QdIAWgHSExGIFgJCsmySRwA8Cv4BElgUP/3If0QvZAAIUAUAAAAEAAAAAHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAIgMJi0Is0wMKi0IR0wAjnEZO4ANGC0M81AAiQwiLQjHTAwmLQhzTAwqLQgHTlEY/4MMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQUMIi0IB00sAwBpSQUEaANIBRlJBEEZwR13gyg8A0ElCAxAA00BCU0CcRgAiAwmLQi3TAwqLQhLTiQH8IhK6AwqLQgzTiQGSEYtCCNOJAZIRi0IE04kBOtCSEQDgiQnDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkHZ0kMIi0IB00sAwBpSQUEaANIBRlJBEEZjRlsQAdNAQgArANVJQnBHY0ZbEADTQEIBtQVJACgC3EkcCEAA4AhGwEbARgK9AL////9/AAAAAAAA////////////AAAJPQAAEnoAAAk9AAAA0AcACT0AoA8AAAQAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x225
+  pc_program_page: 0x23d
+  pc_erase_sector: 0x235
+  pc_erase_all: 0x22d
+  pc_verify: 0x247
+  data_section_offset: 0x9fc
+  flash_properties:
+    address_range:
+      start: 0x10000000
+      end: 0x10080000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xx6_sect256kb
+  description: CY8C6xx6_sect256KB
+  default: true
+  instructions: gLUA8PH5APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAEIUCwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwPvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwvfoA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAABCFAAUhJRghccEcFAAAAgLUA8Mv5APDh+QAggL2AtQDwzvkAIIC9gLUA8Af7gL2AtQDwEfuAvfi1DEYHRgEgAQcAII9CBNHhDALQACQA8PX6G0obSxxOtEIK2TlGMUAH0RxIJBjwGUUcOEYA8AT7GOCcQgrZOUYZQAfRFEgkGNgZRRw4RgDwB/sL4JRCE9k5RhFAENENSCQY0BlFHDhGAPDa+gdLBkoBRi9GACwF0AAgACnQ0AHgAUb35whG+L3/AQAA/w8AAP//AwAA/v//APD//wAA/P+AtQDw7fqAvbC1DEYFRgAsCdAoRgDwtPoAKAXRASBAAi0YZB7z5wAgsL3ARrC1BEYGSElGDRgBIEECKEYA8FT7IEYpRgDw4PqwvcBGRAAAALC1ACOZQgbQ1FzFXKxCAdFbHPfnGUYIGLC9ACkH0EMcSR4AeJBCGEb30AEgcEcAIHBHAACAtf/3Xv+AvYC1//df/4C9gLUA8IP6gL2AtRFG//eu/4C9gLX/99L/gL2Atf/32/+AvXC1FEYFRk4KKEYhRv/3nf8AKAXRASFJAmQYbRh2HvPRcL2AtZEE//dA/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8Pv6C0lgVAtIKBh9IckAAPDz+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwkfpwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8ID6KWjJAskOAPB7+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8G76C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3Cv4AKALQAPD4+QHgAPAN+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDT+eQZ9+cFSElGCFhEQyBGAPDK+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwufmAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAjQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQI0AsAAAAELX/97v9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECNALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRAAI0D4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAjQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3nv0AKAPQ//dE/QZ6A+D/9zb9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAjQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAI0AftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAWAHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEcAABC1//dx/QdIAWgHSExGIFgJCsmySRwA8EP4BElgUP/3Of0QvRAAIUAYAAAAEAAAABC1//dZ/QdIAWgHSExGIFgJCsmySRwA8Cv4BElgUP/3If0QvZAAIUAUAAAAEAAAAAHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAIgMJi0Is0wMKi0IR0wAjnEZO4ANGC0M81AAiQwiLQjHTAwmLQhzTAwqLQgHTlEY/4MMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQUMIi0IB00sAwBpSQUEaANIBRlJBEEZwR13gyg8A0ElCAxAA00BCU0CcRgAiAwmLQi3TAwqLQhLTiQH8IhK6AwqLQgzTiQGSEYtCCNOJAZIRi0IE04kBOtCSEQDgiQnDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkHZ0kMIi0IB00sAwBpSQUEaANIBRlJBEEZjRlsQAdNAQgArANVJQnBHY0ZbEADTQEIBtQVJACgC3EkcCEAA4AhGwEbARgK9AL////9/AAAAAAAA////////////AAAJPQAAEnoAAAk9AAAA0AcACT0AoA8AAAQAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x225
+  pc_program_page: 0x23d
+  pc_erase_sector: 0x235
+  pc_erase_all: 0x22d
+  pc_verify: 0x247
+  data_section_offset: 0x9fc
+  flash_properties:
+    address_range:
+      start: 0x10000000
+      end: 0x10080000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x40000
+      address: 0x0
+- name: cy8c6xxx_wflash
+  description: CY8C6xxx_WFLASH
+  default: true
+  instructions: gLUA8N35APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAEIUCwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwKvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwqfoA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAABCFAAUhJRghccEcFAAAAgLUA8Lf5APDN+QAggL2AtQDwuvkAIIC9gLUFIIAGQCEA8AH4gL2wtQxGBUYALAnQKEYA8PX6ACgF0QEgQAItGGQe8+cAILC9gLUA8On6gL34tQxGB0YFIIEGACCPQgTR4QsC0AAkAPDN+htKG0scTrRCCtk5RjFAB9EcSCQY8BlFHDhGAPDc+hjgnEIK2TlGGUAH0RRIJBjYGUUcOEYA8N/6C+CUQhPZOUYRQBDRDUgkGNAZRRw4RgDwsvoHSwZKAUYvRgAsBdAAIAAp0NAB4AFG9+cIRvi9/wEAAP8PAAD//wMAAP7//wDw//8AAPz/gLUA8MX6gL2wtQRGBkhJRg0YASBBAihGAPA++yBGKUYA8Mr6sL3ARkQAAACwtQAjmUIG0NRcxVysQgHRWxz35xlGCBiwvQApB9BDHEkeAHiQQhhG99ABIHBHACBwRwAAgLX/91z/gL2Atf/3Xf+AvYC1//dx/4C9gLURRv/3wP+AvYC1//fS/4C9gLX/99v/gL0AALC1DEhMRiVYC0glUAtIKBgLSQDw+/oLSWBUC0goGH0hyQAA8PP6CUlgUMADCElgULC9wEYQAAAAIAAAAD9CDwBAQg8AKAAAAOcDAAAkAAAAHAAAAHC1OEwgaA8hAUCIADZKgxgdbAcjK0AE0AQrBNABKzRID+AySA3gEFgfIgJAfSAAAhEqAdADRgHgASPbAxAqANAYRgEpD9AAKTvRK00paapokgCSDwEqFNjSHlNCU0EZQ8kHENEt4CNNKWwqaJIAkg8BKhbY0h5TQlNBGUPJBxLRH+ADKh3RKWgcTg5AamgcSRFAAPCR+nBDKWjJAckPSRwN4AMqDdEpaH8iCkBQQyloyQTJDgDwgPopaMkCyQ4A8Hv6IWiJBokPyEAOSUxGYFANSQloCQ5JHADwbvoLSWBQcL3ARoADJkAAAyZAABJ6AAA2bgEABiZAgAUmQP//AwD/HwAAFAAAABAAIUAYAAAAELUJTEhGAF0AKAvR//ce/gAoAtAA8Pj5AeAA8A36SEYBIQFVEL3ARgQAAAD4tQRGCU0LTgtPrEIF00hGgFkA8NP55Bn35wVISUYIWERDIEYA8Mr5+L3ARgGAAAAkAAAAHAAAAACA//+AtQNJSkZRXEhDAPC5+YC9KAAAAIC1//fV/4C9gLX/9+//gL0CSABoAklKRlBQcEcIECNALAAAAARIAmgESUtGWViRQgDQAWBwR8BGCBAjQCwAAAAQtf/3z/0JSQpoCUtMRuJQASMAegAoAdBYBADgGAQQQgDQEL0QQwhgEL3ARggQI0AsAAAA+LUAkg1GASRlQEABDklHGCZGOWgAIAApIkYA2gJGKkMBKhDRACAAKQHaAUYA4AEhDUII0QCYhkIE0gEg//d+/3Yc5ucBIPi9EAAjQPi1DEZAAQhJRRgAJi9oAC8H1HYcpkIE0gEg//dp/wAv9NX4Q8AP+L0AACNA+LUURg1GBkYBJzFoIWAPIAAHCEAFIUkHiEIG0K9CBNIBIP/3T/9/HO/nQBpBHohB+L3ARvC1hbAMRgSQ//ey/QAoA9D/91j9BnoD4P/3Sv0BJkZAHE0ALgTQAS4w0QKUIDUA4AKUfSADkMEAMEb/97H/B0YAKCTRAScEmAFGOUABkRJJAdFIRkAYDCQsQyBgCCAoQwdgACENSjBG//d0/wAoDtEBmAAoAtFIRgdJRBgDmIEAIEYCmv/3ov8HRgDgASc4RgWw8L0AACNAMAAAAJg6AAD4tQOoAiEAkQGRApAEIAYhACITRgDwBvgDmUhCSEEEsIC9wEbwtYewHUYXRgGRApAEIAyZ//dk/w6eMGABJAAoGdENmgaVBZcMTQOoaGABmUGAApkBgCAgKGAEIAAh//cp/zBgACgG0WhoQWgAKQHQASExYIRoIEYHsPC9iAAjQB+1A6wClARMAZR9JOQAAJT/98j/BLAQvZg6AAActQRGASABqf/3XP8AKADQHL0BmKBwAQxhcQAKYHD/IAIwaUb/907/ACjx0QCZIXEKCuJwCgISD+JxCQMJD6FxHL3ARuC1BElKRgRIUFABqf/3OP+MvcBGMAAAAAABAArgtQVJS0YFSlpQWRhIYAGpEEb/9yf/jL0wAAAAAAEAHOC1BUlLRgVKWlBZGEhgAakQRv/3F/+MvTAAAAAAAQAU4LUFSUtGBUpaUFkYSGABqRBG//cH/4y9MAAAAAABAB0ctQdLTEYHSuJQ4xiDJGQAXGCYYNlgAakQRv/38/4cvTAAAAAAAQAGHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/99/+HL0wAAAAAAEABYAcgAgD0EAcgB780QC/cEfv8xCAcrZwR4DzEIhwRwAAELX/93H9B0gBaAdITEYgWAkKybJJHADwQ/gESWBQ//c5/RC9EAAhQBgAAAAQAAAAELX/91n9B0gBaAdITEYgWAkKybJJHADwK/gESWBQ//ch/RC9kAAhQBQAAAAQAAAAAeAEwAkfBCn70osHAdUCgIAcyQcA0AJwcEcAKQvQwwcC0AJwQBxJHgIpBNODBwLVAoCAHIke4+cAIu7nACLf5wAiAwmLQizTAwqLQhHTACOcRk7gA0YLQzzUACJDCItCMdMDCYtCHNMDCotCAdOURj/gwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJBQwiLQgHTSwDAGlJBQRoA0gFGUkEQRnBHXeDKDwDQSUIDEADTQEJTQJxGACIDCYtCLdMDCotCEtOJAfwiEroDCotCDNOJAZIRi0II04kBkhGLQgTTiQE60JIRAOCJCcMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQdnSQwiLQgHTSwDAGlJBQRoA0gFGUkEQRmNGWxAB00BCACsA1UlCcEdjRlsQANNAQgG1BUkAKALcSRwIQADgCEbARsBGAr0Av////38AAAAAAAD///////////8AAAk9AAASegAACT0AAADQBwAJPQCgDwAABAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x229
+  pc_program_page: 0x241
+  pc_erase_sector: 0x239
+  pc_erase_all: 0x231
+  pc_verify: 0x24b
+  data_section_offset: 0x9d4
+  flash_properties:
+    address_range:
+      start: 0x14000000
+      end: 0x14008000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xxx_sflash_user
+  description: CY8C6xxx_SFLASH_USER
+  default: true
+  instructions: gLUA8AP6APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAEIUCwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwUPsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwz/oA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAABCFAAUhJRghccEcFAAAAgLUA8N35APDz+QAggL2AtQDw4PkAIIC9gLUCSAQhAPAD+IC9AAgAFrC1DEYFRgAsCdAoRgDwKvgAKAXRASBAAi0YZB7z5wAgsL3ARoC1wQoKSpFCDNBBCglKkUII0AlJQRiJCgMpA9OBCgdKkUIC0QDwDPiAvQAggL3ARgHAAgANAAsAAKb/6R+ABQCwtQRGBkhJRg0YASBBAihGAPCc+yBGKUYA8Cb7sL3ARkQAAAD4tQxGBUYAICFKIkmNQgTRlEIC2QAkAPDD+h9KIE60QgzZfyHJAmkYMUIK0R9IJBhwGUccKEYA8NH6H+AXSYxCBdkTSUkZSRwUSxlCDtCUQgrZKUYRQAfREkgkGFAZRxwoRgDwq/oJ4AFGCuAOSCQYCkhAGUccKEYA8MD6BkoBRj1GACwC0AAgACnI0AhG+L3/BwAAAAgAFv8BAAD/DwAA//8DAAD+//8A8P//AAD8/4C1APDH+oC9sLUAI5lCBtDUXMVcrEIB0Vsc9+cZRggYsL0AKQfQQxxJHgB4kEIYRvfQASBwRwAgcEcAAIC1//c2/4C9gLX/9zf/gL2Atf/3Tf+AvYC1EUb/99L/gL2Atf/30v+AvYC1//fb/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8P36C0lgVAtIKBh9IckAAPD1+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwk/pwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8IL6KWjJAskOAPB9+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8HD6C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3+P0AKALQAPD6+QHgAPAP+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDV+eQZ9+cFSElGCFhEQyBGAPDM+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwu/mAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAjQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQI0AsAAAAELX/96n9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECNALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRAAI0D4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAjQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3jP0AKAPQ//cy/QZ6A+D/9yT9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAjQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAI0AftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAUAAAAAgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHAAAQtf/3b/0HSAFoB0hMRiBYCQrJskkcAPBD+ARJYFD/9zf9EL0QACFAGAAAABAAAAAQtf/3V/0HSAFoB0hMRiBYCQrJskkcAPAr+ARJYFD/9x/9EL2QACFAFAAAABAAAAAB4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nACIDCYtCLNMDCotCEdMAI5xGTuADRgtDPNQAIkMIi0Ix0wMJi0Ic0wMKi0IB05RGP+DDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkFDCItCAdNLAMAaUkFBGgDSAUZSQRBGcEdd4MoPANBJQgMQANNAQlNAnEYAIgMJi0It0wMKi0IS04kB/CISugMKi0IM04kBkhGLQgjTiQGSEYtCBNOJATrQkhEA4IkJwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJB2dJDCItCAdNLAMAaUkFBGgDSAUZSQRBGY0ZbEAHTQEIAKwDVSUJwR2NGWxAA00BCAbUFSQAoAtxJHAhAAOAIRsBGwEYCvQC/////fwAAAAAAAP///////////wAACT0AABJ6AAAJPQAAANAHAAk9AKAPAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x275
+  pc_program_page: 0x28d
+  pc_erase_sector: 0x285
+  pc_erase_all: 0x27d
+  pc_verify: 0x297
+  data_section_offset: 0xa24
+  flash_properties:
+    address_range:
+      start: 0x16000800
+      end: 0x16001000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xxx_sflash_nar
+  description: CY8C6xxx_SFLASH_NAR
+  instructions: gLUA8Cn6APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAEIUCwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwdvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADw9foA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAABCFAAUhJRghccEcFAAAAgLUA8AP6APAZ+gAggL2AtQDwBvoAIIC9gLUCSAEhAPAD+IC9ABoAFrC1DEYFRgAsCdAoRgDwKvgAKAXRASBAAi0YZB7z5wAgsL3ARoC1wQoKSpFCDNBBCglKkUII0AlJQRiJCgMpA9OBCgdKkUIC0QDwDPiAvQAggL3ARgHAAgANAAsAAKb/6R+ABQCwtQRGBkhJRg0YASBBAihGAPDA+yBGKUYA8Ez7sL3ARkQAAAD4tQxGBUYAICBPIUmNQgTRvEIC2QAkAPDp+h9OtEIL2R5JaRgxQgrRH0gkGHAZRxwoRgDw+fof4BZJjEIF2QMhSQJpGBNKEUIO0LxCCtkpRjlAB9ESSCQYeBlHHChGAPDT+gngAUYK4A5IJBgJSEAZRxwoRgDw6PoBRj1GA08ALALQACAAKcnQCEb4vf8BAAAAGgAW/w8AAP//AwAA5gMAAP7//wDw//8AAPz/gLUA8O/6gL3wtRJMA0ZjQAElbgJOQB5DdUJ1QQAuC9EAJg1LAi4F0JddhF12HKdC+NAISwAtCtEAI5lCBtDUXMVcrEIB0Vsc9+cZRgsYGEbwvcBGABoAFgAcABawtQNGCUxEQAEgRQJNQCVDANECIQApBtBcHEkeG3iTQiNG99CwvQAgsL3ARgAaABaAtf/3EP+AvYC1//cR/4C9gLX/9yf/gL2AtRFG//eq/4C9gLX/96r/gL2Atf/30P+AvQAAsLUMSExGJVgLSCVQC0goGAtJAPD7+gtJYFQLSCgYfSHJAADw8/oJSWBQwAMISWBQsL3ARhAAAAAgAAAAP0IPAEBCDwAoAAAA5wMAACQAAAAcAAAAcLU4TCBoDyEBQIgANkqDGB1sByMrQATQBCsE0AErNEgP4DJIDeAQWB8iAkB9IAACESoB0ANGAeABI9sDECoA0BhGASkP0AApO9ErTSlpqmiSAJIPASoU2NIeU0JTQRlDyQcQ0S3gI00pbCpokgCSDwEqFtjSHlNCU0EZQ8kHEtEf4AMqHdEpaBxODkBqaBxJEUAA8JH6cEMpaMkByQ9JHA3gAyoN0SlofyIKQFBDKWjJBMkOAPCA+iloyQLJDgDwe/ohaIkGiQ/IQA5JTEZgUA1JCWgJDkkcAPBu+gtJYFBwvcBGgAMmQAADJkAAEnoAADZuAQAGJkCABSZA//8DAP8fAAAUAAAAEAAhQBgAAAAQtQlMSEYAXQAoC9H/99L9ACgC0ADw+PkB4ADwDfpIRgEhAVUQvcBGBAAAAPi1BEYJTQtOC0+sQgXTSEaAWQDw0/nkGffnBUhJRghYREMgRgDwyvn4vcBGAYAAACQAAAAcAAAAAID//4C1A0lKRlFcSEMA8Ln5gL0oAAAAgLX/99X/gL2Atf/37/+AvQJIAGgCSUpGUFBwRwgQI0AsAAAABEgCaARJS0ZZWJFCANABYHBHwEYIECNALAAAABC1//eD/QlJCmgJS0xG4lABIwB6ACgB0FgEAOAYBBBCANAQvRBDCGAQvcBGCBAjQCwAAAD4tQCSDUYBJGVAQAEOSUcYJkY5aAAgACkiRgDaAkYqQwEqENEAIAApAdoBRgDgASENQgjRAJiGQgTSASD/937/dhzm5wEg+L0QACNA+LUMRkABCElFGAAmL2gALwfUdhymQgTSASD/92n/AC/01fhDwA/4vQAAI0D4tRRGDUYGRgEnMWghYA8gAAcIQAUhSQeIQgbQr0IE0gEg//dP/38c7+dAGkEeiEH4vcBG8LWFsAxGBJD/92b9ACgD0P/3DP0GegPg//f+/AEmRkAcTQAuBNABLjDRApQgNQDgApR9IAOQwQAwRv/3sf8HRgAoJNEBJwSYAUY5QAGREkkB0UhGQBgMJCxDIGAIIChDB2AAIQ1KMEb/93T/ACgO0QGYACgC0UhGB0lEGAOYgQAgRgKa//ei/wdGAOABJzhGBbDwvQAAI0AwAAAAmDoAAPi1A6gCIQCRAZECkAQgBiEAIhNGAPAG+AOZSEJIQQSwgL3ARvC1h7AdRhdGAZECkAQgDJn/92T/Dp4wYAEkACgZ0Q2aBpUFlwxNA6hoYAGZQYACmQGAICAoYAQgACH/9yn/MGAAKAbRaGhBaAApAdABITFghGggRgew8L2IACNAH7UDrAKUBEwBlH0k5AAAlP/3yP8EsBC9mDoAABy1BEYBIAGp//dc/wAoANAcvQGYoHABDGFxAApgcP8gAjBpRv/3Tv8AKPHRAJkhcQoK4nAKAhIP4nEJAwkPoXEcvcBG4LUESUpGBEhQUAGp//c4/4y9wEYwAAAAAAEACuC1BUlLRgVKWlBZGEhgAakQRv/3J/+MvTAAAAAAAQAc4LUFSUtGBUpaUFkYSGABqRBG//cX/4y9MAAAAAABABTgtQVJS0YFSlpQWRhIYAGpEEb/9wf/jL0wAAAAAAEAHRy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//fz/hy9MAAAAAABAAYctQdLTEYHSuJQ4xiDJGQAXGCYYNlgAakQRv/33/4cvTAAAAAAAQAFgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHAAAQtf/3cf0HSAFoB0hMRiBYCQrJskkcAPBD+ARJYFD/9zn9EL0QACFAGAAAABAAAAAQtf/3Wf0HSAFoB0hMRiBYCQrJskkcAPAr+ARJYFD/9yH9EL2QACFAFAAAABAAAAAB4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nACIDCYtCLNMDCotCEdMAI5xGTuADRgtDPNQAIkMIi0Ix0wMJi0Ic0wMKi0IB05RGP+DDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkFDCItCAdNLAMAaUkFBGgDSAUZSQRBGcEdd4MoPANBJQgMQANNAQlNAnEYAIgMJi0It0wMKi0IS04kB/CISugMKi0IM04kBkhGLQgjTiQGSEYtCBNOJATrQkhEA4IkJwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJB2dJDCItCAdNLAMAaUkFBGgDSAUZSQRBGY0ZbEAHTQEIAKwDVSUJwR2NGWxAA00BCAbUFSQAoAtxJHAhAAOAIRsBGwEYCvQC/////fwAAAAAAAP///////////wAACT0AABJ6AAAJPQAAANAHAAk9AKAPAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x2c1
+  pc_program_page: 0x2d9
+  pc_erase_sector: 0x2d1
+  pc_erase_all: 0x2c9
+  pc_verify: 0x2e3
+  data_section_offset: 0xa6c
+  flash_properties:
+    address_range:
+      start: 0x16001a00
+      end: 0x16001c00
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xxx_sflash_pkey
+  description: CY8C6xxx_SFLASH_PKEY
+  default: true
+  instructions: gLUA8AP6APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAEIUCwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwUPsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwz/oA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAABCFAAUhJRghccEcFAAAAgLUA8N35APDz+QAggL2AtQDw4PkAIIC9gLUCSAYhAPAD+IC9AFoAFrC1DEYFRgAsCdAoRgDwKvgAKAXRASBAAi0YZB7z5wAgsL3ARoC1wQoKSpFCDNBBCglKkUII0AlJQRiJCgMpA9OBCgdKkUIC0QDwDPiAvQAggL3ARgHAAgANAAsAAKb/6R+ABQCwtQRGBkhJRg0YASBBAihGAPCc+yBGKUYA8Cb7sL3ARkQAAAD4tQxGBUYAICFJjUIF0aEKAykC0wAkAPDD+h5KH0+8QgvZH0lpGDlCCtEgSCQYeBlGHChGAPDS+h/gF0mMQgXZAyFJAmkYFEsZQg7QlEIK2SlGEUAH0RNIJBhQGUYcKEYA8Kz6CeABRgrgD0gkGApIQBlGHChGAPDB+gZKAUY1RgAsAtAAIAApydAIRvi9wEYAWgAW/wEAAP8PAAD//wMAAKYDAAD+//8A8P//AAD8/4C1APDH+oC9sLUAI5lCBtDUXMVcrEIB0Vsc9+cZRggYsL0AKQfQQxxJHgB4kEIYRvfQASBwRwAgcEcAAIC1//c2/4C9gLX/9zf/gL2Atf/3Tf+AvYC1EUb/99L/gL2Atf/30v+AvYC1//fb/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8P36C0lgVAtIKBh9IckAAPD1+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwk/pwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8IL6KWjJAskOAPB9+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8HD6C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3+P0AKALQAPD6+QHgAPAP+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDV+eQZ9+cFSElGCFhEQyBGAPDM+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwu/mAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAjQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQI0AsAAAAELX/96n9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECNALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRAAI0D4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAjQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3jP0AKAPQ//cy/QZ6A+D/9yT9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAjQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAI0AftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAUAAAAAgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHAAAQtf/3b/0HSAFoB0hMRiBYCQrJskkcAPBD+ARJYFD/9zf9EL0QACFAGAAAABAAAAAQtf/3V/0HSAFoB0hMRiBYCQrJskkcAPAr+ARJYFD/9x/9EL2QACFAFAAAABAAAAAB4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nACIDCYtCLNMDCotCEdMAI5xGTuADRgtDPNQAIkMIi0Ix0wMJi0Ic0wMKi0IB05RGP+DDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkFDCItCAdNLAMAaUkFBGgDSAUZSQRBGcEdd4MoPANBJQgMQANNAQlNAnEYAIgMJi0It0wMKi0IS04kB/CISugMKi0IM04kBkhGLQgjTiQGSEYtCBNOJATrQkhEA4IkJwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJB2dJDCItCAdNLAMAaUkFBGgDSAUZSQRBGY0ZbEAHTQEIAKwDVSUJwR2NGWxAA00BCAbUFSQAoAtxJHAhAAOAIRsBGwEYCvQC/////fwAAAAAAAP///////////wAACT0AABJ6AAAJPQAAANAHAAk9AKAPAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x275
+  pc_program_page: 0x28d
+  pc_erase_sector: 0x285
+  pc_erase_all: 0x27d
+  pc_verify: 0x297
+  data_section_offset: 0xa24
+  flash_properties:
+    address_range:
+      start: 0x16005a00
+      end: 0x16006600
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xxx_sflash_toc2
+  description: CY8C6xxx_SFLASH_TOC2
+  default: true
+  instructions: gLUA8AP6APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAEIUCwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwUPsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwz/oA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAABCFAAUhJRghccEcFAAAAgLUA8N35APDz+QAggL2AtQDw4PkAIIC9gLUCSAIhAPAD+IC9AHwAFrC1DEYFRgAsCdAoRgDwKvgAKAXRASBAAi0YZB7z5wAgsL3ARoC1wQoKSpFCDNBBCglKkUII0AlJQRiJCgMpA9OBCgdKkUIC0QDwDPiAvQAggL3ARgHAAgANAAsAAKb/6R+ABQCwtQRGBkhJRg0YASBBAihGAPCc+yBGKUYA8Cb7sL3ARkQAAAD4tQxGBUYAICFKIkmNQgTRlEIC2QAkAPDD+h9KIE60QgzZ4SGJAmkYMUIK0R9IJBhwGUccKEYA8NH6H+AXSYxCBdkTSUkZSRwUSxlCDtCUQgrZKUYRQAfREkgkGFAZRxwoRgDwq/oJ4AFGCuAOSCQYCkhAGUccKEYA8MD6BkoBRj1GACwC0AAgACnI0AhG+L3/AwAAAHwAFv8BAAD/DwAA//8DAAD+//8A8P//AAD8/4C1APDH+oC9sLUAI5lCBtDUXMVcrEIB0Vsc9+cZRggYsL0AKQfQQxxJHgB4kEIYRvfQASBwRwAgcEcAAIC1//c2/4C9gLX/9zf/gL2Atf/3Tf+AvYC1EUb/99L/gL2Atf/30v+AvYC1//fb/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8P36C0lgVAtIKBh9IckAAPD1+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwk/pwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8IL6KWjJAskOAPB9+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8HD6C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3+P0AKALQAPD6+QHgAPAP+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDV+eQZ9+cFSElGCFhEQyBGAPDM+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwu/mAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAjQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQI0AsAAAAELX/96n9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECNALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRAAI0D4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAjQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3jP0AKAPQ//cy/QZ6A+D/9yT9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAjQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAI0AftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAUAAAAAgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHAAAQtf/3b/0HSAFoB0hMRiBYCQrJskkcAPBD+ARJYFD/9zf9EL0QACFAGAAAABAAAAAQtf/3V/0HSAFoB0hMRiBYCQrJskkcAPAr+ARJYFD/9x/9EL2QACFAFAAAABAAAAAB4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nACIDCYtCLNMDCotCEdMAI5xGTuADRgtDPNQAIkMIi0Ix0wMJi0Ic0wMKi0IB05RGP+DDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkFDCItCAdNLAMAaUkFBGgDSAUZSQRBGcEdd4MoPANBJQgMQANNAQlNAnEYAIgMJi0It0wMKi0IS04kB/CISugMKi0IM04kBkhGLQgjTiQGSEYtCBNOJATrQkhEA4IkJwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJB2dJDCItCAdNLAMAaUkFBGgDSAUZSQRBGY0ZbEAHTQEIAKwDVSUJwR2NGWxAA00BCAbUFSQAoAtxJHAhAAOAIRsBGwEYCvQC/////fwAAAAAAAP///////////wAACT0AABJ6AAAJPQAAANAHAAk9AKAPAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x275
+  pc_program_page: 0x28d
+  pc_erase_sector: 0x285
+  pc_erase_all: 0x27d
+  pc_verify: 0x297
+  data_section_offset: 0xa24
+  flash_properties:
+    address_range:
+      start: 0x16007c00
+      end: 0x16008000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xxx_smif
+  description: CY8C6xxx_SMIF
+  instructions: ELUERgLwzvsgRgDwMfoQvQ8gAAICSQloAUBIQkhBcEcABCFAsLUtTUhGQF0AKFHRDyAAAipJCWgBQEgegUFIRkAZAXIC8Br9BEYAKD7RSEZAGUB4ASgt0UhGQRnIeIl4ACkF0eIoA9FIRkAZACEg4AIpBdHkKAPRSEZAGQIhGOAFKQXR5ygD0UhGQBkFIRDgDikF0eooA9FIRkAZDiEI4BUpB9HtKAXRSEZAGQEhwXIVIUFySEZAGQB6ACgC0ALwj/wA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARkQKAAAABCFAAUhJRghccEdECgAAELUuSElGDBgtSAFoYWCBaiFhwWphYQFroWFBauFggWmhYEBr4GEnSAFoIWJBaGFiJUkKaKJiimpiY8pqomMKa+JjSmoiY4pp4mJJayFkAW9hZEBvoGQdSAFo4WSBaqFlwWrhZQFrIWZBamFlgWkhZUBrYGYWSAFooWZBaOFmFUkKaCJnimriZyJGcDLLahNhC2tTYUtqo2eLaWNnSWuRYQFp0WFAaRBi//dE/8B6gAAJSUBYlCFgUBC9wEYMDAAAgAAyQBAAMUAABDJAgAUyQLAAMUAABjJAgAMmQPi1//cp/8B6hQAZSChYGUxJRgkZlCfJWYhCENBIRgYZ//ca//JZgHoAKAXQAyAGIQAjAvAv/ALgDUgoGAJgTkY0GSEdDEgQT39EuEchRigxCki4RyFGTDEJTShGuEdwNIA1KEYhRrhHBkgAITFU+L2AAyZADAwAAIAAMkAABDJAgAUyQAQAAADtIwAA8LWnsDZJSEZAXAAkAChj0QKUNEhJRggYlCFAWAEk5QcFQ4VCFdD/99H+xnr/987+gHotTwAoBtADIAYhACMqRgLw4vsB4LAAPVCwADhYqEJC0R6tKB0gIQGRAvDW/yNIJZBoICGQAyAekCFIJkx8RClGoEcVrzgdGCUpRgLwxf8cSB2QHJAcSBiQ/yAVkBtOMEY5RqBHDK84HSlGAvC1/xEgFJATSBOQFUgPkB8gDJCANjBGOUagRwOtKB0BmQLwpP8LIAaQASYDlg5IKUagR0hGA0lGVAKcIEYnsPC9wEYEAAAADAwAAIADJkASEgAAAAQyQBERERFm5u5ugAUyQO7uBgCAADJAOyMAAPi1GU9IRsBdACYAKAHQNEYN4BZIBWgBJAAtCNAoDw4oBdgoaAAoAtARSYhCAdkgRvi9KEYC8NL7ACgN0ChGAvDt+wAo89AKSYhC8NgAaAAo7dCIQuvYAOAoaElGASLKVQRKiFDT58BGCAAAAAx8ABb////vdAoAAPC1E0pLRppYE2gAJOWyq0IY2a0AVmh1WQAtEdAuDw4uDtguebYHC9Uuaa9pf2i+QgDTPkbvaIdCAti+GYZCA9hkHOPnASDwvQ1gACDwvcBGdAoAAHC1DkpLRppYE2gAJOWyq0IP2a0AVmh1WQAtCNAuDw4uBdguebYHAtVuaY5CA9BkHOznASBwvQVgACBwvXQKAAActQRG//c8/v/37v4AKADQHL3/92//ACgG0QdISUYIGADwDPgAKAHQASAcvQGpIEb/95z/HL3ARmAKAAD4tQVGK0pIRoBYACgG0AEPDikD2KhCAdEAJkngSEYAJIRQJU/DGX0gwgAkSClGAPAx+wEmACg70QCUSEbBGR9POEYA8F/9KGgBKAPRACE4RgDwWfsaTEhGAVkXSoIYOEYA8Lr+ACgj0UhGEklFUChoASgD0QEhOEYA8EX7SEYAWQWIAJ4MT65CEdJIRgBZQGixAEFYACkI0IhpwGsAKATQSEbCGQVIAfDP+3Yc6+cAnjBG+L1wCgAAeAoAAAAAQkB0CgAAELUJTEhGAFkAKAjQAA8OKAXYBkgA8P76SEYAIQFR//cd/gAgEL3ARnAKAAAAAEJA/rUjTEhGAFkGaAAnApcBl/iyhkI62UlGCVlJaIAADVgALTHQKA8OKC7YaGiBByvVaWkAKQjQACIEKgXQAqubXFIcmUL40R/gSh6RQSppykBABwPVqGlBaJFCANMRRuhoAPAY+AAoEtFoaQAoDNADIclDACkI0AKqUhgSeUkcACr30AKqURjIcH8cwecBmP69dAoAAPC1jbAMRgZGACUMlQuVDKn/98r+B0YAKALQOEYNsPC9DJgIkEFpACkF0Auo//fm/gdGACjx0V1ISUYIGP/3HP8AKAHQASfo51lJCJgA8Lj4B0YAKOHRCJmIaYBpBpDIaAqVMBoHkAuYApBSTgAsANGa4DBGBJUlRktGT0qaGAxGAfCu+gEnACjH0WBpACgiRixGBJ0J0EhGR0lCGDBGApkB8J76CJoAKLfRcGgAKPzUACADkAmQCakQRgeaAfDq+wNGPkiDQgWUAdAAKx/RAZMJmAAoBp8A0MdoCJiAaQJoCqwHmCFGAPCZ+AWYuEIA0zhGBpBIRjBJQxgwRgifOUYiRgHwi/sAKAbQACQQ4AMkASUoRgaaDeB4aQAkAChA0EhGJUlDGAqqMEYCmQHwdvsGmgGbIUmLQgaSAdAAKxzRAScAKADQaOcInCBGAPBs+GFpACkD0AKYAPBm+AicIEYTSQDwLfgImQAoBZwA0FTnBpucQgXRIEYE4CBGBZwImQrg2BhKaQAqANEYRiQaB5gYGAeQA5gFRgAoL0YA0WXnO+cGmiBGxOcvRjbnUAoAAMAnCQAAAEJAeAoAAAYAsgD+tQ1GBkYAIAGQApABJBJPSEbCGQ9IMUYB8Dr6cWkAKQrQACgI0QKo//cI/khGwhkCmQhIAfAs+gAoBtCsQgbSZCAB8On/ZBzi5wGY/r0BIP69wEYAAEJAeAoAAEkeiFQAClIe+9FwR/C1hbAERhNNE05oaAAo/NRIRhJJQBihaYlqCXgjeAAiAJIBkgKTA5IEkChGE0YA8L/5ASDABChlMGgAKPzQ92hkIAHwtf+gaYBrOELd0QAgBbDwvQAAQkDEAEJAeAoAAPC1k7AeRhVGACQSlBGUDxgSqThG//eE/QAoAdATsPC9EpgPkEFpACkE0BGo//ei/QAo89FLSElGCBj/99n9ASgB0QEg6udISQ+Y//d1/wAo5NEPmYhpQmrIaBCUOBoOkBGYBpBBSEJPBZQALnbQDJINlklGP0qKGA+eMUYB8Gz5ASEHkQAoa9FwaQAoM0Y3TgnQSEY3SUIYMEYGmQHwXPkPmwAoXNFwaAAo/NSYaQJoEKkLkQ6YHkb/92z/SEYtSUAYCpCzaRhqAXkJkQF4CJEbaEJ5MXgAIACTAZICkQOQCpgEkCFICJkJmgubAPAw+Q2ZDJqRQgDTEUYAKDDRDJE4aAAH/NFIRhpJQBgPmYlpC2pKaht9AJAAJhRIMUYA8Gn5ACgc0Q+ZiGlDaghGnkIJ0DEZaVz5YDloDyIKQAQq+th2HPPn//cr/w6YDJqAGA6QpBgNnrYaBEiG5wWYB5AHmFvnUAoAAFDDAAAAAEJAhABCQHgKAAD4tRxGF0YNRgZGGGANSElGCBj/9zH9ACgA0Pi9aUYwRv/3wvwAKAPQqBkgYAAg+L04RjFGKkYC8K/7ACj00AEg+L3ARmAKAAD+tRdGDUYERh1ISUYIGP/3D/0AKADQ/r0AIACQApAZTn5DYBlHHiVGAZS9QiXYAqkgRv/3lfwAKAHQLR315wKYwmgDaZkYgGlEaKAYo0IKRgDTAkZSHodCOEYA0xBGj0IBnAXTEEYD4ClojkID0S0dhUL52dnnASD+vQCY/r3ARmAKAAABAQEBgLX/9zP9gL2Atf/3R/2AvYC1ASGJBP/3i/2AvYC1C0YAIf/3yf6AveC1Aav/94D/AZiMvYC1//ef/4C9cLUPTAAoGdAAKRfQACsV0Pkk5AAFWQMmtUMFUVpiHMkJaAElFUCiB5IMUhlbB1sL0hjJB8kJURgBYAAkIEZwvQQAsgADIQkCAWCAIgAhgVACRoAyEWT5ItIAgVABItICgBgEIgAqA9ABYIAwUh7553BHSh6RQQJoASOaQ1EYAWBwRwFoASAIQHBHwEZJHgcpG9jARnlECXlJAI9EAwYWCBYWFgsBIckCBuARIQPgCSEJAgHgEyHJAUAYAyEJBANoi0ORB4kLWRgBYHBH8LWFsAOTBUYNmMADgLIKnwAmAC8AkADQMEaSB5ILURgIGAyZCQcJDQKRQBgoZQ6YQGoEkAuYgAeACwGQD0wwRvGyuUIX0qBCFdBobEAHDtRIHLhCAdMAmADgACABmhBDA5pRXAFDApgBQylldhwEqADwBvjk5wWw8L3ARgIAsgAQtQRGAGgAKAbQASAB8Lj9IGhAHiBgAdAAIBC9AEgQvQIAsgDwtYmwVE0AKgDRnuAERkBsQAcA1ZvgmAeAC1Mem7IYGAEjmwTAGCBlACkA0ZHg+SDAACAYAZCENA6YQGoIkAeRBpIAIASQAiECkQWRASEDkQWZAikA0H3gaRyIQgDReeAGnweeIGgPIQFACCVoGrhCANM4RggoDNh4RAB5QACHRE8EExojKjM/CAAweOBgA51D4DBGA5kA8I/6YGEwHQOZAPCK+mBhOOAweHF4CQIIGCBhAp0x4DB4cXgJAggYIGGweOBgAyUo4DBGA5kA8HT6YGEEJSHgMEYDmQDwbfpgYTB54GAFJRjgMEYDmQDwZPpgYTB5cXkJAggYIGEGJQzgMEYDmQDwWPpgYTB5cXkJAggYIGGweeBgByV/G3YZoecHlgaXAC8L0QGaEGgBIYhDEGAFkQSYACgC0ASZASCIRwio//dL/wRNgufoHALgKEYA4AAgCbDwvQEAsgDwtYewW08AKgDRq+AERkBsQAcA1ajgmAeAC1Mem7IYGAEm8wTAGCBlACkA0Z7g+SDAACAYAZDENAyYQGoGkAWRBJIAIAKQBCUDlQOZBCkA0I3geRyIQgDRieAEnwWYImgPIRFAuUIA0zlGCCkN2MBGeUQJeUkAj0ReBBogKDI+TAgA4WgBcDFGUuBhaQFwCg7CcAoMgnAJCkFwYWkBcQoOwnEKDIJxCQpBcQghQOAhaQFwCQpBcAIhOuAhaQFwCQpBcOFogXADITLgYWkBcAoOwnAKDIJwCQpBcClGKOBhaQFwCg7CcAoMgnAJCkFw4WgBcQUhHOBhaQFwCg7CcAoMgnAJCkFwIWkBcQkKQXEGIQ7gYWkBcAoOwnAKDIJwCQpBcCFpAXEJCkFx4WiBcQchfxpAGJPnBZAElwAvDNEBmhBoAiGIQxBgAyADkAKYACgC0AKZAyCIRwSXBqj/95D+BE9y5/gcAuA4RgDgACAHsPC9wEYBALIAAkYISAApCtBTbFsHBtQDIIAESR6JsggYEGUAIHBHwBxwR8BGAQCyAIhpcEcAIgpgimDKYEphimFKYAphASHJBwJoCkMCYHBH8LWJsAVGDphAagiQLE6wHAAqUtAURg8iCkBO0QKRASABkEACLRgYCQOQACAHRgOZj0JC0DkBApqJGCliKWgBmpFDKWAqYCloyQcF0LBCA9AIqP/3Nf7257BCLdAqbgSpCnATDstwEwyLcBIKSnBqbgpxEw7LcRMMi3ESCkpxqm4KchMOy3ITDItyEgpKcupuCnMTDstzEwyLcxIKSnMAIRApBtAEqlJcY1xTQGNUSRz25xA0fxy65zBGCbDwvcBGAgCyABC1ASQiAoMYAyLSAYIY4AcDKQbQAikH0AEpGkYE0AVIEL0ZaAFDGWARaAFDEWAAIBC9wEYEALIAASISAoMYAyLSAYIYCUgDKQbQAikH0AEpGkYE0ARIcEcZaAFAGWARaAFAEWAAIHBHBACyAP///38QtQEkIgKDGAMi0gGCGKAHAykG0AIpB9ABKRpGBNAFSBC9GWgBQxlgEWgBQxFgACAQvcBGBACyAAEiEgKDGAMi0gGCGAlIAykG0AIpB9ABKRpGBNAESHBHGWgBQBlgEWgBQBFgACBwRwQAsgD///+/ISLSAIIYMSPbAMAYAykG0AIpCNABKRBGBdAGSHBHEWgBIwtDE2ABaAEiCkMCYAAgcEfARgQAsgAQtUseByse2AJGQGiRaAAke0QbeVsAn0QGAxYeFhYWA//38v4X4IlpybIKH1FCUUFCaAAqAdQAIgDgASIDaBNDC0PZBwHQBUwF4AEhyQcCaIpDAmAAJCBGEL3ARv8AQgAQtUseByse2AJGQGiRaAAke0QbeVsAn0QGAxYeFhYWA//3wv4X4IlpybIKH1FCUUFCaAAqAdQAIgDgASIDaBNDC0PZBwHQBUwF4AEhyQcCaIpDAmAAJCBGEL3ARv8AQgACRgB4U3gbAhgYACkF0JF4CQTSeBIGURgIGHBH8LWRsAyQACgA0fXgACkA0fLgACoA0e/gS2gAKwDR6+AIaA+QACgA0ebgB5IBIMECDJpRGA2RESHJAVEYBJEJIQkCURgDkRMhyQFRGAKRAQIKkQMhBZEPBMAHDpAAIAVGAZAJkAuXD5ioQgDRx+AeaAAuANG94DJ4UB4HKADZx+AQk4AAAqEIWAkYDZxhSI9GKgAAACAAAABwAQAAJAAAAHABAABwAQAAcAEAACgAAAAEnALgA5wA4AKcIGi4QzN6GQQ5QAgYIGBwaEEHDtWxaQeYAJAMmADwn/gAKAXQCCCoQAmZAUMJkQLgcGiBBwHUEJt+4AiV/yHJQ/JoCkCiYDJpUkIKQOJgcmkAKgqZANERRrJpE2hbHgWfO0ALQyNiFWqSaAAqLNAGlRFoACdLHDtGC50G0BN5GwQrQMmyyxgOmQtDI2RReQkEKUBhZJFoSxwG0BN7GwQrQMmyzxgOmQ9Dp2QTaQArBNBZHh8jC0AOmQtD42QRfQkEC5oRQCFlBp0ALQufKNApaAAiSxwTRgbQK3kbBDtAybLLGA6ZC0MjZml5CQQ5QGFmqWhLHAbQKnsSBDpAybKKGA6ZCkOiZippACoE0FEeHyIKQA6ZCkPiZil9CQQ5QCFnCplJHAhAMXoJBDlAQBgOmQhDIGAQmwidGx1tHDbnBkgRsPC9AZgJmQAp+dADSAAfAUMIRvTnAEj15wQAsgDwtdmwHUYWRg9GEpA+qQAgiHAIgD2piHAIgDypiHAIgHlrEZE/qSgxDpFenGQoBNA/qQAiClRAHPjnE5QSnCBGMUYMlSpG//dz++dNEZkAKShGCtATmAKQP6gBkDggAJA+qiBGM0YA8Kn9D5Y/qYl5BikpRgDYAUYAKBOcANABRgApWNE/qAF4UykA0JDiQXhGKdVKTtGBeEQpS9HBeFApSNEBeQYpRdNAeQEoQtEAJi+W/yAIkAUCKEaEMA2XP689qi+rOUYA8KX9LpYoRoEwPKouqzlGDZ8A8Jz9wkl7MQmRiEIC0QAg+GQ4ZS2WP6k+qi2rKEYA8I39AUYAKBrRLZgClD+vAZcAkD6qEpgRmQ+bAPBT/R03MC4P0Dp4MKmKVYsZeR4JeAEiikBaYAw2vxzx5xFGCEZZsPC9CpA/qIB4QAeBDwAmAyk1RgLQiAD2oQ1YDpgDeA2YwWhAnw5xBiIKYAJpFnEEIQaREWCCahZxBSEHkRFgAmsWcQVgASELkYFjAC8C1H4c9ggD4OpOvxn2HD5DDZ9+YBsJC56eQH5iDpiDfFsGWw8FKwrYmwDipvZYFmDnotJY+mProtJY+2oaYPppYCMTYAAnF3FJmpMEAdVAIwDgCCPWBPYOdhxeQxMH2w6bHHNDDZmLZNMODCAQkANA46bzWEieNgf2DrYc0gDSDlIcckNaQ0pk/SIMmBBAi2j+Qz+qkngBKAvR0AYU1NAHPtGeYAAimoADIBhgASUQRlvgMUYeRpMGG9RSBjNGQtQoRv8lDkZU4D+pynsBIB1GAwKrgCtGKmCJeyApMUYB0xhz/yGZYD+piXsfIgpAAyU74D+oRXoLmlICM0aygDVgAHogKA5GCEYC0wIgGHMImJhgP6gAeh8iAkACIAedJOA/qUp7ACCYgBpgCXsgKTFGAdMYc/8hmWA/qAB7HyICQAIlASAR4D+ownqfgBpggHogKA5GCEYB0x9z/yCYYD+ogHofIgJAAiAGnRh1GmENmABoBChC0QeVDpgAfUEGCZoA1QAiwQcSnDDQgAcW1Q2YwGgAKBLQAnkBeAEg/yQdRgAjAJMBlA+cApQSnAOQE5gEkCBG//cZ+itGAkYAKgPQ90iCQgDQMuEBIP8hACIAkgGRD5kCkQOQE5gEkLchIEYdRhNG//cB+itGAkYBJQAqANGv4BFGE5woRg3gDZgCahd1F2EXc5Zgl4ACIRFgP6kwqgDwbvwKmQAoDZov0AqRP6kOkEAYQB4AeAuZgUCRYTCoCDBImQoH0g6SHNmjEJ0cLxDQDEb8QOYJLkCeWeQF5A5kHFRDdEMEYBOc/x0MMO7nBQCyAA6YGzhACBCZSEMwqUAYAB8AaA2aEGQKmRBtACgA0ZTmLp0ClD+oAZAAlTyqEpgRmQ+bAPDN+wFGACgA0IXmACQUlLxIQRw/qMccDJQOlT+oAF2ABwDVreBYqQAgCHACIiJDP6mKXJMJAysNmgLQmgC2o5oYE2gDIiJDilwRkgEiIkOJXDpGg0IF0NVcFK41VFIeQBz35wAiAJMBkg+YApADkhOdBJUUqxKeMEb/92r5ACgJ0QCVWKkBIgAlMEYrRv/3YPoAKAbQAUYOnQg3CDSsQrzZjeBYqAB4EZkIQEEeiEEMmUkACBgMkClG7ecOky+YE5sCkxSpAZEAkD2qIEYcRhGZD5sA8GP7AUYAKChGANBO5weYQh4UmQQqANnd4JAAAqMYWBgYh0bARnwAAACWAQAAdAEAAH4BAACKAQAAAwAAAAQAAAAEAAAA/f//f/////8BAAAAAQAAAD4AAAABAAAAAQAAAP////8CAAAAQAAAAIAAAAACAAAAAgAAAP////81AAAABQAAAD8AAAA1AAAANQAAABAAAAAAAQAAoA8AAAD6AACIBxCYDp0A1IrgkeAAKQvQXkhAHIFCDZgh0MLlW0nA5QEgEUYTnPDmC5sCICBDP6kIXCJGGkOJXAya0rKKQgfQgAAkGAg0rELv2VBIgRyo5UAcwbINmMFkEZEBKQPYACHBZAFlneUAbQ+QC5gGAgAnOUYTlzpGEZiHQsnQCpETmBAYE5AkHT+oAF0PIQFAACALmgpCC9EzRv4zUgAaQEMcBCgYRvXTOUiAHAqQBSA/qQ1ZEpe6AA+bn1gTmjpgEJpQQzCqE1y7YBAYQWiAaDhh/yCFQ6oZikIC0gEgFUYF4BBGDpINRgHwp/sOmnhg/WASn38cCpm+5wgHDp0Q1bwgFuDIBg6dDtQNmABqHeCIBg6dCtQNmABqFeBIBw6dBtQNmABqE+BsIALg7CAA4DwgKGAUmQ2YAGoDKgjTB50ELQPQBS0S0coFHNQKBhXUSQYB1AIhAOASIQFgACEKRgJ1ACICYQFzhmBBcQJxFKkwqg2YAPC3+gAhR+Y0IQFgAiIAIeznPiEBYAIh5+cFALIAgACyAAEAAAAQAAAAgAAAAOgDAAAAAAAAAwAAAAQAAAABIckCQBgEIQApEdAAIgJggmDCYAJiAmRCZIJkwmQCZQJmQmaCZsJmAmeAMEke6+dwR8BG8LWFsItp22gAKw/QHXkceAl4ASb/JwAjAJMBlwKRA5YEkiFGKkb+9+f/AOABSAWw8L3ARoAAsgDwtYWwi2kbaQArD9AdeRx4CXgBJv8nACMAkwGXApEDlgSSIUYqRv73y/8A4AFIBbDwvcBGgACyALy1BEYBqwEgGHCNaatqACsP0Bt4AJIBqiBGAPAN+AAoAtABqAB4BOA4IClcAagAeAhAQR6IQby9cLWGsBRGBUYIeAqeACL/IQCSAZECqUXBKEYZRhNG/veX/wAoBtEAlgEiACMoRiFG//eO+AawcL3wtYewFkYMRgaqACERgKVp62oyTwArXdApawApWtCqagAqV9ASaAWSCWgCkRloAJbLsgaqIUYElgOQHkb/98T/AChI0QWZAZYEmuhrAigJ0IAoI9BAKDzRQCAGmQFDBq85cC3gFkYAksuyBqoDnShGIUb/96n/ACgBmyzRAJYGqEIcKEYhRv/3n/8AKCPRBq94eAIhAUN5cDJGEeAVRgCSBqhHHAOYIUY6RgGb//eM/wAoENEGqEF4gCIKQ0JwKkYCmACSw7IDmCFGOkYA8Aj4AeB9PzhGB7DwvcBGgACyAPC1h7AGkxVGDEYGRgyfOkb/9xb/ACgS0QWVoGnAayN4ASEAIgGSApMDkQSXAigA0QFGAJEwRgaZBZv+9/3+B7DwvcBG8LWFsItp22kAKw/QHXkceAl4ASb/JwAjAJMBlwKRA5YEkiFGKkb+9+X+AOABSAWw8L3ARoAAsgDwtYmwD0YbSQAqL9AURgaQB5O9aW5pACIIkihoEUaIQgTQY1wSAtIYSRz45wipOEYA8CL4AUYPSHwwAC4X0DJ5/yoU0AtLmUIR0AApAdEIngg2MXgoaDt4ASUAri3GB5gEkAaYI0b+96n+AOAIRgmw8L3ARgQAsgD4tYRpY2gOSJNCF9mAHCNtACsT0ACR5GwALA/QHWguaJZCBdhpaO9oT0O5GZFCAtgbHWQe8OcAmAVgACD4vcBGBACyAPC1ibAVRgJGJ0iPaT5qAC4P0AAtI9AIkg6cemoGlKJCHdMQmAeQSGkAKAWTA9DDsgLgfDAT4At4MnkxeDhodHkAJwCQAZQcRgKTA5cHmASQCJgrRv73VP4AKAWdAdAJsPC9sGhBHA3QMnv/IQCXAauSwweZBJHBsgiYO0b+90D+ACjs0TFpACkE0AiY/vf0/wAo5NEzfQeYAJAImClGBpr+94D+2+fARgQAsgDwtYmwCJAlSI5pt2gALwrQFUYAKh3QEJgHkEhpACgGkwPQw7IC4HwwE+ALeDp5OXgwaHx5ACYAkAGUHEYCkwOWB5gEkAiYK0b+9wT+ACgGnQHQCbDwvbhoQRwN0Dp7/yEAlgGrUsMHmQSRwbIImDNG/vfw/QAo7NE5aQApBNAImP73pP8AKOTRDpo7fQeYAJAImClG/vfe/tvnwEYEALIA8LWHsB5GBpINRgJGCHkFkAt4SHkOmQAnAyQAlBRGAZAClgOXD0YEkRBGGUYFmgab/vfA/QAoDNEpaSBG/vd2/wAoBtENmQyaK30AlyBG/vex/gew8L3ARvy1AZMAkop51AAINAgmACLAshVGpkIQ2Itdg0IL0YsZ33n/LwfRX3i9QgTYm3gBKwHRMkY9Rgg27OcAKg3QUBgBeQCakXBBeVFwgXkRcMB4gAABmQhgACD8vQFI/L3ARoAAsgBwtQNGAGgEKBDRW2kAJOBDGGBIeMAGBQ8dIAUsHdAuRuZA9gcN0YAcZBz25x0gClz/KgPRIigP2IAc+OdbaRpgEeADLAnYCR0AJQQtCdBOXRZwDDJtHPjnW2n/IBhxACBwvQldGWAAIZmAcL3+tQKTFkYBkQCQlAgTSIRCANMERgAsANEBJH0gxwAgRjlGAfBh+AVGR0PgG4eyKEYA8Db7OEYA8Df7AKoHyv/3Yf0xGwDSACEAKALQpkIORu3YACgA0AJI/r3ARkBCDwACALIA/rUURgKqACcXcI1p7mvtai14AJMrRv/3X/0ncAAoAND+vQKpCXj/IkpAFkBxQnFBIXD+vfi1HEYVRg5GB0YaRv/39vwAKADQ+L04RjFGIkb/9179ACj30ThGMUYqRiNG//ec//i9wEbwtY+wBpAAIAmQDpAUnjJIAC5e0B1GF0ayGIxpY2iaQlfYCJGkaBWYDZA4RgeUDJYLlQietWkqaA6vCpA5RgDwTfgieSF4KGhjeTV4DJ4ArCnECZgDkA2YBJAGnShGO0b+9678ASEJBI5CN0YA0w9GACgu0QecoGhBHBHQInsImQl4/yQJmwCTAZQHnAKRA5MNmQSRwbIoRv73kvwAKBjRIWkAKQTQKEb+90b+ACgQ0SN9DZgAkChGC50pRjpG/vd//QAoBdHtGQqYwBn2G67RCZgPsPC9wEYEALIASR6IVAAKUh770XBH8LWRsA+RBpAAIAyQEJAWnD9IACx50B9GFUaiGA+ZiWlLaJpCcdgIagWQSGoHkBeeDZYoRgeeMUYA8Hz/CBmwQgmUDpQC0weYQBoOkAacIEYPmQ2a//dE/AAoVtEKlw+YhmkyaChGEK0IkClG//fC/wWfOHkLkDp4MGgNnnt5D5kJeACQAZMCkQyYA5AEliBGEUYLmitG/vcf/AAoNdG4aEEcDtA6ew+ZCXj/JQybAJMBlQKtSsXBsiBG/vcN/AAoI9E5aQApBNAgRv73wf0AKBvRO30AliBGCp85Rg6a/vdN/AAoEdEPmYhpgmwgRjNG//es/gAoCNEJnA6YJBoInUUZPxgALJTRDJgRsPC9wEYEALIA8LWNsB5GFUYKRgAhDJEKkQuR6RgJkUselGlhaFhPAZOLQgDTqeAGkCBsAJAFlKRpC6kHkhBGKkb/9yL9ACgH0LRCANmZ4CFGuEIKnAvRlOALmtFosUIA2Y/gFGhSaEpDohhSHgqSA5EIkCgbAPDY/gApANCB4ASUA5wBmgqYgkIS2QupB5j/9/v8PUmIQnPQCJAAKCFGCZoEmwjRC5jBaANoACAIkALgIUYJmgSb0BoDkQDwtf4AKQeaXtESnAifApQALlnQC6kQRipG//fY/AAoAZwIlA3RC5nPaAzJA5d7Q9IYUh4IOZRCCJQA0wiSCWkAkX0hygAAmUpDBJIHmgiZjUIy0gqVCZYGnShGEUYWRgKcIkb/91n7ACgh0QWYAmgMrwqYOUb/99r+KEYxRjpGI0b/92j8ACgS0ShGMUYEmiNG//f4/QdGCZ4DmIZCDtk2GgqdLRgAIAAvB5rP0K/nB0YyRgmeCp2q5wdGqOcAJgeaCp2k5wdGOEYNsPC9BACyAHC1FEYNRgZG//ce+wAoANBwvTBGKUYiRv/3GPwAKPfRfSDAAKlpSmxCQzBGKUYjRv/3wP1wvQAACmgCYMpogmIKacJiSmkCY4poQmJKaIJhimlCYwVKgBjACQABymkES8JQwBgJakFgcEfARgAAzr8AADFAsLUMSExGJVgLSCVQC0goGAtJAPAJ/gtJYFQLSCgYfSHJAADwAf4JSWBQwAMISWBQsL3ARqAKAACwCgAAP0IPAEBCDwC4CgAA5wMAALQKAACsCgAAcLU4TCBoDyEBQIgANkqDGB1sByMrQATQBCsE0AErNEgP4DJIDeAQWB8iAkB9IAACESoB0ANGAeABI9sDECoA0BhGASkP0AApO9ErTSlpqmiSAJIPASoU2NIeU0JTQRlDyQcQ0S3gI00pbCpokgCSDwEqFtjSHlNCU0EZQ8kHEtEf4AMqHdEpaBxODkBqaBxJEUAA8J/9cEMpaMkByQ9JHA3gAyoN0SlofyIKQFBDKWjJBMkOAPCO/SloyQLJDgDwif0haIkGiQ/IQA5JTEZgUA1JCWgJDkkcAPB8/QtJYFBwvcBGgAMmQAADJkAAEnoAADZuAQAGJkCABSZA//8DAP8fAACkCgAAEAAhQKgKAAAQtQlMSEYAXQAoC9H99y78ACgC0ADwkvkB4ADwp/lIRgEhAVUQvcBGCQAAAPi1BEYJTQtOC0+sQgXTSEaAWQDwbfnkGffnBUhJRghYREMgRgDwZPn4vcBGAYAAALQKAACsCgAAAID//4C1A0lKRlFcSEMA8FP5gL24CgAAgLX/99X/gL2Atf/37/+AvQJIAGgCSUpGUFBwRwgQI0AMDAAABEgCaARJS0ZZWJFCANABYHBHwEYIECNADAwAABC1/fff+wlJCmgJS0xG4lABIwB6ACgB0FgEAOAYBBBCANAQvRBDCGAQvcBGCBAjQAwMAAD4tQCSDUYBJGVAQAEOSUcYJkY5aAAgACkiRgDaAkYqQwEqENEAIAApAdoBRgDgASENQgjRAJiGQgTSASD/937/dhzm5wEg+L0QACNA+LUMRkABCElFGAAmL2gALwfUdhymQgTSASD/92n/AC/01fhDwA/4vQAAI0D4tRRGDUYGRgEnMWghYA8gAAcIQAUhSQeIQgbQr0IE0gEg//dP/38c7+dAGkEeiEH4vcBG8LWFsAxGBJD998z7ACgD0P33aPsGegPg/fda+wEmRkAcTQAuBNABLjDRApQgNQDgApR9IAOQwQAwRv/3sf8HRgAoJNEBJwSYAUY5QAGREkkB0UhGQBgMJCxDIGAIIChDB2AAIQ1KMEb/93T/ACgO0QGYACgC0UhGB0lEGAOYgQAgRgKa//ei/wdGAOABJzhGBbDwvQAAI0DcDAAAmDoAAPi1A6gCIQCRAZECkAQgBiEAIhNGAPAG+AOZSEJIQQSwgL3ARvC1h7AdRhdGAZECkAQgDJn/92T/Dp4wYAEkACgZ0Q2aBpUFlwxNA6hoYAGZQYACmQGAICAoYAQgACH/9yn/MGAAKAbRaGhBaAApAdABITFghGggRgew8L2IACNAH7UDrAKUBEwBlH0k5AAAlP/3yP8EsBC9mDoAABy1BEYBIAGp//dc/wAoANAcvQGYoHABDGFxAApgcP8gAjBpRv/3Tv8AKPHRAJkhcQoK4nAKAhIP4nEJAwkPoXEcvQAAgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHAAAQtf/31/0HSAFoB0hMRiBYCQrJskkcAPC3+wRJYFD/95/9EL0QACFAqAoAAKAKAAAQtf/3v/0HSAFoB0hMRiBYCQrJskkcAPCf+wRJYFD/94f9EL2QACFApAoAAKAKAAAQtQFoiGjKaGQjQ0OYGAtKS0aYUJYoAdIBIBC9CGhAHAAiQB4G0BMdTGiiWBJ5UgcaRvbVQR6IQRC9wEYMAAAA8LWHsAWQ90hJRgoYA5L2SApQ9kvOGPZLzlD2TA0Z9kwNUcgYBpBQYPRNTRm1YfROjhnuYvNOjhnzT88Z72EuYvJOjhnyT88Z8kqKGPJICBgrRggzhcNuYfBICBhoY/BICBioYgwZLGXuSAgYKGPuSAgYBJDtSAgY7UqKGO1OjhntT88Z7UvLGO1NTRllYqNi52ImY2JjoGMEmOBj/EgIGASQ/EgIGAKQ+0gIGPtKihj7S8sY+0/PGftNTRn7To4ZZmClYOdgI2FiYaBhApjgYQSYIGL2SAgY9kwIUfZICBj2So0YhWEGmlBg9UgIGOhi9EgIGPRKihjqYShi80gIGPNKihjzS8sY806OGa5g62AqYWhh8UgIGKhi8UgIGGhj8EgIGChjDBksZe9ICBgEkO5KiBgCkO5LyBgBkO1NTRntTo4Z7U/PGe1ICBjtSooYBJtjYAKbo2ABm+NgJWFmYadh4GEiYuhICBgEkOdKiBgCkOdLyxjnTU0Z506OGedPzxnnSAgYBJpiYgKaomLjYiVjZmOnY+Bj4kgIGAaakGDhSo0YhWHhSAgY6GLgSAgY4EqKGOphKGLfSAgY30qKGN9LyxjfTAwZrGDrYCphaGHdSAgYaGPdSAgYqGLcSAwYLGXcSooYKmPbSooYClDbSAgYBJDaSAgY2kqKGNpLyxjaTo4Z2k/PGdpNTRllYqdi5mIjY2JjoGMEmOBj1kgIGASQ1kgIGAKQ1UgIGNVKihjVS8sY1U/PGdVNTRnVTo4ZZmClYOdgI2FiYaBhApjgYQSYIGLQSAgYBprQYM9KjBiEYc9ICBjgYs5ICBjOSooY4mEgYs1ICBjNSooYzUvLGM1NTRmlYONgImFgYctICBhgY8tICBigYspICxgjZcpKihgiY8lKihgKUMlICBgGkMhICBjISooYyE1NGchOjhnIT88ZyEwMGVxin2LeYh1jWmOYYwaY2GPESAgYBpDESAgYBJDDSAgYw0qKGMNOjhnDT88Zw0wMGcNNTRldYJxg32AeYVphmGEEmNhhBpgYYgWYBWgoaFxKiFCoaAOakGDoaNBguUgIWAaQASADkAACApAAJCNGBJUoaINCANOd4GhoAFlBaEoHA9QGmpUqANmR4AWTSkZMS9IYUmgSWVFgAXgRcAF6EXLBaNFgAWkRYUFpUWGXaQaZlSlj2IZpMGg4YHBoeGC4aLFook19RKhH8Wj4aKhHMWk4aahHcWl4aahHsGm4Yfhp8WmoRzFqOGqoR3BqeGK4arFqqEfxavhqqEcxazhrqEdxa3hrqEcEnbBruGPwa/hjMGw4ZHBseGSwbETgvAwAABAAAAAUAAAAzAwAABgBAADYAAAAvAoAAKgAAABgAAAAMAAAAEgAAABYAgAAcAIAAHgAAACQAAAAwAAAAIgCAACkAQAAkAEAAHwBAABoAQAAVAEAAEABAABEAgAAApl5YgMgA8cDnjADOGFIRm5JQRj4agg/APDc+BAgACG5Y/ljPmR4ZAggACG4ZPlkBZskHVscXedIRgNJQBgHsPC9wEa8DAAAEAAAADACAAAcAgAACAIAAPQBAADgAQAAzAEAALgBAAAsAQAApAMAAGQDAACgAgAAEAsAADQDAADsAgAAvAIAANQCAADkBAAA/AQAAAQDAABMAwAAHAMAABQFAAC4AwAARAQAAFgEAABsBAAAgAQAAJQEAACoBAAAvAQAANAEAADMAwAA4AMAAPQDAAAIBAAAHAQAADAEAAAsBQAAZAsAAMAFAAB4BQAASAUAAGAFAABwBwAAiAcAAJAFAACoBQAA2AUAAPAFAACgBwAAMAYAALwGAACoBgAAlAYAAIAGAABsBgAAWAYAAFwHAABIBwAANAcAACAHAAAMBwAA+AYAAOQGAADQBgAARAYAALgHAAC4CwAATAgAAAQIAADUBwAA7AcAAPwJAAAUCgAAHAgAADQIAABkCAAAfAgAACwKAAC8CAAASAkAADQJAAAgCQAADAkAAPgIAADkCAAA6AkAANQJAADACQAArAkAAJgJAACECQAAcAkAAFwJAADQCAAADAAAAKQMAACJAgAAACkL0ApoAmCKiIKAimiCYAp7AnMKaQJhCX0BdXBHwEYCSElGCBgCSohQcEe8DAAAEAAAAANGELULQ5sHD9EEKg3TCMgQyRIfo0L40Bi6IbqIQgHZASAQvQAgwEMQvQAqA9DTBwPQUhwH4AAgEL0DeAx4QBxJHBsbB9EDeAx4QBxJHBsbAdGSHvHRGEYQvQHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAAAAiAwmLQizTAwqLQhHTACOcRk7gA0YLQzzUACJDCItCMdMDCYtCHNMDCotCAdOURj/gwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJBQwiLQgHTSwDAGlJBQRoA0gFGUkEQRnBHXeDKDwDQSUIDEADTQEJTQJxGACIDCYtCLdMDCotCEtOJAfwiEroDCotCDNOJAZIRi0II04kBkhGLQgTTiQE60JIRAOCJCcMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQdnSQwiLQgHTSwDAGlJBQRoA0gFGUkEQRmNGWxAB00BCACsA1UlCcEdjRlsQANNAQgG1BUkAKALcSRwIQADgCEbARsBGAr0Av////39wtQZMfEQGTX1EBOAgRgFoCBiARyQdrEL40XC9HAAAABwAAADB/f//AAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABwAAAAAAAAAAAAAYAAAAAgAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAWgAAAAAAAAD/////AAAAAAgAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAA/////////////////////////////////////////////////////////////////////////////////////wAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAgAAAAcAAAAAAAAAAAAAGgAAAAIAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAFoAAAAAAAAA/////wAAAAAIAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAP////////////////////////////////////////////////////////////////////////////////////8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAQAAAAHAAAAAAAAAAAAABwAAAACAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAABaAAAAAAAAAP////8AAAAACAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAD/////////////////////////////////////////////////////////////////////////////////////AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAIAAAABwAAAAAAAAAAAAAeAAAAAgAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAWgAAAAAAAAD/////AAAAAAgAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAA/////////////////////////////////////////////////////////////////////////////////////wAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAP///////////wACAAAAAAcAAAABAAAAAAAAAAEAAAAHAAAAAQAAAAAAAAD//////////wAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACT0AABJ6AAAJPQAAANAHAAk9AKAPAAAEAAAAAwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAABaAAAAAAAAAP////8AAAAACAAAAAAAAAAEAAAAAAAAAAIAAAAUAAAA/////////////////////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0xb05
+  pc_program_page: 0xb21
+  pc_erase_sector: 0xb15
+  pc_erase_all: 0xb0d
+  pc_verify: 0xb2d
+  data_section_offset: 0x33fc
+  flash_properties:
+    address_range:
+      start: 0x18000000
+      end: 0x20000000
+    page_size: 0x1000
+    erased_byte_value: 0xff
+    program_page_timeout: 50000
+    erase_sector_timeout: 600000
+    sectors:
+    - size: 0x40000
+      address: 0x0
+- name: cy8c6xxx_efuse
+  description: CY8C6xxx_EFUSE
+  instructions: gLUA8K/7APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAEIUCwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDw/PwERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwe/wA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAABCFAAUhJRghccEcFAAAAgLUA8In7APCf+wAggL2AtQDwjPsAIIC9/rUWRgVGAZHICClGACoE0AAjC3BJHFIe+OcHJAGaEUahQ5FCF0Ye0sCyAqkA8LD8ACgA0P69AZgEQAggABuwQgDTMEYBGQKqEngrRoxCCNIXRudA/wcB0AEnH3BbHGQc9OcBmocYsRgIJBZGAJG5Qh/ZOEYIMIhCANnMG/gIwLICqQDwhfwAKNTRuBsCqQ54ACLTspxCCNkxRtlAyQcC0MEYASNrVFIc8+fnGQGeAJnd5wAg/r3ARvi1FUYERgAghUIG0CFcAikB0/8pMdFAHPbnACYZT7VCJ9CgXf8oItDxCCspH9CxCrlCAdAyRgHgEUlyGAchEUDTCAAoBdDYsgDwTPgAKA7QFOBqRgAgEHDYsgDwM/gBRgEgACkK0WlGCXgBKQbQdhzV5yBGAPBZ+Pi9ASD4vcBGAACQbwAcJADBCCs5SEJIQXBHwEawtQhLA0AITAhNq0IA0QAZxQjtsg1gByEBQBFwGRlIQkhBsL0A/P//AACQbwAAcJC8tRRGDUYBqQDwBPwAKADQvL0BqQl46UABIgpAInC8vXy1DEYFRgGq//fq/wAoANB8vQGoAHgBKAHRACB8vShGIUYA8AX8ACjy0QGuKEYhRjJG//fV/wFGMngBIFBACENBHohBfL0QtQDwFvgAKA3QBEb/95/+wHkBKAnR/iEhQAIpBdEgRgDwI/gQvQAgEL0AG0EeiEEQvRC1BEYrIQDwD/kAKAvQKyEgRgDwFvkBBwfUQQcH1IEHB9UCIBC9ACAQvQQgEL0DIBC9ASEIQBC9sLWGsAMoA9ACKB7RASQA4AIkAPCt+wAoGNEA8CX4ACgU0QGoECEFqgDwvPsAKA3RACUQLQzQAahBXShGFDAA8Ev4bRwAKPTQAOABIAawsL0FqAF4JiAA8D/4ACj20SsgIUb/93X/8ed8tTwgAawhRgDwaPsieAAkACgh0QAqH9AAJS5GLEYQLhfQMEYsMGlGAPBY+wAoEdFoRgF4ACAKBgfQUg5rRhpwASMZQEAYEUb15yQaCDR2HOXnKEYBqQp44bJRGksemUEAKgDRAUYAKADQAUYIRny9+LUMRgAmxbI3RggvC9AgRvhAwAcF0PmyKEb/9y3/ACgC0X8c8ecwRvi9wEb+tRZGDEYSSQGQQBgAkAAlrEIZ0HBd/ygT0AGYQBmBCgxKkUIB0QCYQBkHIQFAwAjAsgKvOkb/9/n+cF05eIFCAdFtHOTnLEYBmCAY/r3ARgAAkG8AHCQA+LUURg1GBkYTTwAtHdCwCrhCAdAwRgHgDkgwGAchAUDACMCyakb/99X+/ywB0AAsBNFoRgB4ACgE0AjgaEYAeKBCBNF2HG0e3+cAIPi9ASD4vcBGAACQbwAcJACACgJJQRhIQkhBcEcA5Nv/ELUGSgJABksGTKJCAdHAGMAICGDRGEhCSEEQvQD8//8AAJBvAABwkMkACkYIMpFCBdJDXEkc/yv50AEgcEcAIHBHsLXJAEAYCkYIMgAjHEbNGJVCCdLFXAEtAdAAJQHgASWdQCxDWxzy5+CysL3ARvC1yQBAGNkAACMNTZlCFNDGXAEuD9GeCq5CAdAeRgHgBkweGQcnN0ABJLxA9gj2spddJ0OXVVsc6OfwvQAAkG8AHCQAgLX/95T9gL0AIHBHACBwR4C1C0YBRhBGGkb/9+n9gL2Atf/3Mf+AvYC1//dZ/4C9gLULRgFGEEYaRv/3ff0AKAHQACDAQ4C9sLUMSExGJVgLSCVQC0goGAtJAPDt+gtJYFQLSCgYfSHJAADw5foJSWBQwAMISWBQsL3ARhAAAAAgAAAAP0IPAEBCDwAoAAAA5wMAACQAAAAcAAAAcLU4TCBoDyEBQIgANkqDGB1sByMrQATQBCsE0AErNEgP4DJIDeAQWB8iAkB9IAACESoB0ANGAeABI9sDECoA0BhGASkP0AApO9ErTSlpqmiSAJIPASoU2NIeU0JTQRlDyQcQ0S3gI00pbCpokgCSDwEqFtjSHlNCU0EZQ8kHEtEf4AMqHdEpaBxODkBqaBxJEUAA8IP6cEMpaMkByQ9JHA3gAyoN0SlofyIKQFBDKWjJBMkOAPBy+iloyQLJDgDwbfohaIkGiQ/IQA5JTEZgUA1JCWgJDkkcAPBg+gtJYFBwvcBGgAMmQAADJkAAEnoAADZuAQAGJkCABSZA//8DAP8fAAAUAAAAEAAhQBgAAAAQtQlMSEYAXQAoC9H/90z8ACgC0ADwCvoB4ADwH/pIRgEhAVUQvcBGBAAAAPi1BEYJTQtOC0+sQgXTSEaAWQDw5fnkGffnBUhJRghYREMgRgDw3Pn4vcBGAYAAACQAAAAcAAAAAID//4C1A0lKRlFcSEMA8Mv5gL0oAAAAgLX/99X/gL2Atf/37/+AvQJIAGgCSUpGUFBwRwgQI0AsAAAABEgCaARJS0ZZWJFCANABYHBHwEYIECNALAAAABC1//f9+wlJCmgJS0xG4lABIwB6ACgB0FgEAOAYBBBCANAQvRBDCGAQvcBGCBAjQCwAAAD4tQCSDUYBJGVAQAEOSUcYJkY5aAAgACkiRgDaAkYqQwEqENEAIAApAdoBRgDgASENQgjRAJiGQgTSASD/937/dhzm5wEg+L0QACNA+LUMRkABCElFGAAmL2gALwfUdhymQgTSASD/92n/AC/01fhDwA/4vQAAI0D4tRRGDUYGRgEnMWghYA8gAAcIQAUhSQeIQgbQr0IE0gEg//dP/38c7+dAGkEeiEH4vcBG8LWFsAxGBJD/9+D7ACgD0P/3hvsGegPg//d4+wEmRkAcTQAuBNABLjDRApQgNQDgApR9IAOQwQAwRv/3sf8HRgAoJNEBJwSYAUY5QAGREkkB0UhGQBgMJCxDIGAIIChDB2AAIQ1KMEb/93T/ACgO0QGYACgC0UhGB0lEGAOYgQAgRgKa//ei/wdGAOABJzhGBbDwvQAAI0AwAAAAmDoAAPi1A6gCIQCRAZECkAQgBiEAIhNGAPAG+AOZSEJIQQSwgL3ARvC1h7AdRhdGAZECkAQgDJn/92T/Dp4wYAEkACgZ0Q2aBpUFlwxNA6hoYAGZQYACmQGAICAoYAQgACH/9yn/MGAAKAbRaGhBaAApAdABITFghGggRgew8L2IACNAH7UDrAKUBEwBlH0k5AAAlP/3yP8EsBC9mDoAABy1BEYBIAGp//dc/wAoANAcvQGYoHABDGFxAApgcP8gAjBpRv/3Tv8AKPHRAJkhcQoK4nAKAhIP4nEJAwkPoXEcvcBGHLUMRmlG//c9/QCYAAQACgVJQBgBqf/3M/8AKADQHL0BmSFwHL3ARgEAAAPgtQJIAan/9yX/jL0BAAAn4LXCBtIKQAkAA4AYSQdJDUAYA0lAGAGp//cU/4y9wEYBAAABfLUQKQHSASB8vRRGBUYPIEAGEE5JRohRAan/9wH/ACgA0Hy9ACAQKA3QSUaJGQkYSWgpVCoYCw7TcAsMk3AJClFwAB3v50hGgBlAaSBwACB8vcBGMAAAALy1A0YBIMRDHR+lQg7TAisC0C8gAAYA4AVIBktMRuBQ4xhZYJpgAan/987+vL3ARgABAC8wAAAAgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHAAAQtf/3X/0HSAFoB0hMRiBYCQrJskkcAPAj+ARJYFD/9yf9EL0QACFAGAAAABAAAAAQtf/3R/0HSAFoB0hMRiBYCQrJskkcAPAL+ARJYFD/9w/9EL2QACFAFAAAABAAAAAAIgMJi0Is0wMKi0IR0wAjnEZO4ANGC0M81AAiQwiLQjHTAwmLQhzTAwqLQgHTlEY/4MMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQUMIi0IB00sAwBpSQUEaANIBRlJBEEZwR13gyg8A0ElCAxAA00BCU0CcRgAiAwmLQi3TAwqLQhLTiQH8IhK6AwqLQgzTiQGSEYtCCNOJAZIRi0IE04kBOtCSEQDgiQnDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkHZ0kMIi0IB00sAwBpSQUEaANIBRlJBEEZjRlsQAdNAQgArANVJQnBHY0ZbEADTQEIBtQVJACgC3EkcCEAA4AhGwEbARgK9AL////9/AAAAAAAA////////////AAAJPQAAEnoAAAk9AAAA0AcACT0AoA8AAAQAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x5b9
+  pc_program_page: 0x5c9
+  pc_erase_sector: 0x5c5
+  pc_erase_all: 0x5c1
+  pc_verify: 0x5d9
+  data_section_offset: 0xd5c
+  flash_properties:
+    address_range:
+      start: 0x90700000
+      end: 0x90700400
+    page_size: 0x400
+    erased_byte_value: 0xff
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x400
+      address: 0x0
+- name: cy8c6xx7
+  description: CY8C6xx7
+  instructions: gLUA8PH5APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAEIUCwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwPvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwvfoA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAABCFAAUhJRghccEcFAAAAgLUA8Mv5APDh+QAggL2AtQDwzvkAIIC9gLUA8Af7gL2AtQDwEfuAvfi1DEYHRgEgAQcAII9CBNEhDQLQACQA8PX6G0obSxxOtEIK2TlGMUAH0RxIJBjwGUUcOEYA8AT7GOCcQgrZOUYZQAfRFEgkGNgZRRw4RgDwB/sL4JRCE9k5RhFAENENSCQY0BlFHDhGAPDa+gdLBkoBRi9GACwF0AAgACnQ0AHgAUb35whG+L3/AQAA/w8AAP//AwAA/v//APD//wAA/P+AtQDw7fqAvbC1DEYFRgAsCdAoRgDwtPoAKAXRASBAAi0YZB7z5wAgsL3ARrC1BEYGSElGDRgBIEECKEYA8FT7IEYpRgDw4PqwvcBGRAAAALC1ACOZQgbQ1FzFXKxCAdFbHPfnGUYIGLC9ACkH0EMcSR4AeJBCGEb30AEgcEcAIHBHAACAtf/3Xv+AvYC1//df/4C9gLX/91//gL2AtRFG//eu/4C9gLX/99L/gL2Atf/32/+AvXC1FEYFRk4KKEYhRv/3nf8AKAXRASFJAmQYbRh2HvPRcL2AtVEC//dA/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8Pv6C0lgVAtIKBh9IckAAPDz+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwkfpwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8ID6KWjJAskOAPB7+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8G76C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3Cv4AKALQAPD4+QHgAPAN+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDT+eQZ9+cFSElGCFhEQyBGAPDK+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwufmAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAjQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQI0AsAAAAELX/97v9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECNALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRAAI0D4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAjQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3nv0AKAPQ//dE/QZ6A+D/9zb9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAjQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAI0AftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAWAHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEcAABC1//dx/QdIAWgHSExGIFgJCsmySRwA8EP4BElgUP/3Of0QvRAAIUAYAAAAEAAAABC1//dZ/QdIAWgHSExGIFgJCsmySRwA8Cv4BElgUP/3If0QvZAAIUAUAAAAEAAAAAHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAIgMJi0Is0wMKi0IR0wAjnEZO4ANGC0M81AAiQwiLQjHTAwmLQhzTAwqLQgHTlEY/4MMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQUMIi0IB00sAwBpSQUEaANIBRlJBEEZwR13gyg8A0ElCAxAA00BCU0CcRgAiAwmLQi3TAwqLQhLTiQH8IhK6AwqLQgzTiQGSEYtCCNOJAZIRi0IE04kBOtCSEQDgiQnDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkHZ0kMIi0IB00sAwBpSQUEaANIBRlJBEEZjRlsQAdNAQgArANVJQnBHY0ZbEADTQEIBtQVJACgC3EkcCEAA4AhGwEbARgK9AL////9/AAAAAAAA////////////AAAJPQAAEnoAAAk9AAAA0AcACT0AoA8AAAQAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x225
+  pc_program_page: 0x23d
+  pc_erase_sector: 0x235
+  pc_erase_all: 0x22d
+  pc_verify: 0x247
+  data_section_offset: 0x9fc
+  flash_properties:
+    address_range:
+      start: 0x10000000
+      end: 0x10100000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xx7_sect256kb
+  description: CY8C6xx7_sect256KB
+  default: true
+  instructions: gLUA8PH5APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAEIUCwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwPvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwvfoA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAABCFAAUhJRghccEcFAAAAgLUA8Mv5APDh+QAggL2AtQDwzvkAIIC9gLUA8Af7gL2AtQDwEfuAvfi1DEYHRgEgAQcAII9CBNEhDQLQACQA8PX6G0obSxxOtEIK2TlGMUAH0RxIJBjwGUUcOEYA8AT7GOCcQgrZOUYZQAfRFEgkGNgZRRw4RgDwB/sL4JRCE9k5RhFAENENSCQY0BlFHDhGAPDa+gdLBkoBRi9GACwF0AAgACnQ0AHgAUb35whG+L3/AQAA/w8AAP//AwAA/v//APD//wAA/P+AtQDw7fqAvbC1DEYFRgAsCdAoRgDwtPoAKAXRASBAAi0YZB7z5wAgsL3ARrC1BEYGSElGDRgBIEECKEYA8FT7IEYpRgDw4PqwvcBGRAAAALC1ACOZQgbQ1FzFXKxCAdFbHPfnGUYIGLC9ACkH0EMcSR4AeJBCGEb30AEgcEcAIHBHAACAtf/3Xv+AvYC1//df/4C9gLUA8IP6gL2AtRFG//eu/4C9gLX/99L/gL2Atf/32/+AvXC1FEYFRk4KKEYhRv/3nf8AKAXRASFJAmQYbRh2HvPRcL2AtZEE//dA/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8Pv6C0lgVAtIKBh9IckAAPDz+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwkfpwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8ID6KWjJAskOAPB7+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8G76C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3Cv4AKALQAPD4+QHgAPAN+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDT+eQZ9+cFSElGCFhEQyBGAPDK+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwufmAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAjQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQI0AsAAAAELX/97v9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECNALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRAAI0D4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAjQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3nv0AKAPQ//dE/QZ6A+D/9zb9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAjQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAI0AftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAWAHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEcAABC1//dx/QdIAWgHSExGIFgJCsmySRwA8EP4BElgUP/3Of0QvRAAIUAYAAAAEAAAABC1//dZ/QdIAWgHSExGIFgJCsmySRwA8Cv4BElgUP/3If0QvZAAIUAUAAAAEAAAAAHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAIgMJi0Is0wMKi0IR0wAjnEZO4ANGC0M81AAiQwiLQjHTAwmLQhzTAwqLQgHTlEY/4MMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQUMIi0IB00sAwBpSQUEaANIBRlJBEEZwR13gyg8A0ElCAxAA00BCU0CcRgAiAwmLQi3TAwqLQhLTiQH8IhK6AwqLQgzTiQGSEYtCCNOJAZIRi0IE04kBOtCSEQDgiQnDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkHZ0kMIi0IB00sAwBpSQUEaANIBRlJBEEZjRlsQAdNAQgArANVJQnBHY0ZbEADTQEIBtQVJACgC3EkcCEAA4AhGwEbARgK9AL////9/AAAAAAAA////////////AAAJPQAAEnoAAAk9AAAA0AcACT0AoA8AAAQAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x225
+  pc_program_page: 0x23d
+  pc_erase_sector: 0x235
+  pc_erase_all: 0x22d
+  pc_verify: 0x247
+  data_section_offset: 0x9fc
+  flash_properties:
+    address_range:
+      start: 0x10000000
+      end: 0x10100000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x40000
+      address: 0x0
+- name: cy8c6xx8
+  description: CY8C6xx8
+  instructions: gLUA8PH5APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAAIECwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwPvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwvfoA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAAACBAAUhJRghccEcFAAAAgLUA8Mv5APDh+QAggL2AtQDwzvkAIIC9gLUA8Af7gL2AtQDwEfuAvfi1DEYHRgEgAQcAII9CBNEhDQLQACQA8PX6G0obSxxOtEIK2TlGMUAH0RxIJBjwGUUcOEYA8AT7GOCcQgrZOUYZQAfRFEgkGNgZRRw4RgDwB/sL4JRCE9k5RhFAENENSCQY0BlFHDhGAPDa+gdLBkoBRi9GACwF0AAgACnQ0AHgAUb35whG+L3/AQAA/w8AAP//AwAA/v//APD//wAA/P+AtQDw7fqAvbC1DEYFRgAsCdAoRgDwtPoAKAXRASBAAi0YZB7z5wAgsL3ARrC1BEYGSElGDRgBIEECKEYA8FT7IEYpRgDw4PqwvcBGRAAAALC1ACOZQgbQ1FzFXKxCAdFbHPfnGUYIGLC9ACkH0EMcSR4AeJBCGEb30AEgcEcAIHBHAACAtf/3Xv+AvYC1//df/4C9gLX/91//gL2AtRFG//eu/4C9gLX/99L/gL2Atf/32/+AvXC1FEYFRk4KKEYhRv/3nf8AKAXRASFJAmQYbRh2HvPRcL2AtVEC//dA/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8Pv6C0lgVAtIKBh9IckAAPDz+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwkfpwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8ID6KWjJAskOAPB7+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8G76C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3Cv4AKALQAPD4+QHgAPAN+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDT+eQZ9+cFSElGCFhEQyBGAPDK+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwufmAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAiQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQIkAsAAAAELX/97v9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECJALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRwAIkD4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAiQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3nv0AKAPQ//dE/QZ6A+D/9zb9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAiQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAIkAftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAWAHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEcAABC1//dx/QdIAWgHSExGIFgJCsmySRwA8EP4BElgUP/3Of0QvRAAIUAYAAAAEAAAABC1//dZ/QdIAWgHSExGIFgJCsmySRwA8Cv4BElgUP/3If0QvZAAIUAUAAAAEAAAAAHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAIgMJi0Is0wMKi0IR0wAjnEZO4ANGC0M81AAiQwiLQjHTAwmLQhzTAwqLQgHTlEY/4MMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQUMIi0IB00sAwBpSQUEaANIBRlJBEEZwR13gyg8A0ElCAxAA00BCU0CcRgAiAwmLQi3TAwqLQhLTiQH8IhK6AwqLQgzTiQGSEYtCCNOJAZIRi0IE04kBOtCSEQDgiQnDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkHZ0kMIi0IB00sAwBpSQUEaANIBRlJBEEZjRlsQAdNAQgArANVJQnBHY0ZbEADTQEIBtQVJACgC3EkcCEAA4AhGwEbARgK9AL////9/AAAAAAAA////////////AAAJPQAAEnoAAAk9AAAA0AcACT0AoA8AAAQAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x225
+  pc_program_page: 0x23d
+  pc_erase_sector: 0x235
+  pc_erase_all: 0x22d
+  pc_verify: 0x247
+  data_section_offset: 0x9fc
+  flash_properties:
+    address_range:
+      start: 0x10000000
+      end: 0x10100000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xx8_sect256kb
+  description: CY8C6xx8_sect256KB
+  default: true
+  instructions: gLUA8PH5APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAAIECwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwPvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwvfoA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAAACBAAUhJRghccEcFAAAAgLUA8Mv5APDh+QAggL2AtQDwzvkAIIC9gLUA8Af7gL2AtQDwEfuAvfi1DEYHRgEgAQcAII9CBNEhDQLQACQA8PX6G0obSxxOtEIK2TlGMUAH0RxIJBjwGUUcOEYA8AT7GOCcQgrZOUYZQAfRFEgkGNgZRRw4RgDwB/sL4JRCE9k5RhFAENENSCQY0BlFHDhGAPDa+gdLBkoBRi9GACwF0AAgACnQ0AHgAUb35whG+L3/AQAA/w8AAP//AwAA/v//APD//wAA/P+AtQDw7fqAvbC1DEYFRgAsCdAoRgDwtPoAKAXRASBAAi0YZB7z5wAgsL3ARrC1BEYGSElGDRgBIEECKEYA8FT7IEYpRgDw4PqwvcBGRAAAALC1ACOZQgbQ1FzFXKxCAdFbHPfnGUYIGLC9ACkH0EMcSR4AeJBCGEb30AEgcEcAIHBHAACAtf/3Xv+AvYC1//df/4C9gLUA8IP6gL2AtRFG//eu/4C9gLX/99L/gL2Atf/32/+AvXC1FEYFRk4KKEYhRv/3nf8AKAXRASFJAmQYbRh2HvPRcL2AtZEE//dA/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8Pv6C0lgVAtIKBh9IckAAPDz+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwkfpwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8ID6KWjJAskOAPB7+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8G76C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3Cv4AKALQAPD4+QHgAPAN+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDT+eQZ9+cFSElGCFhEQyBGAPDK+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwufmAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAiQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQIkAsAAAAELX/97v9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECJALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRwAIkD4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAiQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3nv0AKAPQ//dE/QZ6A+D/9zb9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAiQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAIkAftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAWAHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEcAABC1//dx/QdIAWgHSExGIFgJCsmySRwA8EP4BElgUP/3Of0QvRAAIUAYAAAAEAAAABC1//dZ/QdIAWgHSExGIFgJCsmySRwA8Cv4BElgUP/3If0QvZAAIUAUAAAAEAAAAAHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAIgMJi0Is0wMKi0IR0wAjnEZO4ANGC0M81AAiQwiLQjHTAwmLQhzTAwqLQgHTlEY/4MMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQUMIi0IB00sAwBpSQUEaANIBRlJBEEZwR13gyg8A0ElCAxAA00BCU0CcRgAiAwmLQi3TAwqLQhLTiQH8IhK6AwqLQgzTiQGSEYtCCNOJAZIRi0IE04kBOtCSEQDgiQnDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkHZ0kMIi0IB00sAwBpSQUEaANIBRlJBEEZjRlsQAdNAQgArANVJQnBHY0ZbEADTQEIBtQVJACgC3EkcCEAA4AhGwEbARgK9AL////9/AAAAAAAA////////////AAAJPQAAEnoAAAk9AAAA0AcACT0AoA8AAAQAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x225
+  pc_program_page: 0x23d
+  pc_erase_sector: 0x235
+  pc_erase_all: 0x22d
+  pc_verify: 0x247
+  data_section_offset: 0x9fc
+  flash_properties:
+    address_range:
+      start: 0x10000000
+      end: 0x10100000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x40000
+      address: 0x0
+- name: cy8c6xxa
+  description: CY8C6xxA
+  instructions: gLUA8PH5APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAAIECwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwPvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwvfoA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAAACBAAUhJRghccEcFAAAAgLUA8Mv5APDh+QAggL2AtQDwzvkAIIC9gLUA8Af7gL2AtQDwEfuAvfi1DEYHRgEgAQcAII9CBNFhDQLQACQA8PX6G0obSxxOtEIK2TlGMUAH0RxIJBjwGUUcOEYA8AT7GOCcQgrZOUYZQAfRFEgkGNgZRRw4RgDwB/sL4JRCE9k5RhFAENENSCQY0BlFHDhGAPDa+gdLBkoBRi9GACwF0AAgACnQ0AHgAUb35whG+L3/AQAA/w8AAP//AwAA/v//APD//wAA/P+AtQDw7fqAvbC1DEYFRgAsCdAoRgDwtPoAKAXRASBAAi0YZB7z5wAgsL3ARrC1BEYGSElGDRgBIEECKEYA8FT7IEYpRgDw4PqwvcBGRAAAALC1ACOZQgbQ1FzFXKxCAdFbHPfnGUYIGLC9ACkH0EMcSR4AeJBCGEb30AEgcEcAIHBHAACAtf/3Xv+AvYC1//df/4C9gLX/91//gL2AtRFG//eu/4C9gLX/99L/gL2Atf/32/+AvXC1FEYFRk4KKEYhRv/3nf8AKAXRASFJAmQYbRh2HvPRcL2AtVEC//dA/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8Pv6C0lgVAtIKBh9IckAAPDz+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwkfpwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8ID6KWjJAskOAPB7+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8G76C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3Cv4AKALQAPD4+QHgAPAN+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDT+eQZ9+cFSElGCFhEQyBGAPDK+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwufmAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAiQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQIkAsAAAAELX/97v9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECJALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRwAIkD4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAiQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3nv0AKAPQ//dE/QZ6A+D/9zb9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAiQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAIkAftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAWAHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEcAABC1//dx/QdIAWgHSExGIFgJCsmySRwA8EP4BElgUP/3Of0QvRAAIUAYAAAAEAAAABC1//dZ/QdIAWgHSExGIFgJCsmySRwA8Cv4BElgUP/3If0QvZAAIUAUAAAAEAAAAAHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAIgMJi0Is0wMKi0IR0wAjnEZO4ANGC0M81AAiQwiLQjHTAwmLQhzTAwqLQgHTlEY/4MMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQUMIi0IB00sAwBpSQUEaANIBRlJBEEZwR13gyg8A0ElCAxAA00BCU0CcRgAiAwmLQi3TAwqLQhLTiQH8IhK6AwqLQgzTiQGSEYtCCNOJAZIRi0IE04kBOtCSEQDgiQnDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkHZ0kMIi0IB00sAwBpSQUEaANIBRlJBEEZjRlsQAdNAQgArANVJQnBHY0ZbEADTQEIBtQVJACgC3EkcCEAA4AhGwEbARgK9AL////9/AAAAAAAA////////////AAAJPQAAEnoAAAk9AAAA0AcACT0AoA8AAAQAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x225
+  pc_program_page: 0x23d
+  pc_erase_sector: 0x235
+  pc_erase_all: 0x22d
+  pc_verify: 0x247
+  data_section_offset: 0x9fc
+  flash_properties:
+    address_range:
+      start: 0x10000000
+      end: 0x10200000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x200
+      address: 0x0
+- name: cy8c6xxa_sect256kb
+  description: CY8C6xxA_sect256KB
+  default: true
+  instructions: gLUA8PH5APBn+IC9DyAAAgJJCWgBQEhCSEFwRwAAIECwtShNSEZAXQAoR9EPIAACJUkJaAFASB6BQUhGQBkBcgDwPvsERgAoNNFIRkAZQHgBKCPRSEZBGch4iXgAKQPR4igB0QAgFuACKQPR5CgB0QIgEOAFKQPR5ygB0QUgCuAOKQPR6igB0Q4gBOAVKQXR7SgD0RUgSUZJGUhySEZAGQB6ACgC0ADwvfoA4AAgSUZJGYhyYEJgQUlGSFVIRkAZsL3ARgUAAAAAACBAAUhJRghccEcFAAAAgLUA8Mv5APDh+QAggL2AtQDwzvkAIIC9gLUA8Af7gL2AtQDwEfuAvfi1DEYHRgEgAQcAII9CBNFhDQLQACQA8PX6G0obSxxOtEIK2TlGMUAH0RxIJBjwGUUcOEYA8AT7GOCcQgrZOUYZQAfRFEgkGNgZRRw4RgDwB/sL4JRCE9k5RhFAENENSCQY0BlFHDhGAPDa+gdLBkoBRi9GACwF0AAgACnQ0AHgAUb35whG+L3/AQAA/w8AAP//AwAA/v//APD//wAA/P+AtQDw7fqAvbC1DEYFRgAsCdAoRgDwtPoAKAXRASBAAi0YZB7z5wAgsL3ARrC1BEYGSElGDRgBIEECKEYA8FT7IEYpRgDw4PqwvcBGRAAAALC1ACOZQgbQ1FzFXKxCAdFbHPfnGUYIGLC9ACkH0EMcSR4AeJBCGEb30AEgcEcAIHBHAACAtf/3Xv+AvYC1//df/4C9gLUA8IP6gL2AtRFG//eu/4C9gLX/99L/gL2Atf/32/+AvXC1FEYFRk4KKEYhRv/3nf8AKAXRASFJAmQYbRh2HvPRcL2AtZEE//dA/4C9AACwtQxITEYlWAtIJVALSCgYC0kA8Pv6C0lgVAtIKBh9IckAAPDz+glJYFDAAwhJYFCwvcBGEAAAACAAAAA/Qg8AQEIPACgAAADnAwAAJAAAABwAAABwtThMIGgPIQFAiAA2SoMYHWwHIytABNAEKwTQASs0SA/gMkgN4BBYHyICQH0gAAIRKgHQA0YB4AEj2wMQKgDQGEYBKQ/QACk70StNKWmqaJIAkg8BKhTY0h5TQlNBGUPJBxDRLeAjTSlsKmiSAJIPASoW2NIeU0JTQRlDyQcS0R/gAyod0SloHE4OQGpoHEkRQADwkfpwQyloyQHJD0kcDeADKg3RKWh/IgpAUEMpaMkEyQ4A8ID6KWjJAskOAPB7+iFoiQaJD8hADklMRmBQDUkJaAkOSRwA8G76C0lgUHC9wEaAAyZAAAMmQAASegAANm4BAAYmQIAFJkD//wMA/x8AABQAAAAQACFAGAAAABC1CUxIRgBdACgL0f/3Cv4AKALQAPD4+QHgAPAN+khGASEBVRC9wEYEAAAA+LUERglNC04LT6xCBdNIRoBZAPDT+eQZ9+cFSElGCFhEQyBGAPDK+fi9wEYBgAAAJAAAABwAAAAAgP//gLUDSUpGUVxIQwDwufmAvSgAAACAtf/31f+AvYC1//fv/4C9AkgAaAJJSkZQUHBHCBAiQCwAAAAESAJoBElLRllYkUIA0AFgcEfARggQIkAsAAAAELX/97v9CUkKaAlLTEbiUAEjAHoAKAHQWAQA4BgEEEIA0BC9EEMIYBC9wEYIECJALAAAAPi1AJINRgEkZUBAAQ5JRxgmRjloACAAKSJGANoCRipDASoQ0QAgACkB2gFGAOABIQ1CCNEAmIZCBNIBIP/3fv92HObnASD4vRwAIkD4tQxGQAEISUUYACYvaAAvB9R2HKZCBNIBIP/3af8AL/TV+EPAD/i9AAAiQPi1FEYNRgZGAScxaCFgDyAABwhABSFJB4hCBtCvQgTSASD/90//fxzv50AaQR6IQfi9wEbwtYWwDEYEkP/3nv0AKAPQ//dE/QZ6A+D/9zb9ASZGQBxNAC4E0AEuMNEClCA1AOAClH0gA5DBADBG//ex/wdGACgk0QEnBJgBRjlAAZESSQHRSEZAGAwkLEMgYAggKEMHYAAhDUowRv/3dP8AKA7RAZgAKALRSEYHSUQYA5iBACBGApr/96L/B0YA4AEnOEYFsPC9AAAiQDAAAACYOgAA+LUDqAIhAJEBkQKQBCAGIQAiE0YA8Ab4A5lIQkhBBLCAvcBG8LWHsB1GF0YBkQKQBCAMmf/3ZP8OnjBgASQAKBnRDZoGlQWXDE0DqGhgAZlBgAKZAYAgIChgBCAAIf/3Kf8wYAAoBtFoaEFoACkB0AEhMWCEaCBGB7DwvYgAIkAftQOsApQETAGUfSTkAACU//fI/wSwEL2YOgAAHLUERgEgAan/91z/ACgA0By9AZigcAEMYXEACmBw/yACMGlG//dO/wAo8dEAmSFxCgricAoCEg/icQkDCQ+hcRy9wEbgtQRJSkYESFBQAan/9zj/jL3ARjAAAAAAAQAK4LUFSUtGBUpaUFkYSGABqRBG//cn/4y9MAAAAAABABzgtQVJS0YFSlpQWRhIYAGpEEb/9xf/jL0wAAAAAAEAFOC1BUlLRgVKWlBZGEhgAakQRv/3B/+MvTAAAAAAAQAdHLUHS0xGB0riUOMYgyRkAFxgmGDZYAGpEEb/9/P+HL0wAAAAAAEABhy1B0tMRgdK4lDjGIMkZABcYJhg2WABqRBG//ff/hy9MAAAAAABAAWAHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEcAABC1//dx/QdIAWgHSExGIFgJCsmySRwA8EP4BElgUP/3Of0QvRAAIUAYAAAAEAAAABC1//dZ/QdIAWgHSExGIFgJCsmySRwA8Cv4BElgUP/3If0QvZAAIUAUAAAAEAAAAAHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAIgMJi0Is0wMKi0IR0wAjnEZO4ANGC0M81AAiQwiLQjHTAwmLQhzTAwqLQgHTlEY/4MMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQUMIi0IB00sAwBpSQUEaANIBRlJBEEZwR13gyg8A0ElCAxAA00BCU0CcRgAiAwmLQi3TAwqLQhLTiQH8IhK6AwqLQgzTiQGSEYtCCNOJAZIRi0IE04kBOtCSEQDgiQnDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkHZ0kMIi0IB00sAwBpSQUEaANIBRlJBEEZjRlsQAdNAQgArANVJQnBHY0ZbEADTQEIBtQVJACgC3EkcCEAA4AhGwEbARgK9AL////9/AAAAAAAA////////////AAAJPQAAEnoAAAk9AAAA0AcACT0AoA8AAAQAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  load_address: 0x8002408
+  pc_init: 0x1
+  pc_uninit: 0x225
+  pc_program_page: 0x23d
+  pc_erase_sector: 0x235
+  pc_erase_all: 0x22d
+  pc_verify: 0x247
+  data_section_offset: 0x9fc
+  flash_properties:
+    address_range:
+      start: 0x10000000
+      end: 0x10200000
+    page_size: 0x200
+    erased_byte_value: 0x0
+    program_page_timeout: 10000
+    erase_sector_timeout: 40000
+    sectors:
+    - size: 0x40000
+      address: 0x0

--- a/probe-rs/targets/XMC4000.yaml
+++ b/probe-rs/targets/XMC4000.yaml
@@ -3,43 +3,43 @@ manufacturer:
   id: 0x41
   cc: 0x0
 chip_detection:
-- !InfineonScu
+- !InfineonXmcScu
   part: 0x1dd
   scu_id: 0x4100
   variants:
     64: XMC4104-Q48x64
     128: XMC4100-Q48x128
-- !InfineonScu
+- !InfineonXmcScu
   part: 0x1dd
   scu_id: 0x4200
   variants:
     256: XMC4200-Q48x256
-- !InfineonScu
+- !InfineonXmcScu
   part: 0x1df
   scu_id: 0x4300
   variants:
     256: XMC4300-F100x256
-- !InfineonScu
+- !InfineonXmcScu
   part: 0x1dc
   scu_id: 0x4400
   variants:
     256: XMC4400-F64x256
     512: XMC4400-F64x512
-- !InfineonScu
+- !InfineonXmcScu
   part: 0x1db
   scu_id: 0x4500
   variants:
     512: XMC4504-F100x512
     768: XMC4500-F100x768
     1024: XMC4500-F100x1024
-- !InfineonScu
+- !InfineonXmcScu
   part: 0x1df
   scu_id: 0x4700
   variants:
     1024: XMC4700-F100x1024
     1536: XMC4700-F100x1536
     2048: XMC4700-F100x2048
-- !InfineonScu
+- !InfineonXmcScu
   part: 0x1df
   scu_id: 0x4800
   variants:


### PR DESCRIPTION
This PR makes minor changes to acquire/reset sequences to be tolerant of some PSOC 6 quirks:

- A system reset resets the SWD interface as well, causing all requests to return NACK until we reinitialize the debug probe.
- Vector catch reset-and-halt takes up to 100ms, because it applies after the core's boot ROM finishes executing & before jumping into application code.
- A power-up request can succeed and return NACK under some circumstances, such as if the request causes the device to wake from deep sleep.

With these changes, probe-rs is able to successfully acquire, program, and debug PSOC 6 devices. I implemented these changes under `architecture/arm` because they're only minor tweaks that add robustness to error paths and should not affect the behavior of any other supported devices; however, I'm happy to move these to a vendor-specific sequence if that would be better.

Additionally, this PR adds target definitions and autodetection for the PSOC 62 family of devices.