### PR TITLE
Try to provide a function name when missing from debuginfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3021,6 +3021,7 @@ dependencies = [
 name = "probe-rs-debug"
 version = "0.27.0"
 dependencies = [
+ "addr2line",
  "bitfield",
  "gimli 0.31.1",
  "insta",

--- a/changelog/changed-debugger-unknown.md
+++ b/changelog/changed-debugger-unknown.md
@@ -1,0 +1,1 @@
+The debugger now shows the name of the nearest symbol as the function name when debug info is not available.

--- a/probe-rs-debug/Cargo.toml
+++ b/probe-rs-debug/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 description = "Debugging functionlity built on top of the probe-rs crate"
 
 [dependencies]
+addr2line = "0.24.2"
 bitfield = "0.19.0"
 gimli = "0.31.1"
 itertools = "0.14.0"

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__print_stacktrace.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__print_stacktrace.snap
@@ -66,7 +66,7 @@ Frame:
   column: Some(Column(1))
  frame_base:      Some(20003ff8)
 Frame:
- function:        <unknown function @ 0x000000ce> : ERROR: UNWIND: Failed to read value for register R7/FP from address 0x0000000000000000 (4 bytes): The coredump does not include the memory for address 0x0 of size 0x4
+ function:        Reset @ 0x000000ce> : ERROR: UNWIND: Failed to read value for register R7/FP from address 0x0000000000000000 (4 bytes): The coredump does not include the memory for address 0x0 of size 0x4
  source_location:
 None
  frame_base:      None

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_in_exception_handler.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_in_exception_handler.snap
@@ -36,7 +36,7 @@ Frame:
   column: Some(Column(1))
  frame_base:      Some(2001fff8)
 Frame:
- function:        <unknown function @ 0x0000013c>
+ function:        Reset @ 0x0000013c>
  source_location:
 None
  frame_base:      None

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_in_exception_trampoline.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_in_exception_trampoline.snap
@@ -29,7 +29,7 @@ Frame:
   column: Some(Column(1))
  frame_base:      Some(2001fff8)
 Frame:
- function:        <unknown function @ 0x0000013c>
+ function:        Reset @ 0x0000013c>
  source_location:
 None
  frame_base:      None

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_inlined.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_inlined.snap
@@ -1,8 +1,6 @@
 ---
-source: probe-rs/src/debug/debug_info.rs
-assertion_line: 1896
+source: probe-rs-debug/src/debug_info.rs
 expression: printed_backtrace
-snapshot_kind: text
 ---
 Frame:
  function:        wait<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
@@ -54,7 +52,7 @@ Frame:
   column: Some(Column(1))
  frame_base:      Some(20003ff8)
 Frame:
- function:        <unknown function @ 0x0000013c>
+ function:        Reset @ 0x0000013c>
  source_location:
 None
  frame_base:      None


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/159688e0-b535-4c95-85b7-86fd0b2c8e72)

This PR tries to provide a function name from object symbol tables. This has the obvious drawback of not always succeeding - see `esp32s3::__INTERRUPTS` in the screenshot. This is likely related to https://github.com/gimli-rs/addr2line/issues/324