### PR TITLE
Rewrite debug on top of DAP server

### DIFF
--- a/changelog/changed-debug.md
+++ b/changelog/changed-debug.md
@@ -1,0 +1,1 @@
+The `probe-rs debug` command now uses the DAP server internally. The commands have been replaced by those available in the DAP server.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -322,10 +322,9 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             } else if context == "repl" {
                 // While the target is running, we only allow a 'break' command.
                 // Override clippy, because the recommendation would change the logic.
-                #[allow(clippy::nonminimal_bool)]
                 if !target_core.core.core_halted()?
-                    && !(arguments.expression.starts_with("break")
-                        || arguments.expression.starts_with("quit"))
+                    && !arguments.expression.starts_with("break")
+                    && !arguments.expression.starts_with("quit")
                 {
                     response_body.result =
                         "The target is running. Only the 'break' or 'quit' commands are allowed."

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -320,94 +320,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             if context == "clipboard" {
                 response_body.result = arguments.expression;
             } else if context == "repl" {
-                // While the target is running, we only allow a 'break' command.
-                // Override clippy, because the recommendation would change the logic.
-                if !target_core.core.core_halted()?
-                    && !arguments.expression.starts_with("break")
-                    && !arguments.expression.starts_with("quit")
-                {
-                    response_body.result =
-                        "The target is running. Only the 'break' or 'quit' commands are allowed."
-                            .to_string();
-                } else {
-                    // The target is halted, so we can allow any repl command.
-                    //TODO: Do we need to look for '/' in the expression, before we split it?
-                    // Now we can make sure we have a valid expression and evaluate it.
-                    let (command_root, repl_commands) =
-                        build_expanded_commands(arguments.expression.trim());
-                    if let Some(repl_command) = repl_commands.first() {
-                        // We have a valid repl command, so we can evaluate it.
-                        // First, let's extract the remainder of the arguments, so that we can pass them to the handler.
-                        let argument_string = arguments
-                            .expression
-                            .trim_start_matches(&command_root)
-                            .trim_start()
-                            .trim_start_matches(repl_command.command)
-                            .trim_start();
-                        match (repl_command.handler)(target_core, argument_string, &arguments) {
-                            Ok(repl_response) => {
-                                // Perform any special post-processing of the response.
-                                match repl_response.command.as_str() {
-                                    "terminate" => {
-                                        // This is a special case, where a repl command has requested that the debug session be terminated.
-                                        response_body.result = repl_response
-                                            .message
-                                            .unwrap_or_else(|| "Success.".to_string());
-                                        self.send_event(
-                                            "terminated",
-                                            Some(TerminatedEventBody { restart: None }),
-                                        )?;
-                                    }
-                                    "variables" => {
-                                        // This is a special case, where a repl command has requested that the variables be displayed.
-                                        if let Some(repl_response_body) = repl_response.body {
-                                            if let Ok(evaluate_response) =
-                                                serde_json::from_value(repl_response_body.clone())
-                                            {
-                                                response_body = evaluate_response;
-                                            } else {
-                                                response_body.result = format!(
-                                                    "Error: Could not parse response body: {repl_response_body:?}"
-                                                );
-                                            };
-                                        } else {
-                                            response_body.result = repl_response
-                                                .message
-                                                .unwrap_or_else(|| "Success.".to_string());
-                                        };
-                                    }
-                                    "setBreakpoints" => {
-                                        response_body.result = repl_response
-                                            .message
-                                            // This should always have a value, but just in case someone was lazy ...
-                                            .unwrap_or_else(|| "Success.".to_string()); // This is a special case, where we've added a breakpoint, and need to synch the DAP client UI.
-                                        self.send_event("breakpoint", repl_response.body)?;
-                                    }
-                                    _other_commands => {
-                                        // In all other cases, the response would have been updated by the repl command handler.
-                                        if repl_response.success {
-                                            response_body.result = repl_response
-                                                .message
-                                                // This should always have a value, but just in case someone was lazy ...
-                                                .unwrap_or_else(|| "Success.".to_string());
-                                        } else {
-                                            response_body.result = format!(
-                                                "Error: {:?} {:?}",
-                                                repl_response.command, repl_response.message
-                                            );
-                                        }
-                                    }
-                                }
-                            }
-                            Err(error) => match &error {
-                                DebuggerError::UserMessage(repl_message) => {
-                                    repl_message.clone_into(&mut response_body.result)
-                                }
-                                other_error => response_body.result = format!("{other_error:?}",),
-                            },
-                        }
-                    }
-                }
+                self.handle_repl(target_core, &arguments, &mut response_body)?;
             } else {
                 // Handle other contexts: 'watch', 'hover', etc.
                 // The Variables request sometimes returns the variable name, and other times the variable id, so this expression will be tested to determine if it is an id or not.
@@ -529,6 +442,92 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             }
         }
         self.send_response(request, Ok(Some(response_body)))
+    }
+
+    fn handle_repl(
+        &mut self,
+        target_core: &mut CoreHandle<'_>,
+        arguments: &EvaluateArguments,
+        response_body: &mut EvaluateResponseBody,
+    ) -> Result<(), anyhow::Error> {
+        if !target_core.core.core_halted()?
+            && !arguments.expression.starts_with("break")
+            && !arguments.expression.starts_with("quit")
+        {
+            response_body.result =
+                "The target is running. Only the 'break' or 'quit' commands are allowed."
+                    .to_string();
+        } else {
+            // The target is halted, so we can allow any repl command.
+            //TODO: Do we need to look for '/' in the expression, before we split it?
+            // Now we can make sure we have a valid expression and evaluate it.
+            let (command_root, repl_commands) =
+                build_expanded_commands(arguments.expression.trim());
+            if let Some(repl_command) = repl_commands.first() {
+                // We have a valid repl command, so we can evaluate it.
+                // First, let's extract the remainder of the arguments, so that we can pass them to the handler.
+                let argument_string = arguments
+                    .expression
+                    .trim_start_matches(&command_root)
+                    .trim_start()
+                    .trim_start_matches(repl_command.command)
+                    .trim_start();
+                match (repl_command.handler)(target_core, argument_string, arguments) {
+                    Ok(repl_response) => {
+                        // In all other cases, the response would have been updated by the repl command handler.
+                        response_body.result = if repl_response.success {
+                            repl_response
+                                .message
+                                // This should always have a value, but just in case someone was lazy ...
+                                .unwrap_or_else(|| "Success.".to_string())
+                        } else {
+                            format!(
+                                "Error: {:?} {:?}",
+                                repl_response.command, repl_response.message
+                            )
+                        };
+
+                        // Perform any special post-processing of the response.
+                        match repl_response.command.as_str() {
+                            "terminate" => {
+                                // This is a special case, where a repl command has requested that the debug session be terminated.
+                                self.send_event(
+                                    "terminated",
+                                    Some(TerminatedEventBody { restart: None }),
+                                )?;
+                            }
+                            "variables" => {
+                                // This is a special case, where a repl command has requested that the variables be displayed.
+                                if let Some(repl_response_body) = repl_response.body {
+                                    if let Ok(evaluate_response) =
+                                        serde_json::from_value(repl_response_body.clone())
+                                    {
+                                        *response_body = evaluate_response;
+                                    } else {
+                                        response_body.result = format!(
+                                            "Error: Could not parse response body: {repl_response_body:?}"
+                                        );
+                                    }
+                                }
+                            }
+                            "setBreakpoints" => {
+                                // This is a special case, where we've added a breakpoint, and need to synch the DAP client UI.
+                                self.send_event("breakpoint", repl_response.body)?;
+                            }
+                            _other_commands => {}
+                        }
+                    }
+                    Err(error) => {
+                        response_body.result = match error {
+                            DebuggerError::UserMessage(repl_message) => repl_message,
+                            other_error => format!("{other_error:?}"),
+                        };
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Works in tandem with the `evaluate` request, to provide possible completions in the Debug Console REPL window.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -503,9 +503,10 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         if !target_core.core.core_halted()?
             && !arguments.expression.starts_with("break")
             && !arguments.expression.starts_with("quit")
+            && !arguments.expression.starts_with("help")
         {
             return Err(DebuggerError::UserMessage(
-                "The target is running. Only the 'break' or 'quit' commands are allowed."
+                "The target is running. Only the 'break', 'help' or 'quit' commands are allowed."
                     .to_string(),
             ));
         }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -320,7 +320,58 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             if context == "clipboard" {
                 response_body.result = arguments.expression;
             } else if context == "repl" {
-                self.handle_repl(target_core, &arguments, &mut response_body)?;
+                match self.handle_repl(target_core, &arguments) {
+                    Ok(repl_response) => {
+                        // In all other cases, the response would have been updated by the repl command handler.
+                        response_body.result = if repl_response.success {
+                            repl_response
+                                .message
+                                // This should always have a value, but just in case someone was lazy ...
+                                .unwrap_or_else(|| "Success.".to_string())
+                        } else {
+                            format!(
+                                "Error: {:?} {:?}",
+                                repl_response.command, repl_response.message
+                            )
+                        };
+
+                        // Perform any special post-processing of the response.
+                        match repl_response.command.as_str() {
+                            "terminate" => {
+                                // This is a special case, where a repl command has requested that the debug session be terminated.
+                                self.send_event(
+                                    "terminated",
+                                    Some(TerminatedEventBody { restart: None }),
+                                )?;
+                            }
+                            "variables" => {
+                                // This is a special case, where a repl command has requested that the variables be displayed.
+                                if let Some(repl_response_body) = repl_response.body {
+                                    if let Ok(evaluate_response) =
+                                        serde_json::from_value(repl_response_body.clone())
+                                    {
+                                        response_body = evaluate_response;
+                                    } else {
+                                        response_body.result = format!(
+                                            "Error: Could not parse response body: {repl_response_body:?}"
+                                        );
+                                    }
+                                }
+                            }
+                            "setBreakpoints" => {
+                                // This is a special case, where we've added a breakpoint, and need to synch the DAP client UI.
+                                self.send_event("breakpoint", repl_response.body)?;
+                            }
+                            _other_commands => {}
+                        }
+                    }
+                    Err(error) => {
+                        response_body.result = match error {
+                            DebuggerError::UserMessage(repl_message) => repl_message,
+                            other_error => format!("{other_error:?}"),
+                        };
+                    }
+                }
             } else {
                 // Handle other contexts: 'watch', 'hover', etc.
                 // The Variables request sometimes returns the variable name, and other times the variable id, so this expression will be tested to determine if it is an id or not.
@@ -448,86 +499,39 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         &mut self,
         target_core: &mut CoreHandle<'_>,
         arguments: &EvaluateArguments,
-        response_body: &mut EvaluateResponseBody,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<Response, DebuggerError> {
         if !target_core.core.core_halted()?
             && !arguments.expression.starts_with("break")
             && !arguments.expression.starts_with("quit")
         {
-            response_body.result =
+            return Err(DebuggerError::UserMessage(
                 "The target is running. Only the 'break' or 'quit' commands are allowed."
-                    .to_string();
-        } else {
-            // The target is halted, so we can allow any repl command.
-            //TODO: Do we need to look for '/' in the expression, before we split it?
-            // Now we can make sure we have a valid expression and evaluate it.
-            let (command_root, repl_commands) =
-                build_expanded_commands(arguments.expression.trim());
-            if let Some(repl_command) = repl_commands.first() {
-                // We have a valid repl command, so we can evaluate it.
-                // First, let's extract the remainder of the arguments, so that we can pass them to the handler.
-                let argument_string = arguments
-                    .expression
-                    .trim_start_matches(&command_root)
-                    .trim_start()
-                    .trim_start_matches(repl_command.command)
-                    .trim_start();
-                match (repl_command.handler)(target_core, argument_string, arguments) {
-                    Ok(repl_response) => {
-                        // In all other cases, the response would have been updated by the repl command handler.
-                        response_body.result = if repl_response.success {
-                            repl_response
-                                .message
-                                // This should always have a value, but just in case someone was lazy ...
-                                .unwrap_or_else(|| "Success.".to_string())
-                        } else {
-                            format!(
-                                "Error: {:?} {:?}",
-                                repl_response.command, repl_response.message
-                            )
-                        };
-
-                        // Perform any special post-processing of the response.
-                        match repl_response.command.as_str() {
-                            "terminate" => {
-                                // This is a special case, where a repl command has requested that the debug session be terminated.
-                                self.send_event(
-                                    "terminated",
-                                    Some(TerminatedEventBody { restart: None }),
-                                )?;
-                            }
-                            "variables" => {
-                                // This is a special case, where a repl command has requested that the variables be displayed.
-                                if let Some(repl_response_body) = repl_response.body {
-                                    if let Ok(evaluate_response) =
-                                        serde_json::from_value(repl_response_body.clone())
-                                    {
-                                        *response_body = evaluate_response;
-                                    } else {
-                                        response_body.result = format!(
-                                            "Error: Could not parse response body: {repl_response_body:?}"
-                                        );
-                                    }
-                                }
-                            }
-                            "setBreakpoints" => {
-                                // This is a special case, where we've added a breakpoint, and need to synch the DAP client UI.
-                                self.send_event("breakpoint", repl_response.body)?;
-                            }
-                            _other_commands => {}
-                        }
-                    }
-                    Err(error) => {
-                        response_body.result = match error {
-                            DebuggerError::UserMessage(repl_message) => repl_message,
-                            other_error => format!("{other_error:?}"),
-                        };
-                    }
-                }
-            }
+                    .to_string(),
+            ));
         }
 
-        Ok(())
+        // The target is halted, so we can allow any repl command.
+        //TODO: Do we need to look for '/' in the expression, before we split it?
+        // Now we can make sure we have a valid expression and evaluate it.
+        let (command_root, repl_commands) = build_expanded_commands(arguments.expression.trim());
+
+        let Some(repl_command) = repl_commands.first() else {
+            return Err(DebuggerError::UserMessage(format!(
+                "Invalid REPL command: {:?}.",
+                command_root
+            )));
+        };
+
+        // We have a valid repl command, so we can evaluate it.
+        // First, let's extract the remainder of the arguments, so that we can pass them to the handler.
+        let argument_string = arguments
+            .expression
+            .trim_start_matches(&command_root)
+            .trim_start()
+            .trim_start_matches(repl_command.command)
+            .trim_start();
+
+        (repl_command.handler)(target_core, argument_string, arguments)
     }
 
     /// Works in tandem with the `evaluate` request, to provide possible completions in the Debug Console REPL window.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/core_status.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/core_status.rs
@@ -47,7 +47,14 @@ impl DapStatus for CoreStatus {
                 ),
                 HaltReason::Request => (
                     "pause",
-                    "Core halted due to a user (debugger client) request".to_string(),
+                    format!(
+                        "Core halted due to a user (debugger client) request @{}.",
+                        if let Some(program_counter) = program_counter {
+                            format!("{program_counter:#010x}")
+                        } else {
+                            "(unspecified location)".to_string()
+                        }
+                    ),
                 ),
                 HaltReason::External => (
                     "external",

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/dap_types.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/dap_types.rs
@@ -237,7 +237,7 @@ impl Display for Message {
 
         if let Some(args) = &self.variables {
             for (key, value) in args {
-                formatted = formatted.replace(&format!("{{{}}}", key), value);
+                formatted = formatted.replace(&format!("{{{key}}}"), value);
             }
         }
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/dap_types.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/dap_types.rs
@@ -230,3 +230,17 @@ fn get_string_argument(
         }),
     }
 }
+
+impl Display for Message {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut formatted = self.format.clone();
+
+        if let Some(args) = &self.variables {
+            for (key, value) in args {
+                formatted = formatted.replace(&format!("{{{}}}", key), value);
+            }
+        }
+
+        f.write_str(&formatted)
+    }
+}

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands.rs
@@ -113,8 +113,6 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
         args: &[],
         handler: |target_core, _, _| {
             target_core.core.run()?;
-            // Changing the status below will result in the debugger automaticlly synching the client status.
-            target_core.core_data.last_known_status = CoreStatus::Running;
             Ok(Response {
                 command: "continue".to_string(),
                 success: true,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands.rs
@@ -71,7 +71,7 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
         args: None,
         handler: |_, _, _| {
             let mut help_text =
-                "Usage:\t-Use <Ctrl+Space> to get a list of available commands.".to_string();
+                "Usage:\t- Use <Ctrl+Space> to get a list of available commands.".to_string();
             help_text.push_str("\n\t- Use <Up/DownArrows> to navigate through the command list.");
             help_text.push_str("\n\t- Use <Hab> to insert the currently selected command.");
             help_text.push_str("\n\t- Note: This implementation is a subset of gdb commands, and is intended to behave similarly.");

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands.rs
@@ -198,7 +198,7 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
         args: Some(&[ReplCommandArgs::Optional(
             "path (e.g. my_dir/backtrace.yaml)",
         )]),
-        handler: |target_core, command_arguments, _request_arguments| {
+        handler: |target_core, command_arguments, _| {
             let args = command_arguments.split_whitespace().collect_vec();
 
             let write_to_file = args.first().map(Path::new);
@@ -411,7 +411,7 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
             ReplCommandArgs::Optional("memory size in bytes"),
             ReplCommandArgs::Optional("path (default: ./coredump)"),
         ]),
-        handler: |target_core, command_arguments, _request_arguments| {
+        handler: |target_core, command_arguments, _| {
             let mut args = command_arguments.split_whitespace().collect_vec();
 
             // If we get an odd number of arguments, treat all n * 2 args at the start as memory blocks

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands.rs
@@ -36,7 +36,7 @@ pub(crate) struct ReplCommand<H: 'static> {
     /// - This is case sensitive.
     pub(crate) command: &'static str,
     pub(crate) help_text: &'static str,
-    pub(crate) sub_commands: Option<&'static [ReplCommand<H>]>,
+    pub(crate) sub_commands: &'static [ReplCommand<H>],
     pub(crate) args: Option<&'static [ReplCommandArgs]>,
     pub(crate) handler: H,
 }
@@ -44,7 +44,7 @@ pub(crate) struct ReplCommand<H: 'static> {
 impl<H> Display for ReplCommand<H> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{} ", self.command)?;
-        if self.sub_commands.is_some() {
+        if !self.sub_commands.is_empty() {
             write!(f, "<subcommand> ")?;
         }
         if let Some(args) = self.args {
@@ -53,9 +53,9 @@ impl<H> Display for ReplCommand<H> {
             }
         }
         write!(f, ": {} ", self.help_text)?;
-        if let Some(sub_commands) = self.sub_commands {
+        if !self.sub_commands.is_empty() {
             write!(f, "\n  Subcommands:")?;
-            for sub_command in sub_commands {
+            for sub_command in self.sub_commands {
                 write!(f, "\n  - {sub_command}")?;
             }
         }
@@ -67,7 +67,7 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
     ReplCommand {
         command: "help",
         help_text: "Information about available commands and how to use them.",
-        sub_commands: None,
+        sub_commands: &[],
         args: None,
         handler: |_, _, _| {
             let mut help_text =
@@ -93,7 +93,7 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
     ReplCommand {
         command: "quit",
         help_text: "Disconnect (and suspend) the target.",
-        sub_commands: None,
+        sub_commands: &[],
         args: None,
         handler: |target_core, _, _| {
             target_core.core.halt(Duration::from_millis(500))?;
@@ -111,7 +111,7 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
     ReplCommand {
         command: "c",
         help_text: "Continue running the program on the target.",
-        sub_commands: None,
+        sub_commands: &[],
         args: None,
         handler: |target_core, _, _| {
             target_core.core.run()?;
@@ -132,7 +132,7 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
         command: "break",
         // Stricly speaking, gdb refers to this as an expression, but we only support variables.
         help_text: "Sets a breakpoint specified location, or next instruction if unspecified.",
-        sub_commands: None,
+        sub_commands: &[],
         args: Some(&[ReplCommandArgs::Optional("*address")]),
         handler: |target_core, command_arguments, _| {
             if command_arguments.is_empty() {
@@ -193,7 +193,7 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
     },
     ReplCommand {
         command: "backtrace",
-        sub_commands: None,
+        sub_commands: &[],
         help_text: "Print the backtrace of the current thread to a local file.",
         args: Some(&[ReplCommandArgs::Optional(
             "path (e.g. my_dir/backtrace.yaml)",
@@ -236,11 +236,11 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
     ReplCommand {
         command: "info",
         help_text: "Information of specified program data.",
-        sub_commands: Some(&[
+        sub_commands: &[
             ReplCommand {
                 command: "frame",
                 help_text: "Describe the current frame, or the frame at the specified (hex) address.",
-                sub_commands: None,
+                sub_commands: &[],
                 args: Some(&[ReplCommandArgs::Optional("address")]),
                 // TODO: This is easy to implement ... just requires deciding how to format the output.
                 handler: |_, _, _| Err(DebuggerError::Unimplemented),
@@ -248,7 +248,7 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
             ReplCommand {
                 command: "locals",
                 help_text: "List local variables of the selected frame.",
-                sub_commands: None,
+                sub_commands: &[],
                 args: None,
                 handler: |target_core, _, evaluate_arguments| {
                     let gdb_nuf = GdbNuf {
@@ -262,7 +262,7 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
             ReplCommand {
                 command: "all-reg",
                 help_text: "List all registers of the selected frame.",
-                sub_commands: None,
+                sub_commands: &[],
                 args: None,
                 // TODO: This is easy to implement ... just requires deciding how to format the output.
                 handler: |_, _, _| Err(DebuggerError::Unimplemented),
@@ -270,12 +270,12 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
             ReplCommand {
                 command: "var",
                 help_text: "List all static variables.",
-                sub_commands: None,
+                sub_commands: &[],
                 args: None,
                 // TODO: This is easy to implement ... just requires deciding how to format the output.
                 handler: |_, _, _| Err(DebuggerError::Unimplemented),
             },
-        ]),
+        ],
         args: None,
         handler: |_, _, _| {
             Err(DebuggerError::UserMessage("Please provide one of the required subcommands. See the `help` command for more information.".to_string()))
@@ -285,7 +285,7 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
         command: "p",
         // Stricly speaking, gdb refers to this as an expression, but we only support variables.
         help_text: "Print known information about variable.",
-        sub_commands: None,
+        sub_commands: &[],
         args: Some(&[
             ReplCommandArgs::Optional("/f (f=format[n|v])"),
             ReplCommandArgs::Required("<local variable name>"),
@@ -330,7 +330,7 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
     ReplCommand {
         command: "x",
         help_text: "Examine Memory, using format specifications, at the specified address.",
-        sub_commands: None,
+        sub_commands: &[],
         args: Some(&[
             ReplCommandArgs::Optional("/Nuf (N=count, u=unit[b|h|w|g], f=format[t|x|i])"),
             ReplCommandArgs::Optional("address (hex)"),
@@ -405,7 +405,7 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
     ReplCommand {
         command: "dump",
         help_text: "Create a core dump at a target location. Specify memory ranges to dump, or leave blank to dump in-scope memory regions.",
-        sub_commands: None,
+        sub_commands: &[],
         args: Some(&[
             ReplCommandArgs::Optional("memory start address"),
             ReplCommandArgs::Optional("memory size in bytes"),

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
@@ -192,13 +192,13 @@ pub(crate) fn build_expanded_commands(
         // If there is only one match, and it has sub-commands, then we can continue iterating (implicit recursion with new sub-command).
         if matches.len() == 1 {
             if let Some(parent_command) = matches.first() {
-                if let Some(sub_commands) = parent_command.sub_commands {
+                if !parent_command.sub_commands.is_empty() {
                     // Build up the full command as we iterate ...
                     if !command_root.is_empty() {
                         command_root.push(' ');
                     }
                     command_root.push_str(parent_command.command);
-                    repl_commands = sub_commands.iter().collect();
+                    repl_commands = parent_command.sub_commands.iter().collect();
                     continue;
                 }
             }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
@@ -82,7 +82,7 @@ pub(crate) fn get_local_variable(
     response_body.result = "".to_string();
     for variable in variable_list {
         if gdb_nuf.format_specifier == GdbFormat::DapReference {
-            response_body.memory_reference = Some(format!("{}", variable.memory_location));
+            response_body.memory_reference = Some(variable.memory_location.to_string());
             response_body.result = format!(
                 "{} : {} ",
                 variable.name,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
@@ -79,7 +79,6 @@ pub(crate) fn get_local_variable(
         type_: None,
         presentation_hint: None,
     };
-    response_body.result = "".to_string();
     for variable in variable_list {
         if gdb_nuf.format_specifier == GdbFormat::DapReference {
             response_body.memory_reference = Some(variable.memory_location.to_string());

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
@@ -189,27 +189,25 @@ pub(crate) fn build_expanded_commands(
         let matches = find_commands(&repl_commands, command_piece);
 
         // If there is only one match, and it has sub-commands, then we can continue iterating (implicit recursion with new sub-command).
-        if matches.len() == 1 {
-            if let Some(parent_command) = matches.first() {
-                if !parent_command.sub_commands.is_empty() {
-                    // Build up the full command as we iterate ...
-                    if !command_root.is_empty() {
-                        command_root.push(' ');
-                    }
-                    command_root.push_str(parent_command.command);
-                    repl_commands = parent_command.sub_commands.iter().collect();
-                    continue;
-                }
-            }
-        }
+        let Some(parent_command) = matches.first() else {
+            // If there are no matches, then we can keep the matches from the previous
+            // iteration (if there were any) but we can't continue;
+            break;
+        };
 
-        if matches.is_empty() {
-            // If there are no matches, then we can keep the matches from the previous iteration (if there were any).
+        if matches.len() == 1 && !parent_command.sub_commands.is_empty() {
+            // Build up the full command as we iterate ...
+            if !command_root.is_empty() {
+                command_root.push(' ');
+            }
+            command_root.push_str(parent_command.command);
+            repl_commands = parent_command.sub_commands.iter().collect();
         } else {
-            // If there are multiple matches, or there is only one match with no sub-commands, then we can use the matches.
+            // If there are multiple matches, or there is only one match with no
+            // sub-commands, then we can use the matches.
             repl_commands = matches;
+            break;
         }
-        break;
     }
     (command_root, repl_commands)
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/mod.rs
@@ -1,8 +1,8 @@
 // Bad things happen to the VSCode debug extenison and debug_adapter if we panic at the wrong time.
 #![warn(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
-mod debug_adapter;
+pub(crate) mod debug_adapter;
 mod peripherals;
-mod server;
+pub(crate) mod server;
 
 #[cfg(test)]
 mod test;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -320,7 +320,6 @@ impl Debugger {
             // The request handler has already reported this error to the user.
             return Ok(());
         }
-        self.debug_logger.flush_to_dap(&mut debug_adapter)?;
 
         let launch_attach_request = loop {
             if let Some(request) = debug_adapter.listen_for_request()? {
@@ -342,7 +341,6 @@ impl Debugger {
                 return Ok(());
             }
         };
-        self.debug_logger.flush_to_dap(&mut debug_adapter)?;
 
         if debug_adapter
             .send_event::<Event>("initialized", None)
@@ -494,6 +492,7 @@ impl Debugger {
         drop(target_core);
 
         debug_adapter.send_response::<()>(launch_attach_request, Ok(None))?;
+        self.debug_logger.flush_to_dap(debug_adapter)?;
 
         Ok(session_data)
     }
@@ -874,6 +873,8 @@ impl Debugger {
             ..Default::default()
         };
         debug_adapter.send_response(&initialize_request, Ok(Some(capabilities)))?;
+
+        self.debug_logger.flush_to_dap(debug_adapter)?;
 
         Ok(())
     }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -403,7 +403,7 @@ impl Debugger {
 
     /// Process launch or attach request
     #[tracing::instrument(skip_all, name = "Handle Launch/Attach Request")]
-    fn handle_launch_attach<P: ProtocolAdapter + 'static>(
+    pub(crate) fn handle_launch_attach<P: ProtocolAdapter + 'static>(
         &mut self,
         registry: &mut Registry,
         launch_attach_request: &Request,
@@ -811,7 +811,7 @@ impl Debugger {
     }
 
     #[tracing::instrument(skip_all, name = "Handling initialize request")]
-    fn handle_initialize<P: ProtocolAdapter>(
+    pub(crate) fn handle_initialize<P: ProtocolAdapter>(
         &mut self,
         debug_adapter: &mut DebugAdapter<P>,
     ) -> Result<(), DebuggerError> {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
@@ -1,29 +1,122 @@
-use std::path::Path;
+use std::cell::RefCell;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::rc::Rc;
 
-use anyhow::anyhow;
-use capstone::{
-    Endian, arch::arm::ArchMode as armArchMode, arch::arm64::ArchMode as aarch64ArchMode,
-    arch::riscv::ArchMode as riscvArchMode, prelude::*,
-};
-use num_traits::Num;
-use parse_int::parse;
-use probe_rs::CoreDump;
-use probe_rs::CoreDumpError;
-use probe_rs::CoreInterface;
-use probe_rs::architecture::arm::ap::AccessPortError;
 use probe_rs::config::Registry;
-use probe_rs::flashing::FileDownloadError;
-use probe_rs::probe::DebugProbeError;
 use probe_rs::probe::list::Lister;
-use probe_rs::{Core, CoreType, InstructionSet, MemoryInterface, RegisterValue};
-use probe_rs_debug::exception_handler_for_core;
-use probe_rs_debug::stack_frame::StackFrameInfo;
-use probe_rs_debug::{debug_info::DebugInfo, registers::DebugRegisters, stack_frame::StackFrame};
 use rustyline::{DefaultEditor, error::ReadlineError};
+use time::UtcOffset;
 
+use crate::cmd::dap_server::debug_adapter::dap::adapter::DebugAdapter;
+use crate::cmd::dap_server::debug_adapter::dap::dap_types::EvaluateArguments;
+use crate::cmd::dap_server::debug_adapter::dap::dap_types::EvaluateResponseBody;
+use crate::cmd::dap_server::debug_adapter::dap::dap_types::InitializeRequestArguments;
+use crate::cmd::dap_server::debug_adapter::dap::dap_types::OutputEventBody;
+use crate::cmd::dap_server::debug_adapter::protocol::ProtocolAdapter;
+use crate::cmd::dap_server::server::configuration::ConsoleLog;
+use crate::cmd::dap_server::server::configuration::CoreConfig;
+use crate::cmd::dap_server::server::configuration::FlashingConfig;
+use crate::cmd::dap_server::server::configuration::SessionConfig;
+use crate::cmd::dap_server::server::debugger::Debugger;
+use crate::util::rtt::RttConfig;
 use crate::{CoreOptions, util::common_options::ProbeOptions};
+
+use super::dap_server::debug_adapter::dap::dap_types::Request;
+use super::dap_server::debug_adapter::dap::dap_types::Response;
+
+struct Shared {
+    stop: bool,
+    next_request: Option<Request>,
+}
+
+/// A barebones adapter for the CLI "client".
+struct CliAdapter {
+    shared: Rc<RefCell<Shared>>,
+    console_log_level: ConsoleLog,
+}
+impl ProtocolAdapter for CliAdapter {
+    fn listen_for_request(&mut self) -> anyhow::Result<Option<Request>> {
+        Ok(self.shared.borrow().next_request.clone())
+    }
+
+    fn send_event<S: serde::Serialize>(
+        &mut self,
+        event_type: &str,
+        event_body: Option<S>,
+    ) -> anyhow::Result<()> {
+        let serialized_body = event_body.as_ref().map(serde_json::to_string).transpose()?;
+
+        match event_type {
+            "probe-rs-show-message" | "output" => {
+                let Some(body) = serialized_body else {
+                    return Ok(());
+                };
+
+                let output = serde_json::from_str::<OutputEventBody>(&body)?;
+
+                print!("{}", output.output);
+            }
+            "terminated" => {
+                self.shared.borrow_mut().stop = true;
+            }
+            // Not interesting
+            "memory" => {}
+            "stopped" => {}
+            "breakpoint" => {}
+            // No RTT support (yet)
+            "probe-rs-rtt-channel-config" | "probe-rs-rtt-data" => {}
+            // No flashing support (yet)
+            "progressStart" | "progressEnd" | "progressUpdate" => {}
+            // We can safely ignore "exited"
+            "exited" => {}
+            _ => {
+                tracing::warn!("Unhandled event {event_type}: {serialized_body:?}");
+            }
+        }
+
+        Ok(())
+    }
+
+    fn send_raw_response(&mut self, response: &Response) -> anyhow::Result<()> {
+        if response.success {
+            match response.command.as_str() {
+                "evaluate" => {
+                    let Some(body) = &response.body else {
+                        unreachable!();
+                    };
+                    let body = serde_json::from_value::<EvaluateResponseBody>(body.clone())?;
+
+                    println!("{}", body.result);
+                }
+                "initialize" => {}
+                "attach" => {}
+                _ => println!("{response:?}"),
+            }
+        } else {
+            todo!("{response:?}");
+        }
+
+        Ok(())
+    }
+
+    fn remove_pending_request(&mut self, request_seq: i64) -> Option<String> {
+        self.shared.borrow_mut().next_request.take().and_then(|r| {
+            if request_seq == r.seq {
+                Some(r.command)
+            } else {
+                None
+            }
+        })
+    }
+
+    fn set_console_log_level(&mut self, log_level: ConsoleLog) {
+        self.console_log_level = log_level;
+    }
+
+    fn console_log_level(&self) -> ConsoleLog {
+        self.console_log_level
+    }
+}
 
 #[derive(clap::Parser)]
 pub struct Cmd {
@@ -39,34 +132,117 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
-        let (mut session, _probe_options) = self.common.simple_attach(registry, lister)?;
+    pub fn run(
+        self,
+        registry: &mut Registry,
+        lister: &Lister,
+        utc_offset: UtcOffset,
+    ) -> anyhow::Result<()> {
+        let shared = Rc::new(RefCell::new(Shared {
+            stop: false,
+            next_request: None,
+        }));
+        let mut debug_adapter = DebugAdapter::new(CliAdapter {
+            shared: shared.clone(),
+            console_log_level: ConsoleLog::Console,
+        });
+        let mut debugger = Debugger::new(utc_offset, None)?;
 
-        let di = self
-            .exe
-            .as_ref()
-            .and_then(|path| DebugInfo::from_file(path).ok());
+        shared.borrow_mut().next_request = Some(Request {
+            command: "initialize".to_string(),
+            arguments: serde_json::to_value(&InitializeRequestArguments {
+                adapter_id: "probe-rs-cli".to_string(),
+                client_id: Some("probe-rs-cli".to_string()),
+                client_name: Some("probe-rs command-line debugger".to_string()),
+                columns_start_at_1: None,
+                lines_start_at_1: None,
+                locale: None,
+                path_format: None,
+                supports_args_can_be_interpreted_by_shell: None,
+                supports_invalidated_event: None,
+                supports_memory_event: None,
+                supports_memory_references: None,
+                supports_progress_reporting: None,
+                supports_run_in_terminal_request: None,
+                supports_start_debugging_request: None,
+                supports_variable_paging: None,
+                supports_variable_type: None,
+            })
+            .ok(),
+            seq: 0,
+            type_: "request".to_string(),
+        });
+        debugger.handle_initialize(&mut debug_adapter)?;
 
-        let cli = DebugCli::new();
+        let attach_request = Request {
+            command: "attach".to_string(),
+            arguments: serde_json::to_value(&SessionConfig {
+                console_log_level: None,
+                cwd: None,
+                probe: self.common.probe,
+                chip: self.common.chip,
+                chip_description_path: self.common.chip_description_path,
+                connect_under_reset: self.common.connect_under_reset,
+                speed: self.common.speed,
+                wire_protocol: self.common.protocol,
+                allow_erase_all: false,
+                flashing_config: FlashingConfig::default(),
+                core_configs: vec![CoreConfig {
+                    core_index: self.shared.core,
+                    program_binary: self.exe,
+                    svd_file: None,
+                    rtt_config: RttConfig {
+                        enabled: false,
+                        channels: vec![],
+                    },
+                }],
+            })
+            .ok(),
+            seq: 1,
+            type_: "request".to_string(),
+        };
 
-        let core = session.core(self.shared.core)?;
+        // A bit weird since we need the request to be removable,
+        // but we also need to pass it directly.
+        shared.borrow_mut().next_request = Some(attach_request.clone());
+        let mut session_data =
+            debugger.handle_launch_attach(registry, &attach_request, &mut debug_adapter, lister)?;
 
-        let mut cli_data = CliData::new(core, di)?;
+        shared.borrow_mut().next_request = Some(Request {
+            command: "configurationDone".to_string(),
+            arguments: serde_json::to_value(()).ok(),
+            seq: 2,
+            type_: "request".to_string(),
+        });
+        debugger.process_next_request(&mut session_data, &mut debug_adapter)?;
 
         let mut rl = DefaultEditor::new()?;
 
-        loop {
-            cli_data.print_state()?;
-
+        let mut seq = 3;
+        while !shared.borrow().stop {
             match rl.readline(">> ") {
                 Ok(line) => {
-                    let history_entry: &str = line.as_ref();
-                    rl.add_history_entry(history_entry)?;
-                    let cli_state = cli.handle_line(&line, &mut cli_data)?;
+                    rl.add_history_entry(&line)?;
 
-                    if cli_state == CliState::Stop {
-                        break;
-                    }
+                    let request = Request {
+                        command: "evaluate".to_string(),
+                        arguments: serde_json::to_value(&EvaluateArguments {
+                            context: Some("repl".to_string()),
+                            expression: line,
+                            format: None,
+                            frame_id: None,
+                        })
+                        .ok(),
+                        seq: {
+                            let s = seq;
+                            seq += 1;
+                            s
+                        },
+                        type_: "request".to_string(),
+                    };
+
+                    shared.borrow_mut().next_request = Some(request);
+                    debugger.process_next_request(&mut session_data, &mut debug_adapter)?;
                 }
                 // For end of file and ctrl-c, we just quit
                 Err(ReadlineError::Eof | ReadlineError::Interrupted) => return Ok(()),
@@ -80,1003 +256,4 @@ impl Cmd {
 
         Ok(())
     }
-}
-
-#[derive(Debug, thiserror::Error)]
-enum CliError {
-    #[error(transparent)]
-    DebugProbe(#[from] DebugProbeError),
-    #[error(transparent)]
-    AccessPort(#[from] AccessPortError),
-    #[error(transparent)]
-    StdIO(#[from] std::io::Error),
-    #[error(transparent)]
-    FileDownload(#[from] FileDownloadError),
-    #[error("Command expected more arguments.")]
-    MissingArgument,
-    #[error("Failed to parse argument '{argument}'.")]
-    ArgumentParseError {
-        argument_index: usize,
-        argument: String,
-        source: anyhow::Error,
-    },
-    #[error(transparent)]
-    ProbeRs(#[from] probe_rs::Error),
-    /// Errors related to the handling of core dumps.
-    #[error("An error with a CoreDump occured")]
-    CoreDump(#[from] CoreDumpError),
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
-}
-
-pub struct DebugCli {
-    commands: Vec<Command>,
-}
-
-/// Parse the argument at the given index.
-fn get_int_argument<T: Num>(args: &[&str], index: usize) -> Result<T, CliError>
-where
-    <T as Num>::FromStrRadixErr: std::error::Error + Send + Sync + 'static,
-{
-    let arg_str = args.get(index).ok_or(CliError::MissingArgument)?;
-
-    parse::<T>(arg_str).map_err(|e| CliError::ArgumentParseError {
-        argument_index: index,
-        argument: arg_str.to_string(),
-        source: e.into(),
-    })
-}
-
-impl DebugCli {
-    fn new() -> DebugCli {
-        let mut cli = DebugCli {
-            commands: Vec::new(),
-        };
-
-        cli.add_command(Command {
-            name: "step",
-            help_text: "Step a single instruction",
-
-            function: |cli_data, _args| {
-                let cpu_info = cli_data.core.step()?;
-                println!("Core stopped at address 0x{:08x}", cpu_info.pc);
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "halt",
-            help_text: "Stop the CPU",
-
-            function: |cli_data, _args| {
-                let cpu_info = cli_data.core.halt(Duration::from_millis(100))?;
-                println!("Core stopped at address 0x{:08x}", cpu_info.pc);
-
-                let mut code = [0u8; 16 * 2];
-
-                cli_data.core.read(cpu_info.pc, &mut code)?;
-
-                let cs = match cli_data.core.instruction_set()? {
-                    InstructionSet::Thumb2 => Capstone::new()
-                        .arm()
-                        .mode(armArchMode::Thumb)
-                        .endian(Endian::Little)
-                        .build(),
-                    InstructionSet::A32 => {
-                        // We need to inspect the CPSR to determine what mode this is opearting in
-                        Capstone::new()
-                            .arm()
-                            .mode(armArchMode::Arm)
-                            .endian(Endian::Little)
-                            .build()
-                    }
-                    InstructionSet::A64 => {
-                        // We need to inspect the CPSR to determine what mode this is opearting in
-                        Capstone::new()
-                            .arm64()
-                            .mode(aarch64ArchMode::Arm)
-                            .endian(Endian::Little)
-                            .build()
-                    }
-                    InstructionSet::RV32 => Capstone::new()
-                        .riscv()
-                        .mode(riscvArchMode::RiscV32)
-                        .endian(Endian::Little)
-                        .build(),
-                    InstructionSet::RV32C => Capstone::new()
-                        .riscv()
-                        .mode(riscvArchMode::RiscV32)
-                        .endian(Endian::Little)
-                        .extra_mode(std::iter::once(
-                            capstone::arch::riscv::ArchExtraMode::RiscVC,
-                        ))
-                        .build(),
-                    InstructionSet::Xtensa => Err(capstone::Error::UnsupportedArch),
-                }
-                .map_err(|err| anyhow!("Error creating capstone: {:?}", err))?;
-
-                // Attempt to dissassemble
-                match cs.disasm_all(&code, cpu_info.pc) {
-                    Ok(instructions) => {
-                        for i in instructions.iter() {
-                            println!("{i}");
-                        }
-                    }
-                    Err(e) => {
-                        println!("Error disassembling instructions: {e}");
-
-                        // Fallback to raw output
-                        for (offset, instruction) in code.iter().enumerate() {
-                            println!(
-                                "{:#010x}: {:010x}",
-                                cpu_info.pc + offset as u64,
-                                instruction
-                            );
-                        }
-                    }
-                };
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "status",
-            help_text: "Show current status of CPU",
-
-            function: |cli_data, _args| {
-                let status = cli_data.core.status()?;
-
-                println!("Status: {:?}", &status);
-
-                if status.is_halted() {
-                    let pc_desc = cli_data.core.program_counter();
-                    let pc: u64 = cli_data
-                        .core
-                        .read_core_reg(pc_desc)?;
-                    println!("Core halted at address {:#0width$x}", pc, width = pc_desc.format_hex_width());
-
-                    // determine if the target is handling an interupt
-
-                    if cli_data.core.architecture() == probe_rs::Architecture::Arm {
-                        match cli_data.core.core_type() {
-                            CoreType::Armv6m | CoreType::Armv7em | CoreType::Armv7m | CoreType::Armv8m | CoreType::Armv7a | CoreType::Armv8a => {
-                                // Unwrap is safe here because ARM always defines this register
-                                let psr_desc = cli_data.core.registers().psr().unwrap();
-
-                                let xpsr: u32 = cli_data.core.read_core_reg(
-                                    psr_desc,
-                                )?;
-
-                                println!("XPSR: {:#0width$x}", xpsr, width = psr_desc.format_hex_width());
-
-                                // This is Cortex-M specific interpretation
-                                // It's hard to generally model these concepts for any possible CoreType,
-                                // but it may be worth considering moving this into the CoreInterface somehow
-                                // in the future
-                                if cli_data.core.core_type().is_cortex_m() {
-
-                                    let exception_number = xpsr & 0xff;
-
-                                    if exception_number != 0 {
-                                        println!("Currently handling exception {exception_number}");
-
-                                        if exception_number == 3 {
-                                            println!("Hard Fault!");
-
-
-                                            let return_address: u64 = cli_data.core.read_core_reg(cli_data.core.return_address())?;
-
-                                            println!("Return address (LR): {return_address:#010x}");
-
-                                            // Get reason for hard fault
-                                            let hfsr = cli_data.core.read_word_32(0xE000_ED2C)?;
-
-                                            if hfsr & (1 << 30) == (1 << 30) {
-                                                println!("-> configurable priority exception has been escalated to hard fault!");
-
-
-                                                // read cfsr
-                                                let cfsr = cli_data.core.read_word_32(0xE000_ED28)?;
-
-                                                let ufsr = (cfsr >> 16) & 0xffff;
-                                                let bfsr = (cfsr >> 8) & 0xff;
-                                                let mmfsr = cfsr & 0xff;
-
-
-                                                if ufsr != 0 {
-                                                    println!("\tUsage Fault     - UFSR: {ufsr:#06x}");
-                                                }
-
-                                                if bfsr != 0 {
-                                                    println!("\tBus Fault       - BFSR: {bfsr:#04x}");
-
-                                                    if bfsr & (1 << 7) == (1 << 7) {
-                                                        // Read address from BFAR
-                                                        let bfar = cli_data.core.read_word_32(0xE000_ED38)?;
-                                                        println!("\t Location       - BFAR: {bfar:#010x}");
-                                                    }
-                                                }
-
-                                                if mmfsr != 0 {
-                                                    println!("\tMemManage Fault - BFSR: {bfsr:04x}");
-                                                }
-
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            // Nothing extra to log
-                            _ => {},
-                        }
-                    }
-                }
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "run",
-            help_text: "Resume execution of the CPU",
-
-            function: |cli_data, _args| {
-                cli_data.core.run()?;
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "quit",
-            help_text: "Exit the program",
-
-            function: |_cli_data, _args| Ok(CliState::Stop),
-        });
-
-        cli.add_command(Command {
-            name: "read8",
-            help_text: "Read 8bit value from memory",
-
-            function: |cli_data, args| {
-                let address = get_int_argument(args, 0)?;
-
-                let num_bytes = if args.len() > 1 {
-                    get_int_argument(args, 1)?
-                } else {
-                    1
-                };
-
-                let mut buff = vec![0u8; num_bytes];
-
-                if num_bytes > 1 {
-                    cli_data.core.read_8(address, &mut buff)?;
-                } else {
-                    buff[0] = cli_data.core.read_word_8(address)?;
-                }
-
-                for (offset, byte) in buff.iter().enumerate() {
-                    println!("0x{:08x} = 0x{:02x}", address + (offset) as u64, byte);
-                }
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "read16",
-            help_text: "Read 16bit value from memory",
-
-            function: |cli_data, args| {
-                let address = get_int_argument(args, 0)?;
-
-                let num_words = if args.len() > 1 {
-                    get_int_argument(args, 1)?
-                } else {
-                    1
-                };
-
-                let mut buff = vec![0u16; num_words];
-
-                if num_words > 1 {
-                    cli_data.core.read_16(address, &mut buff)?;
-                } else {
-                    buff[0] = cli_data.core.read_word_16(address)?;
-                }
-
-                for (offset, word) in buff.iter().enumerate() {
-                    println!("0x{:08x} = 0x{:04x}", address + (offset * 2) as u64, word);
-                }
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "read32",
-            help_text: "Read 32bit value from memory",
-
-            function: |cli_data, args| {
-                let address = get_int_argument(args, 0)?;
-
-                let num_words = if args.len() > 1 {
-                    get_int_argument(args, 1)?
-                } else {
-                    1
-                };
-
-                let mut buff = vec![0u32; num_words];
-
-                if num_words > 1 {
-                    cli_data.core.read_32(address, &mut buff)?;
-                } else {
-                    buff[0] = cli_data.core.read_word_32(address)?;
-                }
-
-                for (offset, word) in buff.iter().enumerate() {
-                    println!("0x{:08x} = 0x{:08x}", address + (offset * 4) as u64, word);
-                }
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "read64",
-            help_text: "Read 64bit value from memory",
-
-            function: |cli_data, args| {
-                let address = get_int_argument(args, 0)?;
-
-                let num_words = if args.len() > 1 {
-                    get_int_argument(args, 1)?
-                } else {
-                    1
-                };
-
-                let mut buff = vec![0u64; num_words];
-
-                if num_words > 1 {
-                    cli_data.core.read_64(address, &mut buff)?;
-                } else {
-                    buff[0] = cli_data.core.read_word_64(address)?;
-                }
-
-                for (offset, word) in buff.iter().enumerate() {
-                    println!("0x{:08x} = 0x{:02x}", address + (offset * 8) as u64, word);
-                }
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "write8",
-            help_text: "Write a 8bit value to memory",
-
-            function: |cli_data, args| {
-                let address = get_int_argument(args, 0)?;
-                let data: u8 = get_int_argument(args, 1)?;
-
-                cli_data.core.write_word_8(address, data)?;
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "write16",
-            help_text: "Write a 16bit value to memory",
-
-            function: |cli_data, args| {
-                let address = get_int_argument(args, 0)?;
-                let data = get_int_argument(args, 1)?;
-
-                cli_data.core.write_word_16(address, data)?;
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "write32",
-            help_text: "Write a 32bit value to memory",
-
-            function: |cli_data, args| {
-                let address = get_int_argument(args, 0)?;
-                let data = get_int_argument(args, 1)?;
-
-                cli_data.core.write_word_32(address, data)?;
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "write64",
-            help_text: "Write a 64bit value to memory",
-
-            function: |cli_data, args| {
-                let address = get_int_argument(args, 0)?;
-                let data = get_int_argument(args, 1)?;
-
-                cli_data.core.write_word_64(address, data)?;
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "break",
-            help_text: "Set a breakpoint at a specific address",
-
-            function: |cli_data, args| {
-                let address = get_int_argument(args, 0)?;
-
-                cli_data.core.set_hw_breakpoint(address)?;
-
-                println!("Set new breakpoint at address {address:#08x}");
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "clear_break",
-            help_text: "Clear a breakpoint",
-
-            function: |cli_data, args| {
-                let address = get_int_argument(args, 0)?;
-
-                cli_data.core.clear_hw_breakpoint(address)?;
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "list_break",
-            help_text: "List all set breakpoints",
-            function: |cli_data, _| {
-                cli_data
-                    .core
-                    .hw_breakpoints()?
-                    .into_iter()
-                    .enumerate()
-                    .flat_map(|(idx, bpt)| bpt.map(|bpt| (idx, bpt)))
-                    .for_each(|(idx, bpt)| println!("Breakpoint {idx} - {bpt:#010X}"));
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "bt",
-            help_text: "Show backtrace",
-
-            function: |cli_data, _args| {
-                match cli_data.state {
-                    DebugState::Halted(ref mut halted_state) => {
-                        if let Some(di) = &mut cli_data.debug_info {
-                            let initial_registers = DebugRegisters::from_core(&mut cli_data.core);
-                            let exception_interface =
-                                exception_handler_for_core(cli_data.core.core_type());
-                            let instruction_set = cli_data.core.instruction_set().ok();
-                            halted_state.stack_frames = di
-                                .unwind(
-                                    &mut cli_data.core,
-                                    initial_registers,
-                                    exception_interface.as_ref(),
-                                    instruction_set,
-                                )
-                                .unwrap();
-
-                            halted_state.frame_indices = halted_state
-                                .stack_frames
-                                .iter()
-                                .map(|sf| sf.id.into())
-                                .collect();
-
-                            for (i, frame) in halted_state.stack_frames.iter().enumerate() {
-                                print!("Frame {}: {} @ {}", i, frame.function_name, frame.pc);
-
-                                if frame.is_inlined {
-                                    print!(" inline");
-                                }
-                                println!();
-
-                                if let Some(location) = &frame.source_location {
-                                    print!("       ");
-
-                                    print!("{}", location.path.to_path().display());
-
-                                    if let Some(line) = location.line {
-                                        print!(":{line}");
-
-                                        if let Some(col) = location.column {
-                                            match col {
-                                                probe_rs_debug::ColumnType::LeftEdge => {
-                                                    print!(":1")
-                                                }
-                                                probe_rs_debug::ColumnType::Column(c) => {
-                                                    print!(":{c}")
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                    println!();
-                                }
-                            }
-
-                            println!();
-                        } else {
-                            println!("No debug information present!");
-                        }
-                    }
-                    DebugState::Running => {
-                        println!("Core must be halted for this command.");
-                    }
-                }
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "regs",
-            help_text: "Show CPU register values",
-
-            function: |cli_data, _args| {
-                match &cli_data.state {
-                    DebugState::Running => println!("Core must be halted for this command."),
-                    DebugState::Halted(state) => {
-                        if let Some(current_frame) = state.get_current_frame() {
-                            let registers = &current_frame.registers;
-
-                            for register in &registers.0 {
-                                print!("{:10}: ", register.core_register.name());
-
-                                if let Some(value) = &register.value {
-                                    println!("{:#}", value);
-                                } else {
-                                    println!("{}", "X".repeat(10));
-                                }
-                            }
-                        } else {
-                            let register_file = cli_data.core.registers();
-
-                            for register in register_file.core_registers() {
-                                let value: RegisterValue = cli_data.core.read_core_reg(register)?;
-
-                                println!("{:10}: {:#}", register.name(), value);
-                            }
-
-                            if let Some(psr) = register_file.psr() {
-                                let value: RegisterValue = cli_data.core.read_core_reg(psr)?;
-                                println!("{:10}: {:#}", psr.name(), value);
-                            }
-                        }
-                    }
-                }
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "fp_regs",
-            help_text: "Show floating point register values",
-
-            function: |cli_data, _args| {
-                if !cli_data.core.fpu_support()? {
-                    println!("Floating point not supported");
-                } else {
-                    let register_file = cli_data.core.registers();
-
-                    let registers = register_file.fpu_registers();
-                    if let Some(registers) = registers {
-                        for register in registers {
-                            let value: RegisterValue = cli_data.core.read_core_reg(register)?;
-
-                            // Print out the register every way it can be interpretted.
-                            // For example, with a u128:
-                            // * Raw value as a u128
-                            // * Value cast as a f64
-                            // * Value cast as a f32
-                            println!("{:10}: {:#}", register.name(), value);
-
-                            if matches!(value, RegisterValue::U128(_) | RegisterValue::U64(_)) {
-                                let data: u128 = value.try_into()?;
-                                let bytes = (data as u64).to_le_bytes();
-                                let fp_data = f64::from_le_bytes(bytes);
-
-                                println!("{:>10}: {:#}", "[as f64]", fp_data);
-                            }
-
-                            if matches!(
-                                value,
-                                RegisterValue::U128(_)
-                                    | RegisterValue::U64(_)
-                                    | RegisterValue::U32(_)
-                            ) {
-                                let data: u128 = value.try_into()?;
-                                let bytes = (data as u32).to_le_bytes();
-                                let fp_data = f32::from_le_bytes(bytes);
-
-                                println!("{:>10}: {:#}", "[as f32]", fp_data);
-                            }
-
-                            println!();
-                        }
-                    } else {
-                        println!("Core has no floating point registers");
-                    }
-                }
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "locals",
-            help_text: "List local variables",
-
-            function: |cli_data, _args| {
-                match cli_data.state {
-                    DebugState::Halted(ref mut halted_state) => {
-                        let current_frame =
-                            if let Some(current_frame) = halted_state.get_current_frame_mut() {
-                                current_frame
-                            } else {
-                                println!("StackFrame not found.");
-                                return Ok(CliState::Continue);
-                            };
-
-                        let local_variable_cache = if let Some(local_variable_cache) =
-                            &mut current_frame.local_variables
-                        {
-                            local_variable_cache
-                        } else {
-                            print!("No Local variables available");
-                            return Ok(CliState::Continue);
-                        };
-
-                        let mut locals = local_variable_cache.root_variable().clone();
-                        // By default, the first level children are always are lazy loaded, so we will force a load here.
-                        if locals.variable_node_type.is_deferred()
-                            && !local_variable_cache.has_children(&locals)
-                        {
-                            if let Err(error) = cli_data
-                                .debug_info
-                                .as_ref()
-                                .unwrap()
-                                .cache_deferred_variables(
-                                    local_variable_cache,
-                                    &mut cli_data.core,
-                                    &mut locals,
-                                    StackFrameInfo {
-                                        registers: &current_frame.registers,
-                                        frame_base: current_frame.frame_base,
-                                        canonical_frame_address: current_frame
-                                            .canonical_frame_address,
-                                    },
-                                )
-                            {
-                                println!("Failed to cache local variables: {error}");
-                                return Ok(CliState::Continue);
-                            }
-                        }
-                        let children = local_variable_cache.get_children(locals.variable_key());
-
-                        for child in children {
-                            println!(
-                                "{}: {} = {}",
-                                child.name,
-                                child.type_name(),
-                                child.to_string(local_variable_cache)
-                            );
-                        }
-                    }
-                    DebugState::Running => println!("Core must be halted for this command."),
-                }
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "up",
-            help_text: "Move up a frame",
-
-            function: |cli_data, _args| {
-                match &mut cli_data.state {
-                    DebugState::Running => println!("Core must be halted for this command."),
-                    DebugState::Halted(halted_state) => {
-                        if halted_state.current_frame < halted_state.frame_indices.len() - 1 {
-                            halted_state.current_frame += 1;
-                        } else {
-                            println!(
-                                "Already at top-most frame. current frame: {}, indices: {:?}",
-                                halted_state.current_frame, halted_state.frame_indices
-                            );
-                        }
-                    }
-                }
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "down",
-            help_text: "Move down a frame",
-
-            function: |cli_data, _args| {
-                match &mut cli_data.state {
-                    DebugState::Running => println!("Core must be halted for this command."),
-                    DebugState::Halted(halted_state) => {
-                        if halted_state.current_frame > 0 {
-                            halted_state.current_frame -= 1;
-                        } else {
-                            println!("Already at bottom-most frame.");
-                        }
-                    }
-                }
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "reset",
-
-            help_text: "Reset the CPU",
-
-            function: |cli_data, _args| {
-                cli_data.core.halt(Duration::from_millis(100))?;
-                cli_data.core.reset_and_halt(Duration::from_millis(100))?;
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "dump",
-            help_text: "Dump the core memory & registers",
-
-            function: |cli_data, args| {
-                let mut args = args.to_vec();
-
-                // If we get an odd number of arguments, treat all n * 2 args at the start as memory blocks
-                // and the last argument as the path tho store the coredump at.
-                let location = Path::new(
-                    if args.len() % 2 != 0 {
-                        args.pop()
-                    } else {
-                        None
-                    }
-                    .unwrap_or("./coredump"),
-                );
-
-                let ranges = args
-                    .chunks(2)
-                    .enumerate()
-                    .map(|(i, c)| {
-                        let start = if let Some(start) = c.first() {
-                            parse_int::parse::<u64>(start).map_err(|e| {
-                                CliError::ArgumentParseError {
-                                    argument_index: i,
-                                    argument: start.to_string(),
-                                    source: e.into(),
-                                }
-                            })?
-                        } else {
-                            unreachable!("This should never be reached as there cannot be an odd number of arguments. Please report this as a bug.")
-                        };
-
-                        let size = if let Some(size) = c.get(1) {
-                            parse_int::parse::<u64>(size).map_err(|e| {
-                                CliError::ArgumentParseError {
-                                    argument_index: i,
-                                    argument: size.to_string(),
-                                    source: e.into(),
-                                }
-                            })?
-                        } else {
-                            unreachable!("This should never be reached as there cannot be an odd number of arguments. Please report this as a bug.")
-                        };
-
-                        Ok::<_, CliError>(start..start + size)
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                println!("Dumping core");
-
-                CoreDump::dump_core(&mut cli_data.core, ranges)?.store(location)?;
-
-                println!("Done.");
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli
-    }
-
-    fn add_command(&mut self, command: Command) {
-        self.commands.push(command)
-    }
-
-    fn handle_line(&self, line: &str, cli_data: &mut CliData) -> Result<CliState, CliError> {
-        let mut command_parts = line.split_whitespace();
-
-        match command_parts.next() {
-            Some("help") => {
-                println!("The following commands are available:");
-
-                for cmd in &self.commands {
-                    println!(" - {}", cmd.name);
-                }
-
-                Ok(CliState::Continue)
-            }
-            Some(command) => {
-                let cmd = self.commands.iter().find(|c| c.name == command);
-
-                if let Some(cmd) = cmd {
-                    let remaining_args: Vec<&str> = command_parts.collect();
-
-                    Self::execute_command(cli_data, cmd, &remaining_args)
-                } else {
-                    println!("Unknown command '{command}'");
-                    println!("Enter 'help' for a list of commands");
-
-                    Ok(CliState::Continue)
-                }
-            }
-            _ => Ok(CliState::Continue),
-        }
-    }
-
-    fn execute_command(
-        cli_data: &mut CliData,
-        command: &Command,
-        args: &[&str],
-    ) -> Result<CliState, CliError> {
-        match (command.function)(cli_data, args) {
-            Ok(cli_state) => {
-                // Resync status from core
-                cli_data.update_debug_status_from_core()?;
-
-                Ok(cli_state)
-            }
-            Err(CliError::MissingArgument) => {
-                println!("Error: Missing argument\n\n{}", command.help_text);
-                Ok(CliState::Continue)
-            }
-            Err(CliError::ArgumentParseError {
-                argument, source, ..
-            }) => {
-                println!(
-                    "Error parsing argument '{}': {}\n\n{}",
-                    argument, source, command.help_text
-                );
-                Ok(CliState::Continue)
-            }
-            other => other,
-        }
-    }
-}
-
-pub struct CliData<'p> {
-    pub core: Core<'p>,
-    pub debug_info: Option<DebugInfo>,
-
-    state: DebugState,
-}
-
-impl<'p> CliData<'p> {
-    fn new(core: Core<'p>, debug_info: Option<DebugInfo>) -> Result<CliData<'p>, CliError> {
-        let mut cli_data = CliData {
-            core,
-            debug_info,
-            state: DebugState::default(),
-        };
-
-        cli_data.update_debug_status_from_core()?;
-
-        Ok(cli_data)
-    }
-
-    /// Fill out DebugStatus for a given core
-    fn update_debug_status_from_core(&mut self) -> Result<(), CliError> {
-        let status = self.core.status()?;
-
-        match status {
-            probe_rs::CoreStatus::Halted(_) => {
-                let registers = DebugRegisters::from_core(&mut self.core);
-                let pc: u64 = registers
-                    .get_program_counter()
-                    .and_then(|reg| reg.value)
-                    .unwrap_or_default()
-                    .try_into()?;
-
-                // If the core was running before, or the PC changed, we need to update the state
-                let core_state_changed = matches!(self.state, DebugState::Running)
-                    || matches!(self.state, DebugState::Halted(HaltedState { program_counter, .. }) if program_counter != pc);
-
-                // TODO: We should resolve the stack frames here
-                if core_state_changed {
-                    self.state = DebugState::Halted(HaltedState {
-                        program_counter: pc,
-                        current_frame: 0,
-                        frame_indices: vec![1],
-                        stack_frames: vec![],
-                    });
-                }
-            }
-            _other => {
-                self.state = DebugState::Running;
-            }
-        }
-
-        Ok(())
-    }
-
-    fn print_state(&mut self) -> Result<(), CliError> {
-        match self.state {
-            DebugState::Running => println!("Core is running."),
-            DebugState::Halted(ref mut halted_state) => {
-                if let Some(current_stack_frame) = halted_state.get_current_frame() {
-                    let pc = current_stack_frame.pc;
-
-                    println!(
-                        "Frame {}: {} () @ {:#}",
-                        halted_state.current_frame, current_stack_frame.function_name, pc,
-                    );
-                }
-            }
-        }
-
-        Ok(())
-    }
-}
-
-#[derive(Default)]
-enum DebugState {
-    #[default]
-    Running,
-    Halted(HaltedState),
-}
-
-struct HaltedState {
-    program_counter: u64,
-    current_frame: usize,
-    frame_indices: Vec<i64>,
-    stack_frames: Vec<StackFrame>,
-}
-
-impl HaltedState {
-    fn get_current_frame(&self) -> Option<&probe_rs_debug::stack_frame::StackFrame> {
-        self.stack_frames.get(self.current_frame)
-    }
-
-    fn get_current_frame_mut(&mut self) -> Option<&mut probe_rs_debug::stack_frame::StackFrame> {
-        self.stack_frames.get_mut(self.current_frame)
-    }
-}
-
-#[derive(PartialEq)]
-pub enum CliState {
-    Continue,
-    Stop,
-}
-
-struct Command {
-    pub name: &'static str,
-    pub help_text: &'static str,
-
-    pub function: fn(&mut CliData, args: &[&str]) -> Result<CliState, CliError>,
 }

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -119,7 +119,7 @@ impl Cli {
             Subcommand::Info(cmd) => cmd.run(client).await,
             Subcommand::Gdb(cmd) => cmd.run(&mut *client.registry().await, &lister),
             Subcommand::Reset(cmd) => cmd.run(client).await,
-            Subcommand::Debug(cmd) => cmd.run(&mut *client.registry().await, &lister),
+            Subcommand::Debug(cmd) => cmd.run(&mut *client.registry().await, &lister, utc_offset),
             Subcommand::Download(cmd) => cmd.run(client).await,
             Subcommand::Run(cmd) => cmd.run(client, utc_offset).await,
             Subcommand::Attach(cmd) => cmd.run(client, utc_offset).await,


### PR DESCRIPTION
This PR nukes the CLI implementation as we don't want to maintain two separate set of REPL commands. This is the first step of improving debug experience, and a big cut of available commands at that. Follow-up steps include:

- Porting the old commands into the DAP REPL command list.
- TUI that can display RTT output.
- Rewriting some commands to be more user friendly (looking at you, `backtrace`).
- Moving the server into the RPC space so that we can debug remote devices that are managed by a probe-rs server.