### PR TITLE
Change reset/hardfault catch behaviour for run and attach

### DIFF
--- a/changelog/changed-catch-defaults.md
+++ b/changelog/changed-catch-defaults.md
@@ -1,0 +1,3 @@
+- Changed the default reset and hardfault catch behavior from no-catch to catch for `probe-rs run` and `probe-rs attach`.
+  The --catch-reset and --catch-hardfault flags still exist but now have no effect.
+- Added new --no-catch-reset and --no-catch-hardfault flags to turn off `catch-reset` and `catch-hardfault`, respectively

--- a/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
@@ -37,8 +37,8 @@ impl Cmd {
             &self.run.shared_options.path,
             Some(rtt_client),
             MonitorOptions {
-                catch_reset: self.run.run_options.catch_reset,
-                catch_hardfault: self.run.run_options.catch_hardfault,
+                catch_reset: !self.run.run_options.no_catch_reset,
+                catch_hardfault: !self.run.run_options.no_catch_hardfault,
                 rtt_client: Some(client_handle),
             },
             self.run.shared_options.always_print_stacktrace,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -19,7 +19,7 @@ pub struct NormalRunOptions {
     /// Deprecated(catch_reset is enabled by default) - Use no_reset_catch to disable this
     #[clap(long, help_heading = "RUN OPTIONS")]
     pub catch_reset: bool,
-    /// Deprecated(catch_hardfault is enabled by default) - Use no_catchhardfault to disable this
+    /// Deprecated(catch_hardfault is enabled by default) - Use no_catch_hardfault to disable this
     #[clap(long, help_heading = "RUN OPTIONS")]
     pub catch_hardfault: bool,
     /// Disable reset vector catch if its supported on the target.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -16,12 +16,18 @@ use time::UtcOffset;
 /// Options only used in normal run mode
 #[derive(Debug, clap::Parser, Clone)]
 pub struct NormalRunOptions {
-    /// Enable reset vector catch if its supported on the target.
+    /// Deprecated(catch_reset is enabled by default) - Use no_reset_catch to disable this
     #[clap(long, help_heading = "RUN OPTIONS")]
     pub catch_reset: bool,
-    /// Enable hardfault vector catch if its supported on the target.
+    /// Deprecated(catch_hardfault is enabled by default) - Use no_catchhardfault to disable this
     #[clap(long, help_heading = "RUN OPTIONS")]
     pub catch_hardfault: bool,
+    /// Disable reset vector catch if its supported on the target.
+    #[clap(long, help_heading = "RUN OPTIONS")]
+    pub no_catch_reset: bool,
+    /// Disable hardfault vector catch if its supported on the target.
+    #[clap(long, help_heading = "RUN OPTIONS")]
+    pub no_catch_hardfault: bool,
 }
 
 /// Options only used when in test run mode
@@ -223,8 +229,8 @@ impl Cmd {
                 &self.shared_options.path,
                 Some(rtt_client),
                 MonitorOptions {
-                    catch_reset: self.run_options.catch_reset,
-                    catch_hardfault: self.run_options.catch_hardfault,
+                    catch_reset: !self.run_options.no_catch_reset,
+                    catch_hardfault: !self.run_options.no_catch_hardfault,
                     rtt_client: Some(client_handle),
                 },
                 self.shared_options.always_print_stacktrace,


### PR DESCRIPTION
`--catch-reset` and `--catch-hardfault` were added in #1899. Since then, we've had quite a few new folk getting confused when probe-rs doesn't output any info on hardfault.

This commit switches the default, which will hopefully be better for most people, and fail loudly + obviously for everyone else.

Closes #3157