### PR TITLE
Update to Rust 1.86, use trait upcasting

### DIFF
--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -937,9 +937,9 @@ impl CoreMemoryInterface for Armv6m<'_> {
     type ErrorType = ArmError;
 
     fn memory(&self) -> &dyn MemoryInterface<Self::ErrorType> {
-        self.memory.as_memory_interface()
+        self.memory.as_ref()
     }
     fn memory_mut(&mut self) -> &mut dyn MemoryInterface<Self::ErrorType> {
-        self.memory.as_memory_interface_mut()
+        self.memory.as_mut()
     }
 }

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -1172,10 +1172,10 @@ impl CoreMemoryInterface for Armv7m<'_> {
     type ErrorType = ArmError;
 
     fn memory(&self) -> &dyn MemoryInterface<Self::ErrorType> {
-        self.memory.as_memory_interface()
+        self.memory.as_ref()
     }
     fn memory_mut(&mut self) -> &mut dyn MemoryInterface<Self::ErrorType> {
-        self.memory.as_memory_interface_mut()
+        self.memory.as_mut()
     }
 }
 

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -565,10 +565,10 @@ impl CoreMemoryInterface for Armv8m<'_> {
     type ErrorType = ArmError;
 
     fn memory(&self) -> &dyn MemoryInterface<Self::ErrorType> {
-        self.memory.as_memory_interface()
+        self.memory.as_ref()
     }
     fn memory_mut(&mut self) -> &mut dyn MemoryInterface<Self::ErrorType> {
-        self.memory.as_memory_interface_mut()
+        self.memory.as_mut()
     }
 }
 

--- a/probe-rs/src/architecture/arm/memory/mod.rs
+++ b/probe-rs/src/architecture/arm/memory/mod.rs
@@ -14,7 +14,7 @@ use super::{
 pub use romtable::{Component, ComponentId, CoresightComponent, PeripheralType, RomTable};
 
 /// An ArmMemoryInterface (ArmProbeInterface + MemoryAp)
-pub trait ArmMemoryInterface: ArmMemoryInterfaceShim {
+pub trait ArmMemoryInterface: MemoryInterface<ArmError> {
     /// The underlying MemoryAp address.
     fn fully_qualified_address(&self) -> FullyQualifiedApAddress;
 
@@ -39,30 +39,4 @@ pub trait ArmMemoryInterface: ArmMemoryInterfaceShim {
     // NOTE: this function should be infallible as it is usually only
     // a visual indication.
     fn update_core_status(&mut self, _state: CoreStatus) {}
-}
-
-/// Implementation detail to allow trait upcasting-like behaviour.
-//
-// TODO: replace with trait upcasting once stable
-pub trait ArmMemoryInterfaceShim: MemoryInterface<ArmError> {
-    /// Returns a reference to the underlying `MemoryInterface`.
-    // TODO: replace with trait upcasting once stable
-    fn as_memory_interface(&self) -> &dyn MemoryInterface<ArmError>;
-
-    /// Returns a mutable reference to the underlying `MemoryInterface`.
-    // TODO: replace with trait upcasting once stable
-    fn as_memory_interface_mut(&mut self) -> &mut dyn MemoryInterface<ArmError>;
-}
-
-impl<T> ArmMemoryInterfaceShim for T
-where
-    T: ArmMemoryInterface,
-{
-    fn as_memory_interface(&self) -> &dyn MemoryInterface<ArmError> {
-        self
-    }
-
-    fn as_memory_interface_mut(&mut self) -> &mut dyn MemoryInterface<ArmError> {
-        self
-    }
 }

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -33,7 +33,7 @@ pub struct CoreInformation {
 }
 
 /// A generic interface to control a MCU core.
-pub trait CoreInterface: MemoryInterface + CoreMemoryInterfaceShim {
+pub trait CoreInterface: MemoryInterface {
     /// Wait until the core is halted. If the core does not halt on its own,
     /// a [`DebugProbeError::Timeout`](crate::probe::DebugProbeError::Timeout) error will be returned.
     fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error>;
@@ -178,32 +178,6 @@ pub trait CoreInterface: MemoryInterface + CoreMemoryInterfaceShim {
     }
 }
 
-/// Implementation detail to allow trait upcasting-like behaviour.
-//
-// TODO: replace with trait upcasting once stable
-pub trait CoreMemoryInterfaceShim: MemoryInterface {
-    /// Returns a reference to the underlying `MemoryInterface`.
-    // TODO: replace with trait upcasting once stable
-    fn as_memory_interface(&self) -> &dyn MemoryInterface;
-
-    /// Returns a mutable reference to the underlying `MemoryInterface`.
-    // TODO: replace with trait upcasting once stable
-    fn as_memory_interface_mut(&mut self) -> &mut dyn MemoryInterface;
-}
-
-impl<T> CoreMemoryInterfaceShim for T
-where
-    T: CoreInterface,
-{
-    fn as_memory_interface(&self) -> &dyn MemoryInterface {
-        self
-    }
-
-    fn as_memory_interface_mut(&mut self) -> &mut dyn MemoryInterface {
-        self
-    }
-}
-
 /// Generic core handle representing a physical core on an MCU.
 ///
 /// This should be considered as a temporary view of the core which locks the debug probe driver to as single consumer by borrowing it.
@@ -222,11 +196,11 @@ impl CoreMemoryInterface for Core<'_> {
     type ErrorType = Error;
 
     fn memory(&self) -> &dyn MemoryInterface<Self::ErrorType> {
-        self.inner.as_memory_interface()
+        self.inner.as_ref()
     }
 
     fn memory_mut(&mut self) -> &mut dyn MemoryInterface<Self::ErrorType> {
-        self.inner.as_memory_interface_mut()
+        self.inner.as_mut()
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.86.0"
 
 components = ["rustfmt", "clippy"]
 # Target used for tests


### PR DESCRIPTION
Not sure if I got all cases where it could be used.