### PR TITLE
Handle esp-idf `ESP_SEMIHOSTING_SYS_BREAKPOINT_SET` and `ESP_SEMIHOSTING_SYS_PANIC_REASON` syscalls

### DIFF
--- a/changelog/fixed-handling-idf-syscall.md
+++ b/changelog/fixed-handling-idf-syscall.md
@@ -1,0 +1,1 @@
+ESP-IDF panics no longer print an infinite list of warnings.

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -280,15 +280,12 @@ pub async fn monitor(
         print_monitor_event(&mut rtt_client.as_mut(), msg)
     });
 
-    let mut cancelled = false;
-
     let result = with_ctrl_c(monitor, async {
-        cancelled = true;
         session.client().publish::<CancelTopic>(&()).await.unwrap();
     })
     .await;
 
-    if cancelled && print_stack_trace {
+    if print_stack_trace {
         display_stack_trace(session, path).await?;
     }
 

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -109,7 +109,20 @@ impl<'state> Riscv32<'state> {
         );
 
         let command = if TRAP_INSTRUCTIONS == actual_instructions {
-            Some(decode_semihosting_syscall(self)?)
+            let syscall = decode_semihosting_syscall(self)?;
+            if let SemihostingCommand::Unknown(details) = syscall {
+                if self
+                    .sequence
+                    .clone()
+                    .on_unknown_semihosting_command(self, details)?
+                {
+                    None
+                } else {
+                    Some(syscall)
+                }
+            } else {
+                Some(syscall)
+            }
         } else {
             None
         };

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -111,15 +111,9 @@ impl<'state> Riscv32<'state> {
         let command = if TRAP_INSTRUCTIONS == actual_instructions {
             let syscall = decode_semihosting_syscall(self)?;
             if let SemihostingCommand::Unknown(details) = syscall {
-                if self
-                    .sequence
+                self.sequence
                     .clone()
                     .on_unknown_semihosting_command(self, details)?
-                {
-                    None
-                } else {
-                    Some(syscall)
-                }
             } else {
                 Some(syscall)
             }

--- a/probe-rs/src/architecture/riscv/sequences.rs
+++ b/probe-rs/src/architecture/riscv/sequences.rs
@@ -3,7 +3,7 @@
 use crate::Session;
 use crate::architecture::riscv::communication_interface::RiscvError;
 use crate::architecture::riscv::{Dmcontrol, Riscv32};
-use crate::semihosting::UnknownCommandDetails;
+use crate::semihosting::{SemihostingCommand, UnknownCommandDetails};
 
 use super::communication_interface::RiscvCommunicationInterface;
 use std::fmt::Debug;
@@ -80,13 +80,14 @@ pub trait RiscvDebugSequence: Send + Sync + Debug {
 
     /// Attempts to handle target-dependent semihosting commands.
     ///
-    /// Returns `Ok(true)` if the command was handled, `Ok(false)` if the command was not handled.
+    /// Returns `Ok(Some(command))` if the command was not fully handled, `Ok(None)`
+    /// if the command was fully handled.
     fn on_unknown_semihosting_command(
         &self,
         _interface: &mut Riscv32,
-        _details: UnknownCommandDetails,
-    ) -> Result<bool, crate::Error> {
-        Ok(false)
+        details: UnknownCommandDetails,
+    ) -> Result<Option<SemihostingCommand>, crate::Error> {
+        Ok(Some(SemihostingCommand::Unknown(details)))
     }
 }
 

--- a/probe-rs/src/architecture/riscv/sequences.rs
+++ b/probe-rs/src/architecture/riscv/sequences.rs
@@ -1,8 +1,9 @@
 //! Debug sequences to operate special requirements RISC-V targets.
 
 use crate::Session;
-use crate::architecture::riscv::Dmcontrol;
 use crate::architecture::riscv::communication_interface::RiscvError;
+use crate::architecture::riscv::{Dmcontrol, Riscv32};
+use crate::semihosting::UnknownCommandDetails;
 
 use super::communication_interface::RiscvCommunicationInterface;
 use std::fmt::Debug;
@@ -75,6 +76,17 @@ pub trait RiscvDebugSequence: Send + Sync + Debug {
     ) -> Result<(), crate::Error> {
         interface.reset_hart_and_halt(timeout)?;
         Ok(())
+    }
+
+    /// Attempts to handle target-dependent semihosting commands.
+    ///
+    /// Returns `Ok(true)` if the command was handled, `Ok(false)` if the command was not handled.
+    fn on_unknown_semihosting_command(
+        &self,
+        _interface: &mut Riscv32,
+        _details: UnknownCommandDetails,
+    ) -> Result<bool, crate::Error> {
+        Ok(false)
     }
 }
 

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -210,15 +210,9 @@ impl<'probe> Xtensa<'probe> {
         let command = if actual_instruction == SEMI_BREAK {
             let syscall = decode_semihosting_syscall(self)?;
             if let SemihostingCommand::Unknown(details) = syscall {
-                if self
-                    .sequence
+                self.sequence
                     .clone()
                     .on_unknown_semihosting_command(self, details)?
-                {
-                    None
-                } else {
-                    Some(syscall)
-                }
             } else {
                 Some(syscall)
             }

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -208,7 +208,20 @@ impl<'probe> Xtensa<'probe> {
         tracing::debug!("Semihosting check pc={pc:#x} instruction={actual_instruction:#010x}");
 
         let command = if actual_instruction == SEMI_BREAK {
-            Some(decode_semihosting_syscall(self)?)
+            let syscall = decode_semihosting_syscall(self)?;
+            if let SemihostingCommand::Unknown(details) = syscall {
+                if self
+                    .sequence
+                    .clone()
+                    .on_unknown_semihosting_command(self, details)?
+                {
+                    None
+                } else {
+                    Some(syscall)
+                }
+            } else {
+                Some(syscall)
+            }
         } else {
             None
         };

--- a/probe-rs/src/architecture/xtensa/sequences.rs
+++ b/probe-rs/src/architecture/xtensa/sequences.rs
@@ -1,7 +1,9 @@
 use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use crate::Session;
+use crate::architecture::xtensa::Xtensa;
 use crate::architecture::xtensa::communication_interface::XtensaCommunicationInterface;
+use crate::semihosting::UnknownCommandDetails;
 
 /// A interface to operate debug sequences for Xtensa targets.
 ///
@@ -34,6 +36,17 @@ pub trait XtensaDebugSequence: Send + Sync + Debug {
         interface.reset_and_halt(timeout)?;
 
         Ok(())
+    }
+
+    /// Attempts to handle target-dependent semihosting commands.
+    ///
+    /// Returns `Ok(true)` if the command was handled, `Ok(false)` if the command was not handled.
+    fn on_unknown_semihosting_command(
+        &self,
+        _interface: &mut Xtensa,
+        _details: UnknownCommandDetails,
+    ) -> Result<bool, crate::Error> {
+        Ok(false)
     }
 }
 

--- a/probe-rs/src/architecture/xtensa/sequences.rs
+++ b/probe-rs/src/architecture/xtensa/sequences.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, sync::Arc, time::Duration};
 use crate::Session;
 use crate::architecture::xtensa::Xtensa;
 use crate::architecture::xtensa::communication_interface::XtensaCommunicationInterface;
-use crate::semihosting::UnknownCommandDetails;
+use crate::semihosting::{SemihostingCommand, UnknownCommandDetails};
 
 /// A interface to operate debug sequences for Xtensa targets.
 ///
@@ -40,13 +40,14 @@ pub trait XtensaDebugSequence: Send + Sync + Debug {
 
     /// Attempts to handle target-dependent semihosting commands.
     ///
-    /// Returns `Ok(true)` if the command was handled, `Ok(false)` if the command was not handled.
+    /// Returns `Ok(Some(command))` if the command was not fully handled, `Ok(None)`
+    /// if the command was fully handled.
     fn on_unknown_semihosting_command(
         &self,
         _interface: &mut Xtensa,
-        _details: UnknownCommandDetails,
-    ) -> Result<bool, crate::Error> {
-        Ok(false)
+        details: UnknownCommandDetails,
+    ) -> Result<Option<SemihostingCommand>, crate::Error> {
+        Ok(Some(SemihostingCommand::Unknown(details)))
     }
 }
 

--- a/probe-rs/src/semihosting.rs
+++ b/probe-rs/src/semihosting.rs
@@ -163,7 +163,7 @@ impl CloseRequest {
 
 /// A request to write to the console
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub struct WriteConsoleRequest(ZeroTerminatedString);
+pub struct WriteConsoleRequest(pub(crate) ZeroTerminatedString);
 impl WriteConsoleRequest {
     /// Reads the string from the target
     pub fn read(&self, core: &mut crate::Core<'_>) -> Result<String, Error> {
@@ -264,9 +264,9 @@ impl Buffer {
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-struct ZeroTerminatedString {
-    address: u32,
-    length: Option<u32>,
+pub(crate) struct ZeroTerminatedString {
+    pub address: u32,
+    pub length: Option<u32>,
 }
 
 impl ZeroTerminatedString {

--- a/probe-rs/src/vendor/espressif/sequences/esp.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp.rs
@@ -2,7 +2,10 @@ use std::time::Duration;
 
 use probe_rs_target::Architecture;
 
-use crate::{Core, CoreInterface, MemoryInterface, Session, semihosting::UnknownCommandDetails};
+use crate::{
+    Core, CoreInterface, MemoryInterface, Session, architecture::riscv::Riscv32,
+    semihosting::UnknownCommandDetails,
+};
 
 #[derive(Debug)]
 pub(super) struct EspFlashSizeDetector {
@@ -301,7 +304,7 @@ pub(super) struct EspBreakpointHandler {}
 
 impl EspBreakpointHandler {
     pub fn handle_idf_semihosting(
-        arch: &mut dyn CoreInterface,
+        arch: &mut Riscv32,
         details: UnknownCommandDetails,
     ) -> Result<bool, crate::Error> {
         match details.operation {

--- a/probe-rs/src/vendor/espressif/sequences/esp32.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32.rs
@@ -9,13 +9,10 @@ use super::esp::EspFlashSizeDetector;
 use crate::{
     MemoryInterface, Session,
     architecture::xtensa::{
-        Xtensa,
         communication_interface::{ProgramCounter, XtensaCommunicationInterface, XtensaError},
         sequences::XtensaDebugSequence,
         xdm,
     },
-    semihosting::UnknownCommandDetails,
-    vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
 /// The debug sequence implementation for the ESP32.
@@ -192,13 +189,5 @@ impl XtensaDebugSequence for ESP32 {
         tracing::info!("Reset complete");
 
         Ok(())
-    }
-
-    fn on_unknown_semihosting_command(
-        &self,
-        interface: &mut Xtensa,
-        details: UnknownCommandDetails,
-    ) -> Result<bool, crate::Error> {
-        EspBreakpointHandler::handle_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32.rs
@@ -9,10 +9,13 @@ use super::esp::EspFlashSizeDetector;
 use crate::{
     MemoryInterface, Session,
     architecture::xtensa::{
+        Xtensa,
         communication_interface::{ProgramCounter, XtensaCommunicationInterface, XtensaError},
         sequences::XtensaDebugSequence,
         xdm,
     },
+    semihosting::UnknownCommandDetails,
+    vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
 /// The debug sequence implementation for the ESP32.
@@ -189,5 +192,13 @@ impl XtensaDebugSequence for ESP32 {
         tracing::info!("Reset complete");
 
         Ok(())
+    }
+
+    fn on_unknown_semihosting_command(
+        &self,
+        interface: &mut Xtensa,
+        details: UnknownCommandDetails,
+    ) -> Result<bool, crate::Error> {
+        EspBreakpointHandler::handle_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32.rs
@@ -9,10 +9,13 @@ use super::esp::EspFlashSizeDetector;
 use crate::{
     MemoryInterface, Session,
     architecture::xtensa::{
+        Xtensa,
         communication_interface::{ProgramCounter, XtensaCommunicationInterface, XtensaError},
         sequences::XtensaDebugSequence,
         xdm,
     },
+    semihosting::{SemihostingCommand, UnknownCommandDetails},
+    vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
 /// The debug sequence implementation for the ESP32.
@@ -189,5 +192,13 @@ impl XtensaDebugSequence for ESP32 {
         tracing::info!("Reset complete");
 
         Ok(())
+    }
+
+    fn on_unknown_semihosting_command(
+        &self,
+        interface: &mut Xtensa,
+        details: UnknownCommandDetails,
+    ) -> Result<Option<SemihostingCommand>, crate::Error> {
+        EspBreakpointHandler::handle_xtensa_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32c2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c2.rs
@@ -9,7 +9,7 @@ use crate::{
         Dmcontrol, Dmstatus, Riscv32, communication_interface::RiscvCommunicationInterface,
         sequences::RiscvDebugSequence,
     },
-    semihosting::UnknownCommandDetails,
+    semihosting::{SemihostingCommand, UnknownCommandDetails},
     vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
@@ -116,7 +116,7 @@ impl RiscvDebugSequence for ESP32C2 {
         &self,
         interface: &mut Riscv32,
         details: UnknownCommandDetails,
-    ) -> Result<bool, crate::Error> {
-        EspBreakpointHandler::handle_idf_semihosting(interface, details)
+    ) -> Result<Option<SemihostingCommand>, crate::Error> {
+        EspBreakpointHandler::handle_riscv_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32c2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c2.rs
@@ -6,9 +6,11 @@ use super::esp::EspFlashSizeDetector;
 use crate::{
     MemoryInterface, Session,
     architecture::riscv::{
-        Dmcontrol, Dmstatus, communication_interface::RiscvCommunicationInterface,
+        Dmcontrol, Dmstatus, Riscv32, communication_interface::RiscvCommunicationInterface,
         sequences::RiscvDebugSequence,
     },
+    semihosting::UnknownCommandDetails,
+    vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
 /// The debug sequence implementation for the ESP32C2.
@@ -108,5 +110,13 @@ impl RiscvDebugSequence for ESP32C2 {
         self.on_connect(interface)?;
 
         Ok(())
+    }
+
+    fn on_unknown_semihosting_command(
+        &self,
+        interface: &mut Riscv32,
+        details: UnknownCommandDetails,
+    ) -> Result<bool, crate::Error> {
+        EspBreakpointHandler::handle_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32c3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c3.rs
@@ -9,7 +9,7 @@ use crate::{
         Dmcontrol, Dmstatus, Riscv32, communication_interface::RiscvCommunicationInterface,
         sequences::RiscvDebugSequence,
     },
-    semihosting::UnknownCommandDetails,
+    semihosting::{SemihostingCommand, UnknownCommandDetails},
     vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
@@ -121,7 +121,7 @@ impl RiscvDebugSequence for ESP32C3 {
         &self,
         interface: &mut Riscv32,
         details: UnknownCommandDetails,
-    ) -> Result<bool, crate::Error> {
-        EspBreakpointHandler::handle_idf_semihosting(interface, details)
+    ) -> Result<Option<SemihostingCommand>, crate::Error> {
+        EspBreakpointHandler::handle_riscv_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32c3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c3.rs
@@ -6,9 +6,11 @@ use super::esp::EspFlashSizeDetector;
 use crate::{
     MemoryInterface, Session,
     architecture::riscv::{
-        Dmcontrol, Dmstatus, communication_interface::RiscvCommunicationInterface,
+        Dmcontrol, Dmstatus, Riscv32, communication_interface::RiscvCommunicationInterface,
         sequences::RiscvDebugSequence,
     },
+    semihosting::UnknownCommandDetails,
+    vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
 /// The debug sequence implementation for the ESP32C3.
@@ -113,5 +115,13 @@ impl RiscvDebugSequence for ESP32C3 {
         self.on_connect(interface)?;
 
         Ok(())
+    }
+
+    fn on_unknown_semihosting_command(
+        &self,
+        interface: &mut Riscv32,
+        details: UnknownCommandDetails,
+    ) -> Result<bool, crate::Error> {
+        EspBreakpointHandler::handle_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32c6.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c6.rs
@@ -10,7 +10,7 @@ use crate::{
         communication_interface::{RiscvCommunicationInterface, Sbaddress0, Sbcs, Sbdata0},
         sequences::RiscvDebugSequence,
     },
-    semihosting::UnknownCommandDetails,
+    semihosting::{SemihostingCommand, UnknownCommandDetails},
     vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
@@ -123,7 +123,7 @@ impl RiscvDebugSequence for ESP32C6 {
         &self,
         interface: &mut Riscv32,
         details: UnknownCommandDetails,
-    ) -> Result<bool, crate::Error> {
-        EspBreakpointHandler::handle_idf_semihosting(interface, details)
+    ) -> Result<Option<SemihostingCommand>, crate::Error> {
+        EspBreakpointHandler::handle_riscv_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32c6.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c6.rs
@@ -6,10 +6,12 @@ use super::esp::EspFlashSizeDetector;
 use crate::{
     MemoryInterface, Session,
     architecture::riscv::{
-        Dmcontrol,
+        Dmcontrol, Riscv32,
         communication_interface::{RiscvCommunicationInterface, Sbaddress0, Sbcs, Sbdata0},
         sequences::RiscvDebugSequence,
     },
+    semihosting::UnknownCommandDetails,
+    vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
 /// The debug sequence implementation for the ESP32C6.
@@ -115,5 +117,13 @@ impl RiscvDebugSequence for ESP32C6 {
         interface.reset_hart_and_halt(timeout)?;
 
         Ok(())
+    }
+
+    fn on_unknown_semihosting_command(
+        &self,
+        interface: &mut Riscv32,
+        details: UnknownCommandDetails,
+    ) -> Result<bool, crate::Error> {
+        EspBreakpointHandler::handle_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
@@ -6,10 +6,12 @@ use super::esp::EspFlashSizeDetector;
 use crate::{
     MemoryInterface, Session,
     architecture::riscv::{
-        Dmcontrol,
+        Dmcontrol, Riscv32,
         communication_interface::{RiscvCommunicationInterface, Sbaddress0, Sbcs, Sbdata0},
         sequences::RiscvDebugSequence,
     },
+    semihosting::UnknownCommandDetails,
+    vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
 /// The debug sequence implementation for the ESP32H2.
@@ -116,5 +118,13 @@ impl RiscvDebugSequence for ESP32H2 {
         interface.reset_hart_and_halt(timeout)?;
 
         Ok(())
+    }
+
+    fn on_unknown_semihosting_command(
+        &self,
+        interface: &mut Riscv32,
+        details: UnknownCommandDetails,
+    ) -> Result<bool, crate::Error> {
+        EspBreakpointHandler::handle_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32h2.rs
@@ -10,7 +10,7 @@ use crate::{
         communication_interface::{RiscvCommunicationInterface, Sbaddress0, Sbcs, Sbdata0},
         sequences::RiscvDebugSequence,
     },
-    semihosting::UnknownCommandDetails,
+    semihosting::{SemihostingCommand, UnknownCommandDetails},
     vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
@@ -124,7 +124,7 @@ impl RiscvDebugSequence for ESP32H2 {
         &self,
         interface: &mut Riscv32,
         details: UnknownCommandDetails,
-    ) -> Result<bool, crate::Error> {
-        EspBreakpointHandler::handle_idf_semihosting(interface, details)
+    ) -> Result<Option<SemihostingCommand>, crate::Error> {
+        EspBreakpointHandler::handle_riscv_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
@@ -9,13 +9,10 @@ use super::esp::EspFlashSizeDetector;
 use crate::{
     MemoryInterface, Session,
     architecture::xtensa::{
-        Xtensa,
         communication_interface::{XtensaCommunicationInterface, XtensaError},
         sequences::XtensaDebugSequence,
         xdm::{self, DebugControlBits, DebugRegisterError},
     },
-    semihosting::UnknownCommandDetails,
-    vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
 /// The debug sequence implementation for the ESP32-S2.
@@ -228,13 +225,5 @@ impl XtensaDebugSequence for ESP32S2 {
         })?;
 
         Ok(())
-    }
-
-    fn on_unknown_semihosting_command(
-        &self,
-        interface: &mut Xtensa,
-        details: UnknownCommandDetails,
-    ) -> Result<bool, crate::Error> {
-        EspBreakpointHandler::handle_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
@@ -9,10 +9,13 @@ use super::esp::EspFlashSizeDetector;
 use crate::{
     MemoryInterface, Session,
     architecture::xtensa::{
+        Xtensa,
         communication_interface::{XtensaCommunicationInterface, XtensaError},
         sequences::XtensaDebugSequence,
         xdm::{self, DebugControlBits, DebugRegisterError},
     },
+    semihosting::{SemihostingCommand, UnknownCommandDetails},
+    vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
 /// The debug sequence implementation for the ESP32-S2.
@@ -225,5 +228,13 @@ impl XtensaDebugSequence for ESP32S2 {
         })?;
 
         Ok(())
+    }
+
+    fn on_unknown_semihosting_command(
+        &self,
+        interface: &mut Xtensa,
+        details: UnknownCommandDetails,
+    ) -> Result<Option<SemihostingCommand>, crate::Error> {
+        EspBreakpointHandler::handle_xtensa_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
@@ -9,10 +9,13 @@ use super::esp::EspFlashSizeDetector;
 use crate::{
     MemoryInterface, Session,
     architecture::xtensa::{
+        Xtensa,
         communication_interface::{XtensaCommunicationInterface, XtensaError},
         sequences::XtensaDebugSequence,
         xdm::{self, DebugControlBits, DebugRegisterError},
     },
+    semihosting::UnknownCommandDetails,
+    vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
 /// The debug sequence implementation for the ESP32-S2.
@@ -225,5 +228,13 @@ impl XtensaDebugSequence for ESP32S2 {
         })?;
 
         Ok(())
+    }
+
+    fn on_unknown_semihosting_command(
+        &self,
+        interface: &mut Xtensa,
+        details: UnknownCommandDetails,
+    ) -> Result<bool, crate::Error> {
+        EspBreakpointHandler::handle_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
@@ -9,10 +9,13 @@ use super::esp::EspFlashSizeDetector;
 use crate::{
     MemoryInterface, Session,
     architecture::xtensa::{
+        Xtensa,
         communication_interface::{ProgramCounter, XtensaCommunicationInterface, XtensaError},
         sequences::XtensaDebugSequence,
         xdm,
     },
+    semihosting::{SemihostingCommand, UnknownCommandDetails},
+    vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
 /// The debug sequence implementation for the ESP32-S3.
@@ -195,5 +198,13 @@ impl XtensaDebugSequence for ESP32S3 {
         tracing::info!("Reset complete");
 
         Ok(())
+    }
+
+    fn on_unknown_semihosting_command(
+        &self,
+        interface: &mut Xtensa,
+        details: UnknownCommandDetails,
+    ) -> Result<Option<SemihostingCommand>, crate::Error> {
+        EspBreakpointHandler::handle_xtensa_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
@@ -9,10 +9,13 @@ use super::esp::EspFlashSizeDetector;
 use crate::{
     MemoryInterface, Session,
     architecture::xtensa::{
+        Xtensa,
         communication_interface::{ProgramCounter, XtensaCommunicationInterface, XtensaError},
         sequences::XtensaDebugSequence,
         xdm,
     },
+    semihosting::UnknownCommandDetails,
+    vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
 /// The debug sequence implementation for the ESP32-S3.
@@ -195,5 +198,13 @@ impl XtensaDebugSequence for ESP32S3 {
         tracing::info!("Reset complete");
 
         Ok(())
+    }
+
+    fn on_unknown_semihosting_command(
+        &self,
+        interface: &mut Xtensa,
+        details: UnknownCommandDetails,
+    ) -> Result<bool, crate::Error> {
+        EspBreakpointHandler::handle_idf_semihosting(interface, details)
     }
 }

--- a/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
@@ -9,13 +9,10 @@ use super::esp::EspFlashSizeDetector;
 use crate::{
     MemoryInterface, Session,
     architecture::xtensa::{
-        Xtensa,
         communication_interface::{ProgramCounter, XtensaCommunicationInterface, XtensaError},
         sequences::XtensaDebugSequence,
         xdm,
     },
-    semihosting::UnknownCommandDetails,
-    vendor::espressif::sequences::esp::EspBreakpointHandler,
 };
 
 /// The debug sequence implementation for the ESP32-S3.
@@ -198,13 +195,5 @@ impl XtensaDebugSequence for ESP32S3 {
         tracing::info!("Reset complete");
 
         Ok(())
-    }
-
-    fn on_unknown_semihosting_command(
-        &self,
-        interface: &mut Xtensa,
-        details: UnknownCommandDetails,
-    ) -> Result<bool, crate::Error> {
-        EspBreakpointHandler::handle_idf_semihosting(interface, details)
     }
 }


### PR DESCRIPTION
It's not perfect, as we can't actually detect if the caller is esp-idf, but this allows `probe-rs run` to run a panicking IDF-based firmware and not end up in a warning-printing loop.