### PR TITLE
Implement probe access lists

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/chip.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/chip.rs
@@ -99,7 +99,8 @@ mod test {
         use crate::rpc::functions::RpcApp;
 
         // Create a local server to run commands against.
-        let (mut local_server, tx, rx) = RpcApp::create_server(16);
+        let (mut local_server, tx, rx) =
+            RpcApp::create_server(16, crate::rpc::functions::ProbeAccess::All);
         let handle = tokio::spawn(async move { local_server.run().await });
 
         // Run the command locally.

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -491,7 +491,7 @@ async fn main() -> Result<()> {
     }
 
     // Create a local server to run commands against.
-    let (mut local_server, tx, rx) = RpcApp::create_server(16);
+    let (mut local_server, tx, rx) = RpcApp::create_server(16, rpc::functions::ProbeAccess::All);
     let handle = tokio::spawn(async move { local_server.run().await });
 
     // Run the command locally.


### PR DESCRIPTION
This PR adds the ability to limit a user's access to probes. The configuration looks like this in TOML:

```toml
[[server.users]]
name = "user1"
token = "token1"
access = "all"

[[server.users]]
name = "user2"
token = "token2"
access = { allow = ["0403:6010:12345678"] }

[[server.users]]
name = "user3"
token = "token3"
deny = { allow = ["0403:6010:12345678"] }
```

A probe selector can be either `VID:PID:serial` or `VID:PID`, both matches. Empty serials are permitted as `VID:PID:`.