### PR TITLE
Xtensa fixes

### DIFF
--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -865,7 +865,7 @@ impl<'probe> XtensaCommunicationInterface<'probe> {
 ///
 /// # Safety
 /// Don't implement this trait
-unsafe trait DataType: Sized {}
+pub(super) unsafe trait DataType: Sized {}
 unsafe impl DataType for u8 {}
 unsafe impl DataType for u16 {}
 unsafe impl DataType for u32 {}
@@ -875,7 +875,7 @@ fn as_bytes<T: DataType>(data: &[T]) -> &[u8] {
     unsafe { std::slice::from_raw_parts(data.as_ptr() as *mut u8, std::mem::size_of_val(data)) }
 }
 
-fn as_bytes_mut<T: DataType>(data: &mut [T]) -> &mut [u8] {
+pub(super) fn as_bytes_mut<T: DataType>(data: &mut [T]) -> &mut [u8] {
     unsafe {
         std::slice::from_raw_parts_mut(data.as_mut_ptr() as *mut u8, std::mem::size_of_val(data))
     }

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -105,7 +105,7 @@ pub(super) struct XtensaInterfaceState {
 
     /// Whether the core is halted.
     // This roughly relates to Core Debug States (true = Running, false = [Stopped, Stepping])
-    is_halted: bool,
+    pub(super) is_halted: bool,
 }
 
 /// Properties of an Xtensa CPU core.
@@ -181,7 +181,7 @@ pub struct XtensaDebugInterfaceState {
 pub struct XtensaCommunicationInterface<'probe> {
     /// The Xtensa debug module
     pub(crate) xdm: Xdm<'probe>,
-    state: &'probe mut XtensaInterfaceState,
+    pub(super) state: &'probe mut XtensaInterfaceState,
     core_properties: &'probe mut XtensaCoreProperties,
 }
 

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -333,7 +333,7 @@ impl<'probe> Xtensa<'probe> {
 
 // We can't use CoreMemoryInterface here, because we need to spill registers before reading.
 // This needs to be considerably cleaned up.
-impl<'probe> MemoryInterface<Error> for Xtensa<'probe> {
+impl MemoryInterface for Xtensa<'_> {
     fn supports_native_64bit_access(&mut self) -> bool {
         self.interface.supports_native_64bit_access()
     }

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -440,7 +440,14 @@ impl CoreInterface for Xtensa<'_> {
     }
 
     fn core_halted(&mut self) -> Result<bool, Error> {
-        Ok(self.interface.core_halted()?)
+        let was_halted = self.interface.state.is_halted;
+        let is_halted = self.interface.core_halted()?;
+
+        if !was_halted && is_halted {
+            self.on_halted()?;
+        }
+
+        Ok(is_halted)
     }
 
     fn status(&mut self) -> Result<CoreStatus, Error> {

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -13,6 +13,7 @@ use crate::{
         },
         communication_interface::{
             DebugCause, IBreakEn, ProgramStatus, WindowProperties, XtensaCommunicationInterface,
+            as_bytes_mut,
         },
         registers::{FP, PC, RA, SP, XTENSA_CORE_REGISTERS},
         sequences::XtensaDebugSequence,
@@ -22,7 +23,6 @@ use crate::{
         BreakpointCause,
         registers::{CoreRegisters, RegisterId, RegisterValue},
     },
-    memory::CoreMemoryInterface,
     semihosting::{SemihostingCommand, decode_semihosting_syscall},
 };
 
@@ -255,8 +255,6 @@ impl<'probe> Xtensa<'probe> {
         tracing::debug!("Core halted: {:#?}", status);
 
         if status.is_halted() {
-            self.spill_registers()?;
-
             self.sequence.on_halt(&mut self.interface)?;
         }
 
@@ -329,15 +327,107 @@ impl<'probe> Xtensa<'probe> {
     }
 }
 
-impl CoreMemoryInterface for Xtensa<'_> {
-    type ErrorType = Error;
-
-    fn memory(&self) -> &dyn MemoryInterface<Self::ErrorType> {
-        &self.interface
+// We can't use CoreMemoryInterface here, because we need to spill registers before reading.
+// This needs to be considerably cleaned up.
+impl<'probe> MemoryInterface<Error> for Xtensa<'probe> {
+    fn supports_native_64bit_access(&mut self) -> bool {
+        self.interface.supports_native_64bit_access()
     }
 
-    fn memory_mut(&mut self) -> &mut dyn MemoryInterface<Self::ErrorType> {
-        &mut self.interface
+    fn read_word_64(&mut self, address: u64) -> Result<u64, Error> {
+        self.halted_access(|this| {
+            this.spill_registers()?;
+
+            this.interface.read_word_64(address)
+        })
+    }
+
+    fn read_word_32(&mut self, address: u64) -> Result<u32, Error> {
+        self.halted_access(|this| {
+            this.spill_registers()?;
+
+            this.interface.read_word_32(address)
+        })
+    }
+
+    fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
+        self.halted_access(|this| {
+            this.spill_registers()?;
+
+            this.interface.read_word_16(address)
+        })
+    }
+
+    fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
+        self.halted_access(|this| {
+            this.spill_registers()?;
+
+            this.interface.read_word_8(address)
+        })
+    }
+
+    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), Error> {
+        self.read_8(address, as_bytes_mut(data))
+    }
+
+    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error> {
+        self.read_8(address, as_bytes_mut(data))
+    }
+
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error> {
+        self.read_8(address, as_bytes_mut(data))
+    }
+
+    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
+        self.halted_access(|this| {
+            this.spill_registers()?;
+
+            this.interface.read_8(address, data)
+        })
+    }
+
+    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
+        self.interface.write_word_64(address, data)
+    }
+
+    fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), Error> {
+        self.interface.write_word_32(address, data)
+    }
+
+    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
+        self.interface.write_word_16(address, data)
+    }
+
+    fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
+        self.interface.write_word_8(address, data)
+    }
+
+    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error> {
+        self.interface.write_64(address, data)
+    }
+
+    fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
+        self.interface.write_32(address, data)
+    }
+
+    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
+        self.interface.write_16(address, data)
+    }
+
+    fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
+        self.interface.write_8(address, data)
+    }
+
+    fn write(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
+        self.interface.write(address, data)
+    }
+
+    fn supports_8bit_transfers(&self) -> Result<bool, Error> {
+        self.interface.supports_8bit_transfers()
+    }
+
+    fn flush(&mut self) -> Result<(), Error> {
+        self.interface.flush()
     }
 }
 
@@ -782,6 +872,21 @@ impl<'a> RegisterWindow<'a> {
                 let sp = interface.read_word_32(self.read_register(CpuRegister::A1) as u64 - 12)?;
 
                 interface.write_32(self.read_register(CpuRegister::A9) as u64 - 16, &a0_a3)?;
+
+                // Enable check at INFO level to avoid spamming the logs.
+                if tracing::enabled!(tracing::Level::INFO) {
+                    // In some cases (spilling on each halt),
+                    // this readback comes back as 0 for some reason. This assertion is temporarily
+                    // meant to help me debug this.
+                    let written =
+                        interface.read_word_32(self.read_register(CpuRegister::A9) as u64 - 12)?;
+                    assert!(
+                        written == self.read_register(CpuRegister::A1),
+                        "Failed to spill A1. Expected {:#x}, got {:#x}",
+                        self.read_register(CpuRegister::A1),
+                        written
+                    );
+                }
 
                 let regs = [
                     self.read_register(CpuRegister::A4),


### PR DESCRIPTION
Spilling on every halt broke ESP32 (and S2, but that was fixable in some other way). This PR cleans some things up, and makes sure we only spill registers before reading memory (because we may read from the stack for unwinding, which needs the registers to be spilled).