### PR TITLE
Armv7a instruction fixes

### DIFF
--- a/changelog/added-armv7a-cpsr-updating.md
+++ b/changelog/added-armv7a-cpsr-updating.md
@@ -1,0 +1,1 @@
+Added the ability to write back the CPSR on ARMv7A and ARMv7R cores.

--- a/changelog/fixed-jumping-to-algorithms-on-armv7a.md
+++ b/changelog/fixed-jumping-to-algorithms-on-armv7a.md
@@ -1,0 +1,1 @@
+Fixed jumping to loaded code on an ARMv7R, where `bx lr` doesn't work when the core is halted but `mov pc, r0` does.

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -3,8 +3,8 @@
 use super::{
     CortexAState,
     instructions::aarch32::{
-        build_bx, build_ldc, build_mcr, build_mov, build_mrc, build_mrs, build_stc, build_vmov,
-        build_vmrs,
+        build_bx, build_ldc, build_mcr, build_mov, build_mrc, build_mrs, build_msr, build_stc,
+        build_vmov, build_vmrs,
     },
     registers::{
         aarch32::{
@@ -217,6 +217,11 @@ impl<'probe> Armv7a<'probe> {
                             // BX r0
                             let instruction = build_bx(0);
                             self.execute_instruction(instruction)?;
+                        }
+                        16 => {
+                            // msr cpsr_fsxc, r0
+                            let instruction = build_msr(0);
+                            self.execute_instruction_with_input(instruction, val.try_into()?)?;
                         }
                         17..=48 => {
                             // Move value to r0, r1

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -3,8 +3,8 @@
 use super::{
     CortexAState,
     instructions::aarch32::{
-        build_bx, build_ldc, build_mcr, build_mov, build_mrc, build_mrs, build_msr, build_stc,
-        build_vmov, build_vmrs,
+        build_ldc, build_mcr, build_mov, build_mrc, build_mrs, build_msr, build_stc, build_vmov,
+        build_vmrs,
     },
     registers::{
         aarch32::{
@@ -214,8 +214,10 @@ impl<'probe> Armv7a<'probe> {
 
                             self.execute_instruction_with_input(instruction, val.try_into()?)?;
 
-                            // BX r0
-                            let instruction = build_bx(0);
+                            // Use `mov pc, r0` rather than `bx r0` because the `bx` instruction is
+                            // `UNPREDICTABLE` in the debug state (ARM Architecture Reference Manual,
+                            // ARMv7-A and ARMv7-R edition, C5.3: "Executing instructions in Debug state").
+                            let instruction = build_mov(15, 0);
                             self.execute_instruction(instruction)?;
                         }
                         16 => {

--- a/probe-rs/src/architecture/arm/core/instructions.rs
+++ b/probe-rs/src/architecture/arm/core/instructions.rs
@@ -51,14 +51,6 @@ pub(crate) mod aarch32 {
         ret
     }
 
-    pub(crate) fn build_bx(reg: u16) -> u32 {
-        let mut ret = 0b1110_0001_0010_1111_1111_1111_0001_0000;
-
-        ret |= reg as u32;
-
-        ret
-    }
-
     pub(crate) fn build_ldc(coproc: u8, ctrl_reg: u8, reg: u16, imm: u8) -> u32 {
         let mut ret = 0b1110_1100_1011_0000_0000_0000_0000_0000;
 
@@ -145,14 +137,6 @@ pub(crate) mod aarch32 {
 
             // MOV r2, pc
             assert_eq!(0xE1A0200F, instr);
-        }
-
-        #[test]
-        fn gen_bx_instruction() {
-            let instr = build_bx(2);
-
-            // BX r2
-            assert_eq!(0xE12FFF12, instr);
         }
 
         #[test]

--- a/probe-rs/src/architecture/arm/core/instructions.rs
+++ b/probe-rs/src/architecture/arm/core/instructions.rs
@@ -81,10 +81,20 @@ pub(crate) mod aarch32 {
         ret
     }
 
+    /// Read the CPSR
     pub(crate) fn build_mrs(reg: u16) -> u32 {
         let mut ret = 0b1110_0001_0000_1111_0000_0000_0000_0000;
 
         ret |= (reg as u32) << 12;
+
+        ret
+    }
+
+    /// Set all bits of the CPSR
+    pub(crate) fn build_msr(reg: u16) -> u32 {
+        let mut ret = 0b1110_0001_0010_1111_1111_0000_0000_0000;
+
+        ret |= reg as u32;
 
         ret
     }
@@ -167,6 +177,14 @@ pub(crate) mod aarch32 {
 
             // MRS r2, CPSR
             assert_eq!(0xE10F2000, instr);
+        }
+
+        #[test]
+        fn gen_msr_instruction() {
+            let instr = build_msr(2);
+
+            // MSR CPSR_FSXC, r0
+            assert_eq!(0xE12FF002, instr);
         }
 
         #[test]


### PR DESCRIPTION
Miscellaneous fixes for ARMv7A (and ARMv7R).

A note on the `bx r0` -> `mov pc, r0` change: The former just doesn't seem to work on Cortex-A cores. I can't find any documentation on this, but I do see [this from openocd](https://github.com/openocd-org/openocd/blob/6a3abda0b46a777490a8ce5bc748e6fed6775354/src/target/arm_dpm.c#L616-L621):

```cpp
	/* on Cortex-A5 (as found on NXP VF610 SoC), BX instruction
	 * executed in debug state doesn't appear to set the PC,
	 * explicitly set it with a "MOV pc, r0". This doesn't influence
	 * CPSR on Cortex-A9 so it should be OK. Maybe due to different
	 * debug version?
	 */
```