### PR TITLE
Remove miette from smoke tester

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,15 +318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace-ext"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
-dependencies = [
- "backtrace",
-]
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,12 +2129,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "is_ci"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,16 +2462,8 @@ version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
- "backtrace",
- "backtrace-ext",
  "cfg-if",
  "miette-derive",
- "owo-colors",
- "supports-color",
- "supports-hyperlinks",
- "supports-unicode",
- "terminal_size",
- "textwrap",
  "unicode-width 0.1.14",
 ]
 
@@ -2705,12 +2682,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "owo-colors"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "parking"
@@ -3973,12 +3944,12 @@ checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 name = "smoke_tester"
 version = "0.27.0"
 dependencies = [
+ "anyhow",
  "clap",
  "colored 3.0.0",
  "env_logger",
  "linkme",
  "log",
- "miette",
  "probe-rs",
  "serde",
  "thiserror 2.0.12",
@@ -4065,27 +4036,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "supports-color"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
-dependencies = [
- "is_ci",
-]
-
-[[package]]
-name = "supports-hyperlinks"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
-
-[[package]]
-name = "supports-unicode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "svd-parser"
@@ -4201,16 +4151,6 @@ dependencies = [
  "once_cell",
  "rustix 1.0.2",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
-dependencies = [
- "rustix 1.0.2",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/smoke-tester/Cargo.toml
+++ b/smoke-tester/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [dependencies]
 
+anyhow = { version = "1.0" }
 serde = { version = "1", features = ["derive"] }
 probe-rs = { workspace = true }
 toml = "0.8.12"
@@ -18,7 +19,6 @@ log = "0.4.21"
 clap = { version = "4.5", features = ["derive"] }
 colored = "3"
 linkme = "0.3.25"
-miette = { version = "7.2.0", features = ["fancy"] }
 thiserror.workspace = true
 
 [lints]

--- a/smoke-tester/src/tests/stepping.rs
+++ b/smoke-tester/src/tests/stepping.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use colored::Colorize;
 use linkme::distributed_slice;
-use miette::IntoDiagnostic;
 use probe_rs::{
     Architecture, BreakpointCause, Core, CoreStatus, Error, HaltReason, MemoryInterface,
     config::MemoryRegion, probe::DebugProbeError,
@@ -40,21 +39,18 @@ fn test_stepping(tracker: &TestTracker, core: &mut Core) -> TestResult {
 
     let code_load_address = ram_region.range.start;
 
-    core.reset_and_halt(Duration::from_millis(100))
-        .into_diagnostic()?;
+    core.reset_and_halt(Duration::from_millis(100))?;
 
-    core.write_8(code_load_address, TEST_CODE)
-        .into_diagnostic()?;
+    core.write_8(code_load_address, TEST_CODE)?;
 
     let registers = core.registers();
-    core.write_core_reg(registers.pc().unwrap(), code_load_address)
-        .into_diagnostic()?;
+    core.write_core_reg(registers.pc().unwrap(), code_load_address)?;
 
-    let core_information = core.step().into_diagnostic()?;
+    let core_information = core.step()?;
 
     let expected_pc = code_load_address + 2;
 
-    let core_status = core.status().into_diagnostic()?;
+    let core_status = core.status()?;
 
     assert_eq!(
         core_information.pc, expected_pc,
@@ -65,9 +61,7 @@ fn test_stepping(tracker: &TestTracker, core: &mut Core) -> TestResult {
         log::warn!("Unexpected core status: {:?}!", core_status);
     }
 
-    let r0_value: u64 = core
-        .read_core_reg(registers.core_register(0))
-        .into_diagnostic()?;
+    let r0_value: u64 = core.read_core_reg(registers.core_register(0))?;
 
     assert_eq!(r0_value, 0);
 
@@ -82,23 +76,19 @@ fn test_stepping(tracker: &TestTracker, core: &mut Core) -> TestResult {
 
     // Run up to the software breakpoint (bkpt) at offset 0x6
     let break_address = code_load_address + 0x6;
-    core.run().into_diagnostic()?;
+    core.run()?;
 
     match core.wait_for_core_halted(Duration::from_millis(100)) {
         Ok(()) => {}
         Err(Error::Probe(DebugProbeError::Timeout)) => {
             println_test_status!(tracker, yellow, "Core did not halt after timeout!");
-            core.halt(Duration::from_millis(100)).into_diagnostic()?;
+            core.halt(Duration::from_millis(100))?;
 
-            let pc: u64 = core
-                .read_core_reg(core.program_counter())
-                .into_diagnostic()?;
+            let pc: u64 = core.read_core_reg(core.program_counter())?;
 
             println_test_status!(tracker, blue, "Core stopped at: {pc:#08x}");
 
-            let r2_val: u64 = core
-                .read_core_reg(registers.core_register(2))
-                .into_diagnostic()?;
+            let r2_val: u64 = core.read_core_reg(registers.core_register(2))?;
 
             println_test_status!(tracker, blue, "$r2 = {r2_val:#08x}");
         }
@@ -107,7 +97,7 @@ fn test_stepping(tracker: &TestTracker, core: &mut Core) -> TestResult {
 
     println_test_status!(tracker, green, "Core halted again!");
 
-    let core_status = core.status().into_diagnostic()?;
+    let core_status = core.status()?;
 
     assert!(matches!(
         core_status,
@@ -115,9 +105,7 @@ fn test_stepping(tracker: &TestTracker, core: &mut Core) -> TestResult {
             | CoreStatus::Halted(HaltReason::Breakpoint(BreakpointCause::Unknown))
     ));
 
-    let pc: u64 = core
-        .read_core_reg(core.program_counter())
-        .into_diagnostic()?;
+    let pc: u64 = core.read_core_reg(core.program_counter())?;
 
     assert_eq!(pc, break_address);
 
@@ -128,13 +116,12 @@ fn test_stepping(tracker: &TestTracker, core: &mut Core) -> TestResult {
     );
 
     // Increase PC by 2 to skip breakpoint.
-    core.write_core_reg(core.program_counter(), pc + 2)
-        .into_diagnostic()?;
+    core.write_core_reg(core.program_counter(), pc + 2)?;
 
     println_test_status!(tracker, blue, "Run core again, with pc = {:#010x}", pc + 2);
 
     // Run to the finish
-    core.run().into_diagnostic()?;
+    core.run()?;
 
     // Final breakpoint is at offset 0x10
 
@@ -144,24 +131,20 @@ fn test_stepping(tracker: &TestTracker, core: &mut Core) -> TestResult {
         Ok(()) => {}
         Err(Error::Probe(DebugProbeError::Timeout)) => {
             println_test_status!(tracker, yellow, "Core did not halt after timeout!");
-            core.halt(Duration::from_millis(100)).into_diagnostic()?;
+            core.halt(Duration::from_millis(100))?;
 
-            let pc: u64 = core
-                .read_core_reg(core.program_counter())
-                .into_diagnostic()?;
+            let pc: u64 = core.read_core_reg(core.program_counter())?;
 
             println_test_status!(tracker, blue, "Core stopped at: {pc:#08x}");
 
-            let r2_val: u64 = core
-                .read_core_reg(registers.core_register(2))
-                .into_diagnostic()?;
+            let r2_val: u64 = core.read_core_reg(registers.core_register(2))?;
 
             println_test_status!(tracker, blue, "$r2 = {r2_val:#08x}");
         }
         Err(other) => return Err(other.into()),
     }
 
-    let core_status = core.status().into_diagnostic()?;
+    let core_status = core.status()?;
 
     assert!(matches!(
         core_status,
@@ -169,16 +152,12 @@ fn test_stepping(tracker: &TestTracker, core: &mut Core) -> TestResult {
             | CoreStatus::Halted(HaltReason::Breakpoint(BreakpointCause::Unknown))
     ));
 
-    let pc: u64 = core
-        .read_core_reg(core.program_counter())
-        .into_diagnostic()?;
+    let pc: u64 = core.read_core_reg(core.program_counter())?;
 
     assert_eq!(pc, break_address, "{pc:#08x} != {break_address:#08x}");
 
     // Register r2 should be 1 to indicate end of test.
-    let r2_val: u64 = core
-        .read_core_reg(registers.core_register(2))
-        .into_diagnostic()?;
+    let r2_val: u64 = core.read_core_reg(registers.core_register(2))?;
     assert_eq!(1, r2_val);
 
     Ok(())


### PR DESCRIPTION
Normally, miette would be a fine library to print human-consumable diagnostics, but we don't use any of that in the smoke tester - and I don't think the offered features would even be that useful. The smoke tester's error output could probably be improved without the library and its added code noise.