### PR TITLE
Rework Xtensa register cache

### DIFF
--- a/probe-rs/src/architecture/xtensa/arch/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/mod.rs
@@ -14,6 +14,12 @@ pub enum Register {
     CurrentPs,
 }
 
+impl Register {
+    pub(crate) fn is_cpu_register(self) -> bool {
+        matches!(self, Register::Cpu(_))
+    }
+}
+
 impl TryFrom<RegisterId> for Register {
     type Error = XtensaError;
 

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -101,7 +101,7 @@ impl DebugLevel {
 #[derive(Default)]
 pub(super) struct XtensaInterfaceState {
     /// The register cache.
-    register_cache: RegisterCache,
+    pub(super) register_cache: RegisterCache,
 
     /// Whether the core is halted.
     // This roughly relates to Core Debug States (true = Running, false = [Stopped, Stepping])

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -288,7 +288,6 @@ impl<'probe> Xtensa<'probe> {
     }
 
     fn spill_registers(&mut self) -> Result<(), Error> {
-        // TODO: lazy-load registers
         if self.state.spilled {
             return Ok(());
         }

--- a/probe-rs/src/architecture/xtensa/register_cache.rs
+++ b/probe-rs/src/architecture/xtensa/register_cache.rs
@@ -71,14 +71,13 @@ impl CacheEntry {
         self.original_value != self.current_value || self.dirty
     }
 
-    /// Marks the register as clean by restoring its original value.
-    pub fn restore(&mut self) {
-        self.current_value = self.original_value;
-        self.dirty = false;
-    }
-
     /// Returns the current value of the register.
     pub fn current_value(&self) -> u32 {
         self.current_value
+    }
+
+    /// Returns the current value of the register.
+    pub fn original_value(&self) -> u32 {
+        self.original_value
     }
 }

--- a/probe-rs/src/architecture/xtensa/register_cache.rs
+++ b/probe-rs/src/architecture/xtensa/register_cache.rs
@@ -1,0 +1,84 @@
+use std::collections::HashMap;
+
+use crate::architecture::xtensa::arch::Register;
+
+#[derive(Default)]
+pub struct RegisterCache {
+    entries: HashMap<Register, CacheEntry>,
+}
+
+impl RegisterCache {
+    pub fn new() -> Self {
+        RegisterCache {
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Stores a register value in the cache.
+    pub fn store(&mut self, id: Register, value: u32) {
+        self.entries.insert(
+            id,
+            CacheEntry {
+                original_value: value,
+                current_value: value,
+                dirty: false,
+            },
+        );
+    }
+
+    /// Loads a register value from the cache.
+    pub fn get_mut(&mut self, id: Register) -> Option<&mut CacheEntry> {
+        self.entries.get_mut(&id)
+    }
+
+    /// Iterates over all entries in the cache.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (Register, &mut CacheEntry)> {
+        self.entries.iter_mut().map(|(k, v)| (*k, v))
+    }
+
+    pub(crate) fn mark_dirty(&mut self, register: Register) {
+        let entry = self
+            .entries
+            .get_mut(&register)
+            .unwrap_or_else(|| panic!("Register {register:?} is not in cache"));
+
+        entry.dirty = true;
+    }
+
+    pub(crate) fn remove(&mut self, register: Register) {
+        self.entries.remove(&register);
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct CacheEntry {
+    /// The original value of the register, as loaded from the target.
+    original_value: u32,
+
+    /// The current value of the register in the target's register.
+    ///
+    /// This may be different from the original value if the register is dirty.
+    current_value: u32,
+
+    /// Indicates whether the register is dirty.
+    dirty: bool,
+}
+
+impl CacheEntry {
+    /// Returns whether the register is dirty, meaning the target's register value has been modified
+    /// but not yet committed.
+    pub fn is_dirty(&self) -> bool {
+        self.original_value != self.current_value || self.dirty
+    }
+
+    /// Marks the register as clean by restoring its original value.
+    pub fn restore(&mut self) {
+        self.current_value = self.original_value;
+        self.dirty = false;
+    }
+
+    /// Returns the current value of the register.
+    pub fn current_value(&self) -> u32 {
+        self.current_value
+    }
+}

--- a/probe-rs/src/vendor/espressif/sequences/esp32.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32.rs
@@ -183,7 +183,7 @@ impl XtensaDebugSequence for ESP32 {
             }
 
             if start.elapsed() >= timeout {
-                return Err(crate::Error::Timeout);
+                return Err(XtensaError::Timeout.into());
             }
         }
 

--- a/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
@@ -215,11 +215,11 @@ impl XtensaDebugSequence for ESP32S2 {
         }
 
         // Wait for reset to happen
-        let start = Instant::now();
         std::thread::sleep(Duration::from_millis(100));
+        let start = Instant::now();
         while !core.xdm.read_power_status()?.core_was_reset() {
             if start.elapsed() > timeout {
-                return Err(crate::Error::Timeout);
+                return Err(XtensaError::Timeout.into());
             }
             std::thread::sleep(Duration::from_millis(10));
         }

--- a/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
@@ -191,7 +191,7 @@ impl XtensaDebugSequence for ESP32S3 {
             }
 
             if start.elapsed() >= timeout {
-                return Err(crate::Error::Timeout);
+                return Err(XtensaError::Timeout.into());
             }
         }
 


### PR DESCRIPTION
This PR allows being more lazy about restoring scrach registers, resulting in a bit of a speedup during flashing.