### PR TITLE
Refactor probe IO traits

### DIFF
--- a/changelog/changed-protocol-traits.md
+++ b/changelog/changed-protocol-traits.md
@@ -1,0 +1,3 @@
+`JTAGAccess` has been renamed to `JtagAccess`.
+Added `JtagAccess::raw_sequence`.
+Added `probe_rs::probe::JtagSequence`.

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -11,7 +11,7 @@ pub mod dp;
 pub mod memory;
 pub mod sequences;
 pub mod swo;
-mod traits;
+pub(crate) mod traits;
 
 pub use self::core::{Dump, armv6m, armv7a, armv7m, armv8a, armv8m};
 use self::{

--- a/probe-rs/src/architecture/arm/traits.rs
+++ b/probe-rs/src/architecture/arm/traits.rs
@@ -9,6 +9,8 @@ use super::{
     dp::{DpAddress, DpRegisterAddress},
 };
 
+pub(crate) mod polyfill;
+
 /// Specifies the address of register to access in a debug or access port.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum RegisterAddress {

--- a/probe-rs/src/architecture/arm/traits/polyfill.rs
+++ b/probe-rs/src/architecture/arm/traits/polyfill.rs
@@ -1,4 +1,4 @@
-//! Implementation of the ARM Debug Interface
+//! Implementation of the ARM Debug Interface for bit-banging SWD and JTAG probes.
 //!
 //! This module implements functions to work with chips implementing the ARM Debug version v5.
 //!
@@ -14,117 +14,12 @@ use crate::{
         dp::{Abort, Ctrl, DPIDR, DebugPortError, DpRegister, RdBuff},
     },
     probe::{
-        CommandResult, DebugProbe, DebugProbeError, JTAGAccess, JtagCommandQueue, JtagWriteCommand,
-        WireProtocol, common::bits_to_byte,
+        CommandResult, DebugProbe, DebugProbeError, IoSequenceItem, JTAGAccess, JtagCommandQueue,
+        JtagWriteCommand, RawProtocolIo, WireProtocol, common::bits_to_byte,
     },
 };
 
 const CTRL_PORT: RegisterAddress = RegisterAddress::DpRegister(Ctrl::ADDRESS);
-
-#[derive(Debug)]
-pub struct SwdSettings {
-    /// Initial number of idle cycles between consecutive writes.
-    ///
-    /// When a WAIT response is received, the number of idle cycles
-    /// will be increased automatically, so this number can be quite
-    /// low.
-    pub num_idle_cycles_between_writes: usize,
-
-    /// How often a SWD transfer is retried when a WAIT response
-    /// is received.
-    pub num_retries_after_wait: usize,
-
-    /// When a SWD transfer is retried due to a WAIT response, the idle
-    /// cycle amount is doubled every time as a backoff. This sets a maximum
-    /// cap to the cycle amount.
-    pub max_retry_idle_cycles_after_wait: usize,
-
-    /// Number of idle cycles inserted before the result
-    /// of a write is checked.
-    ///
-    /// When performing a write operation, the write can
-    /// be buffered, meaning that completing the transfer
-    /// does not mean that the write was performed successfully.
-    ///
-    /// To check that all writes have been executed, the
-    /// `RDBUFF` register can be read from the DP.
-    ///
-    /// If any writes are still pending, this read will result in a WAIT response.
-    /// By adding idle cycles before performing this read, the chance of a
-    /// WAIT response is smaller.
-    pub idle_cycles_before_write_verify: usize,
-
-    /// Number of idle cycles to insert after a transfer
-    ///
-    /// It is recommended that at least 8 idle cycles are
-    /// inserted.
-    pub idle_cycles_after_transfer: usize,
-}
-
-impl Default for SwdSettings {
-    fn default() -> Self {
-        Self {
-            num_idle_cycles_between_writes: 2,
-            num_retries_after_wait: 1000,
-            max_retry_idle_cycles_after_wait: 128,
-            idle_cycles_before_write_verify: 8,
-            idle_cycles_after_transfer: 8,
-        }
-    }
-}
-
-#[derive(Default, Debug)]
-pub struct ProbeStatistics {
-    /// Number of protocol transfers performed.
-    ///
-    /// This includes repeated transfers, and transfers
-    /// which are automatically added to fulfill
-    /// protocol requirements, e.g. a read from a
-    /// DP register will result in two transfers,
-    /// because the read value is returned in the
-    /// second transfer
-    num_transfers: usize,
-
-    /// Number of extra transfers added to fullfil protocol
-    /// requirements. Ideally as low as possible.
-    num_extra_transfers: usize,
-
-    /// Number of calls to the probe IO function.
-    ///
-    /// A single call can perform multiple SWD transfers,
-    /// so this number is ideally a lot lower than then
-    /// number of SWD transfers.
-    num_io_calls: usize,
-
-    /// Number of SWD wait responses encountered.
-    num_wait_resp: usize,
-
-    /// Number of SWD FAULT responses encountered.
-    num_faults: usize,
-}
-
-impl ProbeStatistics {
-    pub fn record_extra_transfer(&mut self) {
-        self.num_extra_transfers += 1;
-    }
-
-    pub fn record_transfers(&mut self, num_transfers: usize) {
-        self.num_transfers += num_transfers;
-    }
-
-    pub fn report_io(&mut self) {
-        self.num_io_calls += 1;
-    }
-
-    pub fn report_swd_response<T>(&mut self, response: &Result<T, DapError>) {
-        match response {
-            Err(DapError::FaultResponse) => self.num_faults += 1,
-            Err(DapError::WaitResponse) => self.num_wait_resp += 1,
-            // Other errors are not counted right now.
-            _ => (),
-        }
-    }
-}
 
 // Constant to be written to ABORT
 const JTAG_ABORT_VALUE: u64 = 0x8;
@@ -826,30 +721,6 @@ enum TransferStatus {
     Failed(DapError),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum IoSequenceItem {
-    Output(bool),
-    Input,
-}
-
-impl From<IoSequenceItem> for bool {
-    fn from(item: IoSequenceItem) -> Self {
-        match item {
-            IoSequenceItem::Output(b) => b,
-            IoSequenceItem::Input => panic!("Input type is not supposed to hold a value!"),
-        }
-    }
-}
-
-impl From<IoSequenceItem> for u8 {
-    fn from(value: IoSequenceItem) -> Self {
-        match value {
-            IoSequenceItem::Output(b) => b as u8,
-            IoSequenceItem::Input => panic!("Input type is not supposed to hold a value!"),
-        }
-    }
-}
-
 struct IoSequence {
     io: Vec<IoSequenceItem>,
 }
@@ -1036,31 +907,7 @@ fn parse_swd_response(resp: &[bool], direction: TransferDirection) -> Result<u32
     }
 }
 
-pub trait RawProtocolIo {
-    fn jtag_shift_tms<M>(&mut self, tms: M, tdi: bool) -> Result<(), DebugProbeError>
-    where
-        M: IntoIterator<Item = bool>;
-
-    fn jtag_shift_tdi<I>(&mut self, tms: bool, tdi: I) -> Result<(), DebugProbeError>
-    where
-        I: IntoIterator<Item = bool>;
-
-    fn swd_io<S>(&mut self, swdio: S) -> Result<Vec<bool>, DebugProbeError>
-    where
-        S: IntoIterator<Item = IoSequenceItem>;
-
-    fn swj_pins(
-        &mut self,
-        pin_out: u32,
-        pin_select: u32,
-        pin_wait: u32,
-    ) -> Result<u32, DebugProbeError>;
-
-    fn swd_settings(&self) -> &SwdSettings;
-
-    fn probe_statistics(&mut self) -> &mut ProbeStatistics;
-}
-
+/// RawDapAccess implementation for probes that implement RawProtocolIo.
 impl<Probe: DebugProbe + RawProtocolIo + JTAGAccess + 'static> RawDapAccess for Probe {
     fn raw_read_register(&mut self, address: RegisterAddress) -> Result<u32, ArmError> {
         let mut transfer = DapTransfer::read(address);
@@ -1303,17 +1150,19 @@ mod test {
             dp::{Ctrl, DpRegister, RdBuff},
         },
         error::Error,
-        probe::{DebugProbe, DebugProbeError, JTAGAccess, WireProtocol},
+        probe::{
+            DebugProbe, DebugProbeError, IoSequenceItem, JTAGAccess, ProbeStatistics,
+            RawProtocolIo, SwdSettings, WireProtocol,
+        },
     };
+    use probe_rs_target::ScanChainElement;
 
     use super::{
-        IoSequenceItem, JTAG_ABORT_IR_VALUE, JTAG_ACCESS_PORT_IR_VALUE, JTAG_DEBUG_PORT_IR_VALUE,
-        JTAG_DR_BIT_LENGTH, JTAG_STATUS_OK, JTAG_STATUS_WAIT, ProbeStatistics, RawProtocolIo,
-        SwdSettings,
+        JTAG_ABORT_IR_VALUE, JTAG_ACCESS_PORT_IR_VALUE, JTAG_DEBUG_PORT_IR_VALUE,
+        JTAG_DR_BIT_LENGTH, JTAG_STATUS_OK, JTAG_STATUS_WAIT,
     };
 
     use bitvec::prelude::*;
-    use probe_rs_target::ScanChainElement;
 
     #[allow(dead_code)]
     enum DapAcknowledge {

--- a/probe-rs/src/architecture/arm/traits/polyfill.rs
+++ b/probe-rs/src/architecture/arm/traits/polyfill.rs
@@ -14,7 +14,7 @@ use crate::{
         dp::{Abort, Ctrl, DPIDR, DebugPortError, DpRegister, RdBuff},
     },
     probe::{
-        CommandResult, DebugProbe, DebugProbeError, IoSequenceItem, JTAGAccess, JtagCommandQueue,
+        CommandResult, DebugProbe, DebugProbeError, IoSequenceItem, JtagAccess, JtagCommandQueue,
         JtagSequence, JtagWriteCommand, RawSwdIo, WireProtocol, common::bits_to_byte,
     },
 };
@@ -68,7 +68,7 @@ fn parse_jtag_response(data: &BitSlice) -> u64 {
 /// Perform a single JTAG transfer and parse the results
 ///
 /// Return is (value, status)
-fn perform_jtag_transfer<P: JTAGAccess + RawSwdIo>(
+fn perform_jtag_transfer<P: JtagAccess + RawSwdIo>(
     probe: &mut P,
     transfer: &DapTransfer,
 ) -> Result<(u32, TransferStatus), DebugProbeError> {
@@ -114,8 +114,8 @@ fn perform_jtag_transfer<P: JTAGAccess + RawSwdIo>(
 
 /// Perform a batch of JTAG transfers.
 ///
-/// Each transfer is sent one at a time using the JTAGAccess trait
-fn perform_jtag_transfers<P: JTAGAccess + RawSwdIo>(
+/// Each transfer is sent one at a time using the JtagAccess trait
+fn perform_jtag_transfers<P: JtagAccess + RawSwdIo>(
     probe: &mut P,
     transfers: &mut [DapTransfer],
 ) -> Result<(), DebugProbeError> {
@@ -302,7 +302,7 @@ fn perform_swd_transfers<P: RawSwdIo>(
 ///
 /// Other errors are not handled, so the debug interface might be in an error state
 /// after this function returns.
-fn perform_transfers<P: DebugProbe + RawSwdIo + JTAGAccess>(
+fn perform_transfers<P: DebugProbe + RawSwdIo + JtagAccess>(
     probe: &mut P,
     transfers: &mut [DapTransfer],
 ) -> Result<(), ArmError> {
@@ -434,7 +434,7 @@ fn perform_transfers<P: DebugProbe + RawSwdIo + JTAGAccess>(
 ///
 /// Other than that, the transfers are sent as-is. You might want to use `perform_transfers` instead, which
 /// does correction for delayed FAULT responses and other helpful stuff.
-fn perform_raw_transfers_retry<P: DebugProbe + RawSwdIo + JTAGAccess>(
+fn perform_raw_transfers_retry<P: DebugProbe + RawSwdIo + JtagAccess>(
     probe: &mut P,
     transfers: &mut [DapTransfer],
 ) -> Result<(), ArmError> {
@@ -502,7 +502,7 @@ fn perform_raw_transfers_retry<P: DebugProbe + RawSwdIo + JTAGAccess>(
     Ok(())
 }
 
-fn clear_overrun_and_sticky_err<P: DebugProbe + RawSwdIo + JTAGAccess>(
+fn clear_overrun_and_sticky_err<P: DebugProbe + RawSwdIo + JtagAccess>(
     probe: &mut P,
 ) -> Result<(), ArmError> {
     tracing::debug!("Clearing overrun and sticky error");
@@ -515,7 +515,7 @@ fn clear_overrun_and_sticky_err<P: DebugProbe + RawSwdIo + JTAGAccess>(
     })
 }
 
-fn write_dp_register<P: DebugProbe + RawSwdIo + JTAGAccess, R: DpRegister>(
+fn write_dp_register<P: DebugProbe + RawSwdIo + JtagAccess, R: DpRegister>(
     probe: &mut P,
     register: R,
 ) -> Result<(), ArmError> {
@@ -538,7 +538,7 @@ fn write_dp_register<P: DebugProbe + RawSwdIo + JTAGAccess, R: DpRegister>(
 ///
 /// This function will just send the transfers as-is, without handling WAIT or FAULT response.
 /// See [`perform_raw_transfers_retry`] for a version that handles WAIT responses
-fn perform_raw_transfers<P: DebugProbe + RawSwdIo + JTAGAccess>(
+fn perform_raw_transfers<P: DebugProbe + RawSwdIo + JtagAccess>(
     probe: &mut P,
     transfers: &mut [DapTransfer],
 ) -> Result<(), DebugProbeError> {
@@ -909,7 +909,7 @@ fn parse_swd_response(resp: &[bool], direction: TransferDirection) -> Result<u32
 
 /// RawDapAccess implementation for probes that implement RawProtocolIo.
 // TODO: JTAG shouldn't be required, but an option - maybe via trait downcasting?
-impl<Probe: DebugProbe + RawSwdIo + JTAGAccess + 'static> RawDapAccess for Probe {
+impl<Probe: DebugProbe + RawSwdIo + JtagAccess + 'static> RawDapAccess for Probe {
     fn raw_read_register(&mut self, address: RegisterAddress) -> Result<u32, ArmError> {
         let mut transfer = DapTransfer::read(address);
         perform_transfers(self, std::slice::from_mut(&mut transfer))?;
@@ -1132,7 +1132,7 @@ impl<Probe: DebugProbe + RawSwdIo + JTAGAccess + 'static> RawDapAccess for Probe
     }
 }
 
-fn send_sequence<P: RawSwdIo + JTAGAccess>(
+fn send_sequence<P: RawSwdIo + JtagAccess>(
     probe: &mut P,
     protocol: WireProtocol,
     sequence: &IoSequence,
@@ -1176,7 +1176,7 @@ mod test {
         },
         error::Error,
         probe::{
-            DebugProbe, DebugProbeError, IoSequenceItem, JTAGAccess, JtagSequence, ProbeStatistics,
+            DebugProbe, DebugProbeError, IoSequenceItem, JtagAccess, JtagSequence, ProbeStatistics,
             RawSwdIo, SwdSettings, WireProtocol,
         },
     };
@@ -1382,7 +1382,7 @@ mod test {
         }
     }
 
-    impl JTAGAccess for MockJaylink {
+    impl JtagAccess for MockJaylink {
         fn raw_sequence(&mut self, _: JtagSequence) -> Result<BitVec, DebugProbeError> {
             todo!()
         }

--- a/probe-rs/src/architecture/arm/traits/polyfill.rs
+++ b/probe-rs/src/architecture/arm/traits/polyfill.rs
@@ -1111,7 +1111,7 @@ impl<Probe: DebugProbe + RawSwdIo + JtagAccess + 'static> RawDapAccess for Probe
             data.push((bits >> i) & 1 == 1);
         }
 
-        self.raw_sequence(JtagSequence {
+        self.shift_raw_sequence(JtagSequence {
             tms,
             data,
             tdo_capture: false,
@@ -1152,7 +1152,7 @@ fn send_sequence<P: RawSwdIo + JtagAccess>(
                     bits.next();
                 }
 
-                probe.raw_sequence(JtagSequence {
+                probe.shift_raw_sequence(JtagSequence {
                     tms: first.into(),
                     data: bitvec![0; count],
                     tdo_capture: false,
@@ -1383,7 +1383,7 @@ mod test {
     }
 
     impl JtagAccess for MockJaylink {
-        fn raw_sequence(&mut self, _: JtagSequence) -> Result<BitVec, DebugProbeError> {
+        fn shift_raw_sequence(&mut self, _: JtagSequence) -> Result<BitVec, DebugProbeError> {
             todo!()
         }
 

--- a/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
@@ -14,7 +14,7 @@ use crate::architecture::riscv::communication_interface::{
 use crate::architecture::riscv::dtm::dtm_access::DtmAccess;
 use crate::error::Error;
 use crate::probe::{
-    CommandResult, DeferredResultIndex, DeferredResultSet, JTAGAccess, JtagCommandQueue,
+    CommandResult, DeferredResultIndex, DeferredResultSet, JtagAccess, JtagCommandQueue,
     JtagWriteCommand,
 };
 use crate::probe::{DebugProbeError, ShiftDrCommand};
@@ -28,10 +28,10 @@ struct DtmState {
     abits: u32,
 }
 
-pub struct JtagDtmBuilder<'f>(&'f mut dyn JTAGAccess);
+pub struct JtagDtmBuilder<'f>(&'f mut dyn JtagAccess);
 
 impl<'f> JtagDtmBuilder<'f> {
-    pub fn new(probe: &'f mut dyn JTAGAccess) -> Self {
+    pub fn new(probe: &'f mut dyn JtagAccess) -> Self {
         Self(probe)
     }
 }
@@ -83,12 +83,12 @@ impl<'probe> RiscvInterfaceBuilder<'probe> for JtagDtmBuilder<'probe> {
 /// which is used to communicate with the RISC-V debug module.
 #[derive(Debug)]
 pub struct JtagDtm<'probe> {
-    pub probe: &'probe mut dyn JTAGAccess,
+    pub probe: &'probe mut dyn JtagAccess,
     state: &'probe mut DtmState,
 }
 
 impl<'probe> JtagDtm<'probe> {
-    fn new(probe: &'probe mut dyn JTAGAccess, state: &'probe mut DtmState) -> Self {
+    fn new(probe: &'probe mut dyn JtagAccess, state: &'probe mut DtmState) -> Self {
         Self { probe, state }
     }
 
@@ -326,7 +326,7 @@ impl DtmAccess for JtagDtm<'_> {
 /// 4. Set tunnel to idle: 3 zero bits
 #[derive(Debug)]
 pub struct TunneledJtagDtm<'probe> {
-    pub probe: &'probe mut dyn JTAGAccess,
+    pub probe: &'probe mut dyn JtagAccess,
     state: &'probe mut DtmState,
     select_dtmcs: JtagWriteCommand,
     select_dmi: JtagWriteCommand,
@@ -334,7 +334,7 @@ pub struct TunneledJtagDtm<'probe> {
 
 impl<'probe> TunneledJtagDtm<'probe> {
     fn new(
-        probe: &'probe mut dyn JTAGAccess,
+        probe: &'probe mut dyn JtagAccess,
         tunnel_ir_id: u32,
         tunnel_ir_width: u32,
         state: &'probe mut DtmState,

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -15,7 +15,7 @@ use crate::{
         register_cache::RegisterCache,
         xdm::{DebugStatus, XdmState},
     },
-    probe::{DebugProbeError, DeferredResultIndex, JTAGAccess},
+    probe::{DebugProbeError, DeferredResultIndex, JtagAccess},
 };
 
 use super::xdm::{Error as XdmError, Xdm};
@@ -250,7 +250,7 @@ pub struct XtensaCommunicationInterface<'probe> {
 impl<'probe> XtensaCommunicationInterface<'probe> {
     /// Create the Xtensa communication interface using the underlying probe driver
     pub fn new(
-        probe: &'probe mut dyn JTAGAccess,
+        probe: &'probe mut dyn JtagAccess,
         state: &'probe mut XtensaDebugInterfaceState,
     ) -> Self {
         let XtensaDebugInterfaceState {

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -9,7 +9,7 @@ use crate::{
     Error as ProbeRsError,
     architecture::xtensa::arch::instruction::{Instruction, InstructionEncoding},
     probe::{
-        CommandResult, DeferredResultIndex, DeferredResultSet, JTAGAccess, JtagCommandQueue,
+        CommandResult, DeferredResultIndex, DeferredResultSet, JtagAccess, JtagCommandQueue,
         JtagWriteCommand, ShiftDrCommand,
     },
 };
@@ -151,14 +151,14 @@ pub struct XdmState {
 #[derive(Debug)]
 pub struct Xdm<'probe> {
     /// The JTAG interface.
-    pub probe: &'probe mut dyn JTAGAccess,
+    pub probe: &'probe mut dyn JtagAccess,
 
     /// Debug module state.
     state: &'probe mut XdmState,
 }
 
 impl<'probe> Xdm<'probe> {
-    pub fn new(probe: &'probe mut dyn JTAGAccess, state: &'probe mut XdmState) -> Self {
+    pub fn new(probe: &'probe mut dyn JtagAccess, state: &'probe mut XdmState) -> Self {
         // TODO implement openocd's esp32_queue_tdi_idle() to prevent potentially damaging flash ICs
 
         Self { probe, state }

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -564,8 +564,8 @@ impl Probe {
         }
     }
 
-    /// Returns a [`JTAGAccess`] from the debug probe, if implemented.
-    pub fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JTAGAccess> {
+    /// Returns a [`JtagAccess`] from the debug probe, if implemented.
+    pub fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JtagAccess> {
         self.inner.try_as_jtag_probe()
     }
 
@@ -692,8 +692,8 @@ pub trait DebugProbe: Any + Send + fmt::Debug {
         false
     }
 
-    /// Returns a [`JTAGAccess`] from the debug probe, if implemented.
-    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JTAGAccess> {
+    /// Returns a [`JtagAccess`] from the debug probe, if implemented.
+    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JtagAccess> {
         None
     }
 
@@ -1029,7 +1029,7 @@ impl<'a> Deserialize<'a> for DebugProbeSelector {
 
 /// Bit-banging interface, ARM edition.
 ///
-/// This trait (and RawJtagIo, JTAGAccess) should not be used by architecture implementations directly.
+/// This trait (and RawJtagIo, JtagAccess) should not be used by architecture implementations directly.
 /// Architectures should implement their own protocol interfaces, and use the probe interface to
 /// perform the low-level operations AS A FALLBACK. Probes should prefer directly implementing the
 /// architecture protocols, if they have the capability. Probes should be able to implement raw
@@ -1256,11 +1256,11 @@ impl ProbeStatistics {
     }
 }
 
-/// Low-Level Access to the JTAG protocol
+/// Low-Level access to the JTAG protocol
 ///
 /// This trait should be implemented by all probes which offer low-level access to
-/// the JTAG protocol, i.e. direction control over the bytes sent and received.
-pub trait JTAGAccess: DebugProbe {
+/// the JTAG protocol, i.e. direct control over the bytes sent and received.
+pub trait JtagAccess: DebugProbe {
     /// Set the JTAG scan chain information for the target under debug.
     ///
     /// This allows the probe to know which TAPs are in the scan chain and their
@@ -1343,7 +1343,7 @@ pub trait JTAGAccess: DebugProbe {
         writes: &JtagCommandQueue,
     ) -> Result<DeferredResultSet, BatchExecutionError> {
         tracing::debug!(
-            "Using default `JTAGAccess::write_register_batch` this will hurt performance. Please implement proper batching for this probe."
+            "Using default `JtagAccess::write_register_batch` this will hurt performance. Please implement proper batching for this probe."
         );
         let mut results = DeferredResultSet::new();
 

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -1035,7 +1035,7 @@ impl<'a> Deserialize<'a> for DebugProbeSelector {
 //
 // TODO: this should be defined in the probe module, and split into JTAG/SWD parts. JTAGAccess
 // is somewhat redundant with this.
-pub(crate) trait RawProtocolIo {
+pub(crate) trait RawProtocolIo: DebugProbe {
     fn jtag_shift_tms<M>(&mut self, tms: M, tdi: bool) -> Result<(), DebugProbeError>
     where
         M: IntoIterator<Item = bool>;

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -1037,14 +1037,6 @@ impl<'a> Deserialize<'a> for DebugProbeSelector {
 // TODO: this should be defined in the probe module, and split into JTAG/SWD parts. JTAGAccess
 // is somewhat redundant with this.
 pub(crate) trait RawProtocolIo: DebugProbe {
-    fn jtag_shift_tms<M>(&mut self, tms: M, tdi: bool) -> Result<(), DebugProbeError>
-    where
-        M: IntoIterator<Item = bool>;
-
-    fn jtag_shift_tdi<I>(&mut self, tms: bool, tdi: I) -> Result<(), DebugProbeError>
-    where
-        I: IntoIterator<Item = bool>;
-
     fn swd_io<S>(&mut self, swdio: S) -> Result<Vec<bool>, DebugProbeError>
     where
         S: IntoIterator<Item = IoSequenceItem>;

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -1036,7 +1036,7 @@ impl<'a> Deserialize<'a> for DebugProbeSelector {
 //
 // TODO: this should be defined in the probe module, and split into JTAG/SWD parts. JTAGAccess
 // is somewhat redundant with this.
-pub(crate) trait RawProtocolIo: DebugProbe {
+pub(crate) trait RawSwdIo: DebugProbe {
     fn swd_io<S>(&mut self, swdio: S) -> Result<Vec<bool>, DebugProbeError>
     where
         S: IntoIterator<Item = IoSequenceItem>;

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -17,14 +17,16 @@ use crate::{
             XtensaCommunicationInterface, XtensaDebugInterfaceState,
         },
     },
-    probe::{DebugProbe, DebugProbeInfo, DebugProbeSelector, JTAGAccess, ProbeFactory},
+    probe::{
+        DebugProbe, DebugProbeInfo, DebugProbeSelector, IoSequenceItem, JTAGAccess, ProbeFactory,
+        ProbeStatistics, RawProtocolIo, SwdSettings,
+    },
 };
 use bitvec::vec::BitVec;
 use serialport::{SerialPortType, available_ports};
 
 use super::{
     DebugProbeError, ProbeCreationError, ProbeError, WireProtocol,
-    arm_debug_interface::{IoSequenceItem, ProbeStatistics, RawProtocolIo, SwdSettings},
     common::{JtagDriverState, RawJtagIo},
 };
 

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
         JTAGAccess, JtagDriverState, ProbeCreationError, ProbeError, ProbeFactory, ProbeStatistics,
-        RawJtagIo, RawSwdIo, SwdSettings, WireProtocol, common::BitbangJtagAccessMarker,
+        RawJtagIo, RawSwdIo, SwdSettings, WireProtocol,
     },
 };
 use bitvec::vec::BitVec;
@@ -1184,8 +1184,6 @@ impl DebugProbe for BlackMagicProbe {
         true
     }
 }
-
-impl BitbangJtagAccessMarker for BlackMagicProbe {}
 
 impl DapProbe for BlackMagicProbe {}
 

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
         JTAGAccess, JtagDriverState, ProbeCreationError, ProbeError, ProbeFactory, ProbeStatistics,
-        RawJtagIo, RawProtocolIo, SwdSettings, WireProtocol, common::BitbangJtagAccessMarker,
+        RawJtagIo, RawSwdIo, SwdSettings, WireProtocol, common::BitbangJtagAccessMarker,
     },
 };
 use bitvec::vec::BitVec;
@@ -1189,7 +1189,7 @@ impl BitbangJtagAccessMarker for BlackMagicProbe {}
 
 impl DapProbe for BlackMagicProbe {}
 
-impl RawProtocolIo for BlackMagicProbe {
+impl RawSwdIo for BlackMagicProbe {
     fn swd_io<S>(&mut self, swdio: S) -> Result<Vec<bool>, DebugProbeError>
     where
         S: IntoIterator<Item = IoSequenceItem>,

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
-        JTAGAccess, JtagDriverState, ProbeCreationError, ProbeError, ProbeFactory, ProbeStatistics,
+        JtagAccess, JtagDriverState, ProbeCreationError, ProbeError, ProbeFactory, ProbeStatistics,
         RawJtagIo, RawSwdIo, SwdSettings, WireProtocol,
     },
 };
@@ -1124,7 +1124,7 @@ impl DebugProbe for BlackMagicProbe {
         self.protocol
     }
 
-    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JTAGAccess> {
+    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JtagAccess> {
         Some(self)
     }
 

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -18,17 +18,13 @@ use crate::{
         },
     },
     probe::{
-        DebugProbe, DebugProbeInfo, DebugProbeSelector, IoSequenceItem, JTAGAccess, ProbeFactory,
-        ProbeStatistics, RawProtocolIo, SwdSettings,
+        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
+        JTAGAccess, JtagDriverState, ProbeCreationError, ProbeError, ProbeFactory, ProbeStatistics,
+        RawJtagIo, RawProtocolIo, SwdSettings, WireProtocol,
     },
 };
 use bitvec::vec::BitVec;
 use serialport::{SerialPortType, available_ports};
-
-use super::{
-    DebugProbeError, ProbeCreationError, ProbeError, WireProtocol,
-    common::{JtagDriverState, RawJtagIo},
-};
 
 const BLACK_MAGIC_PROBE_VID: u16 = 0x1d50;
 const BLACK_MAGIC_PROBE_PID: u16 = 0x6018;

--- a/probe-rs/src/probe/cmsisdap/commands/jtag/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/jtag/mod.rs
@@ -1,12 +1,11 @@
 use bitvec::{bitvec, vec::BitVec};
 
 use crate::probe::{
-    DebugProbeError,
+    DebugProbeError, JtagDriverState, RawJtagIo,
     cmsisdap::{
         CmsisDap,
         commands::jtag::sequence::{Sequence, SequenceRequest},
     },
-    common::{JtagDriverState, RawJtagIo},
 };
 
 pub mod configure;

--- a/probe-rs/src/probe/cmsisdap/commands/jtag/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/jtag/mod.rs
@@ -1,7 +1,7 @@
 use bitvec::{bitvec, vec::BitVec};
 
 use crate::probe::{
-    DebugProbeError, JtagDriverState, RawJtagIo,
+    DebugProbeError, JtagDriverState, JtagSequence, RawJtagIo,
     cmsisdap::{
         CmsisDap,
         commands::jtag::sequence::{Sequence, SequenceRequest},
@@ -76,17 +76,6 @@ impl CmsisDap {
 
         Ok(())
     }
-}
-
-struct JtagSequence {
-    /// TDO capture
-    tdo_capture: bool,
-
-    /// TMS value
-    tms: bool,
-
-    /// Data to generate on TDI
-    data: BitVec,
 }
 
 impl JtagSequence {

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -24,7 +24,6 @@ use crate::{
             CmsisDapError, RequestError,
             general::info::{CapabilitiesCommand, PacketCountCommand, SWOTraceBufferSizeCommand},
         },
-        common::BitbangJtagAccessMarker,
     },
 };
 
@@ -974,9 +973,6 @@ impl DebugProbe for CmsisDap {
         true
     }
 }
-
-// TODO this is a lie that needs to be cleaned up. This probe can do better.
-impl BitbangJtagAccessMarker for CmsisDap {}
 
 impl RawDapAccess for CmsisDap {
     fn core_status_notification(&mut self, status: CoreStatus) -> Result<(), DebugProbeError> {

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -19,12 +19,11 @@ use crate::{
     },
     probe::{
         BatchCommand, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JTAGAccess,
-        ProbeFactory, WireProtocol,
+        JtagDriverState, ProbeFactory, WireProtocol,
         cmsisdap::commands::{
             CmsisDapError, RequestError,
             general::info::{CapabilitiesCommand, PacketCountCommand, SWOTraceBufferSizeCommand},
         },
-        common::JtagDriverState,
     },
 };
 

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -18,7 +18,7 @@ use crate::{
         },
     },
     probe::{
-        BatchCommand, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JTAGAccess,
+        BatchCommand, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JtagAccess,
         JtagDriverState, ProbeFactory, WireProtocol,
         cmsisdap::commands::{
             CmsisDapError, RequestError,
@@ -943,7 +943,7 @@ impl DebugProbe for CmsisDap {
         self
     }
 
-    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JTAGAccess> {
+    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JtagAccess> {
         Some(self)
     }
 

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -24,6 +24,7 @@ use crate::{
             CmsisDapError, RequestError,
             general::info::{CapabilitiesCommand, PacketCountCommand, SWOTraceBufferSizeCommand},
         },
+        common::BitbangJtagAccessMarker,
     },
 };
 
@@ -973,6 +974,9 @@ impl DebugProbe for CmsisDap {
         true
     }
 }
+
+// TODO this is a lie that needs to be cleaned up. This probe can do better.
+impl BitbangJtagAccessMarker for CmsisDap {}
 
 impl RawDapAccess for CmsisDap {
     fn core_status_notification(&mut self, status: CoreStatus) -> Result<(), DebugProbeError> {

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -7,8 +7,8 @@ use bitvec::prelude::*;
 use probe_rs_target::ScanChainElement;
 
 use crate::probe::{
-    BatchExecutionError, ChainParams, CommandResult, DebugProbe, DebugProbeError,
-    DeferredResultSet, JTAGAccess, JtagCommand, JtagCommandQueue, RawJtagIo,
+    BatchExecutionError, ChainParams, CommandResult, DebugProbeError, DeferredResultSet,
+    JTAGAccess, JtagCommand, JtagCommandQueue, RawJtagIo,
 };
 
 pub(crate) fn bits_to_byte(bits: impl IntoIterator<Item = bool>) -> u32 {
@@ -545,7 +545,10 @@ fn prepare_write_register(
     shift_dr(protocol, data, len as usize, capture)
 }
 
-impl<Probe: DebugProbe + RawJtagIo + 'static> JTAGAccess for Probe {
+// TODO: SWD counterpart, better naming
+pub(crate) trait BitbangJtagAccessMarker: RawJtagIo + 'static {}
+
+impl<Probe: BitbangJtagAccessMarker> JTAGAccess for Probe {
     fn set_scan_chain(&mut self, scan_chain: &[ScanChainElement]) -> Result<(), DebugProbeError> {
         self.state_mut().expected_scan_chain = Some(scan_chain.to_vec());
         Ok(())

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -531,7 +531,7 @@ fn prepare_write_register(
     len: u32,
     capture: bool,
 ) -> Result<usize, DebugProbeError> {
-    if address > protocol.state().max_ir_address {
+    if address > protocol.state().max_ir_address() {
         return Err(DebugProbeError::Other(format!(
             "Invalid instruction register access: {}",
             address
@@ -566,13 +566,9 @@ impl<Probe: BitbangJtagAccessMarker> JTAGAccess for Probe {
             return Err(DebugProbeError::TargetNotFound);
         };
 
-        let max_ir_address = (1 << params.irlen) - 1;
-
         tracing::debug!("Selecting JTAG TAP: {target}");
         tracing::debug!("Setting chain params: {params:?}");
-        tracing::debug!("Setting max_ir_address to {max_ir_address}");
 
-        state.max_ir_address = max_ir_address;
         state.chain_params = params;
 
         Ok(())
@@ -700,7 +696,7 @@ impl<Probe: BitbangJtagAccessMarker> JTAGAccess for Probe {
 
         let response = self.read_captured_bits()?;
 
-        tracing::trace!("recieve_write_dr result: {:?}", response);
+        tracing::trace!("write_dr result: {:?}", response);
         Ok(response)
     }
 

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -8,7 +8,7 @@ use probe_rs_target::ScanChainElement;
 
 use crate::probe::{
     BatchExecutionError, ChainParams, CommandResult, DebugProbeError, DeferredResultSet,
-    JTAGAccess, JtagCommand, JtagCommandQueue, JtagSequence, RawJtagIo,
+    JtagAccess, JtagCommand, JtagCommandQueue, JtagSequence, RawJtagIo,
 };
 
 pub(crate) fn bits_to_byte(bits: impl IntoIterator<Item = bool>) -> u32 {
@@ -545,7 +545,7 @@ fn prepare_write_register(
     shift_dr(protocol, data, len as usize, capture)
 }
 
-impl<Probe: RawJtagIo + 'static> JTAGAccess for Probe {
+impl<Probe: RawJtagIo + 'static> JtagAccess for Probe {
     fn raw_sequence(&mut self, sequence: JtagSequence) -> Result<BitVec, DebugProbeError> {
         self.shift_bits(
             std::iter::repeat(sequence.tms),

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -8,7 +8,7 @@ use probe_rs_target::ScanChainElement;
 
 use crate::probe::{
     BatchExecutionError, ChainParams, CommandResult, DebugProbeError, DeferredResultSet,
-    JTAGAccess, JtagCommand, JtagCommandQueue, RawJtagIo,
+    JTAGAccess, JtagCommand, JtagCommandQueue, JtagSequence, RawJtagIo,
 };
 
 pub(crate) fn bits_to_byte(bits: impl IntoIterator<Item = bool>) -> u32 {
@@ -545,10 +545,16 @@ fn prepare_write_register(
     shift_dr(protocol, data, len as usize, capture)
 }
 
-// TODO: SWD counterpart, better naming
-pub(crate) trait BitbangJtagAccessMarker: RawJtagIo + 'static {}
+impl<Probe: RawJtagIo + 'static> JTAGAccess for Probe {
+    fn raw_sequence(&mut self, sequence: JtagSequence) -> Result<BitVec, DebugProbeError> {
+        self.shift_bits(
+            std::iter::repeat(sequence.tms),
+            sequence.data.into_iter(),
+            std::iter::repeat(sequence.tdo_capture),
+        )?;
+        self.read_captured_bits()
+    }
 
-impl<Probe: BitbangJtagAccessMarker> JTAGAccess for Probe {
     fn set_scan_chain(&mut self, scan_chain: &[ScanChainElement]) -> Result<(), DebugProbeError> {
         self.state_mut().expected_scan_chain = Some(scan_chain.to_vec());
         Ok(())

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -546,7 +546,7 @@ fn prepare_write_register(
 }
 
 impl<Probe: RawJtagIo + 'static> JtagAccess for Probe {
-    fn raw_sequence(&mut self, sequence: JtagSequence) -> Result<BitVec, DebugProbeError> {
+    fn shift_raw_sequence(&mut self, sequence: JtagSequence) -> Result<BitVec, DebugProbeError> {
         self.shift_bits(
             std::iter::repeat(sequence.tms),
             sequence.data.into_iter(),

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -8,7 +8,7 @@ use probe_rs_target::ScanChainElement;
 
 use crate::probe::{
     BatchExecutionError, ChainParams, CommandResult, DebugProbe, DebugProbeError,
-    DeferredResultSet, JTAGAccess, JtagCommand, JtagCommandQueue,
+    DeferredResultSet, JTAGAccess, JtagCommand, JtagCommandQueue, RawJtagIo,
 };
 
 pub(crate) fn bits_to_byte(bits: impl IntoIterator<Item = bool>) -> u32 {
@@ -390,80 +390,6 @@ impl JtagState {
             Self::Dr(state) => Self::Dr(state.update(tms)),
             Self::Ir(state) => Self::Ir(state.update(tms)),
         };
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct JtagDriverState {
-    pub state: JtagState,
-    // The maximum IR address
-    pub max_ir_address: u32,
-    pub expected_scan_chain: Option<Vec<ScanChainElement>>,
-    pub scan_chain: Vec<ScanChainElement>,
-    pub chain_params: ChainParams,
-    /// Idle cycles necessary between consecutive
-    /// accesses to the DMI register
-    pub jtag_idle_cycles: usize,
-}
-
-impl Default for JtagDriverState {
-    fn default() -> Self {
-        Self {
-            state: JtagState::Reset,
-            max_ir_address: 0x0F,
-            expected_scan_chain: None,
-            scan_chain: Vec::new(),
-            chain_params: ChainParams::default(),
-            jtag_idle_cycles: 0,
-        }
-    }
-}
-
-/// A trait for implementing low-level JTAG interface operations.
-pub(crate) trait RawJtagIo {
-    /// Returns a mutable reference to the current state.
-    fn state_mut(&mut self) -> &mut JtagDriverState;
-
-    /// Returns the current state.
-    fn state(&self) -> &JtagDriverState;
-
-    /// Shifts a number of bits through the TAP.
-    fn shift_bits(
-        &mut self,
-        tms: impl IntoIterator<Item = bool>,
-        tdi: impl IntoIterator<Item = bool>,
-        cap: impl IntoIterator<Item = bool>,
-    ) -> Result<(), DebugProbeError> {
-        for ((tms, tdi), cap) in tms.into_iter().zip(tdi.into_iter()).zip(cap.into_iter()) {
-            self.shift_bit(tms, tdi, cap)?;
-        }
-
-        Ok(())
-    }
-
-    /// Shifts a single bit through the TAP.
-    ///
-    /// Drivers may choose, and are encouraged, to buffer bits and flush them
-    /// in batches for performance reasons.
-    fn shift_bit(&mut self, tms: bool, tdi: bool, capture: bool) -> Result<(), DebugProbeError>;
-
-    /// Returns the bits captured from TDO and clears the capture buffer.
-    fn read_captured_bits(&mut self) -> Result<BitVec, DebugProbeError>;
-
-    /// Resets the JTAG state machine by shifting out a number of high TMS bits.
-    fn reset_jtag_state_machine(&mut self) -> Result<(), DebugProbeError> {
-        tracing::debug!("Resetting JTAG chain by setting tms high for 5 bits");
-
-        // Reset JTAG chain (5 times TMS high), and enter idle state afterwards
-        let tms = [true, true, true, true, true, false];
-        let tdi = iter::repeat(true);
-
-        self.shift_bits(tms, tdi, iter::repeat(false))?;
-        let response = self.read_captured_bits()?;
-
-        tracing::debug!("Response to reset: {response}");
-
-        Ok(())
     }
 }
 

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JTAGAccess,
-        JtagDriverState, ProbeFactory, RawJtagIo, WireProtocol,
+        JtagDriverState, ProbeFactory, RawJtagIo, WireProtocol, common::BitbangJtagAccessMarker,
     },
 };
 use bitvec::prelude::*;
@@ -50,6 +50,8 @@ pub struct EspUsbJtag {
 
     jtag_state: JtagDriverState,
 }
+
+impl BitbangJtagAccessMarker for EspUsbJtag {}
 
 impl RawJtagIo for EspUsbJtag {
     fn shift_bit(

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -10,15 +10,13 @@ use crate::{
         },
     },
     probe::{
-        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeFactory,
-        WireProtocol, common::RawJtagIo,
+        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JTAGAccess,
+        JtagDriverState, ProbeFactory, RawJtagIo, WireProtocol,
     },
 };
 use bitvec::prelude::*;
 
 use self::protocol::ProtocolHandler;
-
-use super::{JTAGAccess, common::JtagDriverState};
 
 /// Probe factory for USB JTAG interfaces built into certain ESP32 chips.
 #[derive(Debug)]

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JTAGAccess,
-        JtagDriverState, ProbeFactory, RawJtagIo, WireProtocol, common::BitbangJtagAccessMarker,
+        JtagDriverState, ProbeFactory, RawJtagIo, WireProtocol,
     },
 };
 use bitvec::prelude::*;
@@ -50,8 +50,6 @@ pub struct EspUsbJtag {
 
     jtag_state: JtagDriverState,
 }
-
-impl BitbangJtagAccessMarker for EspUsbJtag {}
 
 impl RawJtagIo for EspUsbJtag {
     fn shift_bit(

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -10,7 +10,7 @@ use crate::{
         },
     },
     probe::{
-        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JTAGAccess,
+        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JtagAccess,
         JtagDriverState, ProbeFactory, RawJtagIo, WireProtocol,
     },
 };
@@ -132,7 +132,7 @@ impl DebugProbe for EspUsbJtag {
         Ok(())
     }
 
-    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JTAGAccess> {
+    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JtagAccess> {
         Some(self)
     }
 

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -13,14 +13,13 @@ use crate::{
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
         JTAGAccess, JtagDriverState, ProbeCreationError, ProbeFactory, ProbeStatistics, RawJtagIo,
-        RawProtocolIo, SwdSettings, WireProtocol,
+        RawProtocolIo, SwdSettings, WireProtocol, common::BitbangJtagAccessMarker,
     },
 };
 use bitvec::prelude::*;
 use nusb::DeviceInfo;
 use std::{
     io::{Read, Write},
-    iter,
     time::{Duration, Instant},
 };
 
@@ -415,31 +414,11 @@ impl DebugProbe for FtdiProbe {
     }
 }
 
+impl BitbangJtagAccessMarker for FtdiProbe {}
+
 impl DapProbe for FtdiProbe {}
 
 impl RawProtocolIo for FtdiProbe {
-    fn jtag_shift_tms<M>(&mut self, tms: M, tdi: bool) -> Result<(), DebugProbeError>
-    where
-        M: IntoIterator<Item = bool>,
-    {
-        self.probe_statistics.report_io();
-
-        self.shift_bits(tms, iter::repeat(tdi), iter::repeat(false))?;
-
-        Ok(())
-    }
-
-    fn jtag_shift_tdi<I>(&mut self, tms: bool, tdi: I) -> Result<(), DebugProbeError>
-    where
-        I: IntoIterator<Item = bool>,
-    {
-        self.probe_statistics.report_io();
-
-        self.shift_bits(iter::repeat(tms), tdi, iter::repeat(false))?;
-
-        Ok(())
-    }
-
     fn swd_io<S>(&mut self, _swdio: S) -> Result<Vec<bool>, DebugProbeError>
     where
         S: IntoIterator<Item = IoSequenceItem>,

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
         JTAGAccess, JtagDriverState, ProbeCreationError, ProbeFactory, ProbeStatistics, RawJtagIo,
-        RawProtocolIo, SwdSettings, WireProtocol, common::BitbangJtagAccessMarker,
+        RawSwdIo, SwdSettings, WireProtocol, common::BitbangJtagAccessMarker,
     },
 };
 use bitvec::prelude::*;
@@ -418,7 +418,7 @@ impl BitbangJtagAccessMarker for FtdiProbe {}
 
 impl DapProbe for FtdiProbe {}
 
-impl RawProtocolIo for FtdiProbe {
+impl RawSwdIo for FtdiProbe {
     fn swd_io<S>(&mut self, _swdio: S) -> Result<Vec<bool>, DebugProbeError>
     where
         S: IntoIterator<Item = IoSequenceItem>,

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
         JTAGAccess, JtagDriverState, ProbeCreationError, ProbeFactory, ProbeStatistics, RawJtagIo,
-        RawSwdIo, SwdSettings, WireProtocol, common::BitbangJtagAccessMarker,
+        RawSwdIo, SwdSettings, WireProtocol,
     },
 };
 use bitvec::prelude::*;
@@ -413,8 +413,6 @@ impl DebugProbe for FtdiProbe {
         true
     }
 }
-
-impl BitbangJtagAccessMarker for FtdiProbe {}
 
 impl DapProbe for FtdiProbe {}
 

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
-        JTAGAccess, JtagDriverState, ProbeCreationError, ProbeFactory, ProbeStatistics, RawJtagIo,
+        JtagAccess, JtagDriverState, ProbeCreationError, ProbeFactory, ProbeStatistics, RawJtagIo,
         RawSwdIo, SwdSettings, WireProtocol,
     },
 };
@@ -371,7 +371,7 @@ impl DebugProbe for FtdiProbe {
         Some(WireProtocol::Jtag)
     }
 
-    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JTAGAccess> {
+    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JtagAccess> {
         Some(self)
     }
 

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -11,9 +11,9 @@ use crate::{
         },
     },
     probe::{
-        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JTAGAccess,
-        ProbeCreationError, ProbeFactory, WireProtocol,
-        arm_debug_interface::{IoSequenceItem, ProbeStatistics, RawProtocolIo, SwdSettings},
+        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
+        JTAGAccess, ProbeCreationError, ProbeFactory, ProbeStatistics, RawProtocolIo, SwdSettings,
+        WireProtocol,
         common::{JtagDriverState, RawJtagIo},
     },
 };

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -12,9 +12,8 @@ use crate::{
     },
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
-        JTAGAccess, ProbeCreationError, ProbeFactory, ProbeStatistics, RawProtocolIo, SwdSettings,
-        WireProtocol,
-        common::{JtagDriverState, RawJtagIo},
+        JTAGAccess, JtagDriverState, ProbeCreationError, ProbeFactory, ProbeStatistics, RawJtagIo,
+        RawProtocolIo, SwdSettings, WireProtocol,
     },
 };
 use bitvec::prelude::*;

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -45,9 +45,8 @@ use crate::{
         riscv::{communication_interface::RiscvInterfaceBuilder, dtm::jtag_dtm::JtagDtmBuilder},
     },
     probe::{
-        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeFactory,
-        WireProtocol,
-        arm_debug_interface::{IoSequenceItem, ProbeStatistics, RawProtocolIo, SwdSettings},
+        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
+        ProbeFactory, ProbeStatistics, RawProtocolIo, SwdSettings, WireProtocol,
     },
 };
 

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -10,7 +10,6 @@ mod speed;
 pub mod swo;
 
 use std::fmt;
-use std::iter;
 use std::time::{Duration, Instant};
 
 use bitvec::prelude::*;
@@ -30,6 +29,7 @@ use crate::architecture::xtensa::communication_interface::{
     XtensaCommunicationInterface, XtensaDebugInterfaceState,
 };
 use crate::probe::JTAGAccess;
+use crate::probe::common::BitbangJtagAccessMarker;
 use crate::probe::jlink::bits::IteratorExt;
 use crate::probe::jlink::config::JlinkConfig;
 use crate::probe::jlink::connection::JlinkConnection;
@@ -1158,38 +1158,6 @@ impl DebugProbe for JLink {
 }
 
 impl RawProtocolIo for JLink {
-    fn jtag_shift_tms<M>(&mut self, tms: M, tdi: bool) -> Result<(), DebugProbeError>
-    where
-        M: IntoIterator<Item = bool>,
-    {
-        assert!(
-            self.protocol != WireProtocol::Swd,
-            "Logic error, requested jtag_io when in SWD mode"
-        );
-
-        self.probe_statistics.report_io();
-
-        self.shift_bits(tms, iter::repeat(tdi), iter::repeat(false))?;
-
-        Ok(())
-    }
-
-    fn jtag_shift_tdi<I>(&mut self, tms: bool, tdi: I) -> Result<(), DebugProbeError>
-    where
-        I: IntoIterator<Item = bool>,
-    {
-        assert!(
-            self.protocol != WireProtocol::Swd,
-            "Logic error, requested jtag_io when in SWD mode"
-        );
-
-        self.probe_statistics.report_io();
-
-        self.shift_bits(iter::repeat(tms), tdi, iter::repeat(false))?;
-
-        Ok(())
-    }
-
     fn swd_io<S>(&mut self, swdio: S) -> Result<Vec<bool>, DebugProbeError>
     where
         S: IntoIterator<Item = IoSequenceItem>,
@@ -1259,6 +1227,7 @@ impl RawJtagIo for JLink {
     }
 }
 
+impl BitbangJtagAccessMarker for JLink {}
 impl DapProbe for JLink {}
 
 impl SwoAccess for JLink {

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -45,7 +45,7 @@ use crate::{
     },
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
-        JtagDriverState, ProbeFactory, ProbeStatistics, RawJtagIo, RawProtocolIo, SwdSettings,
+        JtagDriverState, ProbeFactory, ProbeStatistics, RawSwdIo, RawJtagIo, SwdSettings,
         WireProtocol,
     },
 };
@@ -1157,7 +1157,7 @@ impl DebugProbe for JLink {
     }
 }
 
-impl RawProtocolIo for JLink {
+impl RawSwdIo for JLink {
     fn swd_io<S>(&mut self, swdio: S) -> Result<Vec<bool>, DebugProbeError>
     where
         S: IntoIterator<Item = IoSequenceItem>,

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -29,7 +29,6 @@ use crate::architecture::xtensa::communication_interface::{
     XtensaCommunicationInterface, XtensaDebugInterfaceState,
 };
 use crate::probe::JTAGAccess;
-use crate::probe::common::BitbangJtagAccessMarker;
 use crate::probe::jlink::bits::IteratorExt;
 use crate::probe::jlink::config::JlinkConfig;
 use crate::probe::jlink::connection::JlinkConnection;
@@ -45,7 +44,7 @@ use crate::{
     },
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
-        JtagDriverState, ProbeFactory, ProbeStatistics, RawSwdIo, RawJtagIo, SwdSettings,
+        JtagDriverState, ProbeFactory, ProbeStatistics, RawJtagIo, RawSwdIo, SwdSettings,
         WireProtocol,
     },
 };
@@ -1227,7 +1226,6 @@ impl RawJtagIo for JLink {
     }
 }
 
-impl BitbangJtagAccessMarker for JLink {}
 impl DapProbe for JLink {}
 
 impl SwoAccess for JLink {

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -30,7 +30,6 @@ use crate::architecture::xtensa::communication_interface::{
     XtensaCommunicationInterface, XtensaDebugInterfaceState,
 };
 use crate::probe::JTAGAccess;
-use crate::probe::common::{JtagDriverState, RawJtagIo};
 use crate::probe::jlink::bits::IteratorExt;
 use crate::probe::jlink::config::JlinkConfig;
 use crate::probe::jlink::connection::JlinkConnection;
@@ -46,7 +45,8 @@ use crate::{
     },
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
-        ProbeFactory, ProbeStatistics, RawProtocolIo, SwdSettings, WireProtocol,
+        JtagDriverState, ProbeFactory, ProbeStatistics, RawJtagIo, RawProtocolIo, SwdSettings,
+        WireProtocol,
     },
 };
 

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -28,7 +28,7 @@ use crate::architecture::arm::{ArmError, Pins};
 use crate::architecture::xtensa::communication_interface::{
     XtensaCommunicationInterface, XtensaDebugInterfaceState,
 };
-use crate::probe::JTAGAccess;
+use crate::probe::JtagAccess;
 use crate::probe::jlink::bits::IteratorExt;
 use crate::probe::jlink::config::JlinkConfig;
 use crate::probe::jlink::connection::JlinkConnection;
@@ -1082,7 +1082,7 @@ impl DebugProbe for JLink {
         Ok(())
     }
 
-    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JTAGAccess> {
+    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JtagAccess> {
         Some(self)
     }
 

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -11,7 +11,7 @@ use nusb::DeviceInfo;
 use probe_rs_target::ScanChainElement;
 
 use self::{commands::Speed, usb_interface::WchLinkUsbDevice};
-use super::JTAGAccess;
+use super::JtagAccess;
 use crate::{
     architecture::riscv::{
         communication_interface::RiscvInterfaceBuilder, dtm::jtag_dtm::JtagDtmBuilder,
@@ -375,8 +375,8 @@ impl DebugProbe for WchLink {
     }
 }
 
-/// Wrap WCH-Link's USB based DMI access as a fake JTAGAccess
-impl JTAGAccess for WchLink {
+/// Wrap WCH-Link's USB based DMI access as a fake JtagAccess
+impl JtagAccess for WchLink {
     fn set_scan_chain(&mut self, _scan_chain: &[ScanChainElement]) -> Result<(), DebugProbeError> {
         Ok(())
     }

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -17,8 +17,8 @@ use crate::{
         communication_interface::RiscvInterfaceBuilder, dtm::jtag_dtm::JtagDtmBuilder,
     },
     probe::{
-        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeError, ProbeFactory,
-        WireProtocol,
+        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JtagSequence, ProbeError,
+        ProbeFactory, WireProtocol,
     },
 };
 
@@ -505,6 +505,12 @@ impl JTAGAccess for WchLink {
     fn write_dr(&mut self, _data: &[u8], _len: u32) -> Result<BitVec, DebugProbeError> {
         Err(DebugProbeError::NotImplemented {
             function_name: "write_dr",
+        })
+    }
+
+    fn raw_sequence(&mut self, _sequence: JtagSequence) -> Result<BitVec, DebugProbeError> {
+        Err(DebugProbeError::NotImplemented {
+            function_name: "raw_sequence",
         })
     }
 }

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -508,9 +508,9 @@ impl JtagAccess for WchLink {
         })
     }
 
-    fn raw_sequence(&mut self, _sequence: JtagSequence) -> Result<BitVec, DebugProbeError> {
+    fn shift_raw_sequence(&mut self, _sequence: JtagSequence) -> Result<BitVec, DebugProbeError> {
         Err(DebugProbeError::NotImplemented {
-            function_name: "raw_sequence",
+            function_name: "shift_raw_sequence ",
         })
     }
 }


### PR DESCRIPTION
The idea behind this PR (and its follow up work) is to separate architecture implementations from raw protocol IO. The goal is to implement, for each of the architectures, a fallback interface that uses lower level IO for probe compatibility, but also to allow using higher level probe commands where available to accelerate operations.

Bitbanging ARM debug interface implementation was moved to the ARM module as a first approximation of the idea.