### PR TITLE
Armv7a big endian support

### DIFF
--- a/changelog/added-big-endian-flag-to-flash-algorithm.md
+++ b/changelog/added-big-endian-flag-to-flash-algorithm.md
@@ -1,0 +1,1 @@
+Added an `big_endian` flag to flash algorithms to indicate if an algorithm should get a big endian header.

--- a/changelog/added-big-endian-for-armv7a.md
+++ b/changelog/added-big-endian-for-armv7a.md
@@ -1,0 +1,1 @@
+Added initial big endian support for ARMv7A (and therefore ARMv7R)

--- a/changelog/added-big-endian-support-for-rtt.md
+++ b/changelog/added-big-endian-support-for-rtt.md
@@ -1,0 +1,1 @@
+Added big endian support for RTT

--- a/changelog/added-big-endian-support-for-rtt.md
+++ b/changelog/added-big-endian-support-for-rtt.md
@@ -1,1 +1,0 @@
-Added big endian support for RTT

--- a/probe-rs-target/src/flash_algorithm.rs
+++ b/probe-rs-target/src/flash_algorithm.rs
@@ -97,6 +97,14 @@ pub struct RawFlashAlgorithm {
     /// The encoding format accepted by the flash algorithm.
     #[serde(default)]
     pub transfer_encoding: Option<TransferEncoding>,
+
+    /// `true` if the instructions are saved in Big Endian format
+    #[serde(default = "no")]
+    pub big_endian: bool,
+}
+
+fn no() -> bool {
+    false
 }
 
 impl RawFlashAlgorithm {

--- a/probe-rs-target/src/flash_algorithm.rs
+++ b/probe-rs-target/src/flash_algorithm.rs
@@ -99,12 +99,8 @@ pub struct RawFlashAlgorithm {
     pub transfer_encoding: Option<TransferEncoding>,
 
     /// `true` if the instructions are saved in Big Endian format
-    #[serde(default = "no")]
+    #[serde(default)]
     pub big_endian: bool,
-}
-
-fn no() -> bool {
-    false
 }
 
 impl RawFlashAlgorithm {

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -953,21 +953,19 @@ impl CoreInterface for Armv7a<'_> {
     }
 
     fn endianness(&mut self) -> Result<Endian, Error> {
-        Ok(match self.endianness {
-            Some(endianness) => endianness,
-            None => {
-                let endianness = {
-                    let psr = TryInto::<u32>::try_into(self.read_core_reg(XPSR.id())?).unwrap();
-                    if psr & 1 << 9 == 0 {
-                        Endian::Little
-                    } else {
-                        Endian::Big
-                    }
-                };
-                self.endianness = Some(endianness);
-                endianness
+        if let Some(endianness) = self.endianness {
+            return Ok(endianness);
+        }
+        let endianness = {
+            let psr = TryInto::<u32>::try_into(self.read_core_reg(XPSR.id())?).unwrap();
+            if psr & 1 << 9 == 0 {
+                Endian::Little
+            } else {
+                Endian::Big
             }
-        })
+        };
+        self.endianness = Some(endianness);
+        Ok(endianness)
     }
 
     fn fpu_support(&mut self) -> Result<bool, Error> {

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -1305,8 +1305,8 @@ impl MemoryInterface for Armv7a<'_> {
             let endianness = core.endianness()?;
             for (bytes, value) in data.chunks_exact(4).zip(buffer.iter_mut()) {
                 *value = match endianness {
-                    Endian::Little => u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
-                    Endian::Big => u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+                    Endian::Little => u32::from_le_bytes(bytes.try_into().unwrap()),
+                    Endian::Big => u32::from_be_bytes(bytes.try_into().unwrap()),
                 }
             }
             core.write_32(address, &buffer)?;

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -1226,6 +1226,7 @@ mod test {
         ((address - TEST_BASE_ADDRESS) / 4) as u32
     }
 
+    #[derive(Debug)]
     pub struct ExpectedMemoryOp {
         read: bool,
         address: u64,
@@ -1570,6 +1571,14 @@ mod test {
         );
     }
 
+    impl Drop for MockProbe {
+        fn drop(&mut self) {
+            if !self.expected_ops.is_empty() {
+                panic!("self.expected_ops is not empty: {:?}", self.expected_ops);
+            }
+        }
+    }
+
     #[test]
     fn armv7a_new() {
         let mut probe = MockProbe::new();
@@ -1719,7 +1728,6 @@ mod test {
             Dbgdscr::get_mmio_address_from_base(TEST_BASE_ADDRESS).unwrap(),
             dbgdscr.into(),
         );
-        add_read_fp_count_expectations(&mut probe);
 
         let mock_mem = Box::new(probe) as _;
 

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -11,11 +11,11 @@ use super::{
             AARCH32_CORE_REGISTERS, AARCH32_WITH_FP_16_CORE_REGISTERS,
             AARCH32_WITH_FP_32_CORE_REGISTERS,
         },
-        cortex_m::{FP, PC, RA, SP},
+        cortex_m::{FP, PC, RA, SP, XPSR},
     },
 };
 use crate::{
-    Architecture, CoreInformation, CoreInterface, CoreRegister, CoreStatus, CoreType,
+    Architecture, CoreInformation, CoreInterface, CoreRegister, CoreStatus, CoreType, Endian,
     InstructionSet, MemoryInterface,
     architecture::arm::{
         ArmError, core::armv7a_debug_regs::*, memory::ArmMemoryInterface,
@@ -23,13 +23,14 @@ use crate::{
     },
     core::{CoreRegisters, MemoryMappedRegister, RegisterId, RegisterValue},
     error::Error,
-    memory::valid_32bit_address,
+    memory::{MemoryNotAlignedError, valid_32bit_address},
 };
 use std::{
     mem::size_of,
     sync::Arc,
     time::{Duration, Instant},
 };
+use zerocopy::IntoBytes;
 
 /// Errors for the ARMv7-A state machine
 #[derive(thiserror::Error, Debug)]
@@ -939,12 +940,21 @@ impl CoreInterface for Armv7a<'_> {
     }
 
     fn instruction_set(&mut self) -> Result<InstructionSet, Error> {
-        let cpsr: u32 = self.read_core_reg(RegisterId(16))?.try_into()?;
+        let cpsr: u32 = self.read_core_reg(XPSR.id())?.try_into()?;
 
         // CPSR bit 5 - T - Thumb mode
         match (cpsr >> 5) & 1 {
             1 => Ok(InstructionSet::Thumb2),
             _ => Ok(InstructionSet::A32),
+        }
+    }
+
+    fn endianness(&mut self) -> Result<Endian, Error> {
+        let psr = TryInto::<u32>::try_into(self.read_core_reg(XPSR.id())?).unwrap();
+        if psr & 1 << 9 == 0 {
+            Ok(Endian::Little)
+        } else {
+            Ok(Endian::Big)
         }
     }
 
@@ -1033,13 +1043,26 @@ impl MemoryInterface for Armv7a<'_> {
     fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
         self.halted_access(|core| {
             // Find the word this is in and its byte offset
-            let byte_offset = address % 4;
+            let mut byte_offset = address % 4;
             let word_start = address - byte_offset;
 
             // Read the word
             let data = core.read_word_32(word_start)?;
 
-            // Return the byte
+            // We do 32-bit reads, so we need to take a different field
+            // if we're running on a big endian device.
+            if Endian::Big == core.endianness()? {
+                // TODO: This doesn't work accessing 16-bit words that are not aligned.
+                if address & 1 != 0 {
+                    return Err(Error::MemoryNotAligned(MemoryNotAlignedError {
+                        address,
+                        alignment: 2,
+                    }));
+                }
+                byte_offset = 2 - byte_offset;
+            }
+
+            // Return the 16-bit word
             Ok((data >> (byte_offset * 8)) as u16)
         })
     }
@@ -1047,11 +1070,18 @@ impl MemoryInterface for Armv7a<'_> {
     fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
         self.halted_access(|core| {
             // Find the word this is in and its byte offset
-            let byte_offset = address % 4;
+            let mut byte_offset = address % 4;
+
             let word_start = address - byte_offset;
 
             // Read the word
             let data = core.read_word_32(word_start)?;
+
+            // We do 32-bit reads, so we need to take a different field
+            // if we're running on a big endian device.
+            if Endian::Big == core.endianness()? {
+                byte_offset = 3 - byte_offset;
+            }
 
             // Return the byte
             Ok(data.to_le_bytes()[byte_offset as usize])
@@ -1098,6 +1128,36 @@ impl MemoryInterface for Armv7a<'_> {
         })
     }
 
+    fn read(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
+        self.halted_access(|core| {
+            if address % 4 == 0 && data.len() % 4 == 0 {
+                // Avoid heap allocation and copy if we don't need it.
+                core.read_mem_32bit(address, data)?;
+                if core.endianness()? == Endian::Big {
+                    for word in data.chunks_exact_mut(4) {
+                        word.reverse();
+                    }
+                }
+            } else {
+                let start_address = address & !3;
+                let end_address = address + (data.len() as u64);
+                let end_address = end_address + (4 - (end_address & 3));
+                let start_extra_count = address as usize % 4;
+                let mut buffer = vec![0u32; (end_address - start_address) as usize / 4];
+                core.read_32(start_address, &mut buffer)?;
+                if core.endianness()? == Endian::Big {
+                    for word in buffer.iter_mut() {
+                        *word = word.swap_bytes();
+                    }
+                }
+                data.copy_from_slice(
+                    &buffer.as_bytes()[start_extra_count..start_extra_count + data.len()],
+                );
+            }
+            Ok(())
+        })
+    }
+
     fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
         self.halted_access(|core| {
             let data_low = data as u32;
@@ -1129,8 +1189,14 @@ impl MemoryInterface for Armv7a<'_> {
     fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
         self.halted_access(|core| {
             // Find the word this is in and its byte offset
-            let byte_offset = address % 4;
+            let mut byte_offset = address % 4;
             let word_start = address - byte_offset;
+
+            // We do 32-bit reads and writes, so we need to take a different field
+            // if we're running on a big endian device.
+            if Endian::Big == core.endianness()? {
+                byte_offset = 3 - byte_offset;
+            }
 
             // Get the current word value
             let current_word = core.read_word_32(word_start)?;
@@ -1144,8 +1210,21 @@ impl MemoryInterface for Armv7a<'_> {
     fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
         self.halted_access(|core| {
             // Find the word this is in and its byte offset
-            let byte_offset = address % 4;
+            let mut byte_offset = address % 4;
             let word_start = address - byte_offset;
+
+            // We do 32-bit reads and writes, so we need to take a different field
+            // if we're running on a big endian device.
+            if Endian::Big == core.endianness()? {
+                // TODO: This doesn't work when accessing 16-bit words that are not aligned.
+                if address & 1 != 0 {
+                    return Err(Error::MemoryNotAligned(MemoryNotAlignedError {
+                        address,
+                        alignment: 2,
+                    }));
+                }
+                byte_offset = 2 - byte_offset;
+            }
 
             // Get the current word value
             let mut word = core.read_word_32(word_start)?;
@@ -1193,6 +1272,38 @@ impl MemoryInterface for Armv7a<'_> {
             for (i, byte) in data.iter().enumerate() {
                 core.write_word_8(address + (i as u64), *byte)?;
             }
+
+            Ok(())
+        })
+    }
+
+    fn write(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
+        self.halted_access(|core| {
+            let len = data.len();
+            let start_extra_count = ((4 - (address % 4) as usize) % 4).min(len);
+            let end_extra_count = (len - start_extra_count) % 4;
+            assert!(start_extra_count < 4);
+            assert!(end_extra_count < 4);
+
+            if start_extra_count != 0 || end_extra_count != 0 {
+                return Err(MemoryNotAlignedError {
+                    address,
+                    alignment: 4,
+                }
+                .into());
+            }
+
+            // Make sure we don't try to do an empty but potentially unaligned write
+            // We do a 32 bit write of the remaining bytes that are 4 byte aligned.
+            let mut buffer = vec![0u32; data.len() / 4];
+            let endianness = core.endianness()?;
+            for (bytes, value) in data.chunks_exact(4).zip(buffer.iter_mut()) {
+                *value = match endianness {
+                    Endian::Little => u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+                    Endian::Big => u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+                }
+            }
+            core.write_32(address, &buffer)?;
 
             Ok(())
         })
@@ -1853,13 +1964,13 @@ mod test {
         // First read will hit expectations
         assert_eq!(
             RegisterValue::from(REG_VALUE),
-            armv7a.read_core_reg(RegisterId(16)).unwrap()
+            armv7a.read_core_reg(XPSR.id()).unwrap()
         );
 
         // Second read will cache, no new expectations
         assert_eq!(
             RegisterValue::from(REG_VALUE),
-            armv7a.read_core_reg(RegisterId(16)).unwrap()
+            armv7a.read_core_reg(XPSR.id()).unwrap()
         );
     }
 
@@ -2158,12 +2269,7 @@ mod test {
         assert_eq!(MEMORY_VALUE, armv7a.read_word_32(MEMORY_ADDRESS).unwrap());
     }
 
-    #[test]
-    fn armv7a_read_word_8() {
-        const MEMORY_VALUE: u32 = 0xBA5EBA11;
-        const MEMORY_ADDRESS: u64 = 0x12345679;
-        const MEMORY_WORD_ADDRESS: u64 = 0x12345678;
-
+    fn test_read_word(value: u32, address: u64, memory_word_address: u64, endian: Endian) -> u8 {
         let mut probe = MockProbe::new();
         let mut state = CortexAState::new();
 
@@ -2174,7 +2280,11 @@ mod test {
         add_read_fp_count_expectations(&mut probe);
 
         // Read memory
-        add_read_memory_expectations(&mut probe, MEMORY_WORD_ADDRESS, MEMORY_VALUE);
+        add_read_memory_expectations(&mut probe, memory_word_address, value);
+
+        // Set endianx
+        let cpsr = if endian == Endian::Big { 1 << 9 } else { 0 };
+        add_read_cpsr_expectations(&mut probe, cpsr);
 
         let mock_mem = Box::new(probe) as _;
 
@@ -2185,7 +2295,40 @@ mod test {
             DefaultArmSequence::create(),
         )
         .unwrap();
+        armv7a.read_word_8(address).unwrap()
+    }
 
-        assert_eq!(0xBA, armv7a.read_word_8(MEMORY_ADDRESS).unwrap());
+    #[test]
+    fn armv7a_read_word_8() {
+        const MEMORY_VALUE: u32 = 0xBA5EBB11;
+        const MEMORY_ADDRESS: u64 = 0x12345679;
+        const MEMORY_WORD_ADDRESS: u64 = 0x12345678;
+
+        assert_eq!(
+            0xBB,
+            test_read_word(
+                MEMORY_VALUE,
+                MEMORY_ADDRESS,
+                MEMORY_WORD_ADDRESS,
+                Endian::Little
+            )
+        );
+    }
+
+    #[test]
+    fn armv7a_read_word_8_be() {
+        const MEMORY_VALUE: u32 = 0xBA5EBB11;
+        const MEMORY_ADDRESS: u64 = 0x12345679;
+        const MEMORY_WORD_ADDRESS: u64 = 0x12345678;
+
+        assert_eq!(
+            0x5E,
+            test_read_word(
+                MEMORY_VALUE,
+                MEMORY_ADDRESS,
+                MEMORY_WORD_ADDRESS,
+                Endian::Big
+            )
+        );
     }
 }

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -250,7 +250,15 @@ impl FlashAlgorithm {
             None
         };
 
-        let header = Self::algorithm_header(target.architecture());
+        let mut header = Self::algorithm_header(target.architecture()).to_vec();
+
+        // If the ELF file is in Big Endian, we need to swap the contents of the header.
+        if raw.big_endian {
+            for word in header.iter_mut() {
+                *word = word.swap_bytes();
+            }
+        }
+
         let instructions: Vec<u32> = header
             .iter()
             .copied()
@@ -260,7 +268,7 @@ impl FlashAlgorithm {
             .chain(last_elem)
             .collect();
 
-        let header_size = size_of_val(header) as u64;
+        let header_size = size_of_val(header.as_slice()) as u64;
 
         // The start address where we try to load the flash algorithm.
         let addr_load = match raw.load_address {

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -179,11 +179,11 @@ impl Flasher {
         // Load flash algorithm code into target RAM.
         tracing::debug!("Downloading algorithm code to {:#010x}", algo.load_address);
 
-        core.write_32(algo.load_address, algo.instructions.as_slice())
+        core.write(algo.load_address, algo.instructions.as_bytes())
             .map_err(FlashError::Core)?;
 
         let mut data = vec![0; algo.instructions.len()];
-        core.read_32(algo.load_address, &mut data)
+        core.read(algo.load_address, &mut data.as_mut_bytes())
             .map_err(FlashError::Core)?;
 
         for (offset, (original, read_back)) in algo.instructions.iter().zip(data.iter()).enumerate()

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -183,7 +183,7 @@ impl Flasher {
             .map_err(FlashError::Core)?;
 
         let mut data = vec![0; algo.instructions.len()];
-        core.read(algo.load_address, &mut data.as_mut_bytes())
+        core.read(algo.load_address, data.as_mut_bytes())
             .map_err(FlashError::Core)?;
 
         for (offset, (original, read_back)) in algo.instructions.iter().zip(data.iter()).enumerate()

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -53,7 +53,7 @@ use std::ops::Range;
 use std::thread;
 use std::time::Duration;
 use std::time::Instant;
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, IntoBytes};
 
 /// The RTT interface.
 ///
@@ -242,10 +242,16 @@ impl Rtt {
     ) -> Result<Rtt, Error> {
         let is_64_bit = core.is_64_bit();
 
-        let mut mem = [0u8; RttControlBlockHeader::minimal_header_size(true)];
-        core.read(ptr, &mut mem)?;
+        let mut mem = [0u32; RttControlBlockHeader::minimal_header_size(true) / 4];
+        // Read the magic value first as unordered data, and read the subsequent pointers
+        // as ordered u32 values.
+        core.read(ptr, &mut mem.as_mut_bytes()[0..Self::RTT_ID.len()])?;
+        core.read_32(
+            ptr + Self::RTT_ID.len() as u64,
+            &mut mem[Self::RTT_ID.len() / 4..],
+        )?;
 
-        let rtt_header = RttControlBlockHeader::try_from_header(is_64_bit, &mem)
+        let rtt_header = RttControlBlockHeader::try_from_header(is_64_bit, mem.as_bytes())
             .ok_or(Error::ControlBlockNotFound)?;
 
         // Validate that the control block starts with the ID bytes
@@ -271,8 +277,8 @@ impl Rtt {
 
         // Read the rest of the control block
         let channel_buffer_len = rtt_header.total_rtt_buffer_size() - rtt_header.header_size();
-        let mut mem = vec![0; channel_buffer_len];
-        core.read(ptr + rtt_header.header_size() as u64, &mut mem)?;
+        let mut mem = vec![0; channel_buffer_len / 4];
+        core.read_32(ptr + rtt_header.header_size() as u64, &mut mem)?;
 
         let mut up_channels = Vec::new();
         let mut down_channels = Vec::new();
@@ -281,12 +287,12 @@ impl Rtt {
 
         let up_channels_start = 0;
         let up_channels_len = max_up_channels * channel_buffer_size;
-        let up_channels_raw_buffer = &mem[up_channels_start..][..up_channels_len];
+        let up_channels_raw_buffer = &mem.as_bytes()[up_channels_start..][..up_channels_len];
         let up_channels_buffer = rtt_header.parse_channel_buffers(up_channels_raw_buffer)?;
 
         let down_channels_start = up_channels_start + up_channels_len;
         let down_channels_len = max_down_channels * channel_buffer_size;
-        let down_channels_raw_buffer = &mem[down_channels_start..][..down_channels_len];
+        let down_channels_raw_buffer = &mem.as_bytes()[down_channels_start..][..down_channels_len];
         let down_channels_buffer = rtt_header.parse_channel_buffers(down_channels_raw_buffer)?;
 
         let mut offset = ptr + rtt_header.header_size() as u64 + up_channels_start as u64;

--- a/target-gen/src/parser.rs
+++ b/target-gen/src/parser.rs
@@ -78,6 +78,7 @@ pub fn extract_flash_algo(
     algo.instructions = algorithm_binary.blob();
 
     // Flash algorithms are all little endian. Swap the algorithm if necessary.
+    // TODO: See if this is correct on systems where instructions are not 2 or 4 bytes.
     if !elf.little_endian {
         for instruction in algo.instructions.chunks_exact_mut(4) {
             instruction.reverse();

--- a/target-gen/src/parser.rs
+++ b/target-gen/src/parser.rs
@@ -77,14 +77,6 @@ pub fn extract_flash_algo(
     let algorithm_binary = crate::algorithm_binary::AlgorithmBinary::new(&elf, buffer)?;
     algo.instructions = algorithm_binary.blob();
 
-    // Flash algorithms are all little endian. Swap the algorithm if necessary.
-    // TODO: See if this is correct on systems where instructions are not 2 or 4 bytes.
-    if !elf.little_endian {
-        for instruction in algo.instructions.chunks_exact_mut(4) {
-            instruction.reverse();
-        }
-    }
-
     let code_section_offset = algorithm_binary.code_section.start;
 
     // Extract the function pointers,
@@ -134,6 +126,7 @@ pub fn extract_flash_algo(
     algo.default = default;
     algo.data_section_offset = algorithm_binary.data_section.start as u64;
     algo.flash_properties = FlashProperties::from(flash_device);
+    algo.big_endian = !elf.little_endian;
 
     Ok(algo)
 }

--- a/target-gen/src/parser.rs
+++ b/target-gen/src/parser.rs
@@ -77,6 +77,13 @@ pub fn extract_flash_algo(
     let algorithm_binary = crate::algorithm_binary::AlgorithmBinary::new(&elf, buffer)?;
     algo.instructions = algorithm_binary.blob();
 
+    // Flash algorithms are all little endian. Swap the algorithm if necessary.
+    if !elf.little_endian {
+        for instruction in algo.instructions.chunks_exact_mut(4) {
+            instruction.reverse();
+        }
+    }
+
     let code_section_offset = algorithm_binary.code_section.start;
 
     // Extract the function pointers,


### PR DESCRIPTION
Add big endian support for ARMv7A. This includes supporting `target-gen` as well as basic RTT support.