### PR TITLE
Add an option to the probe-rs gdb subcommand to directly spawn gdb

### DIFF
--- a/changelog/added-gdb-spawn.md
+++ b/changelog/added-gdb-spawn.md
@@ -1,0 +1,1 @@
+Added support for spawning gdb directly from `probe-rs gdb` using `--gdb gdb-multiarch`.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -363,7 +363,7 @@ fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
                 GdbInstanceConfiguration::from_session(&session, Some(gdb_connection_string))
             };
 
-            if let Err(e) = crate::cmd::gdb_server::run(&session, instances.iter()) {
+            if let Err(e) = crate::cmd::gdb_server::run(&session, instances.iter(), None) {
                 logging::eprintln("During the execution of GDB an error was encountered:");
                 logging::eprintln(format!("{e:?}"));
             }


### PR DESCRIPTION
This makes attaching gdb to a microcontroller a single step process rather than a three step process (run gdbserver, run gdb, attach gdb to gdbserver)

An example usage would be `probe-rs gdb --reset-halt --chip nRF52840_xxAA --gdb gdb-multiarch target/thumbv7em-none-eabi/debug/nrf52840-test -- -ex "b main" -ex "c"` which attaches the debugger, resets the microcontroller, sets a breakpoint on main and then continues until main.