### PR TITLE
Reset CPU when flashing is skipped

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
@@ -94,15 +94,8 @@ fn monitor_impl(
         cancellation_token: ctx.cancellation_token(),
     };
 
-    let monitor_mode = if session.core(core_id)?.core_halted()? {
-        request.mode
-    } else {
-        // Core is running so we can ignore BootInfo
-        MonitorMode::AttachToRunning
-    };
-
     let mut clear_control_block = true;
-    match monitor_mode {
+    match request.mode {
         MonitorMode::Run(BootInfo::FromRam {
             vector_table_addr, ..
         }) => {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
@@ -156,10 +156,12 @@ fn list_tests_impl(
             session
                 .core(core_id)?
                 .reset_and_halt(Duration::from_millis(100))?;
-            if let Some(rtt_client) = rtt_client.as_mut() {
-                rtt_client.clear_control_block(&mut session.core(core_id)?)?;
-            }
         }
+    }
+
+    let mut core = session.core(0)?;
+    if let Some(rtt_client) = rtt_client.as_mut() {
+        rtt_client.clear_control_block(&mut core)?;
     }
 
     let mut run_loop = RunLoop {
@@ -172,7 +174,6 @@ fn list_tests_impl(
         sender: sender.clone(),
     });
 
-    let mut core = session.core(0)?;
     match run_loop.run_until(
         &mut core,
         true,


### PR DESCRIPTION
This PR changes how the RTT control block is cleared (i.e. the client can be set to prevent clearing, if the flasher initializes the control block), and makes sure the control block is cleared when needed, and that the CPU is reset on `probe-rs run` even if `--preverify` causes the flash process to be skipped.