### PR TITLE
run/attach: Allow sending output to other applications

### DIFF
--- a/changelog/added-store-log.md
+++ b/changelog/added-store-log.md
@@ -1,1 +1,1 @@
-- Added `--target-outptu-file` to `probe-rs run` and `attach`, allowing output to be stored in files or named pipes.
+- Added `--target-output-file` to `probe-rs run` and `attach`, allowing output to be stored in files or named pipes.

--- a/changelog/added-store-log.md
+++ b/changelog/added-store-log.md
@@ -1,0 +1,1 @@
+- Added `--target-outptu-file` to `probe-rs run` and `attach`, allowing output to be stored in files or named pipes.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
@@ -2,7 +2,7 @@ use time::UtcOffset;
 
 use crate::rpc::client::RpcClient;
 use crate::rpc::functions::monitor::{MonitorMode, MonitorOptions};
-use crate::util::cli::{self, rtt_client};
+use crate::util::cli::{self, connect_target_output_files, rtt_client};
 
 #[derive(clap::Parser)]
 #[group(skip)]
@@ -29,6 +29,9 @@ impl Cmd {
         )
         .await?;
 
+        let mut target_output_files =
+            connect_target_output_files(self.run.shared_options.target_output_file).await?;
+
         let client_handle = rtt_client.handle();
 
         cli::monitor(
@@ -42,6 +45,7 @@ impl Cmd {
                 rtt_client: Some(client_handle),
             },
             self.run.shared_options.always_print_stacktrace,
+            &mut target_output_files,
         )
         .await?;
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -4,7 +4,7 @@ use crate::rpc::client::RpcClient;
 use crate::rpc::functions::monitor::{MonitorMode, MonitorOptions};
 
 use crate::FormatOptions;
-use crate::util::cli::{self, rtt_client};
+use crate::util::cli::{self, connect_target_output_files, rtt_client};
 use crate::util::common_options::{BinaryDownloadOptions, ProbeOptions};
 
 use libtest_mimic::{Arguments, FormatSetting};
@@ -158,6 +158,12 @@ pub struct SharedOptions {
     #[clap(long)]
     pub(crate) log_format: Option<String>,
 
+    /// File name to store formatted output at. Different channels can be assigned to different
+    /// files using comma-separated channel=file pairs (eg.
+    /// `0=out/rtt/log.txt,1=out/rtt/data.bin,stderr=out/semihosted.err,out/other-channels.log`).
+    #[clap(long)]
+    pub(crate) target_output_file: Option<String>,
+
     /// Scan the memory to find the RTT control block
     #[clap(long)]
     pub(crate) rtt_scan_memory: bool,
@@ -182,6 +188,9 @@ impl Cmd {
             Some(utc_offset),
         )
         .await?;
+
+        let mut target_output_files =
+            connect_target_output_files(self.shared_options.target_output_file).await?;
 
         let client_handle = rtt_client.handle();
 
@@ -220,6 +229,7 @@ impl Cmd {
                 self.shared_options.always_print_stacktrace,
                 &self.shared_options.path,
                 Some(rtt_client),
+                &mut target_output_files,
             )
             .await
         } else {
@@ -234,6 +244,7 @@ impl Cmd {
                     rtt_client: Some(client_handle),
                 },
                 self.shared_options.always_print_stacktrace,
+                &mut target_output_files,
             )
             .await
         }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -159,7 +159,7 @@ pub struct SharedOptions {
     pub(crate) log_format: Option<String>,
 
     /// File name to store formatted output at. Different channels can be assigned to different
-    /// files using channel=file argumentst to multiple occurrences (eg. `--target-output-file
+    /// files using channel=file arguments to multiple occurrences (eg. `--target-output-file
     /// defmt=out/defmt.txt --target-output-file out/default`). Channel names can be prefixed with
     /// `rtt:` or `semihosting:` (eg. `semihosting:stdout`) to disambiguate.
     #[clap(long)]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -159,10 +159,11 @@ pub struct SharedOptions {
     pub(crate) log_format: Option<String>,
 
     /// File name to store formatted output at. Different channels can be assigned to different
-    /// files using comma-separated channel=file pairs (eg.
-    /// `0=out/rtt/log.txt,1=out/rtt/data.bin,stderr=out/semihosted.err,out/other-channels.log`).
+    /// files using channel=file argumentst to multiple occurrences (eg. `--target-output-file
+    /// defmt=out/defmt.txt --target-output-file out/default`). Channel names can be prefixed with
+    /// `rtt:` or `semihosting:` (eg. `semihosting:stdout`) to disambiguate.
     #[clap(long)]
-    pub(crate) target_output_file: Option<String>,
+    pub(crate) target_output_file: Vec<String>,
 
     /// Scan the memory to find the RTT control block
     #[clap(long)]

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -50,13 +50,13 @@ pub(crate) struct Config {
     long_version = env!("PROBE_RS_LONG_VERSION")
 )]
 struct Cli {
-    /// Location for log file
+    /// Location for log file for probe-rs's own debug output
     ///
     /// If no location is specified, the behaviour depends on `--log-to-folder`.
-    #[clap(long, global = true, help_heading = "LOG CONFIGURATION")]
+    #[clap(long, global = true, help_heading = "DEBUG LOG CONFIGURATION")]
     log_file: Option<PathBuf>,
-    /// Enable logging to the default folder. This option is ignored if `--log-file` is specified.
-    #[clap(long, global = true, help_heading = "LOG CONFIGURATION")]
+    /// Enable logging of probe-rs's own debug data to the default folder. This option is ignored if `--log-file` is specified.
+    #[clap(long, global = true, help_heading = "DEBUG LOG CONFIGURATION")]
     log_to_folder: bool,
     #[clap(
         long,

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -203,18 +203,15 @@ impl ChannelIdentifier {
     }
 }
 
-/// Split a text string like `0=localhost:1234,stdout=localhost:4567,[2001:db8::1]:9` by the
-/// commas, mapping the keys to a [`ChannelIdentifier`] (or
-/// [`CatchAll`][ChannelIdentifier::CatchAll] when no key present).
-///
-/// This takes an Option/AsRef for the callers' convenience -- those usually have an
-/// `Option<String>` from the CLI argument parsing.
+/// Splits argument text strings like `['channel1=file-for-c1', 'stdout=some-file', 'defaultfile']` by the
+/// `=` signs, mapping the keys to a [`ChannelIdentifier`] (or
+/// [`CatchAll`][ChannelIdentifier::CatchAll] when no key present) and opening the values as files
+/// in append mode.
 pub(crate) async fn connect_target_output_files(
-    arg: Option<impl AsRef<str>>,
+    arg: Vec<String>,
 ) -> anyhow::Result<TargetOutputFiles> {
     let mut map = TargetOutputFiles::new();
-    let arg = arg.as_ref().map(|s| s.as_ref()).unwrap_or_default();
-    for component in arg.split(",") {
+    for component in arg {
         let parts: Vec<&str> = component.splitn(2, "=").collect();
         let key;
         let value;

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -191,11 +191,11 @@ impl ChannelIdentifier {
         // This double/triple access (get / get_mut) is a bit weird, but the compiler will not see
         // that the lifetimes of the get_mut are non-overlapping if we return the Ok of an initial
         // get_mut.
-        if map.get(self).is_some() {
+        if map.contains_key(self) {
             return map.get_mut(self);
         };
         if let Some(fallback) = self.unqualified() {
-            if map.get(&fallback).is_some() {
+            if map.contains_key(&fallback) {
                 return map.get_mut(&fallback);
             };
         }


### PR DESCRIPTION
cargo-embed has the convenient feature to send a copy of the output stream over the network; I'd like to use this in Ariel OS both for interactive commissioning (where a process in the background scans the running program's output, eg. for public keys generated there) and for testing (exceeding what embedded-test can do: eg. listen for readiness signals or chosen address, start a network interaction test from the host).

This PR brings that feature to probe-rs run, albeit with subtle differences, which are all IMO sensible in the context of a CLI rather than a TUI tool:
* It embraces the asyncness a bit more (IIUC, the cargo-embed version will either start blocking or indefinitely grow buffers)
* Failure to connect is fatal here. This fits because a TUI tool can give visual warnigns and expect the user to get the hint, whereas a CLI tool should rather fail with a return code.
* This impl allows both per-channel and catch-all-the-streams (whereas cargo-embed has only the former). This is both because I generally think it's a good idea, and because probe-rs does not need a config file with per-channel sections, so users might want it "just to work" with what they don't need to configure anyway.

## Open questions

I don't use semihosting myself, and when I started this, I thought it'd make sense to capture any single channel of RTT or semihosting -- but it turned out that there's not really a convenient object by which to pass around the sockets object for semihosting systems when there is no CliRttClient instance. Consequently, my current code is in some kind of limbo where stdout/stderr redirects are supported on the CLI but don't work.

Is semihosting sufficiently much of a "full feature" to warrant support? Could `print_monitor_event` be a method of *something* where this could be lugged around?

## Usage

```
$ probe-rs run --protocol=swd --chip STM32WB55RG --preverify ${MY_BINARY} --send-log localhost:1338
```

## Status

So far this is just doing ground work (thus the draft PR), but I'm opening it already in order to gather feedback on the plan.