### PR TITLE
Clean up status messago formatting for cargo-embed

### DIFF
--- a/changelog/changed-cargo-embed-status-output-cleanup.md
+++ b/changelog/changed-cargo-embed-status-output-cleanup.md
@@ -1,0 +1,3 @@
+Clean up status output from `cargo-embed`. The configuration profile is
+reported as `Profile` now and status output is aligned with the one from
+flashing.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -169,11 +169,11 @@ async fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
 
     logging::println(format!(
         "      {} {}",
-        "Config".green().bold(),
+        "Profile".green().bold(),
         profile_name
     ));
     logging::println(format!(
-        "      {} {}",
+        "       {} {}",
         "Target".green().bold(),
         path.display()
     ));
@@ -349,7 +349,7 @@ async fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
                 gdb_connection_string.as_deref().unwrap_or("127.0.0.1:1337");
 
             logging::println(format!(
-                "    {} listening at {}",
+                "     {} listening at {}",
                 "GDB stub".green().bold(),
                 gdb_connection_string,
             ));
@@ -384,7 +384,7 @@ async fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
     }
 
     logging::println(format!(
-        "        {} processing config {}",
+        "        {} processing config profile {}",
         "Done".green().bold(),
         profile_name,
     ));


### PR DESCRIPTION
This is a follow-up to https://github.com/probe-rs/probe-rs/pull/3361. It also renames the configuration profile in the status output and harmonizes indentation.

Before:

```bash
$ cargo embed --path firmware.elf with_rtt
      Config with_rtt
      Target firmware.elf
      Erasing ✔ 100% [####################] 168.00 KiB @ 125.87 KiB/s (took 1s)
  Programming ✔ 100% [####################] 168.00 KiB @  20.30 KiB/s (took 8s)                                                                                                                  Finished in 9.61s
    GDB stub listening at 127.0.0.1:1337
```

Now:

```bash
$ cargo embed --path firmware.elf with_rtt
      Profile with_rtt
       Target firmware.elf
      Erasing ✔ 100% [####################] 168.00 KiB @ 126.84 KiB/s (took 1s)
  Programming ✔ 100% [####################] 168.00 KiB @  20.35 KiB/s (took 8s)                                                                                                                  Finished in 9.58s
     GDB stub listening at 127.0.0.1:1337
```