### PR TITLE
flasher: use Thumb2 BKPT instruciton for A32

### DIFF
--- a/changelog/fixed-flasher-support-for-armv7a.md
+++ b/changelog/fixed-flasher-support-for-armv7a.md
@@ -1,0 +1,1 @@
+Fixed flasher support for ARMv7A, which would otherwise have a misaligned `$lr` value on return

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -880,8 +880,11 @@ impl<O: Operation> ActiveFlasher<'_, '_, O> {
             (
                 self.core.return_address(),
                 // For ARM Cortex-M cores, we have to add 1 to the return address,
-                // to ensure that we stay in Thumb mode.
-                if self.instruction_set == InstructionSet::Thumb2 {
+                // to ensure that we stay in Thumb mode. A32 also generally supports
+                // Thumb and uses the same `BKPT` instruction when in this mode.
+                if self.instruction_set == InstructionSet::Thumb2
+                    || self.instruction_set == InstructionSet::A32
+                {
                     Some(into_reg(algo.load_address + 1)?)
                 } else {
                     Some(into_reg(algo.load_address)?)


### PR DESCRIPTION
Armv7 and Armv8 in 32-bit mode both support the Thumb2 breakpoint instruction. Use this instruction for those platforms.