### PR TITLE
Make RttClient non-optional in a couple of places

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
@@ -35,7 +35,7 @@ impl Cmd {
             &session,
             MonitorMode::AttachToRunning,
             &self.run.shared_options.path,
-            Some(rtt_client),
+            rtt_client,
             MonitorOptions {
                 catch_reset: self.run.run_options.catch_reset,
                 catch_hardfault: self.run.run_options.catch_hardfault,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
@@ -39,7 +39,7 @@ impl Cmd {
             MonitorOptions {
                 catch_reset: self.run.run_options.catch_reset,
                 catch_hardfault: self.run.run_options.catch_hardfault,
-                rtt_client: Some(client_handle),
+                rtt_client: client_handle,
             },
             self.run.shared_options.always_print_stacktrace,
         )

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -213,7 +213,7 @@ impl Cmd {
                 },
                 self.shared_options.always_print_stacktrace,
                 &self.shared_options.path,
-                Some(rtt_client),
+                rtt_client,
             )
             .await
         } else {
@@ -221,7 +221,7 @@ impl Cmd {
                 &session,
                 MonitorMode::Run(boot_info),
                 &self.shared_options.path,
-                Some(rtt_client),
+                rtt_client,
                 MonitorOptions {
                     catch_reset: self.run_options.catch_reset,
                     catch_hardfault: self.run_options.catch_hardfault,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -225,7 +225,7 @@ impl Cmd {
                 MonitorOptions {
                     catch_reset: self.run_options.catch_reset,
                     catch_hardfault: self.run_options.catch_hardfault,
-                    rtt_client: Some(client_handle),
+                    rtt_client: client_handle,
                 },
                 self.shared_options.always_print_stacktrace,
             )

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -515,7 +515,7 @@ impl SessionInterface {
     pub async fn list_tests(
         &self,
         boot_info: BootInfo,
-        rtt_client: Option<Key<RttClient>>,
+        rtt_client: Key<RttClient>,
         on_msg: impl FnMut(MonitorEvent),
     ) -> anyhow::Result<Tests> {
         self.client
@@ -533,7 +533,7 @@ impl SessionInterface {
     pub async fn run_test(
         &self,
         test: Test,
-        rtt_client: Option<Key<RttClient>>,
+        rtt_client: Key<RttClient>,
         on_msg: impl FnMut(MonitorEvent),
     ) -> anyhow::Result<TestResult> {
         self.client


### PR DESCRIPTION
None of the callers of the various functions that accept an optional `RttClient` actually pass `None`.