### PR TITLE
Add program counter sampling support to profiling

### DIFF
--- a/changelog/added-pcsr-profiling.md
+++ b/changelog/added-pcsr-profiling.md
@@ -1,0 +1,1 @@
+Added a `probe-rs profile` option to measure the program counter via the ARM DWT program counter sample register (PCSR).

--- a/probe-rs/src/architecture/arm/component/dwt.rs
+++ b/probe-rs/src/architecture/arm/component/dwt.rs
@@ -109,6 +109,23 @@ impl<'a> Dwt<'a> {
         ctrl.set_postpreset(0x0);
         ctrl.store(self.component, self.interface)
     }
+
+    /// Read the program counter sample register for the PC value.
+    ///
+    /// This is an optional DWT component, so your DWT may not implement
+    /// it. An implementation that doesn't include this component returns
+    /// zero.
+    ///
+    /// Make sure that tracing is enabled. Otherwise, the value is unknown.
+    ///
+    /// The PC value is `!0` if the processor is in a debug state or another
+    /// state that disables the DWT.
+    ///
+    /// For more information, see section C1.8.5 of the ARMv7-M architecture
+    /// reference manual.
+    pub fn read_pcsr(&mut self) -> Result<u32, ArmError> {
+        Ok(Pcsr::load(self.component, self.interface)?.eiasample())
+    }
 }
 
 memory_mapped_bitfield_register! {
@@ -197,3 +214,12 @@ memory_mapped_bitfield_register! {
 }
 
 impl DebugComponentInterface for Function {}
+
+memory_mapped_bitfield_register! {
+    pub struct Pcsr(u32);
+    0x1C, "DWT/PCSR",
+    impl From;
+    pub u32, eiasample, _: 31, 0;
+}
+
+impl DebugComponentInterface for Pcsr {}


### PR DESCRIPTION
Some DWT implementations expose the program counter sample register. We can use this to observe the PC value during profiling. It's similar to the naive approach, but we don't need to halt the core to take the measurement.

This commit adds program counter sampling support (PCSR) to `probe-rs profile`. Tested on an i.MX RT MCU. When compared to naive, I measure over 4x more samples during the same duration.