### PR TITLE
deny: Allow inapplicable advisory on atomic-polyfill

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -79,6 +79,8 @@ ignore = [
     "RUSTSEC-2024-0436",
     # This is patched upstream and can be removed one `espflash` is released and updated.
     "RUSTSEC-2025-0018",
+    # Dependency from heapless 0.7, showing up in Cargo.lock but not used on std platforms.
+    "RUSTSEC-2023-0089",
 
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score


### PR DESCRIPTION
[RUSTSEC-2023-0089](https://rustsec.org/advisories/RUSTSEC-2023-0089) is an advisory on atomic-polyfill being unmaintained. That is a dependency from heapless 0.7 coming via postcard (where this is [also tracked](https://github.com/jamesmunns/postcard/issues/223)), showing up in Cargo.lock but [not used on std platforms](https://github.com/rust-embedded/heapless/blob/0eea6da5bc159823d0564fcd6974eab299073dcf/Cargo.toml#L30).