### PR TITLE
Update the actually specified breakpoint unit

### DIFF
--- a/changelog/added-core-set-hw-breakpoint-unit.md
+++ b/changelog/added-core-set-hw-breakpoint-unit.md
@@ -1,0 +1,1 @@
+Added `Core::set_hw_breakpoint_unit` to update a selected breakpoint unit.

--- a/smoke-tester/src/main.rs
+++ b/smoke-tester/src/main.rs
@@ -478,6 +478,7 @@ impl<'dut> TestTracker<'dut> {
                 println_test_status!(self, yellow, "Missing resource for test: {}", message);
             }
             Err(_e) => {
+                println_test_status!(self, red, "{_e:?}");
                 println_test_status!(self, red, "Test failed in {formatted_duration}.");
             }
         };

--- a/smoke-tester/src/tests.rs
+++ b/smoke-tester/src/tests.rs
@@ -299,7 +299,9 @@ fn test_hw_breakpoints(tracker: &TestTracker, core: &mut Core) -> TestResult {
             .into_diagnostic()?;
 
         // Clear all breakpoints again
-        for i in 0..num_breakpoints {
+        core.clear_hw_breakpoint(initial_breakpoint_addr + num_breakpoints as u64 * 4)
+            .into_diagnostic()?;
+        for i in 1..num_breakpoints {
             core.clear_hw_breakpoint(initial_breakpoint_addr + 4 * i as u64)
                 .into_diagnostic()?;
         }


### PR DESCRIPTION
This PR fixes `CoreInterface::set_hw_breakpoint` to use the specified HW breakpoint unit, and adds a matching function to the inherent methods (Core::set_hw_breakpoint_unit). This means `CoreInterface::set_hw_breakpoint` can no longer fail with an unavailable breakpoint unit error if the specfied breakpoint unit exists.