### PR TITLE
Only show RTT window when actually initialized

### DIFF
--- a/changelog/fixed-debugger-rtt-names.md
+++ b/changelog/fixed-debugger-rtt-names.md
@@ -1,0 +1,1 @@
+Fixed an issue where RTT channels show up as unnamed in the debugger.


### PR DESCRIPTION
This fixes an issue where channels show up as unnamed in the debugger. Also RTT location is re-read when the binary is reflashed on session reset.