### PR TITLE
Tweak the generated debuginfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,17 @@ macro_use_imports = "deny"
 inherits = "release"
 lto = "thin"
 
+[profile.dev]
+# Keep stack trace data, but no other debug info by default.
+# See https://kobzol.github.io/rust/rustc/2025/05/20/disable-debuginfo-to-improve-rust-compile-times.html
+# If you have difficulty debugging probe-rs, remove this line temporarily.
+debug = "line-tables-only"
+
+[profile.release]
+# For release builds the default is no debuginfo. Let's instead keep the
+# line tables for better backtraces.
+debug = "line-tables-only"
+
 [profile.dev.package.zip]
 # Set the default for zip in development mode so the creation of the zip does not take forever
 opt-level = 3


### PR DESCRIPTION
This PR removes most debuginfo from the dev builds, and adds line-tables to release/dist build. The goal is to improve build times for dev, and to be able to provide better stack traces on crashes on release.