### PR TITLE
target-gen: support external definitions again

### DIFF
--- a/changelog/added-session-attach-with-registry.md
+++ b/changelog/added-session-attach-with-registry.md
@@ -1,0 +1,1 @@
+Added API calls to automatically attach a Session with a provided Registry

--- a/changelog/fixed-target-gen-registry.md
+++ b/changelog/fixed-target-gen-registry.md
@@ -1,0 +1,1 @@
+Fixed target-gen registry not getting used by probe-rs

--- a/changelog/fixed-target-gen-registry.md
+++ b/changelog/fixed-target-gen-registry.md
@@ -1,1 +1,0 @@
-Fixed target-gen registry not getting used by probe-rs

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -98,7 +98,8 @@ pub fn cmd_test(
     };
 
     // We need to get the chip name so that special startup procedure can be used. (matched on name)
-    let mut session = probe_rs::Session::auto_attach(target_name, session_config)?;
+    let mut session =
+        probe_rs::Session::auto_attach_with_registry(target_name, session_config, &registry)?;
 
     // Register callback to update the progress.
     let t = Rc::new(RefCell::new(Instant::now()));


### PR DESCRIPTION
With the recent reorganization of target definitions, the ability to specify an external target definition was lost.

Add new versions of various session initialization functions that support taking an external registry, and use them as part of `target-gen`.