### PR TITLE
armv7a: update halt status if it's discovered it was halted

### DIFF
--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -279,7 +279,7 @@ impl<'probe> Armv7a<'probe> {
         &mut self,
         op: impl FnOnce(&mut Self) -> Result<R, Error>,
     ) -> Result<R, Error> {
-        let was_running = !(self.state.current_state.is_halted() || self.core_halted()?);
+        let was_running = !(self.state.current_state.is_halted() || self.status()?.is_halted());
 
         if was_running {
             self.halt(Duration::from_millis(100))?;


### PR DESCRIPTION
Add a simple fix to the `halted_access()` call in armv7a.

If the core is halted while we aren't looking, then `self.state` will show it as running but `self.core_halted()?` will show it as halted. If this happens, ensure we update `self.state` by requesting the core's status.

This condition happens rarely, but is exacerbated by `target-gen` and running code on the target. For example, when loading code, it might be the case that the loaded program exits and hits the breakpoint before we have a chance to inspect it. This ensures that the core is definitely halted.