### PR TITLE
armv7a: ensure core is halted when querying endianness

### DIFF
--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -1059,16 +1059,18 @@ impl CoreInterface for Armv7a<'_> {
         if let Some(endianness) = self.endianness {
             return Ok(endianness);
         }
-        let endianness = {
-            let psr = TryInto::<u32>::try_into(self.read_core_reg(XPSR.id())?).unwrap();
-            if psr & 1 << 9 == 0 {
-                Endian::Little
-            } else {
-                Endian::Big
-            }
-        };
-        self.endianness = Some(endianness);
-        Ok(endianness)
+        self.halted_access(|core| {
+            let endianness = {
+                let psr = TryInto::<u32>::try_into(core.read_core_reg(XPSR.id())?).unwrap();
+                if psr & 1 << 9 == 0 {
+                    Endian::Little
+                } else {
+                    Endian::Big
+                }
+            };
+            core.endianness = Some(endianness);
+            Ok(endianness)
+        })
     }
 
     fn fpu_support(&mut self) -> Result<bool, Error> {


### PR DESCRIPTION
Ensure that the ARMv7A core is halted when asking what its endianness is if the value has not yet been cached. This is necessary because this operation reads the state from a register.