### PR TITLE
Undo recently added scan-hack

### DIFF
--- a/changelog/changed-jtag-traits.md
+++ b/changelog/changed-jtag-traits.md
@@ -1,0 +1,1 @@
+The `select_target` function has been moved from RawJtagIo to JTAGAccess.

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -1094,6 +1094,17 @@ pub trait JTAGAccess: DebugProbe {
     /// Executes a TAP reset.
     fn tap_reset(&mut self) -> Result<(), DebugProbeError>;
 
+    /// Selects the JTAG TAP to be used for communication.
+    fn select_target(&mut self, index: usize) -> Result<(), DebugProbeError> {
+        if index != 0 {
+            return Err(DebugProbeError::NotImplemented {
+                function_name: "select_jtag_tap",
+            });
+        }
+
+        Ok(())
+    }
+
     /// Read a JTAG register.
     ///
     /// This function emulates a read by performing a write with all zeros to the DR.

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -1079,7 +1079,6 @@ impl DebugProbe for BlackMagicProbe {
 
         match self.protocol {
             Some(WireProtocol::Jtag) => {
-                self.scan_chain()?;
                 self.select_target(0)?;
 
                 if let ProtocolVersion::V1

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -24,7 +24,7 @@ use crate::{
             CmsisDapError, RequestError,
             general::info::{CapabilitiesCommand, PacketCountCommand, SWOTraceBufferSizeCommand},
         },
-        common::{JtagDriverState, RawJtagIo},
+        common::JtagDriverState,
     },
 };
 

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -967,11 +967,6 @@ impl DebugProbe for CmsisDap {
     fn try_get_riscv_interface_builder<'probe>(
         &'probe mut self,
     ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, DebugProbeError> {
-        // We need to scan as soon as we know this isn't an ARM interface.
-        if self.jtag_state.scan_chain.is_empty() {
-            self.scan_chain()?;
-            RawJtagIo::select_target(self, 0)?;
-        }
         Ok(Box::new(JtagDtmBuilder::new(self)))
     }
 
@@ -979,11 +974,6 @@ impl DebugProbe for CmsisDap {
         &'probe mut self,
         state: &'probe mut XtensaDebugInterfaceState,
     ) -> Result<XtensaCommunicationInterface<'probe>, DebugProbeError> {
-        // We need to scan as soon as we know this isn't an ARM interface.
-        if self.jtag_state.scan_chain.is_empty() {
-            self.scan_chain()?;
-            RawJtagIo::select_target(self, 0)?;
-        }
         Ok(XtensaCommunicationInterface::new(self, state))
     }
 

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -622,6 +622,10 @@ fn prepare_write_register(
 impl<Probe: DebugProbe + RawJtagIo + 'static> JTAGAccess for Probe {
     /// Configures the probe to address the given target.
     fn select_target(&mut self, target: usize) -> Result<(), DebugProbeError> {
+        if self.state().scan_chain.is_empty() {
+            self.scan_chain()?;
+        }
+
         let state = self.state_mut();
 
         let Some(params) = ChainParams::from_jtag_chain(&state.scan_chain, target) else {

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -638,7 +638,6 @@ impl<Probe: DebugProbe + RawJtagIo + 'static> JTAGAccess for Probe {
         tracing::debug!("Setting chain params: {params:?}");
         tracing::debug!("Setting max_ir_address to {max_ir_address}");
 
-        let state = self.state_mut();
         state.max_ir_address = max_ir_address;
         state.chain_params = params;
 

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -465,27 +465,6 @@ pub(crate) trait RawJtagIo {
 
         Ok(())
     }
-
-    /// Configures the probe to address the given target.
-    fn select_target(&mut self, target: usize) -> Result<(), DebugProbeError> {
-        let state = self.state_mut();
-
-        let Some(params) = ChainParams::from_jtag_chain(&state.scan_chain, target) else {
-            return Err(DebugProbeError::TargetNotFound);
-        };
-
-        let max_ir_address = (1 << params.irlen) - 1;
-
-        tracing::debug!("Selecting JTAG TAP: {target}");
-        tracing::debug!("Setting chain params: {params:?}");
-        tracing::debug!("Setting max_ir_address to {max_ir_address}");
-
-        let state = self.state_mut();
-        state.max_ir_address = max_ir_address;
-        state.chain_params = params;
-
-        Ok(())
-    }
 }
 
 fn jtag_move_to_state(
@@ -641,6 +620,27 @@ fn prepare_write_register(
 }
 
 impl<Probe: DebugProbe + RawJtagIo + 'static> JTAGAccess for Probe {
+    /// Configures the probe to address the given target.
+    fn select_target(&mut self, target: usize) -> Result<(), DebugProbeError> {
+        let state = self.state_mut();
+
+        let Some(params) = ChainParams::from_jtag_chain(&state.scan_chain, target) else {
+            return Err(DebugProbeError::TargetNotFound);
+        };
+
+        let max_ir_address = (1 << params.irlen) - 1;
+
+        tracing::debug!("Selecting JTAG TAP: {target}");
+        tracing::debug!("Setting chain params: {params:?}");
+        tracing::debug!("Setting max_ir_address to {max_ir_address}");
+
+        let state = self.state_mut();
+        state.max_ir_address = max_ir_address;
+        state.chain_params = params;
+
+        Ok(())
+    }
+
     fn scan_chain(&mut self) -> Result<(), DebugProbeError> {
         const MAX_CHAIN: usize = 8;
 

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -132,7 +132,6 @@ impl DebugProbe for EspUsbJtag {
     fn attach(&mut self) -> Result<(), DebugProbeError> {
         tracing::debug!("Attaching to ESP USB JTAG");
 
-        self.scan_chain()?;
         self.select_target(0)
     }
 

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -347,8 +347,6 @@ impl DebugProbe for FtdiProbe {
         tracing::debug!("Attaching...");
 
         self.adapter.attach()?;
-
-        self.scan_chain()?;
         self.select_target(0)
     }
 

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -1049,7 +1049,6 @@ impl DebugProbe for JLink {
                 tracing::debug!("Resetting JTAG chain using trst");
                 self.reset_trst()?;
 
-                self.scan_chain()?;
                 self.select_target(0)?;
             }
             WireProtocol::Swd => {

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -377,12 +377,7 @@ impl Session {
 
                     JtagInterface::Riscv(state)
                 }
-                Architecture::Xtensa => {
-                    // Workaround for CMSIS-DAP probe not scanning in `attach_to_unspecified`.
-                    let mut state = XtensaDebugInterfaceState::default();
-                    probe.try_get_xtensa_interface(&mut state)?;
-                    JtagInterface::Xtensa(state)
-                }
+                Architecture::Xtensa => JtagInterface::Xtensa(XtensaDebugInterfaceState::default()),
                 _ => {
                     return Err(Error::Probe(DebugProbeError::Other(format!(
                         "Unsupported core architecture {core_arch:?}",


### PR DESCRIPTION
This PR changes the JTAG traits a bit so that scan_chain can be called from select_target - this should ensure that - at least the bitbanging implementations - scan the chain before trying to use it.