### PR TITLE
Don't exit on ctrl-c when running gdb

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/mod.rs
@@ -97,7 +97,7 @@ impl Cmd {
                         // Kill gdb if using ctrl-c twice within half a second.
                         gdb2.lock().unwrap().kill().unwrap();
                         println!();
-                        // Immediately exit to suppress error about gdb getting killer.
+                        // Immediately exit to suppress error about gdb getting killed.
                         std::process::exit(0);
                     }
                     last_ctrl_c = Instant::now();

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/mod.rs
@@ -88,12 +88,12 @@ impl Cmd {
 
             let gdb2 = gdb.clone();
             tokio::spawn(async move {
-                let mut last_ctrl_c = Instant::now() - Duration::new(100, 0);
+                let mut last_ctrl_c = Instant::now() - Duration::from_secs(100);
                 loop {
                     // Don't exit on ctrl-c as you need to use this key combination
                     // to ask gdb to interrupt execution of the tracee.
                     tokio::signal::ctrl_c().await.unwrap();
-                    if last_ctrl_c.elapsed() < Duration::new(0, 500_000_000) {
+                    if last_ctrl_c.elapsed() < Duration::from_millis(500) {
                         // Kill gdb if using ctrl-c twice within half a second.
                         gdb2.lock().unwrap().kill().unwrap();
                         println!();

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/stub.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/stub.rs
@@ -86,7 +86,7 @@ impl GdbInstanceConfiguration {
 pub fn run<'a>(
     session: &FairMutex<Session>,
     instances: impl Iterator<Item = &'a GdbInstanceConfiguration>,
-    mut gdb_process: Option<Arc<Mutex<Child>>>,
+    gdb_process: Option<Arc<Mutex<Child>>>,
 ) -> anyhow::Result<()> {
     // Turn our group list into GDB targets
     let mut targets = instances
@@ -103,7 +103,7 @@ pub fn run<'a>(
     // Process every target in a loop
     loop {
         // Check if the gdb we spawned has exited and if so exit outself.
-        if let Some(gdb_process) = &mut gdb_process {
+        if let Some(gdb_process) = &gdb_process {
             if let Some(exit_status) = gdb_process.lock().unwrap().try_wait()? {
                 if !exit_status.success() {
                     bail!("Gdb failed with {exit_status}");


### PR DESCRIPTION
You need ctrl-c to ask gdb to interrupt execution of the tracee. It would be bad if the gdbserver gets killed at the same time. We do still exit on two consecutive ctrl-c within half a second though as a fail-safe.

Missed this in https://github.com/probe-rs/probe-rs/pull/3203