### PR TITLE
Fix probe-rs info with STLink

### DIFF
--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1849,9 +1849,7 @@ impl ArmMemoryInterface for StLinkMemoryInterface<'_> {
     }
 
     fn generic_status(&mut self) -> Result<crate::architecture::arm::ap::CSW, ArmError> {
-        Err(ArmError::Probe(DebugProbeError::InterfaceNotAvailable {
-            interface_name: "ARM",
-        }))
+        self.current_ap.generic_status(self.probe)
     }
 }
 


### PR DESCRIPTION
`probe-rs info` always fails using STLink with an error:
```
Probing target via JTAG
-----------------------

ARM Chip with debug port Default:

Debug Port: DPv0, Designer: <unknown>
├── V1(0) MemoryAP
│   └── 0 MemoryAP (AmbaApb2Apb3)
│       └── Error during access: The debug probe encountered an error.
└── V1(1) MemoryAP
    └── 1 MemoryAP (AmbaAhb3)
        └── Error during access: The debug probe encountered an error.


Debug port version DPv0 does not support SWD multidrop. Stopping here.

Probing target via SWD
----------------------

ARM Chip with debug port Default:

Debug Port: DPv2, Designer: STMicroelectronics, Part: 0x4840, Revision: 0x1, Instance: 0x00
├── V1(0) MemoryAP
│   └── 0 MemoryAP (AmbaApb2Apb3)
│       └── Error during access: The debug probe encountered an error.
└── V1(1) MemoryAP
    └── 1 MemoryAP (AmbaAhb3)
        └── Error during access: The debug probe encountered an error.
```

This error is due to `generic_status` always returning an error instead of the CSW. This PR fixes the implementation.

Using this PR `probe-rs info` outputs correctly:
```
Probing target via JTAG
-----------------------

ARM Chip with debug port Default:

Debug Port: DPv0, Designer: <unknown>
├── V1(0) MemoryAP
│   └── 0 MemoryAP (AmbaApb2Apb3)
│       ├── 0xe00e0000 ROM Table (Class 1), Designer: STMicroelectronics
│       └── 0xe00e4000 Core Link / Prime Cell / System component
└── V1(1) MemoryAP
    └── 1 MemoryAP (AmbaAhb3)
        ├── 0xe00fe000 ROM Table (Class 1), Designer: STMicroelectronics
        ├── 0xe00ff000 ROM Table (Class 1), Designer: ARM Ltd
        ├── 0xe000e000 Processor debug architecture (ARMv8-M) (Coresight Component)
        │   └── CPUID
        │       ├── IMPLEMENTER: ARM Ltd
        │       ├── VARIANT: 0
        │       ├── PARTNO: Cortex-M33
        │       └── REVISION: 4
        ├── 0xe0001000 DWT architecture (Coresight Component)
        ├── 0xe0002000 FPB architecture (Coresight Component)
        ├── 0xe0000000 ITM architecture (Coresight Component)
        ├── 0xe0041000 ETM architecture (Coresight Component)
        ├── 0xe0042000 CTI architecture (Coresight Component)
        └── 0xe0040000 Coresight Component, Part: 0x0d21, Devtype: 0x11, Archid: 0x0000, Designer: ARM Ltd


Debug port version DPv0 does not support SWD multidrop. Stopping here.

Probing target via SWD
----------------------

ARM Chip with debug port Default:

Debug Port: DPv2, Designer: STMicroelectronics, Part: 0x4840, Revision: 0x1, Instance: 0x00
├── V1(0) MemoryAP
│   └── 0 MemoryAP (AmbaApb2Apb3)
│       ├── 0xe00e0000 ROM Table (Class 1), Designer: STMicroelectronics
│       └── 0xe00e4000 Core Link / Prime Cell / System component
└── V1(1) MemoryAP
    └── 1 MemoryAP (AmbaAhb3)
        ├── 0xe00fe000 ROM Table (Class 1), Designer: STMicroelectronics
        ├── 0xe00ff000 ROM Table (Class 1), Designer: ARM Ltd
        ├── 0xe000e000 Processor debug architecture (ARMv8-M) (Coresight Component)
        │   └── CPUID
        │       ├── IMPLEMENTER: ARM Ltd
        │       ├── VARIANT: 0
        │       ├── PARTNO: Cortex-M33
        │       └── REVISION: 4
        ├── 0xe0001000 DWT architecture (Coresight Component)
        ├── 0xe0002000 FPB architecture (Coresight Component)
        ├── 0xe0000000 ITM architecture (Coresight Component)
        ├── 0xe0041000 ETM architecture (Coresight Component)
        ├── 0xe0042000 CTI architecture (Coresight Component)
        └── 0xe0040000 Coresight Component, Part: 0x0d21, Devtype: 0x11, Archid: 0x0000, Designer: ARM Ltd
```
