### PR TITLE
RTT control block clearing: Fix incorrect initial state

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
@@ -39,7 +39,7 @@ impl RttClient {
 
             target: None,
             last_control_block_address: None,
-            disallow_clearing_rtt_header: true,
+            disallow_clearing_rtt_header: false,
             try_attaching: true,
             polled_data: false,
             core_id: 0,


### PR DESCRIPTION
Oops