### PR TITLE
algorithm: pass through untouched yaml fields

### DIFF
--- a/changelog/fixed-target-gen-algorithm-yaml-fields.md
+++ b/changelog/fixed-target-gen-algorithm-yaml-fields.md
@@ -1,0 +1,1 @@
+Fixed passing extra fields such as `stack_size` in the `template.yaml` file when generating flash algorithms rather than dropping them

--- a/target-gen/src/commands/elf.rs
+++ b/target-gen/src/commands/elf.rs
@@ -27,10 +27,10 @@ pub fn cmd_elf(
     let elf_file = std::fs::read(file)
         .with_context(|| format!("Failed to open ELF file {}", file.display()))?;
 
-    let mut algorithm = extract_flash_algo(&elf_file, file, true, fixed_load_address)?;
+    let mut algorithm = extract_flash_algo(None, &elf_file, file, true, fixed_load_address)?;
 
-    if let Some(name) = name {
-        algorithm.name = name;
+    if let Some(name) = &name {
+        algorithm.name = name.clone();
     }
 
     if update {
@@ -58,6 +58,17 @@ pub fn cmd_elf(
         };
 
         let current = &family.flash_algorithms[algorithm_to_update];
+        // Re-extract the algorithm, keeping existing values in the target definition
+        let mut algorithm = extract_flash_algo(
+            Some(current.clone()),
+            &elf_file,
+            file,
+            true,
+            fixed_load_address,
+        )?;
+        if let Some(name) = name {
+            algorithm.name = name;
+        }
 
         // if a load address was specified, use it in the replacement
         if let Some(load_addr) = current.load_address {

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -49,6 +49,7 @@ where
 {
     let algo_bytes = kind.read_bytes(&flash_algorithm.file_name)?;
     let mut algo = crate::parser::extract_flash_algo(
+        None,
         &algo_bytes,
         &flash_algorithm.file_name,
         flash_algorithm.default,

--- a/target-gen/src/parser.rs
+++ b/target-gen/src/parser.rs
@@ -58,12 +58,13 @@ fn extract_flash_device(elf: &goblin::elf::Elf, buffer: &[u8]) -> Result<FlashDe
 
 /// Extracts a position & memory independent flash algorithm blob from the provided ELF file.
 pub fn extract_flash_algo(
+    existing_algo: Option<RawFlashAlgorithm>,
     buffer: &[u8],
     file_name: &std::path::Path,
     default: bool,
     fixed_load_address: bool,
 ) -> Result<RawFlashAlgorithm> {
-    let mut algo = RawFlashAlgorithm::default();
+    let mut algo = existing_algo.unwrap_or_default();
 
     let elf = goblin::elf::Elf::parse(buffer)?;
 


### PR DESCRIPTION
Support passing through yaml fields that aren't touched by the elf generator. This allows for passing fields such as the `stack_size`, which otherwise would be lost.