### PR TITLE
Runloop tweaks

### DIFF
--- a/changelog/fixed-rtt-in-run-loop.md
+++ b/changelog/fixed-rtt-in-run-loop.md
@@ -1,0 +1,1 @@
+RTT channel modes should no longer be reset during a test run

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
@@ -136,6 +136,18 @@ pub struct RttPoller<'c> {
 }
 
 impl RunLoopPoller for RttPoller<'_> {
+    fn start(&mut self, core: &mut Core<'_>) -> anyhow::Result<()> {
+        if !self.rtt_client.is_attached() {
+            // Config will be applied on attach
+            return Ok(());
+        }
+
+        // We may have arrived here after a poller exit, reapply config
+        self.rtt_client.configure(core)?;
+
+        Ok(())
+    }
+
     fn poll(&mut self, core: &mut Core<'_>) -> anyhow::Result<Duration> {
         if !self.rtt_client.is_attached() && matches!(self.rtt_client.try_attach(core), Ok(true)) {
             tracing::debug!("Attached to RTT");

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
@@ -11,7 +11,10 @@ use crate::{
 use anyhow::Context;
 use postcard_rpc::{header::VarHeader, server::Sender};
 use postcard_schema::Schema;
-use probe_rs::{BreakpointCause, Core, HaltReason, Session, semihosting::SemihostingCommand};
+use probe_rs::{
+    BreakpointCause, Core, HaltReason, Session,
+    semihosting::{CloseRequest, OpenRequest, SemihostingCommand, WriteRequest},
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
@@ -152,7 +155,7 @@ impl<F: FnMut(MonitorEvent)> MonitorEventHandler<F> {
         match cmd {
             SemihostingCommand::ExitSuccess => Ok(Some(())), // Exit the run loop
             SemihostingCommand::ExitError(details) => {
-                Err(anyhow::anyhow!("Semihosting indicated exit with {details}"))
+                anyhow::bail!("Semihosting indicated exit with {details}")
             }
             SemihostingCommand::Unknown(details) => {
                 tracing::warn!(
@@ -212,74 +215,14 @@ impl SemihostingReader {
     ) -> anyhow::Result<Option<SemihostingOutput>> {
         let out = match command {
             SemihostingCommand::Open(request) => {
-                let path = request.path(core)?;
-                if path == ":tt" {
-                    match request.mode().as_bytes()[0] {
-                        b'w' => {
-                            self.stdout_open = true;
-                            request.respond_with_handle(core, Self::STDOUT)?;
-                        }
-                        b'a' => {
-                            self.stderr_open = true;
-                            request.respond_with_handle(core, Self::STDERR)?;
-                        }
-                        other => {
-                            tracing::warn!(
-                                "Target wanted to open file {path} with mode {mode}, but probe-rs does not support this operation yet. Continuing...",
-                                path = path,
-                                mode = other
-                            );
-                        }
-                    };
-                } else {
-                    tracing::warn!(
-                        "Target wanted to open file {path}, but probe-rs does not support this operation yet. Continuing..."
-                    );
-                }
+                self.handle_open(core, request)?;
                 None
             }
             SemihostingCommand::Close(request) => {
-                let handle = request.file_handle(core)?;
-                if handle == Self::STDOUT.get() {
-                    self.stdout_open = false;
-                    request.success(core)?;
-                } else if handle == Self::STDERR.get() {
-                    self.stderr_open = false;
-                    request.success(core)?;
-                } else {
-                    tracing::warn!(
-                        "Target wanted to close file handle {handle}, but probe-rs does not support this operation yet. Continuing..."
-                    );
-                }
+                self.handle_close(core, request)?;
                 None
             }
-            SemihostingCommand::Write(request) => {
-                let mut out = None;
-                match request.file_handle() {
-                    handle if handle == Self::STDOUT.get() => {
-                        if self.stdout_open {
-                            let bytes = request.read(core)?;
-                            let str = String::from_utf8_lossy(&bytes);
-                            out = Some(SemihostingOutput::StdOut(str.to_string()));
-                            request.write_status(core, 0)?;
-                        }
-                    }
-                    handle if handle == Self::STDERR.get() => {
-                        if self.stderr_open {
-                            let bytes = request.read(core)?;
-                            let str = String::from_utf8_lossy(&bytes);
-                            out = Some(SemihostingOutput::StdErr(str.to_string()));
-                            request.write_status(core, 0)?;
-                        }
-                    }
-                    other => {
-                        tracing::warn!(
-                            "Target wanted to write to file handle {other}, but probe-rs does not support this operation yet. Continuing...",
-                        );
-                    }
-                }
-                out
-            }
+            SemihostingCommand::Write(request) => self.handle_write(core, request)?,
             SemihostingCommand::WriteConsole(request) => {
                 let str = request.read(core)?;
                 Some(SemihostingOutput::StdOut(str))
@@ -290,4 +233,80 @@ impl SemihostingReader {
 
         Ok(out)
     }
+
+    fn handle_open(&mut self, core: &mut Core<'_>, request: OpenRequest) -> anyhow::Result<()> {
+        let path = request.path(core)?;
+        if path != ":tt" {
+            tracing::warn!(
+                "Target wanted to open file {path}, but probe-rs does not support this operation yet. Continuing..."
+            );
+            return Ok(());
+        }
+
+        match request.mode().as_bytes()[0] {
+            b'w' => {
+                self.stdout_open = true;
+                request.respond_with_handle(core, Self::STDOUT)?;
+            }
+            b'a' => {
+                self.stderr_open = true;
+                request.respond_with_handle(core, Self::STDERR)?;
+            }
+            mode => tracing::warn!(
+                "Target wanted to open file {path} with mode {mode}, but probe-rs does not support this operation yet. Continuing..."
+            ),
+        }
+
+        Ok(())
+    }
+
+    fn handle_close(&mut self, core: &mut Core<'_>, request: CloseRequest) -> anyhow::Result<()> {
+        let handle = request.file_handle(core)?;
+        if handle == Self::STDOUT.get() {
+            self.stdout_open = false;
+            request.success(core)?;
+        } else if handle == Self::STDERR.get() {
+            self.stderr_open = false;
+            request.success(core)?;
+        } else {
+            tracing::warn!(
+                "Target wanted to close file handle {handle}, but probe-rs does not support this operation yet. Continuing..."
+            );
+        }
+
+        Ok(())
+    }
+
+    fn handle_write(
+        &mut self,
+        core: &mut Core<'_>,
+        request: WriteRequest,
+    ) -> anyhow::Result<Option<SemihostingOutput>> {
+        match request.file_handle() {
+            handle if handle == Self::STDOUT.get() => {
+                if self.stdout_open {
+                    let string = read_written_string(core, request)?;
+                    return Ok(Some(SemihostingOutput::StdOut(string)));
+                }
+            }
+            handle if handle == Self::STDERR.get() => {
+                if self.stderr_open {
+                    let string = read_written_string(core, request)?;
+                    return Ok(Some(SemihostingOutput::StdErr(string)));
+                }
+            }
+            other => tracing::warn!(
+                "Target wanted to write to file handle {other}, but probe-rs does not support this operation yet. Continuing...",
+            ),
+        }
+
+        Ok(None)
+    }
+}
+
+fn read_written_string(core: &mut Core<'_>, request: WriteRequest) -> anyhow::Result<String> {
+    let bytes = request.read(core)?;
+    let str = String::from_utf8_lossy(&bytes);
+    request.write_status(core, 0)?;
+    Ok(str.to_string())
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/utils/run_loop.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/utils/run_loop.rs
@@ -123,7 +123,9 @@ impl RunLoop<'_> {
 
             let mut had_rtt_data = false;
             if let Some(ref mut rtt_client) = self.rtt_client {
-                _ = rtt_client.try_attach(core);
+                if !rtt_client.is_attached() && matches!(rtt_client.try_attach(core), Ok(true)) {
+                    tracing::debug!("Attached to RTT");
+                }
                 for channel in 0..rtt_client.up_channels().len() {
                     let bytes = rtt_client.poll_channel(core, channel as u32)?;
                     if !bytes.is_empty() {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/utils/run_loop.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/utils/run_loop.rs
@@ -3,7 +3,7 @@ use tokio_util::sync::CancellationToken;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use probe_rs::{Core, Error, HaltReason, VectorCatchCondition};
 
 use crate::util::rtt::client::RttClient;
@@ -110,7 +110,7 @@ impl RunLoop<'_> {
                         // Poll at 1kHz if the core was halted, to speed up reading strings
                         // from semihosting. The core is not expected to be halted for other reasons.
                         next_poll = Duration::from_millis(1);
-                        core.run()?
+                        core.run()?;
                     }
                 },
                 probe_rs::CoreStatus::Running
@@ -119,7 +119,7 @@ impl RunLoop<'_> {
                     // Carry on
                 }
 
-                probe_rs::CoreStatus::LockedUp => return Err(anyhow!("The core is locked up.")),
+                probe_rs::CoreStatus::LockedUp => anyhow::bail!("The core is locked up."),
             }
 
             if let Some(ref mut rtt_client) = self.rtt_client {

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
@@ -36,8 +36,12 @@ impl RttClient {
         }
     }
 
+    pub fn is_attached(&self) -> bool {
+        self.target.is_some()
+    }
+
     pub fn try_attach(&mut self, core: &mut Core) -> Result<bool, Error> {
-        if self.target.is_some() {
+        if self.is_attached() {
             return Ok(true);
         }
 

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
@@ -211,4 +211,22 @@ impl RttClient {
     pub(crate) fn core_id(&self) -> usize {
         self.core_id
     }
+
+    pub(crate) fn configure(&mut self, core: &mut Core<'_>) -> Result<(), Error> {
+        let Some(target) = self.target.as_mut() else {
+            return Ok(());
+        };
+
+        let up_channels = target.active_up_channels.as_mut_slice();
+
+        for (idx, channel) in up_channels.iter_mut().enumerate() {
+            if let Some(config) = self.config.channel_config(idx as u32) {
+                if let Some(mode) = config.mode {
+                    channel.change_mode(core, mode)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
This PR fixes a - maybe somewhat theoretical - error where between embedded-test runs, the RTT channel modes are reset. This issue may affect tests that are run from RAM, otherwise the RTT control block is reset and reconfigured upon the next connection.

The PR refactors RTT polling by distancing it from the run loop itself, allowing us to maybe support different transports in the future, as well as to make the run loop more extensible if needed.