### PR TITLE
Use Rust 1.85

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1872,7 +1872,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             Some(ProgressUpdateEventBody {
                 message: message.map(|msg| match percentage {
                     None => msg.to_string(),
-                    Some(percentage) if percentage == 100.0 => msg.to_string(),
+                    Some(100.0) => msg.to_string(),
                     Some(percentage) => format!("{msg} ({percentage:02.0}%)"),
                 }),
                 percentage,

--- a/probe-rs/src/architecture/arm/dp/mod.rs
+++ b/probe-rs/src/architecture/arm/dp/mod.rs
@@ -33,7 +33,7 @@ pub struct DpRegisterAddress {
 
 impl From<DpRegisterAddress> for u8 {
     fn from(addr: DpRegisterAddress) -> Self {
-        (addr.bank.unwrap_or(0) << 4 & 0xF0) | (addr.address & 0xF)
+        ((addr.bank.unwrap_or(0) << 4) & 0xF0) | (addr.address & 0xF)
     }
 }
 

--- a/probe-rs/src/architecture/arm/memory/adi_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_memory_interface.rs
@@ -91,7 +91,7 @@ where
             self.memory_ap.read_data(self.interface, &mut buf)?;
 
             for i in 0..chunk_size {
-                data[i] = buf[i * 2] as u64 | (buf[i * 2 + 1] as u64) << 32;
+                data[i] = buf[i * 2] as u64 | ((buf[i * 2 + 1] as u64) << 32);
             }
 
             address = address
@@ -496,7 +496,7 @@ where
 
     /// Flushes any pending commands when the underlying probe interface implements command queuing.
     fn flush(&mut self) -> Result<(), ArmError> {
-        self.interface.flush().map_err(Into::into)
+        self.interface.flush()
     }
 
     /// True if the memory ap supports 64 bit accesses which might be more efficient than issuing

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -16,7 +16,7 @@ use crate::{
         dp::{Ctrl, DebugPortError, DpRegister, DLPIDR, TARGETID},
         ArmProbeInterface, RegisterAddress,
     },
-    probe::{DebugProbeError, WireProtocol},
+    probe::WireProtocol,
     MemoryInterface, MemoryMappedRegister, Session,
 };
 
@@ -930,13 +930,11 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
                 // The TARGETSEL write is not ACKed by design. We can't use a normal register write
                 // because many probes don't even send the data phase when NAK.
                 let parity = targetsel.count_ones() % 2;
-                let data = (parity as u64) << 45 | (targetsel as u64) << 13 | 0x1f99;
+                let data = ((parity as u64) << 45) | ((targetsel as u64) << 13) | 0x1f99;
 
                 // Should this be a swd_sequence?
                 // Technically we shouldn't drive SWDIO all the time when sending a request.
-                interface
-                    .swj_sequence(6 * 8, data)
-                    .map_err(DebugProbeError::from)?;
+                interface.swj_sequence(6 * 8, data)?;
             }
 
             tracing::debug!("Reading DPIDR to enable SWD interface");

--- a/probe-rs/src/architecture/riscv/assembly.rs
+++ b/probe-rs/src/architecture/riscv/assembly.rs
@@ -17,7 +17,12 @@ pub const fn sw(offset: u32, base: u32, width: u32, source: u32) -> u32 {
     let offset_lower = offset & 0b11111;
     let offset_upper = offset >> 5;
 
-    offset_upper << 25 | source << 20 | base << 15 | width << 12 | offset_lower << 7 | opcode
+    (offset_upper << 25)
+        | (source << 20)
+        | (base << 15)
+        | (width << 12)
+        | (offset_lower << 7)
+        | opcode
 }
 
 /// Assemble a `addi` instruction.
@@ -74,10 +79,10 @@ fn i_type_instruction(opcode: u8, rs1: u8, funct3: u8, rd: u8, imm: u16) -> u32 
     assert!(rs1 <= 0x1f); // [19:15]
     assert!(imm <= 0xfff); // [31:20]
 
-    (imm as u32) << 20
-        | (rs1 as u32) << 15
-        | (funct3 as u32) << 12
-        | (rd as u32) << 7
+    ((imm as u32) << 20)
+        | ((rs1 as u32) << 15)
+        | ((funct3 as u32) << 12)
+        | ((rd as u32) << 7)
         | opcode as u32
 }
 

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -526,9 +526,9 @@ impl<'state> RiscvCommunicationInterface<'state> {
             let confstrptr_2: Confstrptr2 = self.read_dm_register()?;
             let confstrptr_3: Confstrptr3 = self.read_dm_register()?;
             let confstrptr = (u32::from(confstrptr_0) as u128)
-                | (u32::from(confstrptr_1) as u128) << 8
-                | (u32::from(confstrptr_2) as u128) << 16
-                | (u32::from(confstrptr_3) as u128) << 32;
+                | ((u32::from(confstrptr_1) as u128) << 8)
+                | ((u32::from(confstrptr_2) as u128) << 16)
+                | ((u32::from(confstrptr_3) as u128) << 32);
             Some(confstrptr)
         } else {
             None

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -704,7 +704,7 @@ impl Dmcontrol {
     ///
     /// Combination of the `hartselhi` and `hartsello` registers.
     pub fn hartsel(&self) -> u32 {
-        self.hartselhi() << 10 | self.hartsello()
+        (self.hartselhi() << 10) | self.hartsello()
     }
 
     /// Set the currently selected harts

--- a/probe-rs/src/architecture/xtensa/arch/instruction/format.rs
+++ b/probe-rs/src/architecture/xtensa/arch/instruction/format.rs
@@ -8,23 +8,26 @@
 
 /// Implements the RSR instruction format.
 pub const fn rsr(opcode: u32, rs: u8, t: u8) -> u32 {
-    opcode | (rs as u32) << 8 | (t as u32 & 0x0F) << 4
+    opcode | ((rs as u32) << 8) | ((t as u32 & 0x0F) << 4)
 }
 
 /// Implements the RRR instruction format.
 pub const fn rrr(opcode: u32, r: u8, s: u8, t: u8) -> u32 {
     (opcode & 0xFF000F)
         | ((r as u32 & 0x0F) << 12)
-        | (s as u32 & 0x0F) << 8
-        | (t as u32 & 0x0F) << 4
+        | ((s as u32 & 0x0F) << 8)
+        | ((t as u32 & 0x0F) << 4)
 }
 
 /// Implements the RRI8 instruction format.
 pub const fn rri8(opcode: u32, s: u8, t: u8, imm8: u8) -> u32 {
-    (opcode & 0x00FFFF) | (imm8 as u32) << 16 | ((s as u32 & 0x0F) << 8) | (t as u32 & 0x0F) << 4
+    (opcode & 0x00FFFF)
+        | ((imm8 as u32) << 16)
+        | ((s as u32 & 0x0F) << 8)
+        | ((t as u32 & 0x0F) << 4)
 }
 
 /// Implements the CALLX instruction format.
 pub const fn callx(window: u32, s: u8) -> u32 {
-    0x0000C0 | ((window & 0x03) << 4) | (s as u32 & 0x0F) << 8
+    0x0000C0 | ((window & 0x03) << 4) | ((s as u32 & 0x0F) << 8)
 }

--- a/probe-rs/src/architecture/xtensa/arch/instruction/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/instruction/mod.rs
@@ -46,8 +46,8 @@ pub enum InstructionEncoding {
 impl Instruction {
     const fn encode_bytes(self) -> (usize, u32) {
         let word = match self {
-            Instruction::Lddr32P(src) => 0x0070E0 | (src as u32 & 0x0F) << 8,
-            Instruction::Sddr32P(src) => 0x0070F0 | (src as u32 & 0x0F) << 8,
+            Instruction::Lddr32P(src) => 0x0070E0 | ((src as u32 & 0x0F) << 8),
+            Instruction::Sddr32P(src) => 0x0070F0 | ((src as u32 & 0x0F) << 8),
             Instruction::L32I(s, t, imm) => format::rri8(0x002002, s as u8, t as u8, imm),
             Instruction::S32I(s, t, imm) => format::rri8(0x006002, s as u8, t as u8, imm),
             Instruction::Rsr(sr, t) => format::rsr(0x030000, sr as u8, t as u8),

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -822,7 +822,7 @@ impl BlackMagicProbe {
                         break;
                     }
 
-                    *dest = *dest << 4
+                    *dest = (*dest << 4)
                         | Self::hex_val(byte[0])
                             .or(Err(RemoteError::ParameterError(byte[0] as _)))?;
                 } else {

--- a/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
@@ -64,12 +64,12 @@ fn creating_inner_transfer_request() {
 impl InnerTransferRequest {
     fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
         buffer[0] = (self.APnDP as u8)
-            | (self.RnW as u8) << 1
-            | u8::from(self.A2) << 2
-            | u8::from(self.A3) << 3
-            | u8::from(self.value_match) << 4
-            | u8::from(self.match_mask) << 5
-            | u8::from(self.td_timestamp_request) << 7;
+            | ((self.RnW as u8) << 1)
+            | (u8::from(self.A2) << 2)
+            | (u8::from(self.A3) << 3)
+            | (u8::from(self.value_match) << 4)
+            | (u8::from(self.match_mask) << 5)
+            | (u8::from(self.td_timestamp_request) << 7);
         if let Some(data) = self.data {
             let data = data.to_le_bytes();
             buffer[1..5].copy_from_slice(&data[..]);
@@ -395,9 +395,9 @@ pub(crate) struct InnerTransferBlockRequest {
 impl InnerTransferBlockRequest {
     fn as_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
         buffer[offset] = (self.ap_n_dp as u8)
-            | (self.r_n_w as u8) << 1
-            | u8::from(self.a2) << 2
-            | u8::from(self.a3) << 3;
+            | ((self.r_n_w as u8) << 1)
+            | (u8::from(self.a2) << 2)
+            | (u8::from(self.a3) << 3);
         Ok(1)
     }
 }

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -160,39 +160,33 @@ impl CmsisDap {
     /// The actual clock frequency used by the device might be lower.
     fn set_swj_clock(&mut self, clock_speed_hz: u32) -> Result<(), CmsisDapError> {
         let request = SWJClockRequest { clock_speed_hz };
-        commands::send_command(&mut self.device, &request)
-            .map_err(CmsisDapError::from)
-            .and_then(|v| match v.status {
-                Status::DapOk => Ok(()),
-                Status::DapError => Err(CmsisDapError::ErrorResponse(RequestError::SWJClock {
-                    request,
-                })),
-            })
+        commands::send_command(&mut self.device, &request).and_then(|v| match v.status {
+            Status::DapOk => Ok(()),
+            Status::DapError => Err(CmsisDapError::ErrorResponse(RequestError::SWJClock {
+                request,
+            })),
+        })
     }
 
     fn transfer_configure(&mut self, request: ConfigureRequest) -> Result<(), CmsisDapError> {
-        commands::send_command(&mut self.device, &request)
-            .map_err(CmsisDapError::from)
-            .and_then(|v| match v.status {
-                Status::DapOk => Ok(()),
-                Status::DapError => Err(CmsisDapError::ErrorResponse(
-                    RequestError::TransferConfigure { request },
-                )),
-            })
+        commands::send_command(&mut self.device, &request).and_then(|v| match v.status {
+            Status::DapOk => Ok(()),
+            Status::DapError => Err(CmsisDapError::ErrorResponse(
+                RequestError::TransferConfigure { request },
+            )),
+        })
     }
 
     fn configure_swd(
         &mut self,
         request: swd::configure::ConfigureRequest,
     ) -> Result<(), CmsisDapError> {
-        commands::send_command(&mut self.device, &request)
-            .map_err(CmsisDapError::from)
-            .and_then(|v| match v.status {
-                Status::DapOk => Ok(()),
-                Status::DapError => Err(CmsisDapError::ErrorResponse(RequestError::SwdConfigure {
-                    request,
-                })),
-            })
+        commands::send_command(&mut self.device, &request).and_then(|v| match v.status {
+            Status::DapOk => Ok(()),
+            Status::DapError => Err(CmsisDapError::ErrorResponse(RequestError::SwdConfigure {
+                request,
+            })),
+        })
     }
 
     /// Reset JTAG state machine to Test-Logic-Reset.
@@ -386,48 +380,40 @@ impl CmsisDap {
     }
 
     fn send_jtag_configure(&mut self, request: JtagConfigureRequest) -> Result<(), CmsisDapError> {
-        commands::send_command(&mut self.device, &request)
-            .map_err(CmsisDapError::from)
-            .and_then(|v| match v.status {
-                Status::DapOk => Ok(()),
-                Status::DapError => {
-                    Err(CmsisDapError::ErrorResponse(RequestError::JtagConfigure {
-                        request,
-                    }))
-                }
-            })
+        commands::send_command(&mut self.device, &request).and_then(|v| match v.status {
+            Status::DapOk => Ok(()),
+            Status::DapError => Err(CmsisDapError::ErrorResponse(RequestError::JtagConfigure {
+                request,
+            })),
+        })
     }
 
     fn send_jtag_sequences(
         &mut self,
         request: JtagSequenceRequest,
     ) -> Result<Vec<u8>, CmsisDapError> {
-        commands::send_command(&mut self.device, &request)
-            .map_err(CmsisDapError::from)
-            .and_then(|v| match v {
-                JtagSequenceResponse(Status::DapOk, tdo) => Ok(tdo),
-                JtagSequenceResponse(Status::DapError, _) => {
-                    Err(CmsisDapError::ErrorResponse(RequestError::JtagSequence {
-                        request,
-                    }))
-                }
-            })
+        commands::send_command(&mut self.device, &request).and_then(|v| match v {
+            JtagSequenceResponse(Status::DapOk, tdo) => Ok(tdo),
+            JtagSequenceResponse(Status::DapError, _) => {
+                Err(CmsisDapError::ErrorResponse(RequestError::JtagSequence {
+                    request,
+                }))
+            }
+        })
     }
 
     fn send_swj_sequences(&mut self, request: SequenceRequest) -> Result<(), CmsisDapError> {
         // Ensure all pending commands are processed.
         //self.process_batch()?;
 
-        commands::send_command(&mut self.device, &request)
-            .map_err(CmsisDapError::from)
-            .and_then(|v| match v {
-                SequenceResponse(Status::DapOk) => Ok(()),
-                SequenceResponse(Status::DapError) => {
-                    Err(CmsisDapError::ErrorResponse(RequestError::SwjSequence {
-                        request,
-                    }))
-                }
-            })
+        commands::send_command(&mut self.device, &request).and_then(|v| match v {
+            SequenceResponse(Status::DapOk) => Ok(()),
+            SequenceResponse(Status::DapError) => {
+                Err(CmsisDapError::ErrorResponse(RequestError::SwjSequence {
+                    request,
+                }))
+            }
+        })
     }
 
     /// Read the CTRL register from the currently selected debug port.
@@ -441,7 +427,6 @@ impl CmsisDap {
     fn read_ctrl_register(&mut self) -> Result<Ctrl, ArmError> {
         let response =
             commands::send_command(&mut self.device, &TransferRequest::read(Ctrl::ADDRESS))
-                .map_err(CmsisDapError::from)
                 .map_err(DebugProbeError::from)?;
 
         // We can assume that the single transfer is always executed,
@@ -477,7 +462,6 @@ impl CmsisDap {
             &mut self.device,
             &TransferRequest::write(Abort::ADDRESS, abort.into()),
         )
-        .map_err(CmsisDapError::from)
         .map_err(DebugProbeError::from)?;
 
         // We can assume that the single transfer is always executed,
@@ -532,7 +516,6 @@ impl CmsisDap {
             }
 
             let response = commands::send_command(&mut self.device, &transfers)
-                .map_err(CmsisDapError::from)
                 .map_err(DebugProbeError::from)?;
 
             let count = response.transfers.len();
@@ -758,9 +741,8 @@ impl CmsisDap {
             ConnectRequest::DefaultPort
         };
 
-        let used_protocol = commands::send_command(&mut self.device, &protocol)
-            .map_err(CmsisDapError::from)
-            .and_then(|v| match v {
+        let used_protocol =
+            commands::send_command(&mut self.device, &protocol).and_then(|v| match v {
                 ConnectResponse::SuccessfulInitForSWD => Ok(WireProtocol::Swd),
                 ConnectResponse::SuccessfulInitForJTAG => Ok(WireProtocol::Jtag),
                 ConnectResponse::InitFailed => {

--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -515,7 +515,7 @@ impl From<Command> for u8 {
     fn from(command: Command) -> Self {
         match command {
             Command::Clock { cap, tdi, tms } => {
-                u8::from(cap) << 2 | u8::from(tms) << 1 | u8::from(tdi)
+                (u8::from(cap) << 2) | (u8::from(tms) << 1) | u8::from(tdi)
             }
             Command::Reset(srst) => 8 | u8::from(srst),
             Command::Flush => 0xA,

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -464,8 +464,8 @@ impl JTAGAccess for WchLink {
                 match dmi_op {
                     DMI_OP_READ => {
                         let (addr, data, op) = self.dmi_op_read(dmi_addr)?;
-                        let ret = (addr as u128) << DMI_ADDRESS_BIT_OFFSET
-                            | (data as u128) << DMI_VALUE_BIT_OFFSET
+                        let ret = ((addr as u128) << DMI_ADDRESS_BIT_OFFSET)
+                            | ((data as u128) << DMI_VALUE_BIT_OFFSET)
                             | (op as u128);
                         tracing::trace!("dmi read 0x{:02x} 0x{:08x} op={}", addr, data, op);
                         self.last_dmi_read = Some((addr, data, op));
@@ -480,16 +480,16 @@ impl JTAGAccess for WchLink {
                             self.dmi_op_nop()?
                         };
 
-                        let ret = (addr as u128) << DMI_ADDRESS_BIT_OFFSET
-                            | (data as u128) << DMI_VALUE_BIT_OFFSET
+                        let ret = ((addr as u128) << DMI_ADDRESS_BIT_OFFSET)
+                            | ((data as u128) << DMI_VALUE_BIT_OFFSET)
                             | (op as u128);
                         tracing::trace!("dmi nop 0x{:02x} 0x{:08x} op={}", addr, data, op);
                         Ok(ret.to_le_bytes().to_vec())
                     }
                     DMI_OP_WRITE => {
                         let (addr, data, op) = self.dmi_op_write(dmi_addr, dmi_value)?;
-                        let ret = (addr as u128) << DMI_ADDRESS_BIT_OFFSET
-                            | (data as u128) << DMI_VALUE_BIT_OFFSET
+                        let ret = ((addr as u128) << DMI_ADDRESS_BIT_OFFSET)
+                            | ((data as u128) << DMI_VALUE_BIT_OFFSET)
                             | (op as u128);
                         tracing::trace!("dmi write 0x{:02x} 0x{:08x} op={}", addr, data, op);
                         if dmi_addr == 0x10 && dmi_value == 0x40000001 {

--- a/probe-rs/src/vendor/espressif/sequences/esp32c2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c2.rs
@@ -42,7 +42,7 @@ impl RiscvDebugSequence for ESP32C2 {
         // disable super wdt
         interface.write_word_32(0x600080A4, 0x8F1D312A)?; // write protection off
         let current = interface.read_word_32(0x600080A0)?;
-        interface.write_word_32(0x600080A0, current | 1 << 31)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
+        interface.write_word_32(0x600080A0, current | (1 << 31))?; // set RTC_CNTL_SWD_AUTO_FEED_EN
         interface.write_word_32(0x600080A4, 0x0)?; // write protection on
 
         // tg0 wdg

--- a/probe-rs/src/vendor/espressif/sequences/esp32c3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c3.rs
@@ -42,7 +42,7 @@ impl RiscvDebugSequence for ESP32C3 {
         // disable super wdt
         interface.write_word_32(0x600080B0, 0x8F1D312A)?; // write protection off
         let current = interface.read_word_32(0x600080AC)?;
-        interface.write_word_32(0x600080AC, current | 1 << 31)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
+        interface.write_word_32(0x600080AC, current | (1 << 31))?; // set RTC_CNTL_SWD_AUTO_FEED_EN
         interface.write_word_32(0x600080B0, 0x0)?; // write protection on
 
         // tg0 wdg

--- a/probe-rs/src/vendor/espressif/sequences/esp32c6.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c6.rs
@@ -39,7 +39,7 @@ impl RiscvDebugSequence for ESP32C6 {
         // disable super wdt
         interface.write_word_32(0x600B1C20, 0x50D83AA1)?; // write protection off
         let current = interface.read_word_32(0x600B_1C1C)?;
-        interface.write_word_32(0x600B_1C1C, current | 1 << 18)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
+        interface.write_word_32(0x600B_1C1C, current | (1 << 18))?; // set RTC_CNTL_SWD_AUTO_FEED_EN
         interface.write_word_32(0x600B1C20, 0x0)?; // write protection on
 
         // tg0 wdg

--- a/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
@@ -40,7 +40,7 @@ impl RiscvDebugSequence for ESP32H2 {
         // disable super wdt
         interface.write_word_32(0x600B1C24, 0x50D83AA1)?; // write protection off
         let current = interface.read_word_32(0x600B1C20)?;
-        interface.write_word_32(0x600B1C20, current | 1 << 18)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
+        interface.write_word_32(0x600B1C20, current | (1 << 18))?; // set RTC_CNTL_SWD_AUTO_FEED_EN
         interface.write_word_32(0x600B1C24, 0x0)?; // write protection on
 
         // tg0 wdg

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.85.0"
 
 components = ["rustfmt", "clippy"]
 # Target used for tests


### PR DESCRIPTION
Updates the Rust version to 1.85, and fixes the new clippy warnings.

Prepares for updating the edition.