### PR TITLE
Add --output and --format to the read command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,6 +3086,7 @@ dependencies = [
  "gdbstub",
  "git-version",
  "goblin",
+ "ihex",
  "indicatif",
  "insta",
  "itertools 0.14.0",

--- a/changelog/added-read-output.md
+++ b/changelog/added-read-output.md
@@ -1,0 +1,1 @@
+Added outputting to binary/hex to the read command

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -58,6 +58,7 @@ goblin = { version = "0.9", default-features = false, features = [
     "elf64",
     "endian_fd",
 ] }
+ihex = "3.0"
 indicatif = "0.17"
 insta = { version = "1.38", default-features = false, features = ["yaml"] }
 itm = { version = "0.9.0-rc.1", default-features = false }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/read.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/read.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use ihex::Record;
 use itertools::Itertools;
 
-use crate::rpc::client::RpcClient;
+use crate::rpc::client::{CoreInterface, RpcClient};
 
 use crate::CoreOptions;
 use crate::util::cli;
@@ -21,11 +21,14 @@ enum FileFormat {
 /// e.g. probe-rs read b32 0x400E1490 2
 ///      Reads 2 32-bit words from address 0x400E1490
 ///
-/// Output is a space separated list of hex values padded to the read word width.
+/// Default output is a space separated list of hex values padded to the read word width.
 /// e.g. 2 words
 ///     00 00 (8-bit)
 ///     00000000 00000000 (32-bit)
 ///     0000000000000000 0000000000000000 (64-bit)
+///
+/// If the --output argument is provided, readback data is instead saved to a file as hex/bin.
+/// In this case, the read word width has no effect except determining the total number of bytes
 ///
 /// NOTE: Only supports RAM addresses
 #[derive(clap::Parser)]
@@ -52,86 +55,115 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub async fn run(self, client: RpcClient) -> anyhow::Result<()> {
-        let session = cli::attach_probe(&client, self.probe_options, false).await?;
-        let core = session.core(self.shared.core);
-
-        let nbytes;
-        match self.read_write_options.width {
+    async fn read_to_console(
+        core: CoreInterface,
+        address: u64,
+        width: ReadWriteBitWidth,
+        nwords: usize,
+    ) -> anyhow::Result<()> {
+        match width {
             ReadWriteBitWidth::B8 => {
-                let values = core
-                    .read_memory_8(self.read_write_options.address, self.words)
-                    .await?;
+                let values = core.read_memory_8(address, nwords).await?;
                 for val in values {
                     print!("{:02x} ", val);
                 }
-                nbytes = self.words;
             }
             ReadWriteBitWidth::B16 => {
-                let values = core
-                    .read_memory_16(self.read_write_options.address, self.words)
-                    .await?;
+                let values = core.read_memory_16(address, nwords).await?;
                 for val in values {
                     print!("{:08x} ", val);
                 }
-                nbytes = self.words * 2;
             }
             ReadWriteBitWidth::B32 => {
-                let values = core
-                    .read_memory_32(self.read_write_options.address, self.words)
-                    .await?;
+                let values = core.read_memory_32(address, nwords).await?;
                 for val in values {
                     print!("{:08x} ", val);
                 }
-                nbytes = self.words * 4;
             }
             ReadWriteBitWidth::B64 => {
-                let values = core
-                    .read_memory_64(self.read_write_options.address, self.words)
-                    .await?;
+                let values = core.read_memory_64(address, nwords).await?;
                 for val in values {
                     print!("{:016x} ", val);
-                }
-                nbytes = self.words * 8;
-            }
-        }
-
-        if let Some(path) = self.output {
-            let mut running_address = self.read_write_options.address;
-            // Read a fresh set of data from the chip at the requested location.
-            // We can't reuse the prior data because we don't know how to handle
-            // endianness
-            let data = core
-                .read_memory_8(self.read_write_options.address, nbytes)
-                .await?;
-
-            match self.format {
-                FileFormat::Binary => {
-                    std::fs::File::create(path)?.write_all(&data)?;
-                }
-                FileFormat::Hex => {
-                    let mut records = vec![];
-
-                    for chunk in &data.into_iter().chunks(255) {
-                        let address_msbs: u16 = (running_address >> 16)
-                            .try_into()
-                            .context("Hex format only supports addressing up to 32 bits")?;
-
-                        records.push(Record::ExtendedLinearAddress(address_msbs));
-
-                        records.push(Record::Data {
-                            offset: (running_address & 0xFFFF) as u16,
-                            value: chunk.collect(),
-                        });
-                        running_address += 255;
-                    }
-                    records.push(Record::EndOfFile);
-                    let hexdata = ihex::create_object_file_representation(&records)?;
-                    std::fs::File::create(path)?.write_all(hexdata.as_bytes())?;
                 }
             }
         }
         println!();
+        Ok(())
+    }
+
+    async fn read_to_file(
+        core: CoreInterface,
+        address: u64,
+        width: ReadWriteBitWidth,
+        nwords: usize,
+        path: PathBuf,
+        format: FileFormat,
+    ) -> anyhow::Result<()> {
+        let nbytes = nwords
+            * match width {
+                ReadWriteBitWidth::B8 => 1,
+                ReadWriteBitWidth::B16 => 2,
+                ReadWriteBitWidth::B32 => 4,
+                ReadWriteBitWidth::B64 => 8,
+            };
+
+        let data = core.read_memory_8(address, nbytes).await?;
+
+        let mut running_address = address;
+        match format {
+            FileFormat::Binary => {
+                std::fs::File::create(path)?.write_all(&data)?;
+            }
+            FileFormat::Hex => {
+                let mut records = vec![];
+
+                for chunk in &data.into_iter().chunks(255) {
+                    let address_msbs: u16 = (running_address >> 16)
+                        .try_into()
+                        .context("Hex format only supports addressing up to 32 bits")?;
+
+                    records.push(Record::ExtendedLinearAddress(address_msbs));
+
+                    records.push(Record::Data {
+                        offset: (running_address & 0xFFFF) as u16,
+                        value: chunk.collect(),
+                    });
+                    running_address += 255;
+                }
+                records.push(Record::EndOfFile);
+                let hexdata = ihex::create_object_file_representation(&records)?;
+                std::fs::File::create(path)?.write_all(hexdata.as_bytes())?;
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn run(self, client: RpcClient) -> anyhow::Result<()> {
+        let session = cli::attach_probe(&client, self.probe_options, false).await?;
+        let core = session.core(self.shared.core);
+
+        match self.output {
+            Some(path) => {
+                Cmd::read_to_file(
+                    core,
+                    self.read_write_options.address,
+                    self.read_write_options.width,
+                    self.words,
+                    path,
+                    self.format,
+                )
+                .await?
+            }
+            None => {
+                Cmd::read_to_console(
+                    core,
+                    self.read_write_options.address,
+                    self.read_write_options.width,
+                    self.words,
+                )
+                .await?
+            }
+        };
 
         session.resume_all_cores().await?;
 


### PR DESCRIPTION
Closes #2957 

---

I implemented this as a second read because of endianness reasons.
I don't know how to write (say) u64 bytes back into their byte representation for saving out to a file.