### PR TITLE
cmsisdap: add ntrst support

### DIFF
--- a/changelog/added-jtag-ntrst-pin.md
+++ b/changelog/added-jtag-ntrst-pin.md
@@ -1,1 +1,1 @@
-Added the nTRST pin for JTAG, and ensure it's deasserted at init
+CMSIS-DAP: Added the nTRST pin for JTAG, and ensure it's deasserted at init

--- a/changelog/added-jtag-ntrst-pin.md
+++ b/changelog/added-jtag-ntrst-pin.md
@@ -1,0 +1,1 @@
+Added the nTRST pin for JTAG, and ensure it's deasserted at init

--- a/probe-rs/src/probe/cmsisdap/commands/swj/pins.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swj/pins.rs
@@ -42,7 +42,7 @@ impl SWJPinsRequestBuilder {
         self
     }
 
-    pub fn _ntrst(&mut self, value: bool) -> &mut Self {
+    pub fn ntrst(&mut self, value: bool) -> &mut Self {
         self.ntrst = Some(value);
         self
     }

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -780,6 +780,16 @@ impl CmsisDap {
         // Store the actually used protocol, to handle cases where the default protocol is used.
         tracing::info!("Using protocol {}", used_protocol);
         self.protocol = Some(used_protocol);
+
+        // If operating under JTAG, try to bring the JTAG machinery out of reset. Ignore errors
+        // since not all probes support this.
+        if matches!(self.protocol, Some(WireProtocol::Jtag)) {
+            commands::send_command(
+                &mut self.device,
+                &SWJPinsRequestBuilder::new().ntrst(true).build(),
+            )
+            .ok();
+        }
         self.connected = true;
 
         Ok(())


### PR DESCRIPTION
Add support for deasserting the test reset machinery. This signal is wired up on some safety-critical parts to ensure JTAG doesn't accidentally get triggered.

This enables debugging devices such as the TMS570 with built-in XDS110.