### PR TITLE
Allow opting out of JtagAccess blanket impl

### DIFF
--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -1268,6 +1268,12 @@ impl ProbeStatistics {
     }
 }
 
+/// Marker trait for bitbanging JTAG probes.
+///
+/// This trait exists to control which probes implement [`JtagAccess`]. In some cases,
+/// a probe may implement [`RawJtagIo`] but does not want an auto-implemented [JtagAccess].
+pub(crate) trait AutoImplementJtagAccess: RawJtagIo + 'static {}
+
 /// Low-Level access to the JTAG protocol
 ///
 /// This trait should be implemented by all probes which offer low-level access to

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -18,9 +18,9 @@ use crate::{
         },
     },
     probe::{
-        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
-        JtagAccess, JtagDriverState, ProbeCreationError, ProbeError, ProbeFactory, ProbeStatistics,
-        RawJtagIo, RawSwdIo, SwdSettings, WireProtocol,
+        AutoImplementJtagAccess, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
+        IoSequenceItem, JtagAccess, JtagDriverState, ProbeCreationError, ProbeError, ProbeFactory,
+        ProbeStatistics, RawJtagIo, RawSwdIo, SwdSettings, WireProtocol,
     },
 };
 use bitvec::vec::BitVec;
@@ -1185,6 +1185,7 @@ impl DebugProbe for BlackMagicProbe {
     }
 }
 
+impl AutoImplementJtagAccess for BlackMagicProbe {}
 impl DapProbe for BlackMagicProbe {}
 
 impl RawSwdIo for BlackMagicProbe {

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -18,8 +18,8 @@ use crate::{
         },
     },
     probe::{
-        BatchCommand, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JtagAccess,
-        JtagDriverState, ProbeFactory, WireProtocol,
+        AutoImplementJtagAccess, BatchCommand, DebugProbe, DebugProbeError, DebugProbeInfo,
+        DebugProbeSelector, JtagAccess, JtagDriverState, ProbeFactory, WireProtocol,
         cmsisdap::commands::{
             CmsisDapError, RequestError,
             general::info::{CapabilitiesCommand, PacketCountCommand, SWOTraceBufferSizeCommand},
@@ -973,6 +973,9 @@ impl DebugProbe for CmsisDap {
         true
     }
 }
+
+// TODO: we will want to replace the default implementation with one that can use vendor extensions.
+impl AutoImplementJtagAccess for CmsisDap {}
 
 impl RawDapAccess for CmsisDap {
     fn core_status_notification(&mut self, status: CoreStatus) -> Result<(), DebugProbeError> {

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -7,8 +7,8 @@ use bitvec::prelude::*;
 use probe_rs_target::ScanChainElement;
 
 use crate::probe::{
-    BatchExecutionError, ChainParams, CommandResult, DebugProbeError, DeferredResultSet,
-    JtagAccess, JtagCommand, JtagCommandQueue, JtagSequence, RawJtagIo,
+    AutoImplementJtagAccess, BatchExecutionError, ChainParams, CommandResult, DebugProbeError,
+    DeferredResultSet, JtagAccess, JtagCommand, JtagCommandQueue, JtagSequence, RawJtagIo,
 };
 
 pub(crate) fn bits_to_byte(bits: impl IntoIterator<Item = bool>) -> u32 {
@@ -545,7 +545,7 @@ fn prepare_write_register(
     shift_dr(protocol, data, len as usize, capture)
 }
 
-impl<Probe: RawJtagIo + 'static> JtagAccess for Probe {
+impl<Probe: AutoImplementJtagAccess> JtagAccess for Probe {
     fn shift_raw_sequence(&mut self, sequence: JtagSequence) -> Result<BitVec, DebugProbeError> {
         self.shift_bits(
             std::iter::repeat(sequence.tms),

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -10,8 +10,8 @@ use crate::{
         },
     },
     probe::{
-        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JtagAccess,
-        JtagDriverState, ProbeFactory, RawJtagIo, WireProtocol,
+        AutoImplementJtagAccess, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
+        JtagAccess, JtagDriverState, ProbeFactory, RawJtagIo, WireProtocol,
     },
 };
 use bitvec::prelude::*;
@@ -75,6 +75,8 @@ impl RawJtagIo for EspUsbJtag {
         &self.jtag_state
     }
 }
+
+impl AutoImplementJtagAccess for EspUsbJtag {}
 
 impl DebugProbe for EspUsbJtag {
     fn select_protocol(&mut self, protocol: WireProtocol) -> Result<(), DebugProbeError> {

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -11,9 +11,9 @@ use crate::{
         },
     },
     probe::{
-        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
-        JtagAccess, JtagDriverState, ProbeCreationError, ProbeFactory, ProbeStatistics, RawJtagIo,
-        RawSwdIo, SwdSettings, WireProtocol,
+        AutoImplementJtagAccess, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
+        IoSequenceItem, JtagAccess, JtagDriverState, ProbeCreationError, ProbeFactory,
+        ProbeStatistics, RawJtagIo, RawSwdIo, SwdSettings, WireProtocol,
     },
 };
 use bitvec::prelude::*;
@@ -414,6 +414,7 @@ impl DebugProbe for FtdiProbe {
     }
 }
 
+impl AutoImplementJtagAccess for FtdiProbe {}
 impl DapProbe for FtdiProbe {}
 
 impl RawSwdIo for FtdiProbe {

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -28,11 +28,11 @@ use crate::architecture::arm::{ArmError, Pins};
 use crate::architecture::xtensa::communication_interface::{
     XtensaCommunicationInterface, XtensaDebugInterfaceState,
 };
-use crate::probe::JtagAccess;
 use crate::probe::jlink::bits::IteratorExt;
 use crate::probe::jlink::config::JlinkConfig;
 use crate::probe::jlink::connection::JlinkConnection;
 use crate::probe::usb_util::InterfaceExt;
+use crate::probe::{AutoImplementJtagAccess, JtagAccess};
 use crate::{
     architecture::{
         arm::{
@@ -1226,6 +1226,7 @@ impl RawJtagIo for JLink {
     }
 }
 
+impl AutoImplementJtagAccess for JLink {}
 impl DapProbe for JLink {}
 
 impl SwoAccess for JLink {


### PR DESCRIPTION
In theory, the CMSIS-DAP probe can define more efficient operations for JTAG access than what we implement for bitbanging probes. This is not possible with the current blanket implementation of JtagAccess. The `AutoImplemntJtagAccess` trait now serves as a marker for when the probe wants JtagAccess to be implemented.

I expect other similar marker traits to be introduced in the future.