### PR TITLE
Allow configuring server port and address

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/serve.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/serve.rs
@@ -31,6 +31,19 @@ use crate::{
     },
 };
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ServerConfig {
+    pub users: Vec<ServerUser>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ServerUser {
+    pub name: String,
+    pub token: String,
+}
+
 struct ServerState {
     config: Config,
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/serve.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/serve.rs
@@ -76,7 +76,7 @@ pub struct Cmd {}
 
 impl Cmd {
     pub async fn run(self, config: Config) -> anyhow::Result<()> {
-        if config.server_users.is_empty() {
+        if config.server.users.is_empty() {
             tracing::warn!("No users configured.");
         }
 
@@ -139,7 +139,7 @@ async fn handle_socket(socket: WebSocket, challenge: String, state: Arc<ServerSt
 
     // TODO: we might want to include the username to avoid hashing a bunch of times
     let mut authed_user = None;
-    for user in state.config.server_users.iter() {
+    for user in state.config.server.users.iter() {
         let mut hasher = Sha512::new();
         hasher.update(challenge.as_bytes());
         hasher.update(user.token.as_bytes());

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -39,13 +39,19 @@ struct ServerUser {
     pub token: String,
 }
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg(feature = "remote")]
+pub(crate) struct ServerConfig {
+    pub users: Vec<ServerUser>,
+}
+
 type ConfigPreset = HashMap<String, Value>;
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub(crate) struct Config {
     #[cfg(feature = "remote")]
-    pub server_users: Vec<ServerUser>,
+    pub server: ServerConfig,
 
     /// A named set of `--key=value` pairs.
     pub presets: HashMap<String, ConfigPreset>,

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -31,27 +31,12 @@ use crate::util::parse_u64;
 
 const MAX_LOG_FILES: usize = 20;
 
-#[cfg(feature = "remote")]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct ServerUser {
-    pub name: String,
-    pub token: String,
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-#[cfg(feature = "remote")]
-pub(crate) struct ServerConfig {
-    pub users: Vec<ServerUser>,
-}
-
 type ConfigPreset = HashMap<String, Value>;
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub(crate) struct Config {
     #[cfg(feature = "remote")]
-    pub server: ServerConfig,
+    pub server: cmd::serve::ServerConfig,
 
     /// A named set of `--key=value` pairs.
     pub presets: HashMap<String, ConfigPreset>,

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -114,7 +114,7 @@ impl Cli {
                 cmd::dap_server::run(cmd, &lister, utc_offset, log_path)
             }
             #[cfg(feature = "remote")]
-            Subcommand::Serve(cmd) => cmd.run(_config).await,
+            Subcommand::Serve(cmd) => cmd.run(_config.server).await,
             Subcommand::List(cmd) => cmd.run(client).await,
             Subcommand::Info(cmd) => cmd.run(client).await,
             Subcommand::Gdb(cmd) => cmd.run(&lister),


### PR DESCRIPTION
- The outermost Config no longer has `deny_unknown_fields` so the same config is valid even without the `remote` feature. This is a QoL change for my own sanity.
- Server configuration is now grouped into a single structure. This means `[[server_users]]` becomes `[[server.users]]` in the config TOML, for example.
- The PR adds `port` and `address` under the server configuration.