### PR TITLE
SWD: Encompass direction and value of IO sequence into single type 

### DIFF
--- a/changelog/changed-swd-probe-interface-sequence-type.md
+++ b/changelog/changed-swd-probe-interface-sequence-type.md
@@ -1,0 +1,1 @@
+Changed SWD protocol probe interface with a type to allow passing single stream of enums instead of two streams of bits.

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JTAGAccess,
         ProbeCreationError, ProbeFactory, ScanChainElement, WireProtocol,
-        arm_debug_interface::{ProbeStatistics, RawProtocolIo, SwdSettings},
+        arm_debug_interface::{IoSequenceItem, ProbeStatistics, RawProtocolIo, SwdSettings},
         common::{JtagDriverState, RawJtagIo},
     },
 };
@@ -457,10 +457,9 @@ impl RawProtocolIo for FtdiProbe {
         Ok(())
     }
 
-    fn swd_io<D, S>(&mut self, _dir: D, _swdio: S) -> Result<Vec<bool>, DebugProbeError>
+    fn swd_io<S>(&mut self, _swdio: S) -> Result<Vec<bool>, DebugProbeError>
     where
-        D: IntoIterator<Item = bool>,
-        S: IntoIterator<Item = bool>,
+        S: IntoIterator<Item = IoSequenceItem>,
     {
         Err(DebugProbeError::NotImplemented {
             function_name: "swd_io",

--- a/probe-rs/src/probe/jlink/bits.rs
+++ b/probe-rs/src/probe/jlink/bits.rs
@@ -65,7 +65,11 @@ pub(crate) trait IteratorExt: Sized {
     fn collapse_bytes(self) -> ByteIter<Self>;
 }
 
-impl<I: Iterator<Item = bool>> IteratorExt for I {
+impl<I, T> IteratorExt for I
+where
+    I: Iterator<Item = T>,
+    T: Into<bool>,
+{
     fn collapse_bytes(self) -> ByteIter<Self> {
         ByteIter { inner: self }
     }
@@ -75,7 +79,11 @@ pub(crate) struct ByteIter<I> {
     inner: I,
 }
 
-impl<I: Iterator<Item = bool>> Iterator for ByteIter<I> {
+impl<I, T> Iterator for ByteIter<I>
+where
+    I: Iterator<Item = T>,
+    T: Into<bool>,
+{
     type Item = u8;
 
     fn next(&mut self) -> Option<u8> {
@@ -84,7 +92,7 @@ impl<I: Iterator<Item = bool>> Iterator for ByteIter<I> {
         let mut has_data = false;
         for (pos, bit) in self.inner.by_ref().take(8).enumerate() {
             has_data = true;
-            byte |= (bit as u8) << pos;
+            byte |= (bit.into() as u8) << pos;
         }
 
         has_data.then_some(byte)


### PR DESCRIPTION
The change introduces new type for representing data IO sequence values and replaces bool. Only data i.e. SWD-IO and JTAG TDI signals are replaced with new type.

Advantages:

- Binds both logical meanings i.e. Direction and Value into single type

- Encompasses the bus logic sequence of the direction and value into single enum.

- Allows to avoid passing both vectors and thus dismissing all the validation of the lengths before using the sequence

- encourages to produce valid input from the source by more bounds i.e. input does not have value

- more control over conversion: i.e. one may use .into()/.try_into() instead of ‘as’

Disadvantages:

- some extra conversion needed, on a plus side those are simple and should not introduce more performance overhead