### PR TITLE
Add raw JTAG IO to CMSIS-DAP probes

### DIFF
--- a/changelog/added-cmsis-jtag.md
+++ b/changelog/added-cmsis-jtag.md
@@ -1,0 +1,1 @@
+CMSIS-DAP probes can now be used to connect to RISC-V and Xtensa MCUs.

--- a/changelog/removed-jtag-chain-item.md
+++ b/changelog/removed-jtag-chain-item.md
@@ -1,0 +1,1 @@
+The `JtagChainItem` struct has been removed in favour of `ScanChainElement`.

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -13,6 +13,13 @@ pub struct ScanChainElement {
     pub ir_len: Option<u8>,
 }
 
+impl ScanChainElement {
+    /// Returns the IR length, or 4 if not specified.
+    pub fn ir_len(&self) -> u8 {
+        self.ir_len.unwrap_or(4)
+    }
+}
+
 /// Configuration for JTAG tunneling.
 ///
 /// This JTAG tunnel wraps JTAG IR and DR accesses as DR access to a specific instruction. For

--- a/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
@@ -157,7 +157,7 @@ impl<'probe> JtagDtm<'probe> {
                     // Operation still in progress, reset dmi status and try again.
                     self.clear_error_state()?;
                     self.probe
-                        .set_idle_cycles(self.probe.idle_cycles().saturating_add(1));
+                        .set_idle_cycles(self.probe.idle_cycles().saturating_add(1))?;
                 }
                 Err(e) => return Err(e.map_as_err().unwrap_err()),
             };
@@ -194,7 +194,7 @@ impl DtmAccess for JtagDtm<'_> {
         }
 
         // Setup the number of idle cycles between JTAG accesses
-        self.probe.set_idle_cycles(idle_cycles as u8);
+        self.probe.set_idle_cycles(idle_cycles as u8)?;
         self.state.abits = abits;
 
         Ok(())
@@ -258,7 +258,7 @@ impl DtmAccess for JtagDtm<'_> {
                         self.state.jtag_results.merge_from(e.results);
 
                         self.probe
-                            .set_idle_cycles(self.probe.idle_cycles().saturating_add(1));
+                            .set_idle_cycles(self.probe.idle_cycles().saturating_add(1))?;
                     }
                     Error::Riscv(error) => return Err(error),
                     Error::Probe(error) => return Err(error.into()),
@@ -424,7 +424,7 @@ impl<'probe> TunneledJtagDtm<'probe> {
                     // Operation still in progress, reset dmi status and try again.
                     self.clear_error_state()?;
                     self.probe
-                        .set_idle_cycles(self.probe.idle_cycles().saturating_add(1));
+                        .set_idle_cycles(self.probe.idle_cycles().saturating_add(1))?;
                 }
                 Err(e) => return Err(e.map_as_err().unwrap_err()),
             };
@@ -459,7 +459,7 @@ impl DtmAccess for TunneledJtagDtm<'_> {
         }
 
         // Setup the number of idle cycles between JTAG accesses
-        self.probe.set_idle_cycles(idle_cycles as u8);
+        self.probe.set_idle_cycles(idle_cycles as u8)?;
         self.state.abits = abits;
 
         Ok(())
@@ -520,7 +520,7 @@ impl DtmAccess for TunneledJtagDtm<'_> {
                         self.state.jtag_results.merge_from(e.results);
 
                         self.probe
-                            .set_idle_cycles(self.probe.idle_cycles().saturating_add(1));
+                            .set_idle_cycles(self.probe.idle_cycles().saturating_add(1))?;
                     }
                     Error::Riscv(error) => return Err(error),
                     Error::Probe(error) => return Err(error.into()),

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -1106,7 +1106,7 @@ pub trait JTAGAccess: DebugProbe {
     /// the idle state for several cycles between consecutive accesses to the DR register.
     ///
     /// This function configures the number of idle cycles which are inserted after each access.
-    fn set_idle_cycles(&mut self, idle_cycles: u8);
+    fn set_idle_cycles(&mut self, idle_cycles: u8) -> Result<(), DebugProbeError>;
 
     /// Return the currently configured idle cycles.
     fn idle_cycles(&self) -> u8;

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -26,7 +26,6 @@ use crate::architecture::xtensa::communication_interface::{
 };
 use crate::config::TargetSelector;
 use crate::config::registry::Registry;
-use crate::probe::common::IdCode;
 use crate::{Error, Permissions, Session};
 use common::ScanChainError;
 use nusb::DeviceInfo;
@@ -1218,16 +1217,6 @@ impl From<ShiftDrCommand> for JtagCommand {
     }
 }
 
-/// Represents a Jtag Tap within the chain.
-#[derive(Debug)]
-pub struct JtagChainItem {
-    /// The IDCODE of the device.
-    pub idcode: Option<IdCode>,
-
-    /// The length of the instruction register.
-    pub irlen: usize,
-}
-
 /// Chain parameters to select a target tap within the chain.
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct ChainParams {
@@ -1239,19 +1228,20 @@ pub(crate) struct ChainParams {
 }
 
 impl ChainParams {
-    fn from_jtag_chain(chain: &[JtagChainItem], selected: usize) -> Option<Self> {
+    fn from_jtag_chain(chain: &[ScanChainElement], selected: usize) -> Option<Self> {
         let mut params = Self::default();
 
         let mut found = false;
         for (index, tap) in chain.iter().enumerate() {
+            let ir_len = tap.ir_len() as usize;
             if index == selected {
-                params.irlen = tap.irlen;
+                params.irlen = ir_len;
                 found = true;
             } else if found {
-                params.irpost += tap.irlen;
+                params.irpost += ir_len;
                 params.drpost += 1;
             } else {
-                params.irpre += tap.irlen;
+                params.irpre += ir_len;
                 params.drpre += 1;
             }
         }

--- a/probe-rs/src/probe/arm_debug_interface.rs
+++ b/probe-rs/src/probe/arm_debug_interface.rs
@@ -186,13 +186,13 @@ fn perform_jtag_transfer<P: JTAGAccess + RawProtocolIo>(
     let data = payload.to_le_bytes();
 
     let idle_cycles = probe.idle_cycles();
-    probe.set_idle_cycles(transfer.idle_cycles_after.min(255) as u8);
+    probe.set_idle_cycles(transfer.idle_cycles_after.min(255) as u8)?;
 
     // This is a bit confusing, but a read from any port is still
     // a JTAG write as we have to transmit the address
     let result = probe.write_register(address, &data[..], JTAG_DR_BIT_LENGTH);
 
-    probe.set_idle_cycles(idle_cycles);
+    probe.set_idle_cycles(idle_cycles)?;
 
     let result = result?;
 
@@ -260,7 +260,7 @@ fn perform_jtag_transfers<P: JTAGAccess + RawProtocolIo>(
         .max()
         .unwrap_or(0);
     let idle_cycles = probe.idle_cycles();
-    probe.set_idle_cycles(max_idle_cycles.min(255) as u8);
+    probe.set_idle_cycles(max_idle_cycles.min(255) as u8)?;
 
     // Execute as much of the queue as we can. We'll handle the rest in a following iteration
     // if we can.
@@ -290,7 +290,7 @@ fn perform_jtag_transfers<P: JTAGAccess + RawProtocolIo>(
         }
     }
 
-    probe.set_idle_cycles(idle_cycles);
+    probe.set_idle_cycles(idle_cycles)?;
 
     // Process the results. At this point we should only have OK/FAULT responses.
     for (i, transfer) in transfers.iter_mut().enumerate() {
@@ -1519,8 +1519,9 @@ mod test {
             todo!()
         }
 
-        fn set_idle_cycles(&mut self, idle_cycles: u8) {
+        fn set_idle_cycles(&mut self, idle_cycles: u8) -> Result<(), DebugProbeError> {
             self.idle_cycles = idle_cycles;
+            Ok(())
         }
 
         fn idle_cycles(&self) -> u8 {

--- a/probe-rs/src/probe/cmsisdap/commands/jtag/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/jtag/mod.rs
@@ -1,3 +1,169 @@
+use bitvec::{order::Lsb0, vec::BitVec};
+
+use crate::probe::{
+    DebugProbeError,
+    cmsisdap::{
+        CmsisDap,
+        commands::jtag::sequence::{Sequence, SequenceRequest},
+    },
+    common::{JtagDriverState, RawJtagIo},
+};
+
 pub mod configure;
 pub mod idcode;
 pub mod sequence;
+
+// Implement everything necessary to bitbang JTAG for non-ARM interfaces. As this is
+// mutually exclusive with ARM JTAG, we can ignore the ARM-side batching implementation.
+impl RawJtagIo for CmsisDap {
+    fn shift_bit(
+        &mut self,
+        tms: bool,
+        tdi: bool,
+        capture_tdo: bool,
+    ) -> Result<(), DebugProbeError> {
+        self.state_mut().state.update(tms);
+        if self.jtag_buffer.shift_bit(tms, tdi, capture_tdo) {
+            self.flush_jtag()?;
+        }
+        Ok(())
+    }
+
+    fn read_captured_bits(&mut self) -> Result<BitVec<u8, Lsb0>, DebugProbeError> {
+        self.flush_jtag()?;
+        Ok(std::mem::take(&mut self.jtag_buffer.response))
+    }
+
+    fn state_mut(&mut self) -> &mut JtagDriverState {
+        &mut self.jtag_state
+    }
+
+    fn state(&self) -> &JtagDriverState {
+        &self.jtag_state
+    }
+}
+
+impl CmsisDap {
+    fn flush_jtag(&mut self) -> Result<(), DebugProbeError> {
+        if let Some(seq) = self.jtag_buffer.current_sequence.take() {
+            self.jtag_buffer.complete_sequences.push(seq);
+        }
+
+        // Transform into sequence::Sequence
+        let sequences = self
+            .jtag_buffer
+            .complete_sequences
+            .drain(..)
+            .map(|s| Sequence::new(s.tck_cycles, s.tdo_capture, s.tms, to_bytes(&s.data)))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let command = SequenceRequest::new(sequences)?;
+
+        let response = self.send_jtag_sequences(command)?;
+        self.jtag_buffer.response.extend_from_bitslice(&response);
+
+        Ok(())
+    }
+}
+
+fn to_bytes(data: &[bool]) -> [u8; 8] {
+    let mut bytes = [0; 8];
+    for (i, &bit) in data.iter().enumerate() {
+        if bit {
+            bytes[i / 8] |= 1 << (i % 8);
+        }
+    }
+    bytes
+}
+
+struct JtagSequence {
+    /// Number of TCK cycles: 1..64 (64 encoded as 0)
+    tck_cycles: u8,
+
+    /// TDO capture
+    tdo_capture: bool,
+
+    /// TMS value
+    tms: bool,
+
+    /// Data to generate on TDI
+    data: Vec<bool>,
+}
+
+impl JtagSequence {
+    /// Returns the size of the sequence in bytes.
+    fn size(&self) -> usize {
+        // Sequence info + TDI data
+        1 + self.data.len().div_ceil(8)
+    }
+
+    fn append(&mut self, tdi: bool, tms: bool, tdo_capture: bool) -> Option<JtagSequence> {
+        if tms == self.tms && tdo_capture == self.tdo_capture && self.tck_cycles < 64 {
+            self.data.push(tdi);
+            self.tck_cycles += 1;
+            None
+        } else {
+            let seq = std::mem::replace(
+                self,
+                JtagSequence {
+                    tck_cycles: 1,
+                    tdo_capture,
+                    tms,
+                    data: vec![tdi],
+                },
+            );
+            Some(seq)
+        }
+    }
+}
+
+pub(crate) struct JtagBuffer {
+    packet_size: usize,
+    current_sequence: Option<JtagSequence>,
+    complete_sequences: Vec<JtagSequence>,
+    response: BitVec<u8, Lsb0>,
+}
+impl JtagBuffer {
+    pub(crate) fn new(packet_size: u16) -> Self {
+        Self {
+            packet_size: packet_size as usize,
+            current_sequence: None,
+            complete_sequences: Vec::with_capacity(packet_size as usize),
+            response: BitVec::with_capacity(packet_size as usize),
+        }
+    }
+}
+impl JtagBuffer {
+    fn total_buffer_bytes(&self) -> usize {
+        // Command + Sequence count + (Sequence info + data bytes)+
+        1 + 1
+            + self
+                .complete_sequences
+                .iter()
+                .map(|s| s.size())
+                .sum::<usize>()
+            + self.current_sequence.as_ref().map_or(0, |s| s.size())
+    }
+
+    /// Returns `true` if the buffered sequences need to be flushed.
+    fn shift_bit(&mut self, tms: bool, tdi: bool, capture_tdo: bool) -> bool {
+        let seq = self.current_sequence.get_or_insert_with(|| JtagSequence {
+            tck_cycles: 0,
+            tdo_capture: capture_tdo,
+            tms,
+            data: Vec::with_capacity(64),
+        });
+
+        if let Some(complete_sequence) = seq.append(tdi, tms, capture_tdo) {
+            self.complete_sequences.push(complete_sequence);
+        }
+
+        self.should_flush()
+    }
+
+    fn should_flush(&self) -> bool {
+        // In the worst case, the next bit will append two bytes. If we only have 1 byte left,
+        // we need to flush the buffer.
+        self.total_buffer_bytes() >= self.packet_size - 1
+    }
+}

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -722,8 +722,9 @@ impl<Probe: DebugProbe + RawJtagIo + 'static> JTAGAccess for Probe {
         self.reset_jtag_state_machine()
     }
 
-    fn set_idle_cycles(&mut self, idle_cycles: u8) {
+    fn set_idle_cycles(&mut self, idle_cycles: u8) -> Result<(), DebugProbeError> {
         self.state_mut().jtag_idle_cycles = idle_cycles as usize;
+        Ok(())
     }
 
     fn idle_cycles(&self) -> u8 {

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -8,7 +8,7 @@ use probe_rs_target::ScanChainElement;
 
 use crate::probe::{
     BatchExecutionError, ChainParams, CommandResult, DebugProbe, DebugProbeError,
-    DeferredResultSet, JTAGAccess, JtagChainItem, JtagCommand, JtagCommandQueue,
+    DeferredResultSet, JTAGAccess, JtagCommand, JtagCommandQueue,
 };
 
 pub(crate) fn bits_to_byte(bits: impl IntoIterator<Item = bool>) -> u32 {
@@ -399,7 +399,7 @@ pub(crate) struct JtagDriverState {
     // The maximum IR address
     pub max_ir_address: u32,
     pub expected_scan_chain: Option<Vec<ScanChainElement>>,
-    pub scan_chain: Vec<JtagChainItem>,
+    pub scan_chain: Vec<ScanChainElement>,
     pub chain_params: ChainParams,
     /// Idle cycles necessary between consecutive
     /// accesses to the DMI register
@@ -710,7 +710,10 @@ impl<Probe: DebugProbe + RawJtagIo + 'static> JTAGAccess for Probe {
         let chain = idcodes
             .into_iter()
             .zip(ir_lens)
-            .map(|(idcode, irlen)| JtagChainItem { irlen, idcode })
+            .map(|(idcode, irlen)| ScanChainElement {
+                ir_len: Some(irlen as u8),
+                name: idcode.map(|i| i.to_string()),
+            })
             .collect::<Vec<_>>();
 
         self.state_mut().scan_chain = chain;

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -415,8 +415,9 @@ impl JTAGAccess for WchLink {
         }
     }
 
-    fn set_idle_cycles(&mut self, idle_cycles: u8) {
+    fn set_idle_cycles(&mut self, idle_cycles: u8) -> Result<(), DebugProbeError> {
         self.idle_cycles = idle_cycles;
+        Ok(())
     }
 
     fn idle_cycles(&self) -> u8 {

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -226,9 +226,11 @@ impl Session {
             }
         }
         probe.attach_to_unspecified()?;
-        if probe.scan_chain().iter().len() > 0 {
-            for core in &cores {
-                probe.select_jtag_tap(core.interface_idx())?;
+        if let Ok(chain) = probe.scan_chain() {
+            if !chain.is_empty() {
+                for core in &cores {
+                    probe.select_jtag_tap(core.interface_idx())?;
+                }
             }
         }
 

--- a/probe-rs/src/vendor/mod.rs
+++ b/probe-rs/src/vendor/mod.rs
@@ -180,7 +180,7 @@ fn try_detect_arm_chip(
 fn try_detect_riscv_chip(registry: &Registry, probe: &mut Probe) -> Result<Option<Target>, Error> {
     let mut found_target = None;
 
-    probe.select_jtag_tap(0)?;
+    _ = probe.select_jtag_tap(0);
 
     match probe.try_get_riscv_interface_builder() {
         Ok(factory) => {
@@ -228,7 +228,7 @@ fn try_detect_riscv_chip(registry: &Registry, probe: &mut Probe) -> Result<Optio
 fn try_detect_xtensa_chip(registry: &Registry, probe: &mut Probe) -> Result<Option<Target>, Error> {
     let mut found_target = None;
 
-    probe.select_jtag_tap(0)?;
+    _ = probe.select_jtag_tap(0);
 
     let mut state = XtensaDebugInterfaceState::default();
     match probe.try_get_xtensa_interface(&mut state) {


### PR DESCRIPTION
Slightly on the hacky side but the default CMSIS-DAP command set doesn't implement any sort of JTAG IR/DR scan helpers without the ARM-specific bits being attached to the sequence, which is unfortunate. We could define our own but the documentation doesn't really explain how we could add vendor-specific commands - and we would still need to polyfill for non-dap-rs-based probes.

The PR also fixes the JTAG_Sequence command which previously assumed that only whole bytes were captured.