### PR TITLE
memory: delegate `read()` to the memory object

### DIFF
--- a/changelog/added-read-implementation-to-memoryinterface.md
+++ b/changelog/added-read-implementation-to-memoryinterface.md
@@ -1,0 +1,1 @@
+Added the `MemoryInterface::read()` default implementation, which was missing in the calls that are delegated to the memory object

--- a/changelog/fixed-adi-memory-interface-read.md
+++ b/changelog/fixed-adi-memory-interface-read.md
@@ -1,0 +1,1 @@
+Fixed the implementation of `fn read()` in `ADIMemoryInterface` when reading byte values and other non-aligned data.

--- a/changelog/fixed-smoke-tester-readme-command.md
+++ b/changelog/fixed-smoke-tester-readme-command.md
@@ -1,0 +1,1 @@
+Fixed the command in the README for `smoke-tester`, which was missing the verb `test`.

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -400,6 +400,10 @@ where
         self.memory_mut().read_8(address, data).map_err(Error::from)
     }
 
+    fn read(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
+        self.memory_mut().read(address, data).map_err(Error::from)
+    }
+
     fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
         self.memory_mut()
             .write_word_64(address, data)

--- a/smoke-tester/README.md
+++ b/smoke-tester/README.md
@@ -6,7 +6,7 @@
 To test a single board quickly, the chip and probe can be specified directly on the command line:
 
 ```console
-cargo run -- --chip nrf51822_xxAB --probe 0d28:0204
+cargo run -- test --chip nrf51822_xxAB --probe 0d28:0204
 ```
 
 ## Multiple boards
@@ -33,4 +33,3 @@ The smoke tester can called like this:
 ```console
 cargo run -- --dut-definitions <dut_dir>
 ```
-


### PR DESCRIPTION
The default implementation of `read()` was left out of an earlier implementation that forwarded a bunch of calls to the underlying `self.memory_mut().read()`.