### PR TITLE
Remove global registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2974,6 +2974,7 @@ dependencies = [
  "scroll",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "signal-hook",
  "svd-parser",

--- a/changelog/added-with-registry.md
+++ b/changelog/added-with-registry.md
@@ -1,0 +1,1 @@
+Added `Probe::attach_with_registry` and `attach_under_reset_with_registry` to allow working with a custom registry.

--- a/changelog/changed-registry.md
+++ b/changelog/changed-registry.md
@@ -1,0 +1,2 @@
+- `Registry` is now a public structure instead of internally global configuration.
+- The `add_target_family, add_target_from_yaml, families, get_family_by_name, get_target_and_family_by_name, get_target_by_name, get_targets_by_family_name search_chips` functions have been removed in favour of `Registry` methods.

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -33,6 +33,7 @@ jep106 = "0.2"
 num-traits = "0.2"
 scroll = "0.12"
 serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
 thiserror = { workspace = true }
 tracing = "0.1"
 typed-path = "0.10"

--- a/probe-rs-tools/src/bin/probe-rs/cmd/benchmark.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/benchmark.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Context;
-use probe_rs::{MemoryInterface, probe::list::Lister};
+use probe_rs::{MemoryInterface, config::Registry, probe::list::Lister};
 
 use crate::util::common_options::LoadedProbeOptions;
 use crate::util::common_options::ProbeOptions;
@@ -83,9 +83,9 @@ struct TestData {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
+    pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
         let speed = self.common.speed;
-        let common_options = self.common.load()?;
+        let common_options = self.common.load(registry)?;
         let mut max_speed = self.max_speed;
         let mut speeds = vec![];
         // if no max-speed specified, assume the user just wants to use a single speed (as per other cli cmds)

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -7,10 +7,12 @@ use anyhow::{Context, Result, anyhow};
 use clap::Parser;
 use colored::Colorize;
 use parking_lot::FairMutex;
+use probe_rs::config::Registry;
 use probe_rs::flashing::{BootInfo, FormatKind};
 use probe_rs::probe::list::Lister;
 use probe_rs::rtt::ScanRegion;
 use probe_rs::{Session, probe::DebugProbeSelector};
+use probe_rs_target::ChipFamily;
 use std::ffi::OsString;
 use std::time::Instant;
 use std::{fs, thread};
@@ -138,10 +140,14 @@ fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
 
     let _log_guard = setup_logging(None, config.general.log_level);
 
+    let mut registry = Registry::from_builtin_families();
+
     // Make sure we load the config given in the cli parameters.
     for cdp in &config.general.chip_descriptions {
         let file = File::open(Path::new(cdp))?;
-        probe_rs::config::add_target_from_yaml(file)
+        let family: ChipFamily = serde_yaml::from_reader(file)?;
+        registry
+            .add_target_family(family)
             .with_context(|| format!("failed to load the chip description from {cdp}"))?;
     }
     let image_instr_set;
@@ -212,7 +218,7 @@ fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
     };
 
     let lister = Lister::new();
-    let (mut session, probe_options) = match probe_options.simple_attach(&lister) {
+    let (mut session, probe_options) = match probe_options.simple_attach(&mut registry, &lister) {
         Ok((session, probe_options)) => (session, probe_options),
 
         Err(OperationError::MultipleProbesFound { list }) => {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -12,12 +12,10 @@ use probe_rs::flashing::{BootInfo, FormatKind};
 use probe_rs::probe::list::Lister;
 use probe_rs::rtt::ScanRegion;
 use probe_rs::{Session, probe::DebugProbeSelector};
-use probe_rs_target::ChipFamily;
 use std::ffi::OsString;
 use std::time::Instant;
 use std::{fs, thread};
 use std::{
-    fs::File,
     io::Write,
     panic,
     path::{Path, PathBuf},
@@ -144,10 +142,9 @@ fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
 
     // Make sure we load the config given in the cli parameters.
     for cdp in &config.general.chip_descriptions {
-        let file = File::open(Path::new(cdp))?;
-        let family: ChipFamily = serde_yaml::from_reader(file)?;
+        let file = std::fs::read_to_string(Path::new(cdp))?;
         registry
-            .add_target_family(family)
+            .add_target_family_from_yaml(&file)
             .with_context(|| format!("failed to load the chip description from {cdp}"))?;
     }
     let image_instr_set;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/chip.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/chip.rs
@@ -99,7 +99,7 @@ mod test {
         use crate::rpc::functions::RpcApp;
 
         // Create a local server to run commands against.
-        let (mut local_server, tx, rx) = RpcApp::create_server(true, 16);
+        let (mut local_server, tx, rx) = RpcApp::create_server(16);
         let handle = tokio::spawn(async move { local_server.run().await });
 
         // Run the command locally.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
@@ -7,6 +7,7 @@ use clap_complete::{
     Generator, Shell, generate,
     shells::{Bash, PowerShell, Zsh},
 };
+use probe_rs::config::Registry;
 use probe_rs::probe::list::Lister;
 
 use crate::Cli;
@@ -118,7 +119,7 @@ pub enum CompleteKind {
 /// Output will be one line per chip and print the full name probe-rs expects.
 pub fn list_chips(starts_with: &str) -> Result<String> {
     let mut output = String::new();
-    for family in probe_rs::config::families() {
+    for family in Registry::from_builtin_families().families() {
         for variant in family.variants() {
             if variant.name.starts_with(starts_with) {
                 writeln!(output, "{}", variant.name)?;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -13,7 +13,11 @@ use crate::{
     util::common_options::OperationError,
 };
 use anyhow::{Result, anyhow};
-use probe_rs::{CoreStatus, Session, config::TargetSelector, probe::list::Lister};
+use probe_rs::{
+    CoreStatus, Session,
+    config::{Registry, TargetSelector},
+    probe::list::Lister,
+};
 use probe_rs_debug::{
     DebugRegisters, SourceLocation, debug_info::DebugInfo, exception_handler_for_core,
 };
@@ -64,13 +68,14 @@ pub(crate) struct SessionData {
 
 impl SessionData {
     pub(crate) fn new(
+        registry: &mut Registry,
         lister: &Lister,
         config: &mut configuration::SessionConfig,
         timestamp_offset: UtcOffset,
     ) -> Result<Self, DebuggerError> {
         let target_selector = TargetSelector::from(config.chip.as_deref());
 
-        let options = config.probe_options().load()?;
+        let options = config.probe_options().load(registry)?;
         let target_probe = options.attach_probe(lister)?;
         let target_session = options
             .attach_session(target_probe, target_selector)

--- a/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
@@ -13,6 +13,7 @@ use probe_rs::CoreDump;
 use probe_rs::CoreDumpError;
 use probe_rs::CoreInterface;
 use probe_rs::architecture::arm::ap::AccessPortError;
+use probe_rs::config::Registry;
 use probe_rs::flashing::FileDownloadError;
 use probe_rs::probe::DebugProbeError;
 use probe_rs::probe::list::Lister;
@@ -38,8 +39,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
-        let (mut session, _probe_options) = self.common.simple_attach(lister)?;
+    pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
+        let (mut session, _probe_options) = self.common.simple_attach(registry, lister)?;
 
         let di = self
             .exe

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/mod.rs
@@ -9,7 +9,7 @@ pub(crate) use stub::{GdbInstanceConfiguration, run};
 use std::time::Duration;
 
 use parking_lot::FairMutex;
-use probe_rs::probe::list::Lister;
+use probe_rs::{config::Registry, probe::list::Lister};
 
 use crate::util::common_options::ProbeOptions;
 
@@ -33,8 +33,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
-        let (mut session, _probe_options) = self.common.simple_attach(lister)?;
+    pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
+        let (mut session, _probe_options) = self.common.simple_attach(registry, lister)?;
 
         if self.reset_halt {
             session

--- a/probe-rs-tools/src/bin/probe-rs/cmd/itm.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/itm.rs
@@ -3,6 +3,7 @@
 use std::time::{Duration, Instant};
 
 use probe_rs::architecture::arm::{component::TraceSink, swo::SwoConfig};
+use probe_rs::config::Registry;
 use probe_rs::probe::list::Lister;
 
 use crate::CoreOptions;
@@ -68,8 +69,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
-        let (mut session, _probe_options) = self.common.simple_attach(lister)?;
+    pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
+        let (mut session, _probe_options) = self.common.simple_attach(registry, lister)?;
 
         match self.source {
             ItmSource::TraceMemory { coreclk } => {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/profile.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/profile.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 use addr2line::Loader;
 use anyhow::anyhow;
 use itm::TracePacket;
+use probe_rs::config::Registry;
 use probe_rs::{
     architecture::arm::{
         SwoConfig,
@@ -67,12 +68,12 @@ impl std::fmt::Display for ProfileMethod {
 }
 
 impl ProfileCmd {
-    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
+    pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, probe_options) = self
             .run
             .shared_options
             .probe_options
-            .simple_attach(lister)?;
+            .simple_attach(registry, lister)?;
 
         let loader = build_loader(
             &mut session,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/serve.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/serve.rs
@@ -147,7 +147,7 @@ async fn ws_handler(ws: WebSocketUpgrade, state: State<Arc<ServerState>>) -> imp
 /// Actual websocket statemachine (one will be spawned per connection)
 async fn handle_socket(socket: WebSocket, challenge: String, state: Arc<ServerState>) {
     let (writer, reader) = socket.split();
-    let (mut server, tx, mut rx) = RpcApp::create_server(false, 16);
+    let (mut server, tx, mut rx) = RpcApp::create_server(16);
 
     let mut reader = WebsocketRx::new(reader.map(|message| {
         message.map(|message| match message {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/trace.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/trace.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use probe_rs::MemoryInterface;
+use probe_rs::config::Registry;
 use probe_rs::probe::list::Lister;
 use scroll::{LE, Pwrite};
 
@@ -24,13 +25,13 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
+    pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
         let mut xs = vec![];
         let mut ys = vec![];
 
         let start = Instant::now();
 
-        let (mut session, _probe_options) = self.common.simple_attach(lister)?;
+        let (mut session, _probe_options) = self.common.simple_attach(registry, lister)?;
 
         let mut core = session.core(self.shared.core)?;
 

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -117,19 +117,19 @@ impl Cli {
             Subcommand::Serve(cmd) => cmd.run(_config.server).await,
             Subcommand::List(cmd) => cmd.run(client).await,
             Subcommand::Info(cmd) => cmd.run(client).await,
-            Subcommand::Gdb(cmd) => cmd.run(&lister),
+            Subcommand::Gdb(cmd) => cmd.run(&mut *client.registry().await, &lister),
             Subcommand::Reset(cmd) => cmd.run(client).await,
-            Subcommand::Debug(cmd) => cmd.run(&lister),
+            Subcommand::Debug(cmd) => cmd.run(&mut *client.registry().await, &lister),
             Subcommand::Download(cmd) => cmd.run(client).await,
             Subcommand::Run(cmd) => cmd.run(client, utc_offset).await,
             Subcommand::Attach(cmd) => cmd.run(client, utc_offset).await,
             Subcommand::Verify(cmd) => cmd.run(client).await,
             Subcommand::Erase(cmd) => cmd.run(client).await,
-            Subcommand::Trace(cmd) => cmd.run(&lister),
-            Subcommand::Itm(cmd) => cmd.run(&lister),
+            Subcommand::Trace(cmd) => cmd.run(&mut *client.registry().await, &lister),
+            Subcommand::Itm(cmd) => cmd.run(&mut *client.registry().await, &lister),
             Subcommand::Chip(cmd) => cmd.run(client).await,
-            Subcommand::Benchmark(cmd) => cmd.run(&lister),
-            Subcommand::Profile(cmd) => cmd.run(&lister),
+            Subcommand::Benchmark(cmd) => cmd.run(&mut *client.registry().await, &lister),
+            Subcommand::Profile(cmd) => cmd.run(&mut *client.registry().await, &lister),
             Subcommand::Read(cmd) => cmd.run(client).await,
             Subcommand::Write(cmd) => cmd.run(client).await,
             Subcommand::Complete(cmd) => cmd.run(&lister),
@@ -491,7 +491,7 @@ async fn main() -> Result<()> {
     }
 
     // Create a local server to run commands against.
-    let (mut local_server, tx, rx) = RpcApp::create_server(true, 16);
+    let (mut local_server, tx, rx) = RpcApp::create_server(16);
     let handle = tokio::spawn(async move { local_server.run().await });
 
     // Run the command locally.

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -374,17 +374,9 @@ impl RpcClient {
             .await
     }
 
-    pub async fn load_chip_family(
-        &self,
-        families: probe_rs_target::ChipFamily,
-    ) -> anyhow::Result<()> {
-        // FIXME: There's a chance ChipFamily won't match on the client and server
-        let family = postcard::to_stdvec(&families).context("Failed to serialize chip family")?;
-
-        self.send_resp::<LoadChipFamilyEndpoint, _>(&LoadChipFamilyRequest {
-            family_data: family,
-        })
-        .await
+    pub async fn load_chip_family(&self, families_yaml: String) -> anyhow::Result<()> {
+        self.send_resp::<LoadChipFamilyEndpoint, _>(&LoadChipFamilyRequest { families_yaml })
+            .await
     }
 
     pub async fn list_chip_families(&self) -> anyhow::Result<Vec<ChipFamily>> {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -378,7 +378,7 @@ impl RpcClient {
         &self,
         families: probe_rs_target::ChipFamily,
     ) -> anyhow::Result<()> {
-        // I refuse to add a schema to ChipFamily until we can actually load it on the server.
+        // FIXME: There's a chance ChipFamily won't match on the client and server
         let family = postcard::to_stdvec(&families).context("Failed to serialize chip family")?;
 
         self.send_resp::<LoadChipFamilyEndpoint, _>(&LoadChipFamilyRequest {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/chip.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/chip.rs
@@ -334,7 +334,9 @@ pub async fn chip_info(
 // Used to avoid uploading a temp file to the remote.
 #[derive(Serialize, Deserialize, Schema)]
 pub struct LoadChipFamilyRequest {
-    pub family_data: Vec<u8>,
+    /// Chip description in YAML format.
+    // TODO: instead, serialize the whole ChipFamily struct
+    pub families_yaml: String,
 }
 
 pub async fn load_chip_family(
@@ -342,7 +344,7 @@ pub async fn load_chip_family(
     _header: VarHeader,
     request: LoadChipFamilyRequest,
 ) -> NoResponse {
-    let family = postcard::from_bytes::<probe_rs_target::ChipFamily>(&request.family_data)
+    let family = serde_yaml::from_str(&request.families_yaml)
         .context("Failed to deserialize chip family data")?;
 
     ctx.registry().await.add_target_family(family)?;

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/chip.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/chip.rs
@@ -1,6 +1,5 @@
 use std::ops::Range;
 
-use anyhow::Context;
 use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;
 use probe_rs::Target;
@@ -344,10 +343,9 @@ pub async fn load_chip_family(
     _header: VarHeader,
     request: LoadChipFamilyRequest,
 ) -> NoResponse {
-    let family = serde_yaml::from_str(&request.families_yaml)
-        .context("Failed to deserialize chip family data")?;
-
-    ctx.registry().await.add_target_family(family)?;
+    ctx.registry()
+        .await
+        .add_target_family_from_yaml(&request.families_yaml)?;
 
     Ok(())
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/chip.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/chip.rs
@@ -6,7 +6,7 @@ use postcard_schema::Schema;
 use probe_rs::Target;
 use serde::{Deserialize, Serialize};
 
-use crate::rpc::functions::{NoResponse, RpcContext, RpcError, RpcResult};
+use crate::rpc::functions::{NoResponse, RpcContext, RpcResult};
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Schema)]
 pub struct JEP106Code {
@@ -47,12 +47,12 @@ pub struct ChipFamily {
     pub variants: Vec<Chip>,
 }
 
-impl From<probe_rs_target::ChipFamily> for ChipFamily {
-    fn from(value: probe_rs_target::ChipFamily) -> Self {
+impl From<&probe_rs_target::ChipFamily> for ChipFamily {
+    fn from(value: &probe_rs_target::ChipFamily) -> Self {
         Self {
-            name: value.name,
+            name: value.name.clone(),
             manufacturer: value.manufacturer.map(|m| m.into()),
-            variants: value.variants.into_iter().map(|v| v.into()).collect(),
+            variants: value.variants.iter().map(|v| v.into()).collect(),
         }
     }
 }
@@ -70,17 +70,26 @@ pub struct Chip {
     pub name: String,
 }
 
-impl From<probe_rs_target::Chip> for Chip {
-    fn from(value: probe_rs_target::Chip) -> Self {
-        Self { name: value.name }
+impl From<&probe_rs_target::Chip> for Chip {
+    fn from(value: &probe_rs_target::Chip) -> Self {
+        Self {
+            name: value.name.clone(),
+        }
     }
 }
 
 pub type ListFamiliesResponse = RpcResult<Vec<ChipFamily>>;
 
-pub fn list_families(_ctx: &mut RpcContext, _header: VarHeader, _req: ()) -> ListFamiliesResponse {
-    Ok(probe_rs::config::families()
-        .into_iter()
+pub async fn list_families(
+    ctx: &mut RpcContext,
+    _header: VarHeader,
+    _req: (),
+) -> ListFamiliesResponse {
+    Ok(ctx
+        .registry()
+        .await
+        .families()
+        .iter()
         .map(|f| f.into())
         .collect())
 }
@@ -310,12 +319,16 @@ impl Default for MemoryAccess {
 
 pub type ChipInfoResponse = RpcResult<ChipData>;
 
-pub fn chip_info(
-    _ctx: &mut RpcContext,
+pub async fn chip_info(
+    ctx: &mut RpcContext,
     _header: VarHeader,
     request: ChipInfoRequest,
 ) -> ChipInfoResponse {
-    Ok(probe_rs::config::get_target_by_name(request.name)?.into())
+    Ok(ctx
+        .registry()
+        .await
+        .get_target_by_name(request.name)?
+        .into())
 }
 
 // Used to avoid uploading a temp file to the remote.
@@ -329,17 +342,10 @@ pub async fn load_chip_family(
     _header: VarHeader,
     request: LoadChipFamilyRequest,
 ) -> NoResponse {
-    if !ctx.is_local() {
-        return RpcResult::Err(RpcError::from(
-            "Loading chip families is not supported in the remote interface yet.",
-        ));
-    }
-
     let family = postcard::from_bytes::<probe_rs_target::ChipFamily>(&request.family_data)
         .context("Failed to deserialize chip family data")?;
 
-    // TODO: this can only be done safely if we have separate registries per connection.
-    probe_rs::config::add_target_family(family)?;
+    ctx.registry().await.add_target_family(family)?;
 
     Ok(())
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -70,7 +70,8 @@ pub async fn target_info(
     _hdr: VarHeader,
     request: TargetInfoRequest,
 ) -> NoResponse {
-    let probe_options = ProbeOptions::from(&request).load()?;
+    let mut registry = ctx.registry().await;
+    let probe_options = ProbeOptions::from(&request).load(&mut registry)?;
 
     let probe = probe_options.attach_probe(&ctx.lister())?;
 

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/probe.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/probe.rs
@@ -247,7 +247,8 @@ pub async fn attach(
     _header: VarHeader,
     request: AttachRequest,
 ) -> RpcResult<AttachResult> {
-    let common_options = ProbeOptions::from(&request).load()?;
+    let mut registry = ctx.registry().await;
+    let common_options = ProbeOptions::from(&request).load(&mut registry)?;
     let target = common_options.get_target_selector()?;
 
     let Ok(probe) = common_options.attach_probe(&ctx.lister()) else {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/mod.rs
@@ -13,7 +13,7 @@ use postcard_schema::{
     Schema,
     schema::{DataModelType, NamedType, NamedValue},
 };
-use probe_rs::Session;
+use probe_rs::{Session, config::Registry};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
@@ -120,6 +120,7 @@ impl ObjectStorage {
 pub struct SessionState {
     dry_run: bool,
     object_storage: Arc<Mutex<ObjectStorage>>,
+    registry: Arc<Mutex<Registry>>,
 }
 
 #[allow(unused)]
@@ -128,6 +129,7 @@ impl SessionState {
         Self {
             dry_run: false,
             object_storage: Arc::new(Mutex::new(ObjectStorage::new())),
+            registry: Arc::new(Mutex::new(Registry::from_builtin_families())),
         }
     }
 

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -5,7 +5,6 @@ use std::{future::Future, ops::DerefMut, path::Path, time::Instant};
 use anyhow::Context;
 use colored::Colorize;
 use libtest_mimic::{Failed, Trial};
-use probe_rs_target::ChipFamily;
 use time::UtcOffset;
 use tokio::{runtime::Handle, sync::mpsc::UnboundedSender};
 use tokio_util::sync::CancellationToken;
@@ -56,8 +55,7 @@ pub async fn attach_probe(
 
         // Load the YAML locally to validate it before sending it to the remote.
         // We may also need it locally.
-        let family: ChipFamily = serde_yaml::from_str(&file)?;
-        client.registry().await.add_target_family(family)?;
+        client.registry().await.add_target_family_from_yaml(&file)?;
 
         client.load_chip_family(file).await?;
     }

--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -1,8 +1,4 @@
-use std::{
-    fs::File,
-    io::Write,
-    path::{Path, PathBuf},
-};
+use std::{io::Write, path::PathBuf};
 
 use super::cargo::ArtifactError;
 use crate::util::parse_u64;
@@ -167,20 +163,14 @@ impl<'r> LoadedProbeOptions<'r> {
     /// Note: should be called before any functions in [ProbeOptions].
     fn maybe_load_chip_desc(&mut self) -> Result<(), OperationError> {
         if let Some(ref cdp) = self.0.chip_description_path {
-            let file = File::open(Path::new(cdp)).map_err(|error| {
+            let yaml = std::fs::read_to_string(cdp).map_err(|error| {
                 OperationError::ChipDescriptionNotFound {
                     source: error,
                     path: cdp.clone(),
                 }
             })?;
-            let family = serde_yaml::from_reader(file).map_err(|error| {
-                OperationError::FailedChipDescriptionParsing {
-                    source: error.into(),
-                    path: cdp.clone(),
-                }
-            })?;
 
-            self.1.add_target_family(family).map_err(|error| {
+            self.1.add_target_family_from_yaml(&yaml).map_err(|error| {
                 OperationError::FailedChipDescriptionParsing {
                     source: error,
                     path: cdp.clone(),

--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -8,7 +8,7 @@ use super::cargo::ArtifactError;
 use crate::util::parse_u64;
 use probe_rs::{
     Permissions, Session, Target,
-    config::{RegistryError, TargetSelector},
+    config::{Registry, RegistryError, TargetSelector},
     flashing::{FileDownloadError, FlashError},
     integration::FakeProbe,
     probe::{
@@ -124,17 +124,18 @@ pub struct ProbeOptions {
 }
 
 impl ProbeOptions {
-    pub fn load(self) -> Result<LoadedProbeOptions, OperationError> {
-        LoadedProbeOptions::new(self)
+    pub fn load(self, registry: &mut Registry) -> Result<LoadedProbeOptions, OperationError> {
+        LoadedProbeOptions::new(self, registry)
     }
 
     /// Convenience method that attaches to the specified probe, target,
     /// and target session.
-    pub fn simple_attach(
+    pub fn simple_attach<'r>(
         self,
+        registry: &'r mut Registry,
         lister: &Lister,
-    ) -> Result<(Session, LoadedProbeOptions), OperationError> {
-        let common_options = self.load()?;
+    ) -> Result<(Session, LoadedProbeOptions<'r>), OperationError> {
+        let common_options = self.load(registry)?;
 
         let target = common_options.get_target_selector()?;
         let probe = common_options.attach_probe(lister)?;
@@ -145,14 +146,16 @@ impl ProbeOptions {
 }
 
 /// Common options and logic when interfacing with a [Probe] which already did all pre operation preparation.
-#[derive(Debug, Clone)]
-pub struct LoadedProbeOptions(ProbeOptions);
+pub struct LoadedProbeOptions<'r>(ProbeOptions, &'r mut Registry);
 
-impl LoadedProbeOptions {
+impl<'r> LoadedProbeOptions<'r> {
     /// Performs necessary init calls such as loading all chip descriptions
     /// and returns a newtype that ensures initialization.
-    pub(crate) fn new(probe_options: ProbeOptions) -> Result<Self, OperationError> {
-        let options = Self(probe_options);
+    pub(crate) fn new(
+        probe_options: ProbeOptions,
+        registry: &'r mut Registry,
+    ) -> Result<Self, OperationError> {
+        let mut options = Self(probe_options, registry);
         // Load the target description, if given in the cli parameters.
         options.maybe_load_chip_desc()?;
         Ok(options)
@@ -162,7 +165,7 @@ impl LoadedProbeOptions {
     /// to probe-rs registry.
     ///
     /// Note: should be called before any functions in [ProbeOptions].
-    fn maybe_load_chip_desc(&self) -> Result<(), OperationError> {
+    fn maybe_load_chip_desc(&mut self) -> Result<(), OperationError> {
         if let Some(ref cdp) = self.0.chip_description_path {
             let file = File::open(Path::new(cdp)).map_err(|error| {
                 OperationError::ChipDescriptionNotFound {
@@ -170,7 +173,14 @@ impl LoadedProbeOptions {
                     path: cdp.clone(),
                 }
             })?;
-            probe_rs::config::add_target_from_yaml(file).map_err(|error| {
+            let family = serde_yaml::from_reader(file).map_err(|error| {
+                OperationError::FailedChipDescriptionParsing {
+                    source: error.into(),
+                    path: cdp.clone(),
+                }
+            })?;
+
+            self.1.add_target_family(family).map_err(|error| {
                 OperationError::FailedChipDescriptionParsing {
                     source: error,
                     path: cdp.clone(),
@@ -184,7 +194,7 @@ impl LoadedProbeOptions {
     /// Resolves a resultant target selector from passed [ProbeOptions].
     pub fn get_target_selector(&self) -> Result<TargetSelector, OperationError> {
         let target = if let Some(chip_name) = &self.0.chip {
-            let target = probe_rs::config::get_target_by_name(chip_name).map_err(|error| {
+            let target = self.1.get_target_by_name(chip_name).map_err(|error| {
                 OperationError::ChipNotFound {
                     source: error,
                     name: chip_name.clone(),
@@ -327,7 +337,7 @@ impl LoadedProbeOptions {
     }
 }
 
-impl AsRef<ProbeOptions> for LoadedProbeOptions {
+impl AsRef<ProbeOptions> for LoadedProbeOptions<'_> {
     fn as_ref(&self) -> &ProbeOptions {
         &self.0
     }

--- a/probe-rs/src/config/mod.rs
+++ b/probe-rs/src/config/mod.rs
@@ -6,6 +6,7 @@
 //! which can be used together with a flash algorithm to program the flash memory
 //! of a target.
 //!
+//!
 //! ## Built-in targets
 //!
 //! The built-in targets are added at build-time, from the `build.rs` script.
@@ -16,9 +17,10 @@
 //!
 //! ## Adding targets at runtime
 //!
-//! To add a target at runtime, the [add_target_from_yaml] function can
-//! be used to read targets from a YAML file.
-//!
+//! Targets are collected in a [`Registry`] in families. A registry with the built-in
+//! targets can be created via the [`Registry::from_builtin_families`] function.
+//! To add a target at runtime, use [Registry::add_target_family]. The target family
+//! is a [`ChipFamily`] struct, usually read from a target description YAML file.
 
 mod chip_info;
 pub(crate) mod registry;

--- a/probe-rs/src/config/mod.rs
+++ b/probe-rs/src/config/mod.rs
@@ -30,13 +30,9 @@ pub use probe_rs_target::{
     SectorDescription, SectorInfo, TargetDescriptionSource,
 };
 
-pub use registry::{
-    RegistryError, add_target_family, add_target_from_yaml, families, get_family_by_name,
-    get_target_and_family_by_name, get_target_by_name, get_targets_by_family_name, search_chips,
-};
+pub use registry::{Registry, RegistryError};
 pub use target::{DebugSequence, Target, TargetSelector};
 
 // Crate-internal API
 pub(crate) use chip_info::ChipInfo;
-pub(crate) use registry::get_target_by_chip_info;
 pub(crate) use target::CoreExt;

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -2,16 +2,9 @@
 
 use super::{Chip, ChipFamily, ChipInfo, Core, Target, TargetDescriptionSource};
 use crate::config::CoreType;
-use parking_lot::{RwLock, RwLockReadGuard};
 use probe_rs_target::{CoreAccessOptions, RiscvCoreAccessOptions};
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::io::Read;
-use std::ops::Deref;
-use std::sync::LazyLock;
-
-static REGISTRY: LazyLock<RwLock<Registry>> =
-    LazyLock::new(|| RwLock::new(Registry::from_builtin_families()));
 
 /// Error type for all errors which occur when working
 /// with the internal registry of targets.
@@ -121,7 +114,8 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
 }
 
 /// Registry of all available targets.
-struct Registry {
+#[derive(Default)]
+pub struct Registry {
     /// All the available chips.
     families: Vec<ChipFamily>,
 }
@@ -141,7 +135,13 @@ fn builtin_targets() -> Vec<ChipFamily> {
 }
 
 impl Registry {
-    fn from_builtin_families() -> Self {
+    /// Create a new registry.
+    pub fn new() -> Self {
+        Self { families: vec![] }
+    }
+
+    /// Add a target from the built-in targets.
+    pub fn from_builtin_families() -> Self {
         let mut families = builtin_targets();
 
         add_generic_targets(&mut families);
@@ -153,7 +153,13 @@ impl Registry {
         Self { families }
     }
 
-    fn get_target_by_name(&self, name: impl AsRef<str>) -> Result<Target, RegistryError> {
+    /// Returns the list of chip families.
+    pub fn families(&self) -> &[ChipFamily] {
+        &self.families
+    }
+
+    /// Returns a particular target by its name.
+    pub fn get_target_by_name(&self, name: impl AsRef<str>) -> Result<Target, RegistryError> {
         let (target, _) = self.get_target_and_family_by_name(name.as_ref())?;
         Ok(target)
     }
@@ -250,7 +256,8 @@ impl Registry {
         Ok((targ, family.clone()))
     }
 
-    fn get_targets_by_family_name(&self, name: &str) -> Result<Vec<String>, RegistryError> {
+    /// Get all target names in a given family.
+    pub fn get_targets_by_family_name(&self, name: &str) -> Result<Vec<String>, RegistryError> {
         let mut found_family = None;
         let mut exact_matches = 0;
         for family in self.families.iter() {
@@ -274,7 +281,11 @@ impl Registry {
         Ok(family.variants.iter().map(|v| v.name.to_string()).collect())
     }
 
-    fn search_chips(&self, name: &str) -> Vec<String> {
+    /// Search for a chip.
+    ///
+    /// This function returns chips that have the given name as a prefix, with any lowercase `x`
+    /// characters in the prefix matching any character in the chip name.
+    pub fn search_chips(&self, name: &str) -> Vec<String> {
         tracing::debug!("Searching registry for chip with name {name}");
 
         let mut targets = Vec::new();
@@ -294,7 +305,10 @@ impl Registry {
         targets
     }
 
-    fn get_target_by_chip_info(&self, chip_info: ChipInfo) -> Result<Target, RegistryError> {
+    pub(crate) fn get_target_by_chip_info(
+        &self,
+        chip_info: ChipInfo,
+    ) -> Result<Target, RegistryError> {
         let (family, chip) = match chip_info {
             ChipInfo::Arm(chip_info) => {
                 // Try get the corresponding chip.
@@ -339,7 +353,8 @@ impl Registry {
         Target::new(family, chip)
     }
 
-    fn add_target_family(&mut self, family: ChipFamily) -> Result<String, RegistryError> {
+    /// Add a target family to the registry.
+    pub fn add_target_family(&mut self, family: ChipFamily) -> Result<String, RegistryError> {
         validate_family(&family).map_err(|error| {
             RegistryError::InvalidChipFamilyDefinition(Box::new(family.clone()), error)
         })?;
@@ -353,105 +368,6 @@ impl Registry {
 
         Ok(family_name)
     }
-}
-
-/// Get a target from the internal registry based on its name.
-pub fn get_family_by_name(name: impl AsRef<str>) -> Result<ChipFamily, RegistryError> {
-    let registry = REGISTRY.read_recursive();
-
-    registry
-        .families
-        .iter()
-        .find(|f| f.name.eq_ignore_ascii_case(name.as_ref()))
-        .cloned()
-        .ok_or_else(|| RegistryError::ChipNotFound(name.as_ref().to_string()))
-}
-
-/// Get a target from the internal registry based on its name.
-pub fn get_target_by_name(name: impl AsRef<str>) -> Result<Target, RegistryError> {
-    REGISTRY.read_recursive().get_target_by_name(name)
-}
-
-/// Get a target & chip family from the internal registry based on its name.
-pub fn get_target_and_family_by_name(
-    name: impl AsRef<str>,
-) -> Result<(Target, ChipFamily), RegistryError> {
-    REGISTRY
-        .read_recursive()
-        .get_target_and_family_by_name(name.as_ref())
-}
-
-/// Get all target from the internal registry based on its family name.
-pub fn get_targets_by_family_name(
-    family_name: impl AsRef<str>,
-) -> Result<Vec<String>, RegistryError> {
-    REGISTRY
-        .read_recursive()
-        .get_targets_by_family_name(family_name.as_ref())
-}
-
-/// Returns targets from the internal registry that match the given name.
-pub fn search_chips(name: impl AsRef<str>) -> Result<Vec<String>, RegistryError> {
-    Ok(REGISTRY.read_recursive().search_chips(name.as_ref()))
-}
-
-/// Try to retrieve a target based on [ChipInfo] read from a target.
-pub(crate) fn get_target_by_chip_info(chip_info: ChipInfo) -> Result<Target, RegistryError> {
-    REGISTRY.read_recursive().get_target_by_chip_info(chip_info)
-}
-
-/// Parse a target description and add the contained targets
-/// to the internal target registry.
-///
-/// # Examples
-///
-/// ## Add targets from a YAML file
-///
-/// ```no_run
-/// use std::path::Path;
-/// use std::fs::File;
-///
-/// let file = File::open(Path::new("/path/target.yaml"))?;
-/// probe_rs::config::add_target_from_yaml(file)?;
-///
-/// # Ok::<(), anyhow::Error>(())
-/// ```
-///
-/// ## Add targets from a embedded YAML file
-///
-/// ```ignore
-/// const BUILTIN_TARGET_YAML: &[u8] = include_bytes!("/path/target.yaml");
-/// probe_rs::config::add_target_from_yaml(BUILTIN_TARGET_YAML)?;
-/// ```
-pub fn add_target_from_yaml<R>(yaml_reader: R) -> Result<String, RegistryError>
-where
-    R: Read,
-{
-    let family: ChipFamily = serde_yaml::from_reader(yaml_reader)?;
-
-    add_target_family(family)
-}
-
-/// Add a target family to the internal registry.
-pub fn add_target_family(family: ChipFamily) -> Result<String, RegistryError> {
-    REGISTRY.write().add_target_family(family)
-}
-
-/// Get a list of all families which are contained in the internal
-/// registry.
-///
-/// As opposed to `families()` this function does not clone the families, but using it is
-/// slightly more cumbersome.
-pub fn families_ref() -> impl Deref<Target = [ChipFamily]> {
-    RwLockReadGuard::map(REGISTRY.read_recursive(), |registry| {
-        registry.families.as_slice()
-    })
-}
-
-/// Get a list of all families which are contained in the internal
-/// registry.
-pub fn families() -> Vec<ChipFamily> {
-    families_ref().to_vec()
 }
 
 /// See if `name` matches the start of `pattern`, treating any lower-case `x`
@@ -583,11 +499,14 @@ mod tests {
 
     #[test]
     fn add_targets_with_and_without_scanchain() -> TestResult {
+        let mut registry = Registry::new();
+
         let file = File::open("tests/scan_chain_test.yaml")?;
-        add_target_from_yaml(file)?;
+        let family: ChipFamily = serde_yaml::from_reader(file)?;
+        registry.add_target_family(family)?;
 
         // Check that the scan chain can read from a target correctly
-        let mut target = get_target_by_name("FULL_SCAN_CHAIN").unwrap();
+        let mut target = registry.get_target_by_name("FULL_SCAN_CHAIN").unwrap();
         let scan_chain = target.jtag.unwrap().scan_chain.unwrap();
         for device in scan_chain {
             if device.name == Some("core0".to_string()) {
@@ -598,15 +517,15 @@ mod tests {
         }
 
         // Now check that a device without a scan chain is read correctly
-        target = get_target_by_name("NO_JTAG_INFO").unwrap();
+        target = registry.get_target_by_name("NO_JTAG_INFO").unwrap();
         assert_eq!(target.jtag, None);
 
         // Now check that a device without a scan chain is read correctly
-        target = get_target_by_name("NO_SCAN_CHAIN").unwrap();
+        target = registry.get_target_by_name("NO_SCAN_CHAIN").unwrap();
         assert_eq!(target.jtag.unwrap().scan_chain, None);
 
         // Check a device with a minimal scan chain
-        target = get_target_by_name("PARTIAL_SCAN_CHAIN").unwrap();
+        target = registry.get_target_by_name("PARTIAL_SCAN_CHAIN").unwrap();
         let scan_chain = target.jtag.unwrap().scan_chain.unwrap();
         assert_eq!(scan_chain[0].ir_len, Some(FIRST_IR_LENGTH));
         assert_eq!(scan_chain[1].ir_len, Some(SECOND_IR_LENGTH));

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -368,6 +368,12 @@ impl Registry {
 
         Ok(family_name)
     }
+
+    /// Add a target family to the registry from a YAML-formatted string.
+    pub fn add_target_family_from_yaml(&mut self, yaml: &str) -> Result<String, RegistryError> {
+        let family: ChipFamily = serde_yaml::from_str(yaml)?;
+        self.add_target_family(family)
+    }
 }
 
 /// See if `name` matches the start of `pattern`, treating any lower-case `x`
@@ -402,7 +408,6 @@ mod tests {
     use crate::flashing::FlashAlgorithm;
 
     use super::*;
-    use std::fs::File;
     type TestResult = Result<(), RegistryError>;
 
     // Need to synchronize this with probe-rs/tests/scan_chain_test.yaml
@@ -501,9 +506,8 @@ mod tests {
     fn add_targets_with_and_without_scanchain() -> TestResult {
         let mut registry = Registry::new();
 
-        let file = File::open("tests/scan_chain_test.yaml")?;
-        let family: ChipFamily = serde_yaml::from_reader(file)?;
-        registry.add_target_family(family)?;
+        let file = std::fs::read_to_string("tests/scan_chain_test.yaml")?;
+        registry.add_target_family_from_yaml(&file)?;
 
         // Check that the scan chain can read from a target correctly
         let mut target = registry.get_target_by_name("FULL_SCAN_CHAIN").unwrap();

--- a/probe-rs/src/vendor/microchip/mod.rs
+++ b/probe-rs/src/vendor/microchip/mod.rs
@@ -5,7 +5,7 @@ use probe_rs_target::{Chip, chip_detection::ChipDetectionMethod};
 use crate::{
     Error,
     architecture::arm::{ArmChipInfo, ArmProbeInterface, FullyQualifiedApAddress},
-    config::{DebugSequence, registry},
+    config::{DebugSequence, Registry},
     vendor::{
         Vendor,
         microchip::sequences::atsam::{AtSAM, DsuDid},
@@ -36,6 +36,7 @@ impl Vendor for Microchip {
 
     fn try_detect_arm_chip(
         &self,
+        registry: &Registry,
         interface: &mut dyn ArmProbeInterface,
         chip_info: ArmChipInfo,
     ) -> Result<Option<String>, Error> {
@@ -52,8 +53,7 @@ impl Vendor for Microchip {
                 .read_word_32(DsuDid::ADDRESS)?,
         );
 
-        let families = registry::families_ref();
-        for family in families.iter() {
+        for family in registry.families() {
             for info in family
                 .chip_detection
                 .iter()

--- a/probe-rs/src/vendor/nordicsemi/mod.rs
+++ b/probe-rs/src/vendor/nordicsemi/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     architecture::arm::{
         ArmChipInfo, ArmProbeInterface, FullyQualifiedApAddress, memory::ArmMemoryInterface,
     },
-    config::{DebugSequence, registry},
+    config::{DebugSequence, Registry},
     vendor::{
         Vendor,
         nordicsemi::sequences::{nrf52::Nrf52, nrf53::Nrf5340, nrf91::Nrf9160},
@@ -45,6 +45,7 @@ impl Vendor for NordicSemi {
 
     fn try_detect_arm_chip(
         &self,
+        registry: &Registry,
         probe: &mut dyn ArmProbeInterface,
         chip_info: ArmChipInfo,
     ) -> Result<Option<String>, Error> {
@@ -59,8 +60,7 @@ impl Vendor for NordicSemi {
         // Cache to avoid reading the same register multiple times
         let mut register_values: HashMap<u32, u32> = HashMap::new();
 
-        let families = registry::families_ref();
-        for family in families.iter() {
+        for family in registry.families() {
             for info in family.chip_detection.iter() {
                 let target = if let Some(spec) = info.as_nordic_ficr() {
                     ficr_info_detect(&mut register_values, memory_interface.as_mut(), spec)

--- a/smoke-tester/src/dut_definition.rs
+++ b/smoke-tester/src/dut_definition.rs
@@ -6,9 +6,9 @@
 use miette::IntoDiagnostic;
 use miette::Result;
 use miette::WrapErr;
+use probe_rs::config::Registry;
 use probe_rs::{
     Target,
-    config::get_target_by_name,
     probe::{DebugProbeSelector, Probe, list::Lister},
 };
 use serde::Deserialize;
@@ -213,7 +213,8 @@ impl DutDefinition {
 }
 
 fn lookup_unique_target(chip: &str) -> Result<Target> {
-    let target = get_target_by_name(chip).into_diagnostic()?;
+    let registry = Registry::from_builtin_families();
+    let target = registry.get_target_by_name(chip).into_diagnostic()?;
 
     if !target.name.eq_ignore_ascii_case(chip) {
         miette::bail!(

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::fs::File;
 use std::path::Path;
 use std::rc::Rc;
 use std::time::Instant;
@@ -62,9 +61,8 @@ pub fn cmd_test(
     let mut registry = Registry::new();
 
     // Add the target to the registry from the generated YAML file
-    let file = File::open(Path::new(definition_export_path))?;
-    let family = serde_yaml::from_reader(file)?;
-    let family_name = registry.add_target_family(family)?;
+    let yaml = std::fs::read_to_string(definition_export_path)?;
+    let family_name = registry.add_target_family_from_yaml(&yaml)?;
 
     let targets = registry
         .get_targets_by_family_name(&family_name)

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -3,6 +3,7 @@ use cmsis_pack::pdsc::{AccessPort, Algorithm, Core, Device, Package, Processor};
 use cmsis_pack::{pack_index::PdscRef, utils::FromElem};
 use futures::StreamExt;
 use jep106::JEP106Code;
+use probe_rs::config::Registry;
 use probe_rs::flashing::FlashAlgorithm;
 use probe_rs_target::{
     Architecture, ArmCoreAccessOptions, Chip, ChipFamily, Core as ProbeCore, CoreAccessOptions,
@@ -79,7 +80,8 @@ where
     devices.sort_by(|a, b| a.0.cmp(&b.0));
 
     // Only process this, if this belongs to a supported family.
-    let currently_supported_chip_families = probe_rs::config::families();
+    let registry = Registry::from_builtin_families();
+    let currently_supported_chip_families = registry.families();
 
     for (device_name, device) in devices {
         if only_supported_familes


### PR DESCRIPTION
The main point behind this change is to remove global state from probe-rs, allowing the CLI to use separate registries in parallel sessions without interfering with each other.