### PR TITLE
Xtensa: clear exceptions that occur during batched execution

### DIFF
--- a/changelog/fixed-xtensa-exceptions.md
+++ b/changelog/fixed-xtensa-exceptions.md
@@ -1,0 +1,1 @@
+Xtensa exceptions should no longer cause the debugger to crash.

--- a/probe-rs/src/vendor/espressif/sequences/esp32.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32.rs
@@ -77,11 +77,13 @@ impl ESP32 {
 
 impl XtensaDebugSequence for ESP32 {
     fn on_connect(&self, interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
-        // Peripheral address range
         interface
             .core_properties()
-            .slow_memory_access_ranges
-            .push(0x3FF0_0000..0x3FF8_0000);
+            .fast_memory_access_ranges
+            .extend_from_slice(&[
+                0x3FF8_0000..0x4000_0000, // Data
+                0x4000_0000..0x400C_2000, // Instruction
+            ]);
 
         self.disable_wdts(interface)
     }

--- a/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
@@ -146,6 +146,14 @@ impl ESP32S2 {
 
 impl XtensaDebugSequence for ESP32S2 {
     fn on_connect(&self, interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
+        interface
+            .core_properties()
+            .fast_memory_access_ranges
+            .extend_from_slice(&[
+                0x3FF9_E000..0x4000_0000, // Data
+                0x4000_0000..0x4007_2000, // Instruction
+            ]);
+
         self.disable_wdts(interface)
     }
 

--- a/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
@@ -83,11 +83,15 @@ impl ESP32S3 {
 
 impl XtensaDebugSequence for ESP32S3 {
     fn on_connect(&self, interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
-        // External memory bus
         interface
             .core_properties()
-            .slow_memory_access_ranges
-            .push(0x3C00_0000..0x3E00_0000);
+            .fast_memory_access_ranges
+            .extend_from_slice(&[
+                0x3FC8_8000..0x3FD0_0000, // Internal DRAM
+                0x3FF0_0000..0x3FF2_0000, // Internal DROM
+                0x4000_0000..0x4006_0000, // Internal IROM
+                0x4037_0000..0x403E_0000, // Internal IRAM
+            ]);
 
         self.disable_wdts(interface)
     }


### PR DESCRIPTION
This PR fixes most of the errors that occur while reading from a nonexistent memory address. Stepping via the debugger will still end up crashing, and I'm not yet sure why.