### PR TITLE
DAP adapter cleanup

### DIFF
--- a/changelog/changed-download-options.md
+++ b/changelog/changed-download-options.md
@@ -1,0 +1,1 @@
+`DownloadOptions` and `FlashProgress` now have a lifetime `'p` to allow using short-lived `FlashProgress` objects.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -169,12 +169,9 @@ impl Debugger {
                     )));
                 };
 
-                let Ok(mut target_core) = session_data.attach_core(target_core_config.core_index)
-                else {
-                    return Err(DebuggerError::Other(anyhow!(
-                        "Unable to connect to target core"
-                    )));
-                };
+                let mut target_core = session_data
+                    .attach_core(target_core_config.core_index)
+                    .context("Unable to connect to target core")?;
 
                 // For some operations, we need to make sure the core isn't sleeping, by calling `Core::halt()`.
                 // When we do this, we need to flag it (`unhalt_me = true`), and later call `Core::run()` again.
@@ -195,9 +192,7 @@ impl Debugger {
                     | "disassemble" => {
                         if new_status == &CoreStatus::Sleeping {
                             match target_core.core.halt(Duration::from_millis(100)) {
-                                Ok(_) => {
-                                    unhalt_me = true;
-                                }
+                                Ok(_) => unhalt_me = true,
                                 Err(error) => {
                                     let err = DebuggerError::from(error);
                                     debug_adapter.send_response::<()>(&request, Err(&err))?;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -161,7 +161,7 @@ impl Debugger {
 
                 // Attach to the core. so that we have the handle available for processing the request.
 
-                let Some(target_core_config) = self.config.core_configs.get_mut(core_id) else {
+                let Some(target_core_config) = self.config.core_configs.get(core_id) else {
                     return Err(DebuggerError::Other(anyhow!(
                         "No core configuration found for core id {}",
                         core_id

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -184,9 +184,9 @@ fn print_instr_sets(instr_sets: &[InstructionSet]) -> String {
 /// ```
 #[derive(Default)]
 #[non_exhaustive]
-pub struct DownloadOptions {
+pub struct DownloadOptions<'p> {
     /// An optional progress reporter which is used if this argument is set to `Some(...)`.
-    pub progress: Option<FlashProgress>,
+    pub progress: Option<FlashProgress<'p>>,
     /// If `keep_unwritten_bytes` is `true`, erased portions of the flash that are not overwritten by the ELF data
     /// are restored afterwards, such that the old contents are untouched.
     ///
@@ -211,7 +211,7 @@ pub struct DownloadOptions {
     pub disable_double_buffering: bool,
 }
 
-impl DownloadOptions {
+impl DownloadOptions<'_> {
     /// DownloadOptions with default values.
     pub fn new() -> Self {
         Self::default()

--- a/probe-rs/src/flashing/progress.rs
+++ b/probe-rs/src/flashing/progress.rs
@@ -15,13 +15,13 @@ use std::{sync::Arc, time::Duration};
 /// let progress = FlashProgress::new(|event| println!("Event: {:#?}", event));
 /// ```
 #[derive(Clone)]
-pub struct FlashProgress {
-    handler: Arc<dyn Fn(ProgressEvent)>,
+pub struct FlashProgress<'a> {
+    handler: Arc<dyn Fn(ProgressEvent) + 'a>,
 }
 
-impl FlashProgress {
+impl<'a> FlashProgress<'a> {
     /// Create a new `FlashProgress` structure with a given `handler` to be called on events.
-    pub fn new(handler: impl Fn(ProgressEvent) + 'static) -> Self {
+    pub fn new(handler: impl Fn(ProgressEvent) + 'a) -> Self {
         Self {
             handler: Arc::new(handler),
         }


### PR DESCRIPTION
This PR implements some FlashProgress/DownloadOptions changes that no longer require us to move DebugAdapter, and applies cleanups enabled by this change.