### PR TITLE
delegate `core.endianness()` to inner interface

### DIFF
--- a/changelog/fixed-delegate-endianness-to-core-inner.md
+++ b/changelog/fixed-delegate-endianness-to-core-inner.md
@@ -1,0 +1,1 @@
+Fixed an issue where the endianness call on the core was not getting delegated to the inner core interface.

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -519,6 +519,12 @@ impl<'probe> Core<'probe> {
         self.inner.core_type()
     }
 
+    /// Returns the endianness of the current operating mode
+    /// of the core.
+    pub fn endianness(&mut self) -> Result<Endian, Error> {
+        self.inner.endianness()
+    }
+
     /// Determine the instruction set the core is operating in
     /// This must be queried while halted as this is a runtime
     /// decision for some core types

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -519,12 +519,6 @@ impl<'probe> Core<'probe> {
         self.inner.core_type()
     }
 
-    /// Returns the endianness of the current operating mode
-    /// of the core.
-    pub fn endianness(&mut self) -> Result<Endian, Error> {
-        self.inner.endianness()
-    }
-
     /// Determine the instruction set the core is operating in
     /// This must be queried while halted as this is a runtime
     /// decision for some core types
@@ -672,6 +666,12 @@ impl CoreInterface for Core<'_> {
 
     fn core_type(&self) -> CoreType {
         self.core_type()
+    }
+
+    /// Returns the endianness of the current operating mode
+    /// of the core.
+    fn endianness(&mut self) -> Result<Endian, Error> {
+        self.inner.endianness()
     }
 
     fn instruction_set(&mut self) -> Result<InstructionSet, Error> {


### PR DESCRIPTION
Have `core.endianness()` call `self.inner.endianness()`. This is required to get interfaces such as gdb working.