### PR TITLE
Separate probing errors from firmware exits

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -45,7 +45,7 @@ use crate::{
             },
             info::{InfoEvent, TargetInfoRequest},
             memory::{ReadMemoryRequest, WriteMemoryRequest},
-            monitor::{MonitorMode, MonitorOptions, MonitorRequest},
+            monitor::{MonitorExitReason, MonitorMode, MonitorOptions, MonitorRequest},
             probe::{
                 AttachRequest, AttachResult, DebugProbeEntry, DebugProbeSelector,
                 ListProbesRequest, SelectProbeRequest, SelectProbeResult,
@@ -501,7 +501,7 @@ impl SessionInterface {
         mode: MonitorMode,
         options: MonitorOptions,
         on_msg: impl AsyncFnMut(MonitorEvent),
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<MonitorExitReason> {
         self.client
             .send_and_read_stream::<MonitorEndpoint, MonitorEvent, _>(
                 &MonitorRequest {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
@@ -4,8 +4,6 @@ use std::{convert::Infallible, future::Future};
 use crate::rpc::functions::file::{
     AppendFileRequest, CreateFileResponse, append_temp_file, create_temp_file,
 };
-use crate::rpc::functions::probe::{SelectProbeRequest, SelectProbeResponse, select_probe};
-use crate::rpc::transport::memory::{WireRx, WireTx};
 use crate::{
     rpc::{
         Key, SessionState,
@@ -20,10 +18,10 @@ use crate::{
             },
             info::{InfoEvent, TargetInfoRequest, target_info},
             memory::{ReadMemoryRequest, WriteMemoryRequest, read_memory, write_memory},
-            monitor::{MonitorRequest, RttEvent, SemihostingEvent, monitor},
+            monitor::{MonitorRequest, MonitorResponse, RttEvent, SemihostingEvent, monitor},
             probe::{
-                AttachRequest, AttachResponse, ListProbesRequest, ListProbesResponse, attach,
-                list_probes,
+                AttachRequest, AttachResponse, ListProbesRequest, ListProbesResponse,
+                SelectProbeRequest, SelectProbeResponse, attach, list_probes, select_probe,
             },
             reset::{ResetCoreRequest, reset},
             resume::{ResumeAllCoresRequest, resume_all_cores},
@@ -34,6 +32,7 @@ use crate::{
                 run_test,
             },
         },
+        transport::memory::{WireRx, WireTx},
     },
     util::common_options::OperationError,
 };
@@ -467,7 +466,7 @@ endpoints! {
     | FlashEndpoint             | FlashRequest           | NoResponse              | "flash/flash"      |
     | EraseEndpoint             | EraseRequest           | NoResponse              | "flash/erase"      |
     | VerifyEndpoint            | VerifyRequest          | VerifyResponse          | "flash/verify"     |
-    | MonitorEndpoint           | MonitorRequest         | NoResponse              | "monitor"          |
+    | MonitorEndpoint           | MonitorRequest         | MonitorResponse         | "monitor"          |
 
     | ListTestsEndpoint         | ListTestsRequest       | ListTestsResponse       | "tests/list"       |
     | RunTestEndpoint           | RunTestRequest         | RunTestResponse         | "tests/run"        |

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
@@ -175,6 +175,9 @@ fn list_tests_impl(
             version: 1,
             tests: vec![],
         }),
+        ReturnReason::LockedUp => {
+            anyhow::bail!("The target locked up while waiting for the test list.")
+        }
     }
 }
 
@@ -266,6 +269,9 @@ fn run_test_impl(
             expected_outcome, outcome
         ))),
         ReturnReason::Cancelled => Ok(TestResult::Cancelled),
+        ReturnReason::LockedUp => {
+            anyhow::bail!("The target locked up while running the test.")
+        }
     }
 }
 


### PR DESCRIPTION
This PR separates errors and abnormal firmware exit conditions in `monitor`. This technically closes #3307 although the solution is "good enough" as opposed to "good".