### PR TITLE
ESP32S2: access peripherals via fast instructions

### DIFF
--- a/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
@@ -150,6 +150,7 @@ impl XtensaDebugSequence for ESP32S2 {
             .core_properties()
             .fast_memory_access_ranges
             .extend_from_slice(&[
+                0x3F40_0000..0x3F50_0000, // Peripherals
                 0x3FF9_E000..0x4000_0000, // Data
                 0x4000_0000..0x4007_2000, // Instruction
             ]);


### PR DESCRIPTION
This PR adds the peripheral address space to the LDDR32.P/SDDR32.P-enabled memory ranges. This is fixing an issue around system reset - I don't really know why (i.e. why the normal memory access instructions result in a timeout during reset), but regardless, this fixes an issue we have.