### PR TITLE
Debugger: resolve slices

### DIFF
--- a/changelog/changed-slice-debug.md
+++ b/changelog/changed-slice-debug.md
@@ -1,0 +1,1 @@
+The debugger now turns the data pointer in slices into arrays so that their data can be inspected.

--- a/probe-rs-debug/src/language.rs
+++ b/probe-rs-debug/src/language.rs
@@ -1,9 +1,9 @@
-use gimli::DwLang;
+use gimli::{DebuggingInformationEntry, DwLang};
 use probe_rs::MemoryInterface;
 
 use crate::{
-    Bitfield, DebugError, Modifier, Variable, VariableCache, VariableName, VariableType,
-    VariableValue,
+    Bitfield, DebugError, DebugInfo, GimliReader, Modifier, Variable, VariableCache, VariableName,
+    VariableType, VariableValue, stack_frame::StackFrameInfo, unit_info::UnitInfo,
 };
 
 /// C, C89, C99, C11, ...
@@ -72,6 +72,20 @@ pub trait ProgrammingLanguage {
             Modifier::Atomic => format!("_Atomic {}", name),
             Modifier::Typedef(ty) => ty.to_string(),
         }
+    }
+
+    // Post-process raw type representations for more user-friendly output.
+    fn process_struct(
+        &self,
+        _unit_info: &UnitInfo,
+        _debug_info: &DebugInfo,
+        _node: &DebuggingInformationEntry<GimliReader>,
+        _variable: &mut Variable,
+        _memory: &mut dyn MemoryInterface,
+        _cache: &mut VariableCache,
+        _frame_info: StackFrameInfo<'_>,
+    ) -> Result<(), DebugError> {
+        Ok(())
     }
 }
 

--- a/probe-rs-debug/src/language.rs
+++ b/probe-rs-debug/src/language.rs
@@ -75,6 +75,7 @@ pub trait ProgrammingLanguage {
     }
 
     // Post-process raw type representations for more user-friendly output.
+    #[allow(clippy::too_many_arguments)]
     fn process_struct(
         &self,
         _unit_info: &UnitInfo,

--- a/probe-rs-debug/src/language/rust.rs
+++ b/probe-rs-debug/src/language/rust.rs
@@ -1,15 +1,96 @@
 use crate::{
-    DebugError, Variable, VariableCache, VariableLocation, VariableName, VariableType,
-    VariableValue,
+    DebugError, DebugInfo, GimliReader, ObjectRef, Variable, VariableCache, VariableLocation,
+    VariableName, VariableNodeType, VariableType, VariableValue,
     language::{
         ProgrammingLanguage,
         value::{Value, format_float},
     },
+    stack_frame::StackFrameInfo,
+    unit_info::UnitInfo,
 };
 
+use gimli::DebuggingInformationEntry;
 use probe_rs::MemoryInterface;
 #[derive(Debug, Clone)]
 pub struct Rust;
+impl Rust {
+    /// Replaces *const data pointer with *const [data; len] in slices.
+    fn expand_slice(
+        &self,
+        unit_info: &UnitInfo,
+        debug_info: &DebugInfo,
+        _node: &DebuggingInformationEntry<GimliReader>,
+        variable: &mut Variable,
+        memory: &mut dyn MemoryInterface,
+        cache: &mut VariableCache,
+        frame_info: StackFrameInfo<'_>,
+    ) -> Result<(), DebugError> {
+        let mut children = cache.get_children(variable.variable_key);
+        fn is_field(var: &Variable, name: &str) -> bool {
+            matches!(var.name, VariableName::Named(ref var_name) if var_name == name)
+        }
+
+        // Do we have a length?
+        let Some(length) = children.clone().find(|c| is_field(c, "length")) else {
+            return Ok(());
+        };
+        let VariableValue::Valid(length_value) = &length.value else {
+            return Ok(());
+        };
+        let length = length_value.parse().unwrap_or(0_usize);
+
+        // Do we have a data pointer?
+        let Some(location) = children.find(|c| is_field(c, "data_ptr")) else {
+            return Ok(());
+        };
+
+        // Turn the data pointer into an array.
+        let pointer_key = location.variable_key;
+
+        std::mem::drop(children);
+
+        let mut pointee = cache.get_children(pointer_key).cloned().next().unwrap();
+
+        // Do we know the type of the data?
+        let Some(type_node_offset) = pointee.type_node_offset else {
+            return Ok(());
+        };
+
+        // Let's just remove the pointer. While it may be interesting where the data is, the
+        // address can be read using the debugger, and is otherwise just noise on the UI.
+        cache.remove_cache_entry(pointer_key)?;
+
+        // Replace the pointee type with an array of known length. We don't have to modify the
+        // memory location, as the pointer is already pointing to the first element of the array.
+        pointee.parent_key = ObjectRef::Invalid;
+        pointee.variable_key = ObjectRef::Invalid;
+        pointee.value = VariableValue::Empty;
+        pointee.type_name = VariableType::Array {
+            item_type_name: { Box::new(pointee.type_name) },
+            count: length,
+        };
+        pointee.variable_node_type = VariableNodeType::RecurseToBaseType;
+
+        cache.add_variable(variable.variable_key, &mut pointee)?;
+
+        let array_member_type_node = unit_info
+            .unit
+            .entry(type_node_offset)
+            .expect("Failed to get array member type node. This is a bug, please report it!");
+
+        unit_info.expand_array_members(
+            debug_info,
+            &array_member_type_node,
+            cache,
+            &mut pointee,
+            memory,
+            &[0..length as u64],
+            frame_info,
+        )?;
+
+        Ok(())
+    }
+}
 
 impl ProgrammingLanguage for Rust {
     fn read_variable_value(
@@ -119,10 +200,30 @@ impl ProgrammingLanguage for Rust {
 
     fn auto_resolve_children(&self, name: &str) -> bool {
         name.starts_with("&str")
+            || name.starts_with("&[")
             || name.starts_with("Option")
             || name.starts_with("Some")
             || name.starts_with("Result")
             || name.starts_with("Ok")
             || name.starts_with("Err")
+    }
+
+    fn process_struct(
+        &self,
+        unit_info: &UnitInfo,
+        debug_info: &DebugInfo,
+        node: &DebuggingInformationEntry<GimliReader>,
+        variable: &mut Variable,
+        memory: &mut dyn MemoryInterface,
+        cache: &mut VariableCache,
+        frame_info: StackFrameInfo<'_>,
+    ) -> Result<(), DebugError> {
+        if variable.type_name().starts_with("&[") {
+            self.expand_slice(
+                unit_info, debug_info, node, variable, memory, cache, frame_info,
+            )?;
+        }
+
+        Ok(())
     }
 }

--- a/probe-rs-debug/src/language/rust.rs
+++ b/probe-rs-debug/src/language/rust.rs
@@ -15,6 +15,7 @@ use probe_rs::MemoryInterface;
 pub struct Rust;
 impl Rust {
     /// Replaces *const data pointer with *const [data; len] in slices.
+    #[allow(clippy::too_many_arguments)]
     fn expand_slice(
         &self,
         unit_info: &UnitInfo,
@@ -49,7 +50,7 @@ impl Rust {
 
         std::mem::drop(children);
 
-        let mut pointee = cache.get_children(pointer_key).cloned().next().unwrap();
+        let mut pointee = cache.get_children(pointer_key).next().unwrap().clone();
 
         // Do we know the type of the data?
         let Some(type_node_offset) = pointee.type_node_offset else {
@@ -78,13 +79,14 @@ impl Rust {
             .entry(type_node_offset)
             .expect("Failed to get array member type node. This is a bug, please report it!");
 
+        let member_range = 0..length as u64;
         unit_info.expand_array_members(
             debug_info,
             &array_member_type_node,
             cache,
             &mut pointee,
             memory,
-            &[0..length as u64],
+            &[member_range],
             frame_info,
         )?;
 

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32s3_esp_hal_panic.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32s3_esp_hal_panic.snap
@@ -233,16 +233,24 @@ expression: stack_frames
                           value: "&[&str] @ 0x3FCDC414"
                           children:
                             - name:
-                                Named: data_ptr
+                                Named: length
                               type_name:
-                                Pointer: "&str"
-                              value: "&str @ 0x3FCDC414"
+                                Base: usize
+                              value: "1"
+                            - name:
+                                Named: "*data_ptr"
+                              type_name:
+                                Array:
+                                  item_type_name:
+                                    Struct: "&str"
+                                  count: 1
+                              value: "[&str; 1] = [\n\t< WarnAndContinue { message: \"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\" } >]"
                               children:
                                 - name:
-                                    Named: "*data_ptr"
+                                    Indexed: 0
                                   type_name:
                                     Struct: "&str"
-                                  value: "< WarnAndContinue { message: \"Variable does not have a memory location: location=Error(\\\"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\\\")\" } >"
+                                  value: "< WarnAndContinue { message: \"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\" } >"
                                   children:
                                     - name:
                                         Named: data_ptr
@@ -254,17 +262,12 @@ expression: stack_frames
                                             Named: "*data_ptr"
                                           type_name:
                                             Base: u8
-                                          value: "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location"
+                                          value: "Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4."
                                     - name:
                                         Named: length
                                       type_name:
                                         Base: usize
                                       value: "< Probe(Other(\"The coredump does not include the memory for address 0x3c010688 of size 0x4\")) >"
-                            - name:
-                                Named: length
-                              type_name:
-                                Base: usize
-                              value: "1"
                         - name:
                             Named: fmt
                           type_name:
@@ -283,50 +286,18 @@ expression: stack_frames
                           value: "&[core::fmt::rt::Argument] @ 0x3FCDC41C"
                           children:
                             - name:
-                                Named: data_ptr
-                              type_name:
-                                Pointer: Argument
-                              value: "*raw Argument @ 0x3FCDC41C"
-                              children:
-                                - name:
-                                    Named: "*data_ptr"
-                                  type_name:
-                                    Struct: Argument
-                                  value: Argument @ 0x00000004
-                                  children:
-                                    - name:
-                                        Named: ty
-                                      type_name:
-                                        Struct: ArgumentType
-                                      value: ArgumentType @ 0x00000004
-                                      children:
-                                        - name:
-                                            Named: Placeholder
-                                          type_name:
-                                            Struct: Placeholder
-                                          value: Placeholder @ 0x00000004
-                                          children:
-                                            - name:
-                                                Named: value
-                                              type_name:
-                                                Struct: NonNull<()>
-                                              value: NonNull<()> @ 0x00000004
-                                            - name:
-                                                Named: formatter
-                                              type_name:
-                                                Pointer: "unsafe fn(core::ptr::non_null::NonNull<()>, &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error>"
-                                              value: "*raw unsafe fn(core::ptr::non_null::NonNull<()>, &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error> @ 0x00000008"
-                                              children:
-                                                - name:
-                                                    Named: "*formatter"
-                                                  type_name:
-                                                    Other: "Result<(), core::fmt::Error>"
-                                                  value: "Unimplemented: Get value of type Other(\"Result<(), core::fmt::Error>\") of (None bytes) at location <unknown value>"
-                            - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "0"
+                            - name:
+                                Named: "*data_ptr"
+                              type_name:
+                                Array:
+                                  item_type_name:
+                                    Struct: Argument
+                                  count: 0
+                              value: "[Argument; 0] = []"
                 - name:
                     Named: location
                   type_name:
@@ -343,7 +314,7 @@ expression: stack_frames
                             Named: file
                           type_name:
                             Struct: "&str"
-                          value: "< WarnAndContinue { message: \"Variable does not have a memory location: location=Error(\\\"Failed to read referenced variable address from memory location 0x3C01069C : The coredump does not include the memory for address 0x3c01069c of size 0x4.\\\")\" } >"
+                          value: "< WarnAndContinue { message: \"Failed to read referenced variable address from memory location 0x3C01069C : The coredump does not include the memory for address 0x3c01069c of size 0x4.\" } >"
                           children:
                             - name:
                                 Named: data_ptr
@@ -355,7 +326,7 @@ expression: stack_frames
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
-                                  value: "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location"
+                                  value: "Failed to read referenced variable address from memory location 0x3C01069C : The coredump does not include the memory for address 0x3c01069c of size 0x4."
                             - name:
                                 Named: length
                               type_name:
@@ -616,16 +587,24 @@ expression: stack_frames
                                   value: "&[&str] @ 0x3FCDC414"
                                   children:
                                     - name:
-                                        Named: data_ptr
+                                        Named: length
                                       type_name:
-                                        Pointer: "&str"
-                                      value: "&str @ 0x3FCDC414"
+                                        Base: usize
+                                      value: "1"
+                                    - name:
+                                        Named: "*data_ptr"
+                                      type_name:
+                                        Array:
+                                          item_type_name:
+                                            Struct: "&str"
+                                          count: 1
+                                      value: "[&str; 1] = [\n\t< WarnAndContinue { message: \"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\" } >]"
                                       children:
                                         - name:
-                                            Named: "*data_ptr"
+                                            Indexed: 0
                                           type_name:
                                             Struct: "&str"
-                                          value: "< WarnAndContinue { message: \"Variable does not have a memory location: location=Error(\\\"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\\\")\" } >"
+                                          value: "< WarnAndContinue { message: \"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\" } >"
                                           children:
                                             - name:
                                                 Named: data_ptr
@@ -637,17 +616,12 @@ expression: stack_frames
                                                     Named: "*data_ptr"
                                                   type_name:
                                                     Base: u8
-                                                  value: "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location"
+                                                  value: "Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4."
                                             - name:
                                                 Named: length
                                               type_name:
                                                 Base: usize
                                               value: "< Probe(Other(\"The coredump does not include the memory for address 0x3c010688 of size 0x4\")) >"
-                                    - name:
-                                        Named: length
-                                      type_name:
-                                        Base: usize
-                                      value: "1"
                                 - name:
                                     Named: fmt
                                   type_name:
@@ -666,27 +640,18 @@ expression: stack_frames
                                   value: "&[core::fmt::rt::Argument] @ 0x3FCDC41C"
                                   children:
                                     - name:
-                                        Named: data_ptr
-                                      type_name:
-                                        Pointer: Argument
-                                      value: "*raw Argument @ 0x3FCDC41C"
-                                      children:
-                                        - name:
-                                            Named: "*data_ptr"
-                                          type_name:
-                                            Struct: Argument
-                                          value: Argument @ 0x00000004
-                                          children:
-                                            - name:
-                                                Named: ty
-                                              type_name:
-                                                Struct: ArgumentType
-                                              value: ArgumentType @ 0x00000004
-                                    - name:
                                         Named: length
                                       type_name:
                                         Base: usize
                                       value: "0"
+                                    - name:
+                                        Named: "*data_ptr"
+                                      type_name:
+                                        Array:
+                                          item_type_name:
+                                            Struct: Argument
+                                          count: 0
+                                      value: "[Argument; 0] = []"
                         - name:
                             Named: location
                           type_name:
@@ -703,7 +668,7 @@ expression: stack_frames
                                     Named: file
                                   type_name:
                                     Struct: "&str"
-                                  value: "< WarnAndContinue { message: \"Variable does not have a memory location: location=Error(\\\"Failed to read referenced variable address from memory location 0x3C01069C : The coredump does not include the memory for address 0x3c01069c of size 0x4.\\\")\" } >"
+                                  value: "< WarnAndContinue { message: \"Failed to read referenced variable address from memory location 0x3C01069C : The coredump does not include the memory for address 0x3c01069c of size 0x4.\" } >"
                                   children:
                                     - name:
                                         Named: data_ptr
@@ -715,7 +680,7 @@ expression: stack_frames
                                             Named: "*data_ptr"
                                           type_name:
                                             Base: u8
-                                          value: "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location"
+                                          value: "Failed to read referenced variable address from memory location 0x3C01069C : The coredump does not include the memory for address 0x3c01069c of size 0x4."
                                     - name:
                                         Named: length
                                       type_name:
@@ -1002,16 +967,24 @@ expression: stack_frames
                           value: "&[&str] @ 0x3FCDC414"
                           children:
                             - name:
-                                Named: data_ptr
+                                Named: length
                               type_name:
-                                Pointer: "&str"
-                              value: "&str @ 0x3FCDC414"
+                                Base: usize
+                              value: "1"
+                            - name:
+                                Named: "*data_ptr"
+                              type_name:
+                                Array:
+                                  item_type_name:
+                                    Struct: "&str"
+                                  count: 1
+                              value: "[&str; 1] = [\n\t< WarnAndContinue { message: \"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\" } >]"
                               children:
                                 - name:
-                                    Named: "*data_ptr"
+                                    Indexed: 0
                                   type_name:
                                     Struct: "&str"
-                                  value: "< WarnAndContinue { message: \"Variable does not have a memory location: location=Error(\\\"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\\\")\" } >"
+                                  value: "< WarnAndContinue { message: \"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\" } >"
                                   children:
                                     - name:
                                         Named: data_ptr
@@ -1023,17 +996,12 @@ expression: stack_frames
                                             Named: "*data_ptr"
                                           type_name:
                                             Base: u8
-                                          value: "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location"
+                                          value: "Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4."
                                     - name:
                                         Named: length
                                       type_name:
                                         Base: usize
                                       value: "< Probe(Other(\"The coredump does not include the memory for address 0x3c010688 of size 0x4\")) >"
-                            - name:
-                                Named: length
-                              type_name:
-                                Base: usize
-                              value: "1"
                         - name:
                             Named: fmt
                           type_name:
@@ -1052,50 +1020,18 @@ expression: stack_frames
                           value: "&[core::fmt::rt::Argument] @ 0x3FCDC41C"
                           children:
                             - name:
-                                Named: data_ptr
-                              type_name:
-                                Pointer: Argument
-                              value: "*raw Argument @ 0x3FCDC41C"
-                              children:
-                                - name:
-                                    Named: "*data_ptr"
-                                  type_name:
-                                    Struct: Argument
-                                  value: Argument @ 0x00000004
-                                  children:
-                                    - name:
-                                        Named: ty
-                                      type_name:
-                                        Struct: ArgumentType
-                                      value: ArgumentType @ 0x00000004
-                                      children:
-                                        - name:
-                                            Named: Placeholder
-                                          type_name:
-                                            Struct: Placeholder
-                                          value: Placeholder @ 0x00000004
-                                          children:
-                                            - name:
-                                                Named: value
-                                              type_name:
-                                                Struct: NonNull<()>
-                                              value: NonNull<()> @ 0x00000004
-                                            - name:
-                                                Named: formatter
-                                              type_name:
-                                                Pointer: "unsafe fn(core::ptr::non_null::NonNull<()>, &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error>"
-                                              value: "*raw unsafe fn(core::ptr::non_null::NonNull<()>, &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error> @ 0x00000008"
-                                              children:
-                                                - name:
-                                                    Named: "*formatter"
-                                                  type_name:
-                                                    Other: "Result<(), core::fmt::Error>"
-                                                  value: "Unimplemented: Get value of type Other(\"Result<(), core::fmt::Error>\") of (None bytes) at location <unknown value>"
-                            - name:
                                 Named: length
                               type_name:
                                 Base: usize
                               value: "0"
+                            - name:
+                                Named: "*data_ptr"
+                              type_name:
+                                Array:
+                                  item_type_name:
+                                    Struct: Argument
+                                  count: 0
+                              value: "[Argument; 0] = []"
                 - name:
                     Named: location
                   type_name:
@@ -1112,7 +1048,7 @@ expression: stack_frames
                             Named: file
                           type_name:
                             Struct: "&str"
-                          value: "< WarnAndContinue { message: \"Variable does not have a memory location: location=Error(\\\"Failed to read referenced variable address from memory location 0x3C01069C : The coredump does not include the memory for address 0x3c01069c of size 0x4.\\\")\" } >"
+                          value: "< WarnAndContinue { message: \"Failed to read referenced variable address from memory location 0x3C01069C : The coredump does not include the memory for address 0x3c01069c of size 0x4.\" } >"
                           children:
                             - name:
                                 Named: data_ptr
@@ -1124,7 +1060,7 @@ expression: stack_frames
                                     Named: "*data_ptr"
                                   type_name:
                                     Base: u8
-                                  value: "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location"
+                                  value: "Failed to read referenced variable address from memory location 0x3C01069C : The coredump does not include the memory for address 0x3c01069c of size 0x4."
                             - name:
                                 Named: length
                               type_name:
@@ -1355,16 +1291,24 @@ expression: stack_frames
               value: "&[&str] @ 0x3FCDC414"
               children:
                 - name:
-                    Named: data_ptr
+                    Named: length
                   type_name:
-                    Pointer: "&str"
-                  value: "&str @ 0x3FCDC414"
+                    Base: usize
+                  value: "1"
+                - name:
+                    Named: "*data_ptr"
+                  type_name:
+                    Array:
+                      item_type_name:
+                        Struct: "&str"
+                      count: 1
+                  value: "[&str; 1] = [\n\t< WarnAndContinue { message: \"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\" } >]"
                   children:
                     - name:
-                        Named: "*data_ptr"
+                        Indexed: 0
                       type_name:
                         Struct: "&str"
-                      value: "< WarnAndContinue { message: \"Variable does not have a memory location: location=Error(\\\"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\\\")\" } >"
+                      value: "< WarnAndContinue { message: \"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\" } >"
                       children:
                         - name:
                             Named: data_ptr
@@ -1376,17 +1320,12 @@ expression: stack_frames
                                 Named: "*data_ptr"
                               type_name:
                                 Base: u8
-                              value: "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location"
+                              value: "Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4."
                         - name:
                             Named: length
                           type_name:
                             Base: usize
                           value: "< Probe(Other(\"The coredump does not include the memory for address 0x3c010688 of size 0x4\")) >"
-                - name:
-                    Named: length
-                  type_name:
-                    Base: usize
-                  value: "1"
             - name:
                 Named: fmt
               type_name:
@@ -1405,56 +1344,18 @@ expression: stack_frames
               value: "&[core::fmt::rt::Argument] @ 0x3FCDC41C"
               children:
                 - name:
-                    Named: data_ptr
-                  type_name:
-                    Pointer: Argument
-                  value: "*raw Argument @ 0x3FCDC41C"
-                  children:
-                    - name:
-                        Named: "*data_ptr"
-                      type_name:
-                        Struct: Argument
-                      value: Argument @ 0x00000004
-                      children:
-                        - name:
-                            Named: ty
-                          type_name:
-                            Struct: ArgumentType
-                          value: ArgumentType @ 0x00000004
-                          children:
-                            - name:
-                                Named: Placeholder
-                              type_name:
-                                Struct: Placeholder
-                              value: Placeholder @ 0x00000004
-                              children:
-                                - name:
-                                    Named: value
-                                  type_name:
-                                    Struct: NonNull<()>
-                                  value: NonNull<()> @ 0x00000004
-                                  children:
-                                    - name:
-                                        Named: pointer
-                                      type_name:
-                                        Pointer: "*const ()"
-                                      value: "*const () @ 0x00000004"
-                                - name:
-                                    Named: formatter
-                                  type_name:
-                                    Pointer: "unsafe fn(core::ptr::non_null::NonNull<()>, &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error>"
-                                  value: "*raw unsafe fn(core::ptr::non_null::NonNull<()>, &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error> @ 0x00000008"
-                                  children:
-                                    - name:
-                                        Named: "*formatter"
-                                      type_name:
-                                        Other: "Result<(), core::fmt::Error>"
-                                      value: "Unimplemented: Get value of type Other(\"Result<(), core::fmt::Error>\") of (None bytes) at location <unknown value>"
-                - name:
                     Named: length
                   type_name:
                     Base: usize
                   value: "0"
+                - name:
+                    Named: "*data_ptr"
+                  type_name:
+                    Array:
+                      item_type_name:
+                        Struct: Argument
+                      count: 0
+                  value: "[Argument; 0] = []"
         - name:
             Named: pi
           type_name:
@@ -1485,16 +1386,24 @@ expression: stack_frames
                       value: "&[&str] @ 0x3FCDC414"
                       children:
                         - name:
-                            Named: data_ptr
+                            Named: length
                           type_name:
-                            Pointer: "&str"
-                          value: "&str @ 0x3FCDC414"
+                            Base: usize
+                          value: "1"
+                        - name:
+                            Named: "*data_ptr"
+                          type_name:
+                            Array:
+                              item_type_name:
+                                Struct: "&str"
+                              count: 1
+                          value: "[&str; 1] = [\n\t< WarnAndContinue { message: \"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\" } >]"
                           children:
                             - name:
-                                Named: "*data_ptr"
+                                Indexed: 0
                               type_name:
                                 Struct: "&str"
-                              value: "< WarnAndContinue { message: \"Variable does not have a memory location: location=Error(\\\"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\\\")\" } >"
+                              value: "< WarnAndContinue { message: \"Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4.\" } >"
                               children:
                                 - name:
                                     Named: data_ptr
@@ -1506,17 +1415,12 @@ expression: stack_frames
                                         Named: "*data_ptr"
                                       type_name:
                                         Base: u8
-                                      value: "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location"
+                                      value: "Failed to read referenced variable address from memory location 0x3C010684 : The coredump does not include the memory for address 0x3c010684 of size 0x4."
                                 - name:
                                     Named: length
                                   type_name:
                                     Base: usize
                                   value: "< Probe(Other(\"The coredump does not include the memory for address 0x3c010688 of size 0x4\")) >"
-                        - name:
-                            Named: length
-                          type_name:
-                            Base: usize
-                          value: "1"
                     - name:
                         Named: fmt
                       type_name:
@@ -1535,56 +1439,18 @@ expression: stack_frames
                       value: "&[core::fmt::rt::Argument] @ 0x3FCDC41C"
                       children:
                         - name:
-                            Named: data_ptr
-                          type_name:
-                            Pointer: Argument
-                          value: "*raw Argument @ 0x3FCDC41C"
-                          children:
-                            - name:
-                                Named: "*data_ptr"
-                              type_name:
-                                Struct: Argument
-                              value: Argument @ 0x00000004
-                              children:
-                                - name:
-                                    Named: ty
-                                  type_name:
-                                    Struct: ArgumentType
-                                  value: ArgumentType @ 0x00000004
-                                  children:
-                                    - name:
-                                        Named: Placeholder
-                                      type_name:
-                                        Struct: Placeholder
-                                      value: Placeholder @ 0x00000004
-                                      children:
-                                        - name:
-                                            Named: value
-                                          type_name:
-                                            Struct: NonNull<()>
-                                          value: NonNull<()> @ 0x00000004
-                                          children:
-                                            - name:
-                                                Named: pointer
-                                              type_name:
-                                                Pointer: "*const ()"
-                                              value: "*const () @ 0x00000004"
-                                        - name:
-                                            Named: formatter
-                                          type_name:
-                                            Pointer: "unsafe fn(core::ptr::non_null::NonNull<()>, &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error>"
-                                          value: "*raw unsafe fn(core::ptr::non_null::NonNull<()>, &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error> @ 0x00000008"
-                                          children:
-                                            - name:
-                                                Named: "*formatter"
-                                              type_name:
-                                                Other: "Result<(), core::fmt::Error>"
-                                              value: "Unimplemented: Get value of type Other(\"Result<(), core::fmt::Error>\") of (None bytes) at location <unknown value>"
-                        - name:
                             Named: length
                           type_name:
                             Base: usize
                           value: "0"
+                        - name:
+                            Named: "*data_ptr"
+                          type_name:
+                            Array:
+                              item_type_name:
+                                Struct: Argument
+                              count: 0
+                          value: "[Argument; 0] = []"
             - name:
                 Named: location
               type_name:
@@ -1601,7 +1467,7 @@ expression: stack_frames
                         Named: file
                       type_name:
                         Struct: "&str"
-                      value: "< WarnAndContinue { message: \"Variable does not have a memory location: location=Error(\\\"Failed to read referenced variable address from memory location 0x3C01069C : The coredump does not include the memory for address 0x3c01069c of size 0x4.\\\")\" } >"
+                      value: "< WarnAndContinue { message: \"Failed to read referenced variable address from memory location 0x3C01069C : The coredump does not include the memory for address 0x3c01069c of size 0x4.\" } >"
                       children:
                         - name:
                             Named: data_ptr
@@ -1613,7 +1479,7 @@ expression: stack_frames
                                 Named: "*data_ptr"
                               type_name:
                                 Base: u8
-                              value: "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location"
+                              value: "Failed to read referenced variable address from memory location 0x3C01069C : The coredump does not include the memory for address 0x3c01069c of size 0x4."
                         - name:
                             Named: length
                           type_name:

--- a/probe-rs-debug/src/unit_info.rs
+++ b/probe-rs-debug/src/unit_info.rs
@@ -1081,46 +1081,16 @@ impl UnitInfo {
                 }
             }
             gimli::DW_TAG_structure_type => {
-                let type_name = type_name.unwrap_or_else(|| "<unnamed struct>".to_string());
-                child_variable.type_name = VariableType::Struct(type_name.clone());
-
-                self.process_memory_location(
+                self.extract_struct(
+                    type_name,
                     debug_info,
                     node,
                     parent_variable,
                     child_variable,
                     memory,
+                    cache,
                     frame_info,
                 )?;
-
-                if child_variable.memory_location != VariableLocation::Unavailable {
-                    // The default behaviour is to defer the processing of child types.
-                    child_variable.variable_node_type =
-                        VariableNodeType::TypeOffset(self.debug_info_offset()?, node.offset());
-                    // In some cases, it really simplifies the UX if we can auto resolve the
-                    // children and derive a value that is visible at first glance to the user.
-                    if self.language.auto_resolve_children(&type_name) {
-                        let temp_node_type = std::mem::replace(
-                            &mut child_variable.variable_node_type,
-                            VariableNodeType::RecurseToBaseType,
-                        );
-
-                        let mut tree = self.unit.entries_tree(Some(node.offset()))?;
-
-                        self.process_tree(
-                            debug_info,
-                            tree.root()?,
-                            child_variable,
-                            memory,
-                            cache,
-                            frame_info,
-                        )?;
-                        child_variable.variable_node_type = temp_node_type;
-                    }
-                } else {
-                    // If something is already broken, then do nothing ...
-                    child_variable.variable_node_type = VariableNodeType::DoNotRecurse;
-                }
             }
             gimli::DW_TAG_enumeration_type => {
                 self.extract_enumeration_type(
@@ -1279,6 +1249,61 @@ impl UnitInfo {
 
         child_variable.extract_value(memory, cache);
         cache.update_variable(child_variable)?;
+
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn extract_struct(
+        &self,
+        type_name: Option<String>,
+        debug_info: &DebugInfo,
+        node: &DebuggingInformationEntry<GimliReader>,
+        parent_variable: &Variable,
+        child_variable: &mut Variable,
+        memory: &mut dyn MemoryInterface,
+        cache: &mut VariableCache,
+        frame_info: StackFrameInfo<'_>,
+    ) -> Result<(), DebugError> {
+        let type_name = type_name.unwrap_or_else(|| "<unnamed struct>".to_string());
+        child_variable.type_name = VariableType::Struct(type_name.clone());
+        self.process_memory_location(
+            debug_info,
+            node,
+            parent_variable,
+            child_variable,
+            memory,
+            frame_info,
+        )?;
+
+        if child_variable.memory_location != VariableLocation::Unavailable {
+            // The default behaviour is to defer the processing of child types.
+            child_variable.variable_node_type =
+                VariableNodeType::TypeOffset(self.debug_info_offset()?, node.offset());
+            // In some cases, it really simplifies the UX if we can auto resolve the
+            // children and derive a value that is visible at first glance to the user.
+            if self.language.auto_resolve_children(&type_name) {
+                let temp_node_type = std::mem::replace(
+                    &mut child_variable.variable_node_type,
+                    VariableNodeType::RecurseToBaseType,
+                );
+
+                let mut tree = self.unit.entries_tree(Some(node.offset()))?;
+
+                self.process_tree(
+                    debug_info,
+                    tree.root()?,
+                    child_variable,
+                    memory,
+                    cache,
+                    frame_info,
+                )?;
+                child_variable.variable_node_type = temp_node_type;
+            }
+        } else {
+            // If something is already broken, then do nothing ...
+            child_variable.variable_node_type = VariableNodeType::DoNotRecurse;
+        }
 
         Ok(())
     }

--- a/probe-rs-debug/src/unit_info.rs
+++ b/probe-rs-debug/src/unit_info.rs
@@ -2029,15 +2029,13 @@ impl UnitInfo {
         // Address Pointer Conditions (any of):
         // 1. Variable names that start with '*' (e.g '*__0), AND the variable is a variant of the parent.
         // 2. Pointer names that start with '*' (e.g. '*const u8')
-        // 3. Pointers to base types (includes &str types)
-        // 4. Pointers to variable names that start with `*`
-        // 5. Pointers to types with refrenced memory addresses (e.g. variants, generics, arrays, etc.)
+        // 3. Pointers to variable names that start with `*`
+        // 4. Pointers to types with refrenced memory addresses (e.g. variants, generics, arrays, etc.)
         (matches!(child_variable.name, VariableName::Named(ref var_name) if var_name.starts_with('*'))
                 && matches!(parent_variable.role, VariantRole::VariantPart(_)))
             || matches!(&parent_variable.type_name, VariableType::Pointer(Some(pointer_name)) if pointer_name.starts_with('*'))
             || (matches!(&parent_variable.type_name, VariableType::Pointer(_))
                 && (matches!(child_variable.type_name, VariableType::Base(_))
-                    || matches!(child_variable.type_name, VariableType::Struct(ref type_name) if type_name.starts_with("&str"))
                     || matches!(child_variable.name, VariableName::Named(ref var_name) if var_name.starts_with('*'))
                     || self.has_address_pointer(unit_ref).unwrap_or_else(|error| {
                         child_variable.set_value(VariableValue::Error(format!("Failed to determine if a struct has variant or generic type fields: {error}")));

--- a/probe-rs-debug/src/unit_info.rs
+++ b/probe-rs-debug/src/unit_info.rs
@@ -989,6 +989,7 @@ impl UnitInfo {
 
             return Ok(());
         }
+        child_variable.type_node_offset = Some(node.offset());
 
         match node.tag() {
             gimli::DW_TAG_base_type => {
@@ -1305,7 +1306,15 @@ impl UnitInfo {
             child_variable.variable_node_type = VariableNodeType::DoNotRecurse;
         }
 
-        Ok(())
+        self.language.process_struct(
+            self,
+            debug_info,
+            node,
+            child_variable,
+            memory,
+            cache,
+            frame_info,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1494,7 +1503,7 @@ impl UnitInfo {
 
     /// Create child variable entries to represent array members and their values.
     #[allow(clippy::too_many_arguments)]
-    fn expand_array_members(
+    pub(crate) fn expand_array_members(
         &self,
         debug_info: &DebugInfo,
         array_member_type_node: &DebuggingInformationEntry<GimliReader>,

--- a/probe-rs-debug/src/unit_info.rs
+++ b/probe-rs-debug/src/unit_info.rs
@@ -2063,13 +2063,15 @@ impl UnitInfo {
         // Address Pointer Conditions (any of):
         // 1. Variable names that start with '*' (e.g '*__0), AND the variable is a variant of the parent.
         // 2. Pointer names that start with '*' (e.g. '*const u8')
-        // 3. Pointers to variable names that start with `*`
-        // 4. Pointers to types with refrenced memory addresses (e.g. variants, generics, arrays, etc.)
+        // 3. Pointers to base types (includes &str types)
+        // 4. Pointers to variable names that start with `*`
+        // 5. Pointers to types with refrenced memory addresses (e.g. variants, generics, arrays, etc.)
         (matches!(child_variable.name, VariableName::Named(ref var_name) if var_name.starts_with('*'))
                 && matches!(parent_variable.role, VariantRole::VariantPart(_)))
             || matches!(&parent_variable.type_name, VariableType::Pointer(Some(pointer_name)) if pointer_name.starts_with('*'))
             || (matches!(&parent_variable.type_name, VariableType::Pointer(_))
                 && (matches!(child_variable.type_name, VariableType::Base(_))
+                    || matches!(child_variable.type_name, VariableType::Struct(ref type_name) if type_name.starts_with("&str"))
                     || matches!(child_variable.name, VariableName::Named(ref var_name) if var_name.starts_with('*'))
                     || self.has_address_pointer(unit_ref).unwrap_or_else(|error| {
                         child_variable.set_value(VariableValue::Error(format!("Failed to determine if a struct has variant or generic type fields: {error}")));

--- a/probe-rs-debug/src/variable.rs
+++ b/probe-rs-debug/src/variable.rs
@@ -434,6 +434,9 @@ impl VariableLocation {
                     message: "Register value is not a valid address".to_string(),
                 }),
             },
+            VariableLocation::Error(error) => Err(DebugError::WarnAndContinue {
+                message: error.clone(),
+            }),
             other => Err(DebugError::WarnAndContinue {
                 message: format!("Variable does not have a memory location: location={other:?}"),
             }),
@@ -631,13 +634,15 @@ impl Variable {
                 // requested by the user, just display the type_name as the value
                 self.type_name
                     .display_name(language::from_dwarf(self.language).as_ref())
+            } else if let VariableLocation::Error(ref error) = self.memory_location {
+                    error.clone()
             } else {
                 // This condition should only be true for intermediate nodes
                 // from DWARF. These should not show up in the final
                 // `VariableCache`. If a user sees this error, then there is
                 // a logic problem in the stack unwind
                 "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location".to_string()
-            }
+                            }
         } else if matches!(self.type_name, VariableType::Struct(ref name) if name == "None") {
             "None".to_string()
         } else if matches!(self.type_name, VariableType::Array { count: 0, .. }) {

--- a/probe-rs-debug/src/variable.rs
+++ b/probe-rs-debug/src/variable.rs
@@ -485,6 +485,8 @@ pub struct Variable {
     /// The value will be zero until it is stored in VariableCache, at which time its value will be
     /// set to the same as the VariableCache::variable_cache_key
     pub(super) variable_key: ObjectRef,
+    /// The offset to the variable's type information.
+    pub(crate) type_node_offset: Option<UnitOffset>,
     /// Every variable must have a unique parent assigned to it when stored in the VariableCache.
     pub parent_key: ObjectRef,
     /// The variable name refers to the name of any of the types of values described in the [VariableCache]
@@ -524,6 +526,7 @@ impl Variable {
             language: unit_info
                 .map(|info| info.get_language())
                 .unwrap_or(gimli::DW_LANG_Rust),
+            type_node_offset: None,
             variable_key: Default::default(),
             parent_key: Default::default(),
             name: Default::default(),
@@ -635,14 +638,14 @@ impl Variable {
                 self.type_name
                     .display_name(language::from_dwarf(self.language).as_ref())
             } else if let VariableLocation::Error(ref error) = self.memory_location {
-                    error.clone()
+                error.clone()
             } else {
                 // This condition should only be true for intermediate nodes
                 // from DWARF. These should not show up in the final
                 // `VariableCache`. If a user sees this error, then there is
                 // a logic problem in the stack unwind
                 "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location".to_string()
-                            }
+            }
         } else if matches!(self.type_name, VariableType::Struct(ref name) if name == "None") {
             "None".to_string()
         } else if matches!(self.type_name, VariableType::Array { count: 0, .. }) {


### PR DESCRIPTION
This PR introduces a language-specific way to transform variables, resolves slices to look like array pointers, and prevents some errors from being eaten before the user can see them.

For example, a PanicInfo may now look like this:

![image](https://github.com/user-attachments/assets/211244cb-043f-4f40-80d4-4a151a009f16)
