### PR TITLE
fix: restore the sifli debug's serial port dtr and rts to their false

### DIFF
--- a/changelog/fixed-sifli-debug-open.md
+++ b/changelog/fixed-sifli-debug-open.md
@@ -1,0 +1,1 @@
+Fixed that the serial port dtr and rts of sifli debug devices may not be in the expected state when they are open

--- a/probe-rs/src/probe/sifliuart/mod.rs
+++ b/probe-rs/src/probe/sifliuart/mod.rs
@@ -435,7 +435,7 @@ impl SifliUartFactory {
             .map_err(|_| {
                 DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::CouldNotOpen)
             })?;
-        port.write_data_terminal_ready(false).map_err(|_| {;
+        port.write_data_terminal_ready(false).map_err(|_| {
             DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::CouldNotOpen)
         })?;
         port.write_request_to_send(false).map_err(|_| {

--- a/probe-rs/src/probe/sifliuart/mod.rs
+++ b/probe-rs/src/probe/sifliuart/mod.rs
@@ -187,7 +187,6 @@ impl SifliUart {
         writer
             .write_all(&header)
             .map_err(CommandError::ProbeError)?;
-        // tracing::info!("Send data: {:?}", send_data);
         writer
             .write_all(&send_data)
             .map_err(CommandError::ProbeError)?;
@@ -407,7 +406,7 @@ impl SifliUartFactory {
                     .as_ref()
                     .unwrap()
                     .to_lowercase()
-                    .contains("Sifli"))
+                    .contains("sifli"))
         {
             return None;
         }
@@ -429,12 +428,19 @@ impl SifliUartFactory {
     }
 
     fn open_port(&self, port_name: &str) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
-        let port = serialport::new(port_name, DEFUALT_UART_BAUD)
+        let mut port = serialport::new(port_name, DEFUALT_UART_BAUD)
+            .dtr_on_open(false)
             .timeout(Duration::from_secs(3))
             .open()
             .map_err(|_| {
                 DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::CouldNotOpen)
             })?;
+        port.write_data_terminal_ready(false).map_err(|_| {;
+            DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::CouldNotOpen)
+        })?;
+        port.write_request_to_send(false).map_err(|_| {
+            DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::CouldNotOpen)
+        })?;
 
         let reader = port.try_clone().map_err(|_| {
             DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::CouldNotOpen)


### PR DESCRIPTION
On macos systems, opening the /dev/cu device enables RTS, which is not friendly to boards that have the RTS/DTR line connected as an automatic download.
Therefore this pr sets the status of DTR and RTS to false by default