### PR TITLE
Halt Xtensa core before manipulating registers or breakpoints

### DIFF
--- a/changelog/fixed-xtensa-halt.md
+++ b/changelog/fixed-xtensa-halt.md
@@ -1,0 +1,1 @@
+Xtensa cores are now halted before modifying breakpoints and registers.


### PR DESCRIPTION
Since a lot of operations need the CPU to execute instructions, the CPU needs to be halted otherwise the debug module will just return errors. This is most noticeable during a debug session, where trying to set a breakpoint on a running target can just fail.