### PR TITLE
armv7a: add dcc fast mode (and some banked access)

### DIFF
--- a/changelog/added-armv7a-dcc-fast-mode.md
+++ b/changelog/added-armv7a-dcc-fast-mode.md
@@ -1,0 +1,1 @@
+Added DCC Fast mode for ARMv7A to improve reading and writing speeds. As part of this, add a helper for banked register writes.

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -56,7 +56,7 @@ impl<'a> BankedAccess<'a> {
     fn dscr(&mut self) -> Result<Dbgdscr, ArmError> {
         self.interface
             .read_raw_ap_register(&self.ap, self.dscr)
-            .map(|v| Dbgdscr::from(v))
+            .map(Dbgdscr::from)
     }
 
     fn set_dscr(&mut self, value: Dbgdscr) -> Result<(), ArmError> {

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -1234,7 +1234,9 @@ impl MemoryInterface for Armv7a<'_> {
                     // Grab the last value. Ignore any errors here since they will generate
                     // an abort that will be caught below.
                     if let Ok(last) = banked.dtrrx() {
-                        data.last_mut().map(|v| *v = last);
+                        if let Some(v) = data.last_mut() {
+                            *v = last;
+                        }
                     }
                 }
 

--- a/probe-rs/src/architecture/arm/core/armv7a_debug_regs.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a_debug_regs.rs
@@ -57,7 +57,7 @@ memory_mapped_bitfield_register! {
     /// Fast mode.
     ///
     /// The value 0b11 is reserved.
-    pub extdccmode, _: 21, 20;
+    pub extdccmode, set_extdccmode: 21, 20;
 
     /// Asynchronous Aborts Discarded. The possible values of this bit are:
     ///


### PR DESCRIPTION
Add DCC Fast mode for reads and writes on ARMv7A. When accessing more than two words, it becomes faster to use this mode to perform repeated reads or writes. By using banked access, this further improves performance, yielding a net 10x speedup versus the previous word-wise approach.

This also adds a `BankedHelper` to lock the memory interface to ensure the Target Address Register doesn't change while in banked mode. This helper also has a function to ensure that the interface is taken out of DCC Fast mode even if there is a memory access failure.