### PR TITLE
Add blank check to algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4137,6 +4137,7 @@ dependencies = [
  "tokio",
  "tracing-subscriber",
  "xshell",
+ "zerocopy",
  "zip",
 ]
 

--- a/changelog/added-blank-check-to-flasher.md
+++ b/changelog/added-blank-check-to-flasher.md
@@ -1,0 +1,1 @@
+Added support for calling `BlankCheck` on a target to determine whether it has been erased for cases where a blank flash can't be determined by a simple memory compare, such as parts with ECC flash.

--- a/probe-rs-target/src/flash_algorithm.rs
+++ b/probe-rs-target/src/flash_algorithm.rs
@@ -66,6 +66,9 @@ pub struct RawFlashAlgorithm {
     /// Address of the (non-standard) `ReadFlash()` entry point. Optional.
     #[serde(serialize_with = "hex_option")]
     pub pc_read: Option<u64>,
+    /// Address of the `BlankCheck()` entry point. Optional.
+    #[serde(serialize_with = "hex_option")]
+    pub pc_blank_check: Option<u64>,
     /// The offset from the start of RAM to the data section.
     #[serde(serialize_with = "hex_u_int")]
     pub data_section_offset: u64,

--- a/probe-rs/src/flashing/erase.rs
+++ b/probe-rs/src/flashing/erase.rs
@@ -247,3 +247,90 @@ pub fn erase_sectors(
 
     Ok(())
 }
+
+/// Check that a memory range has been erased.
+pub fn run_blank_check(
+    session: &mut Session,
+    progress: FlashProgress,
+    start_sector: usize,
+    sectors: usize,
+) -> Result<(), FlashError> {
+    tracing::debug!("Performing blank check...");
+
+    let mut algos: HashMap<(String, String), Vec<NvmRegion>> = HashMap::new();
+    tracing::debug!("Regions:");
+    for region in session
+        .target()
+        .memory_map
+        .iter()
+        .filter_map(MemoryRegion::as_nvm_region)
+    {
+        if region.is_alias {
+            tracing::debug!("Skipping alias memory region {:#010x?}", region.range);
+            continue;
+        }
+        tracing::debug!(
+            "    region: {:#010x?} ({} bytes)",
+            region.range,
+            region.range.end - region.range.start
+        );
+
+        let algo = FlashLoader::get_flash_algorithm_for_region(region, session.target())?;
+
+        // Get the first core that can access the region
+        let core_name = region
+            .cores
+            .first()
+            .ok_or_else(|| FlashError::NoNvmCoreAccess(region.clone()))?;
+
+        let entry = algos
+            .entry((algo.name.clone(), core_name.clone()))
+            .or_default();
+        entry.push(region.clone());
+
+        tracing::debug!("     -- using algorithm: {}", algo.name);
+    }
+
+    for ((algo_name, core_name), regions) in algos {
+        tracing::debug!("Checking for blank sector with algorithm: {}", algo_name);
+
+        // This can't fail, algo_name comes from the target.
+        let algo = session.target().flash_algorithm_by_name(&algo_name);
+        let algo = algo.unwrap();
+
+        let core_index = session.target().core_index_by_name(&core_name).unwrap();
+        let mut flasher = Flasher::new(session.target(), core_index, algo)?;
+
+        let sectors = flasher
+            .flash_algorithm()
+            .iter_sectors()
+            .skip(start_sector)
+            .take(sectors)
+            .filter(|info| {
+                let range = info.base_address..info.base_address + info.size;
+                regions.iter().any(|r| r.range.contains_range(&range))
+            })
+            .collect::<Vec<_>>();
+
+        flasher.run_blank_check(session, &progress, |active, _| {
+            for info in sectors {
+                tracing::debug!(
+                    "    sector: {:#010x}-{:#010x} ({} bytes)",
+                    info.base_address,
+                    info.base_address + info.size,
+                    info.size
+                );
+
+                let sector = FlashSector {
+                    address: info.base_address,
+                    size: info.size,
+                };
+
+                active.blank_check(&sector)?;
+            }
+            Ok(())
+        })?;
+    }
+
+    Ok(())
+}

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -40,6 +40,8 @@ pub struct FlashAlgorithm {
     pub pc_verify: Option<u64>,
     /// Address of the (non-standard) `ReadFlash()` entry point. Optional.
     pub pc_read: Option<u64>,
+    /// Address of the `BlankCheck()` entry point. Optional.
+    pub pc_blank_check: Option<u64>,
     /// Initial value of the R9 register for calling flash algo entry points, which
     /// determines where the position-independent data resides.
     pub static_base: u64,
@@ -388,6 +390,7 @@ impl FlashAlgorithm {
             pc_erase_all: raw.pc_erase_all.map(|v| code_start + v),
             pc_verify: raw.pc_verify.map(|v| code_start + v),
             pc_read: raw.pc_read.map(|v| code_start + v),
+            pc_blank_check: raw.pc_blank_check.map(|v| code_start + v),
             static_base: code_start + raw.data_section_offset,
             stack_top,
             stack_size,

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -1,5 +1,6 @@
 use probe_rs_target::{RawFlashAlgorithm, TransferEncoding};
 use tracing::Level;
+use zerocopy::IntoBytes;
 
 use super::{FlashAlgorithm, FlashBuilder, FlashError, FlashPage, FlashProgress};
 use crate::config::NvmRegion;
@@ -207,9 +208,23 @@ impl Flasher {
         if algo.stack_overflow_check {
             // Fill the stack with known data.
             let stack_bottom = algo.stack_top - algo.stack_size;
-            let fill = vec![STACK_FILL_BYTE; algo.stack_size as usize];
-            core.write_8(stack_bottom, &fill)
-                .map_err(FlashError::Core)?;
+            if algo.stack_size & 3 == 0 {
+                let fill = vec![
+                    u32::from_ne_bytes([
+                        STACK_FILL_BYTE,
+                        STACK_FILL_BYTE,
+                        STACK_FILL_BYTE,
+                        STACK_FILL_BYTE
+                    ]);
+                    algo.stack_size as usize / 4
+                ];
+                core.write_32(stack_bottom, &fill)
+                    .map_err(FlashError::Core)?;
+            } else {
+                let fill = vec![STACK_FILL_BYTE; algo.stack_size as usize];
+                core.write_8(stack_bottom, &fill)
+                    .map_err(FlashError::Core)?;
+            }
         }
 
         tracing::debug!("RAM contents match flashing algo blob.");
@@ -270,6 +285,21 @@ impl Flasher {
         }
 
         result
+    }
+
+    pub(super) fn run_blank_check<'p, T, F>(
+        &mut self,
+        session: &mut Session,
+        progress: &FlashProgress<'p>,
+        f: F,
+    ) -> Result<T, FlashError>
+    where
+        F: FnOnce(&mut ActiveFlasher<'_, 'p, Erase>, &mut [LoadedRegion]) -> Result<T, FlashError>,
+    {
+        let (mut active, data) = self.init(session, progress, None)?;
+        let r = f(&mut active, data)?;
+        active.uninit()?;
+        Ok(r)
     }
 
     pub(super) fn run_erase<'p, T, F>(
@@ -1123,7 +1153,7 @@ impl<O: Operation> ActiveFlasher<'_, '_, O> {
         let t1 = Instant::now();
 
         self.core
-            .write_32(address, &words)
+            .write(address, words.as_bytes())
             .map_err(FlashError::Core)?;
 
         tracing::info!(
@@ -1204,6 +1234,68 @@ impl ActiveFlasher<'_, '_, Erase> {
             })
         } else {
             self.progress.sector_erased(sector.size(), t1.elapsed());
+            Ok(())
+        }
+    }
+
+    pub(super) fn blank_check(&mut self, sector: &FlashSector) -> Result<(), FlashError> {
+        let address = sector.address();
+        let size = sector.size();
+        tracing::info!(
+            "Checking for blanked flash between address {:#010x} and {:#010x}",
+            address,
+            address + size
+        );
+        let t1 = Instant::now();
+
+        if let Some(blank_check) = self.flash_algorithm.pc_blank_check {
+            let error_code = self.call_function_and_wait(
+                &Registers {
+                    pc: into_reg(blank_check)?,
+                    r0: Some(into_reg(address)?),
+                    r1: Some(into_reg(size)?),
+                    r2: Some(into_reg(
+                        self.flash_algorithm
+                            .flash_properties
+                            .erased_byte_value
+                            .into(),
+                    )?),
+                    r3: None,
+                },
+                false,
+                Duration::from_millis(
+                    // self.flash_algorithm.flash_properties.erase_sector_timeout as u64,
+                    10_000,
+                ),
+            )?;
+            tracing::info!(
+                "Done checking blank. Result is {}. This took {:?}",
+                error_code,
+                t1.elapsed()
+            );
+
+            if error_code != 0 {
+                Err(FlashError::RoutineCallFailed {
+                    name: "blank_check",
+                    error_code,
+                })
+            } else {
+                self.progress.sector_erased(sector.size(), t1.elapsed());
+                Ok(())
+            }
+        } else {
+            let mut data = vec![0; size as usize];
+            self.core
+                .read(address, &mut data)
+                .map_err(FlashError::Core)?;
+            if !data
+                .iter()
+                .all(|v| *v == self.flash_algorithm.flash_properties.erased_byte_value)
+            {
+                return Err(FlashError::ChipEraseFailed {
+                    source: "Not all sectors were erased".into(),
+                });
+            }
             Ok(())
         }
     }

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -51,6 +51,7 @@ tracing-subscriber = { version = "0.3.18", features = [
 ] }
 xshell = { version = "0.2", default-features = false }
 parse_int = "0.9"
+zerocopy = { version = "0.8.0", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/target-gen/src/parser.rs
+++ b/target-gen/src/parser.rs
@@ -91,6 +91,7 @@ pub fn extract_flash_algo(
             "ProgramPage" => algo.pc_program_page = sym.st_value - code_section_offset as u64,
             "Verify" => algo.pc_verify = Some(sym.st_value - code_section_offset as u64),
             "ReadFlash" => algo.pc_read = Some(sym.st_value - code_section_offset as u64),
+            "BlankCheck" => algo.pc_blank_check = Some(sym.st_value - code_section_offset as u64),
             "_SEGGER_RTT" => {
                 algo.rtt_location = Some(sym.st_value);
                 log::debug!("Found RTT control block at address {:#010x}", sym.st_value);


### PR DESCRIPTION
Add blank_check to flash algorithms. This is code that runs on the target, and is used for checking whether flash is blank or not on parts where the blank status isn't a simple pattern. This is common on ECC parts, where frequently a blank flash isn't even valid.