### PR TITLE
Add --skip-section option to flashing commands

### DIFF
--- a/changelog/added-skip-section-option.md
+++ b/changelog/added-skip-section-option.md
@@ -1,0 +1,1 @@
+Added `--skip-section` option to flashing commands

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -253,6 +253,15 @@ pub struct IdfCliOptions {
 
 #[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default, Schema)]
 #[serde(default)]
+pub struct ElfCliOptions {
+    /// Section name to skip flashing. This option may be specified multiple times, and is only
+    /// considered when `elf` is selected as the format.
+    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION")]
+    skip_section: Vec<String>,
+}
+
+#[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default, Schema)]
+#[serde(default)]
 pub struct FormatOptions {
     /// If a format is provided, use it.
     /// If a target has a preferred format, we use that.
@@ -270,6 +279,9 @@ pub struct FormatOptions {
 
     #[clap(flatten)]
     idf_options: IdfCliOptions,
+
+    #[clap(flatten)]
+    elf_options: ElfCliOptions,
 }
 
 /// A finite list of all the available binary formats probe-rs understands.

--- a/probe-rs-tools/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/flash.rs
@@ -13,7 +13,7 @@ use colored::Colorize;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use parking_lot::Mutex;
 use probe_rs::InstructionSet;
-use probe_rs::flashing::{BinOptions, FlashProgress, Format, IdfOptions};
+use probe_rs::flashing::{BinOptions, ElfOptions, FlashProgress, Format, IdfOptions};
 use probe_rs::{
     Session,
     flashing::{DownloadOptions, FileDownloadError, FlashLoader},
@@ -106,7 +106,9 @@ pub fn build_loader(
             skip: format_options.bin_options.skip,
         }),
         FormatKind::Hex => Format::Hex,
-        FormatKind::Elf => Format::Elf,
+        FormatKind::Elf => Format::Elf(ElfOptions {
+            skip_sections: format_options.elf_options.skip_section,
+        }),
         FormatKind::Uf2 => Format::Uf2,
         FormatKind::Idf => Format::Idf(IdfOptions {
             bootloader: format_options.idf_options.idf_bootloader.map(PathBuf::from),


### PR DESCRIPTION
I'm working on an application which has ~100 KiB of application code and a ~450KiB firmware image for a WiFi module. In order to speed up iteration, I would like the option to skip reflashing the firmware image when I just made a simple code change.

To this end, this PR adds a `--skip-section` command-line flag to the flashing tools, allowing the user to specify one or more section names from the input ELF file to be skipped during flashing. This way, I can modify my linker script to place the firmware image in a specific section at a constant address, and use this option to avoid flashing that section if I haven't changed the firmware image.