### PR TITLE
Improve error handling paths of acquire/reset sequences for PSOC compatibility

### DIFF
--- a/changelog/fixed-psoc-reset-quirks.md
+++ b/changelog/fixed-psoc-reset-quirks.md
@@ -1,0 +1,1 @@
+Improved error handling within ARM acquire/reset sequences to better support chips with unusual reset behaviors

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -216,4 +216,8 @@ impl DapAccess for MockMemoryAp {
     fn try_dap_probe(&self) -> Option<&dyn DapProbe> {
         None
     }
+
+    fn try_dap_probe_mut(&mut self) -> Option<&mut dyn DapProbe> {
+        None
+    }
 }

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -674,6 +674,13 @@ impl DapAccess for ArmCommunicationInterface<Initialized> {
     fn try_dap_probe(&self) -> Option<&dyn DapProbe> {
         self.probe.as_deref()
     }
+
+    fn try_dap_probe_mut(&mut self) -> Option<&mut dyn DapProbe> {
+        self.probe
+            .as_deref_mut()
+            // Need to explicitly coerce lifetimes: https://github.com/rust-lang/rust/issues/108999
+            .map(|p: &mut (dyn DapProbe + 'static)| p as &mut (dyn DapProbe + '_))
+    }
 }
 
 /// Information about the chip target we are currently attached to.

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -611,6 +611,8 @@ impl CoreInterface for Armv6m<'_> {
 
         self.sequence
             .reset_system(&mut *self.memory, crate::CoreType::Armv6m, None)?;
+        // Invalidate cached core status
+        self.set_core_status(CoreStatus::Unknown);
         Ok(())
     }
 

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -620,8 +620,24 @@ impl CoreInterface for Armv6m<'_> {
         self.sequence
             .reset_system(&mut *self.memory, crate::CoreType::Armv6m, None)?;
 
-        // Update core status
-        let _ = self.status()?;
+        // Invalidate cached core status
+        self.set_core_status(CoreStatus::Unknown);
+
+        // Some processors may not enter the halt state immediately after clearing the reset state.
+        // Particularly: on PSOC 6, vector catch takes effect after the core's boot ROM finishes
+        // executing, when jumping to the reset vector of the user application.
+        match self.wait_for_core_halted(Duration::from_millis(100)) {
+            Ok(()) => (),
+            Err(Error::Arm(ArmError::Timeout)) if self.status()? == CoreStatus::Sleeping => {
+                // On PSOC 6, if no application is loaded in flash, or if this core is waiting for
+                // another core to boot it, the boot ROM sleeps and vector catch is not triggered.
+                tracing::warn!(
+                    "reset_and_halt timed out and core is sleeping; assuming core is quiescent"
+                );
+                self.halt(Duration::from_millis(100))?;
+            }
+            Err(e) => return Err(e),
+        }
 
         const XPSR_THUMB: u32 = 1 << 24;
 

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -812,8 +812,24 @@ impl CoreInterface for Armv7m<'_> {
         self.sequence
             .reset_system(&mut *self.memory, crate::CoreType::Armv7m, None)?;
 
-        // Update core status
-        let _ = self.status()?;
+        // Invalidate cached core status
+        self.set_core_status(CoreStatus::Unknown);
+
+        // Some processors may not enter the halt state immediately after clearing the reset state.
+        // Particularly: on PSOC 6, vector catch takes effect after the core's boot ROM finishes
+        // executing, when jumping to the reset vector of the user application.
+        match self.wait_for_core_halted(Duration::from_millis(100)) {
+            Ok(()) => (),
+            Err(Error::Arm(ArmError::Timeout)) if self.status()? == CoreStatus::Sleeping => {
+                // On PSOC 6, if no application is loaded in flash, or if this core is waiting for
+                // another core to boot it, the boot ROM sleeps and vector catch is not triggered.
+                tracing::warn!(
+                    "reset_and_halt timed out and core is sleeping; assuming core is quiescent"
+                );
+                self.halt(Duration::from_millis(100))?;
+            }
+            Err(e) => return Err(e),
+        }
 
         const XPSR_THUMB: u32 = 1 << 24;
 

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -801,6 +801,8 @@ impl CoreInterface for Armv7m<'_> {
 
         self.sequence
             .reset_system(&mut *self.memory, crate::CoreType::Armv7m, None)?;
+        // Invalidate cached core status
+        self.set_core_status(CoreStatus::Unknown);
         Ok(())
     }
 

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -244,8 +244,24 @@ impl CoreInterface for Armv8m<'_> {
         self.sequence
             .reset_system(&mut *self.memory, crate::CoreType::Armv8m, None)?;
 
-        // Update core status
-        let _ = self.status()?;
+        // Invalidate cached core status
+        self.set_core_status(CoreStatus::Unknown);
+
+        // Some processors may not enter the halt state immediately after clearing the reset state.
+        // Particularly: on PSOC 6, vector catch takes effect after the core's boot ROM finishes
+        // executing, when jumping to the reset vector of the user application.
+        match self.wait_for_core_halted(Duration::from_millis(100)) {
+            Ok(()) => (),
+            Err(Error::Arm(ArmError::Timeout)) if self.status()? == CoreStatus::Sleeping => {
+                // On PSOC 6, if no application is loaded in flash, or if this core is waiting for
+                // another core to boot it, the boot ROM sleeps and vector catch is not triggered.
+                tracing::warn!(
+                    "reset_and_halt timed out and core is sleeping; assuming core is quiescent"
+                );
+                self.halt(Duration::from_millis(100))?;
+            }
+            Err(e) => return Err(e),
+        }
 
         const XPSR_THUMB: u32 = 1 << 24;
 

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -233,6 +233,8 @@ impl CoreInterface for Armv8m<'_> {
 
         self.sequence
             .reset_system(&mut *self.memory, crate::CoreType::Armv8m, None)?;
+        // Invalidate cached core status
+        self.set_core_status(CoreStatus::Unknown);
         Ok(())
     }
 

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -658,7 +658,28 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
                 // Setting this on MINDP is unpredictable.
                 ctrl.set_mask_lane(0b1111);
             }
-            interface.write_dp_register(dp, ctrl.clone())?;
+
+            match interface
+                .write_dp_register(dp, ctrl.clone())
+                .and_then(|_| interface.flush())
+            {
+                Ok(()) => {}
+                Err(e @ ArmError::Dap(DapError::NoAcknowledge)) => {
+                    // If we get a NACK from the power-up request, ignore the error & perform a line reset.
+                    // (CMSIS-DAP transports read DP.RDBUFF right after a write to DP.CTRL_STAT.
+                    //  This fails in some cases on PSOC 6, for example if the device is waking from DeepSleep.
+                    //  If something really went wrong, we'll hit an error or timeout in the polling loop below.)
+                    let Some(probe) = interface.try_dap_probe_mut() else {
+                        tracing::warn!(
+                            "Power-up request returned NACK, but we don't have a DapProbe, so we can't reconnect"
+                        );
+                        return Err(e);
+                    };
+                    tracing::info!("Power-up request returned NACK, reconnecting");
+                    self.debug_port_connect(probe, dp)?;
+                }
+                Err(e) => return Err(e),
+            }
 
             let start = Instant::now();
             loop {

--- a/probe-rs/src/architecture/arm/traits.rs
+++ b/probe-rs/src/architecture/arm/traits.rs
@@ -424,4 +424,7 @@ pub trait DapAccess {
 
     /// Gain access to the Probe that implements this trait
     fn try_dap_probe(&self) -> Option<&dyn DapProbe>;
+
+    /// Gain mutable access to the Probe that implements this trait
+    fn try_dap_probe_mut(&mut self) -> Option<&mut dyn DapProbe>;
 }

--- a/probe-rs/src/probe/blackmagic/arm.rs
+++ b/probe-rs/src/probe/blackmagic/arm.rs
@@ -654,6 +654,10 @@ impl DapAccess for BlackMagicProbeArmDebug {
     fn try_dap_probe(&self) -> Option<&dyn DapProbe> {
         Some(&*self.probe)
     }
+
+    fn try_dap_probe_mut(&mut self) -> Option<&mut dyn DapProbe> {
+        Some(&mut *self.probe)
+    }
 }
 
 impl ArmMemoryInterface for BlackMagicProbeMemoryInterface<'_> {

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -774,6 +774,10 @@ impl DapAccess for FakeArmInterface<Initialized> {
     fn try_dap_probe(&self) -> Option<&dyn DapProbe> {
         None
     }
+
+    fn try_dap_probe_mut(&mut self) -> Option<&mut dyn DapProbe> {
+        None
+    }
 }
 
 #[cfg(all(test, feature = "builtin-targets"))]

--- a/probe-rs/src/probe/sifliuart/arm.rs
+++ b/probe-rs/src/probe/sifliuart/arm.rs
@@ -144,6 +144,10 @@ impl DapAccess for SifliUartArmDebug {
     fn try_dap_probe(&self) -> Option<&dyn DapProbe> {
         None
     }
+
+    fn try_dap_probe_mut(&mut self) -> Option<&mut dyn DapProbe> {
+        None
+    }
 }
 
 #[allow(unused)]

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1460,6 +1460,10 @@ impl DapAccess for StlinkArmDebug {
     fn try_dap_probe(&self) -> Option<&dyn DapProbe> {
         None
     }
+
+    fn try_dap_probe_mut(&mut self) -> Option<&mut dyn DapProbe> {
+        None
+    }
 }
 
 impl ArmProbeInterface for StlinkArmDebug {


### PR DESCRIPTION
This PR adds error recovery paths for a few situations encountered when working with PSOC devices:

- A system reset resets the debug interface, causing a NACK and requiring us to reinitialize the interface.
- PSOC devices take some time to enter a halted state after performing a reset with vector catch, since the vector catch applies after the core's boot ROM finishes executing (or not at all if there is no user application present in flash).
- A power-up request can cause a spurious NACK, requiring a line reset.

Split out from #3110 as requested by @Yatekii.