### PR TITLE
dpv0: add reset sequence for dpv0

### DIFF
--- a/changelog/added-reset-for-dpv0.md
+++ b/changelog/added-reset-for-dpv0.md
@@ -1,0 +1,1 @@
+Added reset support for DPv0, where error conditions must be cleared by writing to Ctrl and not to Abort.


### PR DESCRIPTION
Add a reset sequence for devices that are DPv0. These are older parts that are found on devices such as the TMS570 and devices that are JTAG-only.

These devices only have one bit in the `ABORT` register. In order to clear error conditions, bits must be set in the `CTRL` register as well.