### PR TITLE
Disable WDTs every time MCU is halted

### DIFF
--- a/changelog/fixed-idf-debug-timeout.md
+++ b/changelog/fixed-idf-debug-timeout.md
@@ -1,0 +1,1 @@
+Fixed an issue where halting an ESP-IDF based firmware caused WDT resets.

--- a/probe-rs/src/architecture/riscv/sequences.rs
+++ b/probe-rs/src/architecture/riscv/sequences.rs
@@ -18,6 +18,11 @@ pub trait RiscvDebugSequence: Send + Sync + Debug {
         Ok(())
     }
 
+    /// Executed when the target is halted.
+    fn on_halt(&self, _interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
+        Ok(())
+    }
+
     /// Detects the flash size of the target.
     fn detect_flash_size(&self, _session: &mut Session) -> Result<Option<usize>, crate::Error> {
         Ok(None)

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -220,11 +220,12 @@ impl<'probe> Xtensa<'probe> {
     fn on_halted(&mut self) -> Result<(), Error> {
         self.state.pc_written = false;
 
-        // Poll core status. For now we don't do anything with it, but in the future we
-        // may check expected status, and record the status to prevent decoding semihosting
-        // multiple times (possibly incorrectly after answering).
         let status = self.status()?;
         tracing::debug!("Core halted: {:#?}", status);
+
+        if status.is_halted() {
+            self.sequence.on_halt(&mut self.interface)?;
+        }
 
         Ok(())
     }

--- a/probe-rs/src/architecture/xtensa/sequences.rs
+++ b/probe-rs/src/architecture/xtensa/sequences.rs
@@ -15,6 +15,11 @@ pub trait XtensaDebugSequence: Send + Sync + Debug {
         Ok(())
     }
 
+    /// Executed when the target is halted.
+    fn on_halt(&self, _interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
+        Ok(())
+    }
+
     /// Detects the flash size of the target.
     fn detect_flash_size(&self, _session: &mut Session) -> Result<Option<usize>, crate::Error> {
         Ok(None)

--- a/probe-rs/src/vendor/espressif/sequences/esp32.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32.rs
@@ -37,39 +37,51 @@ impl ESP32 {
             },
         })
     }
-}
 
-impl XtensaDebugSequence for ESP32 {
-    fn on_connect(&self, core: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
-        // Peripheral address range
-        core.add_slow_memory_access_range(0x3FF0_0000..0x3FF8_0000);
+    fn disable_wdts(
+        &self,
+        interface: &mut XtensaCommunicationInterface,
+    ) -> Result<(), crate::Error> {
         tracing::info!("Disabling ESP32 watchdogs...");
 
         // tg0 wdg
         const TIMG0_BASE: u64 = 0x3ff5f000;
         const TIMG0_WRITE_PROT: u64 = TIMG0_BASE | 0x64;
         const TIMG0_WDTCONFIG0: u64 = TIMG0_BASE | 0x48;
-        core.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        core.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
-        core.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
+        interface.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        interface.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
+        interface.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
 
         // tg1 wdg
         const TIMG1_BASE: u64 = 0x3ff60000;
         const TIMG1_WRITE_PROT: u64 = TIMG1_BASE | 0x64;
         const TIMG1_WDTCONFIG0: u64 = TIMG1_BASE | 0x48;
-        core.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        core.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
-        core.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
+        interface.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        interface.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
+        interface.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
 
         // rtc wdg
         const RTC_CNTL_BASE: u64 = 0x3ff48000;
         const RTC_WRITE_PROT: u64 = RTC_CNTL_BASE | 0xa4;
         const RTC_WDTCONFIG0: u64 = RTC_CNTL_BASE | 0x8c;
-        core.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
-        core.write_word_32(RTC_WDTCONFIG0, 0x0)?;
-        core.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
+        interface.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        interface.write_word_32(RTC_WDTCONFIG0, 0x0)?;
+        interface.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
 
         Ok(())
+    }
+}
+
+impl XtensaDebugSequence for ESP32 {
+    fn on_connect(&self, interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
+        // Peripheral address range
+        interface.add_slow_memory_access_range(0x3FF0_0000..0x3FF8_0000);
+
+        self.disable_wdts(interface)
+    }
+
+    fn on_halt(&self, interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
+        self.disable_wdts(interface)
     }
 
     fn detect_flash_size(&self, session: &mut Session) -> Result<Option<usize>, crate::Error> {

--- a/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
@@ -31,11 +31,12 @@ impl ESP32H2 {
             },
         })
     }
-}
 
-impl RiscvDebugSequence for ESP32H2 {
-    fn on_connect(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
-        tracing::info!("Disabling esp32h2 watchdogs...");
+    fn disable_wdts(
+        &self,
+        interface: &mut RiscvCommunicationInterface,
+    ) -> Result<(), crate::Error> {
+        tracing::info!("Disabling ESP32-H2 watchdogs...");
 
         // disable super wdt
         interface.write_word_32(0x600B1C24, 0x50D83AA1)?; // write protection off
@@ -59,6 +60,16 @@ impl RiscvDebugSequence for ESP32H2 {
         interface.write_word_32(0x600B_1C1C, 0x0)?; // write protection on
 
         Ok(())
+    }
+}
+
+impl RiscvDebugSequence for ESP32H2 {
+    fn on_connect(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
+        self.disable_wdts(interface)
+    }
+
+    fn on_halt(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
+        self.disable_wdts(interface)
     }
 
     fn detect_flash_size(&self, session: &mut Session) -> Result<Option<usize>, crate::Error> {

--- a/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
@@ -112,10 +112,8 @@ impl ESP32S2 {
     ) -> Result<(), crate::Error> {
         self.set_stall(false, core)
     }
-}
 
-impl XtensaDebugSequence for ESP32S2 {
-    fn on_connect(&self, core: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
+    fn disable_wdts(&self, core: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
         tracing::info!("Disabling ESP32-S2 watchdogs...");
 
         // disable super wdt
@@ -140,6 +138,16 @@ impl XtensaDebugSequence for ESP32S2 {
         core.write_word_32(Self::RTC_WRITE_PROT, 0x0)?; // write protection on
 
         Ok(())
+    }
+}
+
+impl XtensaDebugSequence for ESP32S2 {
+    fn on_connect(&self, interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
+        self.disable_wdts(interface)
+    }
+
+    fn on_halt(&self, interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
+        self.disable_wdts(interface)
     }
 
     fn detect_flash_size(&self, session: &mut Session) -> Result<Option<usize>, crate::Error> {


### PR DESCRIPTION
If the target re-enables WDTs without our knowledge, halting (i.e. by the debugger UI) will just cause a WDT reset. This PR brute forces the WDTs to be off.


Probably closes https://github.com/probe-rs/probe-rs/issues/2859 and closes https://github.com/probe-rs/probe-rs/issues/2317 as this is one source of DMI timeouts.