### PR TITLE
ST-Link: do not panic when trying to initialize with multidrop DP address

### DIFF
--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1287,7 +1287,7 @@ impl UninitializedArmProbe for UninitializedStLink {
             return Err((
                 self,
                 ProbeRsError::Probe(DebugProbeError::Other(String::from(
-                    "Multidrop not supported on ST-Link",
+                    "Multidrop is not supported on ST-Link",
                 ))),
             ));
         }

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1283,7 +1283,15 @@ impl UninitializedArmProbe for UninitializedStLink {
         _sequence: Arc<dyn ArmDebugSequence>,
         dp: DpAddress,
     ) -> Result<Box<dyn ArmProbeInterface>, (Box<dyn UninitializedArmProbe>, ProbeRsError)> {
-        assert_eq!(dp, DpAddress::Default, "Multidrop not supported on ST-Link");
+        if dp != DpAddress::Default {
+            return Err((
+                self,
+                ProbeRsError::Probe(DebugProbeError::Other(String::from(
+                    "Multidrop not supported on ST-Link",
+                ))),
+            ));
+        }
+
         let interface = StlinkArmDebug::new(self.probe)
             .map_err(|(s, e)| (s as Box<_>, ProbeRsError::from(e)))?;
 


### PR DESCRIPTION
The changes made to `probe-rs info` mean that now we try to unconditionally scan through known DPs. This resulted in hitting an ST-Link assertion for some devices, which I think is not ideal.

The result was that calling `probe-rs info` on these devices could just error like this:

```
❯ cargo probe-rs info --preset stm32u545re --protocol swd
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.54s
     Running `target\debug\probe-rs.exe info --preset stm32u545re --protocol swd`
Probing target via SWD
----------------------

 WARN postcard_rpc::host_client::util: in_worker: wire receive error, exiting
 WARN probe_rs::rpc::client: Failed to read topic
Error while probing target: Connection closed
```