### PR TITLE
Move preverify logic down to `probe_rs::flashing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,6 +1217,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,6 +3014,7 @@ dependencies = [
  "clap",
  "docsplay",
  "dunce",
+ "enum-map",
  "env_logger",
  "espflash",
  "fastrand",
@@ -3088,6 +3109,7 @@ dependencies = [
  "directories",
  "docsplay",
  "dunce",
+ "enum-map",
  "fastrand",
  "figment",
  "futures-util",

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -38,6 +38,7 @@ thiserror = { workspace = true }
 tracing = "0.1"
 typed-path = "0.10"
 probe-rs-mi = { workspace = true }
+enum-map = "2.7.3"
 
 itertools = "0.14"
 

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
@@ -34,6 +34,8 @@ pub struct DownloadOptions {
     /// If the chip was pre-erased with external erasers, this flag can set to true to skip erasing
     /// It may be useful for mass production.
     pub skip_erase: bool,
+    /// Before flashing, read back all the flashed data to skip flashing if the device is up to date.
+    pub preverify: bool,
     /// After flashing, read back all the flashed data to verify it has been written correctly.
     pub verify: bool,
     /// Disable double buffering when loading flash.
@@ -84,7 +86,7 @@ impl FlashRequest {
         options.keep_unwritten_bytes = self.options.keep_unwritten_bytes;
         options.do_chip_erase = self.options.do_chip_erase;
         options.skip_erase = self.options.skip_erase;
-        options.preverify = false;
+        options.preverify = self.options.preverify;
         options.verify = self.options.verify;
         options.disable_double_buffering = self.options.disable_double_buffering;
 
@@ -180,6 +182,9 @@ pub struct FlashDataBlockSpan {
 
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Schema)]
 pub enum Operation {
+    /// Checking flash contents prior to writing.
+    Preverify,
+
     /// Reading back flash contents to restore erased regions that should be kept unchanged.
     Fill,
 
@@ -196,6 +201,7 @@ pub enum Operation {
 impl From<flashing::ProgressOperation> for Operation {
     fn from(operation: flashing::ProgressOperation) -> Self {
         match operation {
+            flashing::ProgressOperation::Preverify => Operation::Preverify,
             flashing::ProgressOperation::Fill => Operation::Fill,
             flashing::ProgressOperation::Erase => Operation::Erase,
             flashing::ProgressOperation::Program => Operation::Program,

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
@@ -210,6 +210,18 @@ impl From<flashing::ProgressOperation> for Operation {
     }
 }
 
+impl From<Operation> for flashing::ProgressOperation {
+    fn from(operation: Operation) -> Self {
+        match operation {
+            Operation::Preverify => Self::Preverify,
+            Operation::Fill => Self::Fill,
+            Operation::Erase => Self::Erase,
+            Operation::Program => Self::Program,
+            Operation::Verify => Self::Verify,
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Schema)]
 pub enum ProgressEvent {
     FlashLayoutReady {

--- a/probe-rs-tools/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/flash.rs
@@ -121,6 +121,7 @@ pub fn build_loader(
 }
 
 pub struct ProgressBars {
+    pub preverify: ProgressBarGroup,
     pub erase: ProgressBarGroup,
     pub fill: ProgressBarGroup,
     pub program: ProgressBarGroup,
@@ -241,6 +242,7 @@ impl CliProgressBars {
         logging::set_progress_bar(multi_progress.clone());
 
         let progress_bars = Mutex::new(ProgressBars {
+            preverify: ProgressBarGroup::new(" Preverifying"),
             erase: ProgressBarGroup::new("      Erasing"),
             fill: ProgressBarGroup::new("Reading flash"),
             program: ProgressBarGroup::new("  Programming"),
@@ -268,6 +270,7 @@ impl CliProgressBars {
                     ProgressBar::no_length()
                 });
                 match operation {
+                    Operation::Preverify => progress_bars.preverify.add(bar),
                     Operation::Fill => progress_bars.fill.add(bar),
                     Operation::Erase => progress_bars.erase.add(bar),
                     Operation::Program => progress_bars.program.add(bar),
@@ -276,6 +279,7 @@ impl CliProgressBars {
             }
 
             ProgressEvent::Started(operation) => match operation {
+                Operation::Preverify => progress_bars.preverify.mark_start_now(),
                 Operation::Fill => progress_bars.fill.mark_start_now(),
                 Operation::Erase => progress_bars.erase.mark_start_now(),
                 Operation::Program => progress_bars.program.mark_start_now(),
@@ -283,6 +287,7 @@ impl CliProgressBars {
             },
 
             ProgressEvent::Progress { operation, size } => match operation {
+                Operation::Preverify => progress_bars.preverify.inc(size),
                 Operation::Fill => progress_bars.fill.inc(size),
                 Operation::Erase => progress_bars.erase.inc(size),
                 Operation::Program => progress_bars.program.inc(size),
@@ -290,6 +295,7 @@ impl CliProgressBars {
             },
 
             ProgressEvent::Failed(operation) => match operation {
+                Operation::Preverify => progress_bars.preverify.abandon(),
                 Operation::Fill => progress_bars.fill.abandon(),
                 Operation::Erase => progress_bars.erase.abandon(),
                 Operation::Program => progress_bars.program.abandon(),
@@ -297,6 +303,7 @@ impl CliProgressBars {
             },
 
             ProgressEvent::Finished(operation) => match operation {
+                Operation::Preverify => progress_bars.preverify.finish(),
                 Operation::Fill => progress_bars.fill.finish(),
                 Operation::Erase => progress_bars.erase.finish(),
                 Operation::Program => progress_bars.program.finish(),

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -70,6 +70,7 @@ hexdump = { version = "0.1", optional = true }
 
 rmp-serde = { version = "1" }
 dunce = "1.0.5"
+enum-map = "2.7.3"
 
 [build-dependencies]
 probe-rs-target = { workspace = true, optional = true }

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -424,6 +424,25 @@ impl Flasher {
         result
     }
 
+    /// Verifies all the to-be-written bytes of this flasher prior to flashing.
+    pub(super) fn preverify(
+        &mut self,
+        session: &mut Session,
+        progress: &FlashProgress,
+        ignore_filled: bool,
+    ) -> Result<bool, FlashError> {
+        progress.started_verifying();
+
+        let result = self.do_verify(session, progress, ignore_filled);
+
+        match result.is_ok() {
+            true => progress.finished_preverifying(),
+            false => progress.failed_preverifying(),
+        }
+
+        result
+    }
+
     /// Verifies all the to-be-written bytes of this flasher.
     pub(super) fn verify(
         &mut self,

--- a/probe-rs/src/flashing/progress.rs
+++ b/probe-rs/src/flashing/progress.rs
@@ -115,6 +115,16 @@ impl<'a> FlashProgress<'a> {
         self.emit(ProgressEvent::Finished(ProgressOperation::Program));
     }
 
+    /// Signal that the preverifying procedure failed.
+    pub(super) fn failed_preverifying(&self) {
+        self.emit(ProgressEvent::Failed(ProgressOperation::Preverify));
+    }
+
+    /// Signal that the preverifying procedure completed successfully.
+    pub(super) fn finished_preverifying(&self) {
+        self.emit(ProgressEvent::Finished(ProgressOperation::Preverify));
+    }
+
     /// Signal that the erasing procedure failed.
     pub(super) fn failed_erasing(&self) {
         self.emit(ProgressEvent::Failed(ProgressOperation::Erase));
@@ -153,6 +163,9 @@ impl<'a> FlashProgress<'a> {
 /// The operation that is currently in progress.
 #[derive(Clone, Copy, Debug)]
 pub enum ProgressOperation {
+    /// Checking flash contents prior to writing.
+    Preverify,
+
     /// Reading back flash contents to restore erased regions that should be kept unchanged.
     Fill,
 

--- a/probe-rs/src/flashing/progress.rs
+++ b/probe-rs/src/flashing/progress.rs
@@ -46,113 +46,105 @@ impl<'a> FlashProgress<'a> {
         });
     }
 
+    // -------------
+
+    /// Signal that the procedure started.
+    pub(super) fn started(&self, operation: ProgressOperation) {
+        self.emit(ProgressEvent::Started(operation));
+    }
+
+    /// Signal that the page programming procedure has made progress.
+    pub(super) fn progressed(&self, operation: ProgressOperation, size: u64, time: Duration) {
+        self.emit(ProgressEvent::Progress {
+            operation,
+            size,
+            time,
+        });
+    }
+
+    /// Signal that the procedure failed.
+    pub(super) fn failed(&self, operation: ProgressOperation) {
+        self.emit(ProgressEvent::Failed(operation));
+    }
+
+    /// Signal that the procedure completed successfully.
+    pub(super) fn finished(&self, operation: ProgressOperation) {
+        self.emit(ProgressEvent::Finished(operation));
+    }
+
+    // -------------
+
     pub(super) fn add_progress_bar(&self, operation: ProgressOperation, total: Option<u64>) {
         self.emit(ProgressEvent::AddProgressBar { operation, total });
     }
 
     /// Signal that the erasing procedure started.
     pub(super) fn started_erasing(&self) {
-        self.emit(ProgressEvent::Started(ProgressOperation::Erase));
+        self.started(ProgressOperation::Erase);
     }
 
     /// Signal that the filling procedure started.
     pub(super) fn started_filling(&self) {
-        self.emit(ProgressEvent::Started(ProgressOperation::Fill));
+        self.started(ProgressOperation::Fill);
     }
 
     /// Signal that the programming procedure started.
     pub(super) fn started_programming(&self) {
-        self.emit(ProgressEvent::Started(ProgressOperation::Program));
+        self.started(ProgressOperation::Program);
     }
 
     pub(crate) fn started_verifying(&self) {
-        self.emit(ProgressEvent::Started(ProgressOperation::Verify));
+        self.started(ProgressOperation::Verify);
     }
 
     /// Signal that the page programming procedure has made progress.
     pub(super) fn page_programmed(&self, size: u64, time: Duration) {
-        self.emit(ProgressEvent::Progress {
-            operation: ProgressOperation::Program,
-            size,
-            time,
-        });
+        self.progressed(ProgressOperation::Program, size, time);
     }
 
     /// Signal that the sector erasing procedure has made progress.
     pub(super) fn sector_erased(&self, size: u64, time: Duration) {
-        self.emit(ProgressEvent::Progress {
-            operation: ProgressOperation::Erase,
-            size,
-            time,
-        });
+        self.progressed(ProgressOperation::Erase, size, time);
     }
 
     /// Signal that the page filling procedure has made progress.
     pub(super) fn page_filled(&self, size: u64, time: Duration) {
-        self.emit(ProgressEvent::Progress {
-            operation: ProgressOperation::Fill,
-            size,
-            time,
-        });
+        self.progressed(ProgressOperation::Fill, size, time);
     }
 
     /// Signal that the page filling procedure has made progress.
     pub(super) fn page_verified(&self, size: u64, time: Duration) {
-        self.emit(ProgressEvent::Progress {
-            operation: ProgressOperation::Verify,
-            size,
-            time,
-        });
+        self.progressed(ProgressOperation::Verify, size, time);
     }
 
     /// Signal that the programming procedure failed.
     pub(super) fn failed_programming(&self) {
-        self.emit(ProgressEvent::Failed(ProgressOperation::Program));
+        self.failed(ProgressOperation::Program);
     }
 
     /// Signal that the programming procedure completed successfully.
     pub(super) fn finished_programming(&self) {
-        self.emit(ProgressEvent::Finished(ProgressOperation::Program));
-    }
-
-    /// Signal that the preverifying procedure failed.
-    pub(super) fn failed_preverifying(&self) {
-        self.emit(ProgressEvent::Failed(ProgressOperation::Preverify));
-    }
-
-    /// Signal that the preverifying procedure completed successfully.
-    pub(super) fn finished_preverifying(&self) {
-        self.emit(ProgressEvent::Finished(ProgressOperation::Preverify));
+        self.finished(ProgressOperation::Program);
     }
 
     /// Signal that the erasing procedure failed.
     pub(super) fn failed_erasing(&self) {
-        self.emit(ProgressEvent::Failed(ProgressOperation::Erase));
-    }
-
-    /// Signal that the verifying procedure failed.
-    pub(super) fn failed_verifying(&self) {
-        self.emit(ProgressEvent::Failed(ProgressOperation::Verify));
+        self.failed(ProgressOperation::Erase);
     }
 
     /// Signal that the erasing procedure completed successfully.
     pub(super) fn finished_erasing(&self) {
-        self.emit(ProgressEvent::Finished(ProgressOperation::Erase));
+        self.finished(ProgressOperation::Erase);
     }
 
     /// Signal that the filling procedure failed.
     pub(super) fn failed_filling(&self) {
-        self.emit(ProgressEvent::Failed(ProgressOperation::Fill));
+        self.failed(ProgressOperation::Fill);
     }
 
     /// Signal that the filling procedure completed successfully.
     pub(super) fn finished_filling(&self) {
-        self.emit(ProgressEvent::Finished(ProgressOperation::Fill));
-    }
-
-    /// Signal that the verifying procedure completed successfully.
-    pub(super) fn finished_verifying(&self) {
-        self.emit(ProgressEvent::Finished(ProgressOperation::Verify));
+        self.finished(ProgressOperation::Fill);
     }
 
     pub(super) fn message(&self, message: String) {
@@ -161,7 +153,7 @@ impl<'a> FlashProgress<'a> {
 }
 
 /// The operation that is currently in progress.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, enum_map::Enum)]
 pub enum ProgressOperation {
     /// Checking flash contents prior to writing.
     Preverify,


### PR DESCRIPTION
This makes `--preverify` work on other commands like `cargo flash`, which already accepted the option but did nothing with it.

The functional changes are all in the first commit.

The second commit removes a lot of code that is duplicated for each operation (which became even worse now that I added one). This brings in [`enum_map`](https://crates.io/crates/enum-map/2.7.3) as a dependency, enabling type-safe mappings indexed by `ProgressOperation`. I don't feel too strongly about this being accepted, but deleting code is fun.

I checked that `probe-rs run --preverify` still works.

----

Ideas for future work (don't count on me getting to it):
* The DAP server still does its own preverify (in `Debugger::flash`). It could simply pass `verify_before_flashing` into the `download_options` but it's not something I tested. This would put all preverify logic in one place.
* Instead of reflashing *all* regions on a single mismatch, we could check which regions didn't match and only erase/program those regions. This becomes easier to implement with these changes.
* I'm not immediately finding any existing testing in this area, so that would be nice to have.
* Slight oddity with CLI progress bars: The erase/program/verify bars appear as soon as preverify starts (and then disappear if preverify passes). Not sure whether this is desirable, but it is a visible change from previous `probe-rs run` behaviour.
