### PR TITLE
Return architecture-specific errors from `try_get_X_interface` functions

### DIFF
--- a/changelog/changed-try-get-interface.md
+++ b/changelog/changed-try-get-interface.md
@@ -1,0 +1,1 @@
+Changed `Probe::try_get_X_interface` to return architecture-specific errors.

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -736,7 +736,7 @@ impl ResolvedCoreOptions {
         }
     }
 
-    fn interface_idx(&self) -> usize {
+    fn jtag_tap_index(&self) -> usize {
         match self {
             Self::Arm { options, .. } => options.jtag_tap.unwrap_or(0),
             Self::Riscv { options, .. } => options.jtag_tap.unwrap_or(0),

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -34,8 +34,8 @@ impl CombinedCoreState {
         self.specific_state.core_type()
     }
 
-    pub fn interface_idx(&self) -> usize {
-        self.core_state.core_access_options.interface_idx()
+    pub fn jtag_tap_index(&self) -> usize {
+        self.core_state.core_access_options.jtag_tap_index()
     }
 
     pub(crate) fn attach_arm<'probe>(

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -9,12 +9,15 @@ use std::{
 use crate::{
     architecture::{
         arm::{
-            ArmCommunicationInterface,
+            ArmCommunicationInterface, ArmError,
             communication_interface::{DapProbe, UninitializedArmProbe},
         },
-        riscv::{communication_interface::RiscvInterfaceBuilder, dtm::jtag_dtm::JtagDtmBuilder},
+        riscv::{
+            communication_interface::{RiscvError, RiscvInterfaceBuilder},
+            dtm::jtag_dtm::JtagDtmBuilder,
+        },
         xtensa::communication_interface::{
-            XtensaCommunicationInterface, XtensaDebugInterfaceState,
+            XtensaCommunicationInterface, XtensaDebugInterfaceState, XtensaError,
         },
     },
     probe::{
@@ -1130,7 +1133,7 @@ impl DebugProbe for BlackMagicProbe {
 
     fn try_get_riscv_interface_builder<'probe>(
         &'probe mut self,
-    ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, DebugProbeError> {
+    ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, RiscvError> {
         Ok(Box::new(JtagDtmBuilder::new(self)))
     }
 
@@ -1145,8 +1148,7 @@ impl DebugProbe for BlackMagicProbe {
     /// Turn this probe into an ARM probe
     fn try_get_arm_interface<'probe>(
         mut self: Box<Self>,
-    ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, DebugProbeError)>
-    {
+    ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
         let has_adiv5 = match self.remote_protocol {
             ProtocolVersion::V0 => false,
             ProtocolVersion::V0P
@@ -1176,7 +1178,7 @@ impl DebugProbe for BlackMagicProbe {
     fn try_get_xtensa_interface<'probe>(
         &'probe mut self,
         state: &'probe mut XtensaDebugInterfaceState,
-    ) -> Result<XtensaCommunicationInterface<'probe>, DebugProbeError> {
+    ) -> Result<XtensaCommunicationInterface<'probe>, XtensaError> {
         Ok(XtensaCommunicationInterface::new(self, state))
     }
 

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -12,9 +12,12 @@ use crate::{
             dp::{Abort, Ctrl, DpRegister},
             swo::poll_interval_from_buf_size,
         },
-        riscv::{communication_interface::RiscvInterfaceBuilder, dtm::jtag_dtm::JtagDtmBuilder},
+        riscv::{
+            communication_interface::{RiscvError, RiscvInterfaceBuilder},
+            dtm::jtag_dtm::JtagDtmBuilder,
+        },
         xtensa::communication_interface::{
-            XtensaCommunicationInterface, XtensaDebugInterfaceState,
+            XtensaCommunicationInterface, XtensaDebugInterfaceState, XtensaError,
         },
     },
     probe::{
@@ -930,8 +933,7 @@ impl DebugProbe for CmsisDap {
 
     fn try_get_arm_interface<'probe>(
         self: Box<Self>,
-    ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, DebugProbeError)>
-    {
+    ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
         Ok(Box::new(ArmCommunicationInterface::new(self, false)))
     }
 
@@ -958,14 +960,14 @@ impl DebugProbe for CmsisDap {
 
     fn try_get_riscv_interface_builder<'probe>(
         &'probe mut self,
-    ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, DebugProbeError> {
+    ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, RiscvError> {
         Ok(Box::new(JtagDtmBuilder::new(self)))
     }
 
     fn try_get_xtensa_interface<'probe>(
         &'probe mut self,
         state: &'probe mut XtensaDebugInterfaceState,
-    ) -> Result<XtensaCommunicationInterface<'probe>, DebugProbeError> {
+    ) -> Result<XtensaCommunicationInterface<'probe>, XtensaError> {
         Ok(XtensaCommunicationInterface::new(self, state))
     }
 

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -3,10 +3,12 @@ mod protocol;
 
 use crate::{
     architecture::{
-        arm::communication_interface::UninitializedArmProbe,
-        riscv::{communication_interface::RiscvInterfaceBuilder, dtm::jtag_dtm::JtagDtmBuilder},
+        riscv::{
+            communication_interface::{RiscvError, RiscvInterfaceBuilder},
+            dtm::jtag_dtm::JtagDtmBuilder,
+        },
         xtensa::communication_interface::{
-            XtensaCommunicationInterface, XtensaDebugInterfaceState,
+            XtensaCommunicationInterface, XtensaDebugInterfaceState, XtensaError,
         },
     },
     probe::{
@@ -140,7 +142,7 @@ impl DebugProbe for EspUsbJtag {
 
     fn try_get_riscv_interface_builder<'probe>(
         &'probe mut self,
-    ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, DebugProbeError> {
+    ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, RiscvError> {
         Ok(Box::new(JtagDtmBuilder::new(self)))
     }
 
@@ -153,23 +155,10 @@ impl DebugProbe for EspUsbJtag {
         self
     }
 
-    fn try_get_arm_interface<'probe>(
-        self: Box<Self>,
-    ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, DebugProbeError)>
-    {
-        // This probe cannot debug ARM targets.
-        Err((
-            self,
-            DebugProbeError::InterfaceNotAvailable {
-                interface_name: "SWD/ARM",
-            },
-        ))
-    }
-
     fn try_get_xtensa_interface<'probe>(
         &'probe mut self,
         state: &'probe mut XtensaDebugInterfaceState,
-    ) -> Result<XtensaCommunicationInterface<'probe>, DebugProbeError> {
+    ) -> Result<XtensaCommunicationInterface<'probe>, XtensaError> {
         Ok(XtensaCommunicationInterface::new(self, state))
     }
 

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -533,8 +533,7 @@ impl DebugProbe for FakeProbe {
 
     fn try_get_arm_interface<'probe>(
         self: Box<Self>,
-    ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, DebugProbeError)>
-    {
+    ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
         Ok(Box::new(FakeArmInterface::new(self)))
     }
 

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -2,12 +2,15 @@
 use crate::{
     architecture::{
         arm::{
-            ArmCommunicationInterface,
+            ArmCommunicationInterface, ArmError,
             communication_interface::{DapProbe, UninitializedArmProbe},
         },
-        riscv::{communication_interface::RiscvInterfaceBuilder, dtm::jtag_dtm::JtagDtmBuilder},
+        riscv::{
+            communication_interface::{RiscvError, RiscvInterfaceBuilder},
+            dtm::jtag_dtm::JtagDtmBuilder,
+        },
         xtensa::communication_interface::{
-            XtensaCommunicationInterface, XtensaDebugInterfaceState,
+            XtensaCommunicationInterface, XtensaDebugInterfaceState, XtensaError,
         },
     },
     probe::{
@@ -377,7 +380,7 @@ impl DebugProbe for FtdiProbe {
 
     fn try_get_riscv_interface_builder<'probe>(
         &'probe mut self,
-    ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, DebugProbeError> {
+    ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, RiscvError> {
         Ok(Box::new(JtagDtmBuilder::new(self)))
     }
 
@@ -391,11 +394,8 @@ impl DebugProbe for FtdiProbe {
 
     fn try_get_arm_interface<'probe>(
         self: Box<Self>,
-    ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, DebugProbeError)>
-    {
-        let uninitialized_interface = ArmCommunicationInterface::new(self, true);
-
-        Ok(Box::new(uninitialized_interface))
+    ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
+        Ok(Box::new(ArmCommunicationInterface::new(self, true)))
     }
 
     fn has_arm_interface(&self) -> bool {
@@ -405,7 +405,7 @@ impl DebugProbe for FtdiProbe {
     fn try_get_xtensa_interface<'probe>(
         &'probe mut self,
         state: &'probe mut XtensaDebugInterfaceState,
-    ) -> Result<XtensaCommunicationInterface<'probe>, DebugProbeError> {
+    ) -> Result<XtensaCommunicationInterface<'probe>, XtensaError> {
         Ok(XtensaCommunicationInterface::new(self, state))
     }
 

--- a/probe-rs/src/probe/sifliuart/mod.rs
+++ b/probe-rs/src/probe/sifliuart/mod.rs
@@ -4,6 +4,7 @@
 mod arm;
 
 use crate::Error;
+use crate::architecture::arm::ArmError;
 use crate::architecture::arm::communication_interface::UninitializedArmProbe;
 use crate::probe::sifliuart::arm::UninitializedSifliUartArmProbe;
 use crate::probe::{
@@ -355,8 +356,7 @@ impl DebugProbe for SifliUart {
 
     fn try_get_arm_interface<'probe>(
         self: Box<Self>,
-    ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, DebugProbeError)>
-    {
+    ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
         Ok(Box::new(UninitializedSifliUartArmProbe { probe: self }))
     }
 

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -307,8 +307,7 @@ impl DebugProbe for StLink<StLinkUsbDevice> {
 
     fn try_get_arm_interface<'probe>(
         self: Box<Self>,
-    ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, DebugProbeError)>
-    {
+    ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
         Ok(Box::new(UninitializedStLink { probe: self }))
     }
 

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -14,7 +14,8 @@ use self::{commands::Speed, usb_interface::WchLinkUsbDevice};
 use super::JtagAccess;
 use crate::{
     architecture::riscv::{
-        communication_interface::RiscvInterfaceBuilder, dtm::jtag_dtm::JtagDtmBuilder,
+        communication_interface::{RiscvError, RiscvInterfaceBuilder},
+        dtm::jtag_dtm::JtagDtmBuilder,
     },
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JtagSequence, ProbeError,
@@ -370,7 +371,7 @@ impl DebugProbe for WchLink {
 
     fn try_get_riscv_interface_builder<'probe>(
         &'probe mut self,
-    ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, DebugProbeError> {
+    ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, RiscvError> {
         Ok(Box::new(JtagDtmBuilder::new(self)))
     }
 }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -124,7 +124,7 @@ impl ArchitectureInterface {
         match self {
             ArchitectureInterface::Arm(interface) => combined_state.attach_arm(target, interface),
             ArchitectureInterface::Jtag(probe, ifaces) => {
-                let idx = combined_state.interface_idx();
+                let idx = combined_state.jtag_tap_index();
                 if let Some(probe) = probe.try_as_jtag_probe() {
                     probe.select_target(idx)?;
                 }
@@ -236,7 +236,7 @@ impl Session {
                 if let Ok(chain) = probe.scan_chain() {
                     if !chain.is_empty() {
                         for core in &cores {
-                            probe.select_target(core.interface_idx())?;
+                            probe.select_target(core.jtag_tap_index())?;
                         }
                     }
                 }
@@ -351,7 +351,7 @@ impl Session {
 
         // FIXME: This is terribly JTAG-specific. Since we don't really support anything else yet,
         // it should be fine for now.
-        let highest_idx = cores.iter().map(|c| c.interface_idx()).max().unwrap_or(0);
+        let highest_idx = cores.iter().map(|c| c.jtag_tap_index()).max().unwrap_or(0);
         let tap_count = if let Some(probe) = probe.try_as_jtag_probe() {
             match probe.scan_chain() {
                 Ok(scan_chain) => scan_chain.len().max(highest_idx + 1),
@@ -367,7 +367,7 @@ impl Session {
         // Create a new interface by walking through the cores and initialising the TAPs that
         // we find mentioned.
         for core in cores.iter() {
-            let iface_idx = core.interface_idx();
+            let iface_idx = core.jtag_tap_index();
 
             let core_arch = core.core_type().architecture();
 
@@ -530,7 +530,7 @@ impl Session {
     fn interface_idx(&self, core: usize) -> Result<usize, Error> {
         self.cores
             .get(core)
-            .map(|c| c.interface_idx())
+            .map(|c| c.jtag_tap_index())
             .ok_or(Error::CoreNotFound(core))
     }
 

--- a/probe-rs/src/vendor/mod.rs
+++ b/probe-rs/src/vendor/mod.rs
@@ -18,7 +18,7 @@ use crate::{
         },
     },
     config::{ChipInfo, DebugSequence, Registry},
-    probe::{DebugProbeError, Probe},
+    probe::Probe,
 };
 
 pub mod espressif;
@@ -180,6 +180,11 @@ fn try_detect_arm_chip(
 fn try_detect_riscv_chip(registry: &Registry, probe: &mut Probe) -> Result<Option<Target>, Error> {
     let mut found_target = None;
 
+    if !probe.has_riscv_interface() {
+        tracing::debug!("No RISC-V interface available, skipping detection.");
+        return Ok(None);
+    }
+
     if let Some(probe) = probe.try_as_jtag_probe() {
         _ = probe.select_target(0);
     }
@@ -215,10 +220,6 @@ fn try_detect_riscv_chip(registry: &Registry, probe: &mut Probe) -> Result<Optio
             // TODO: disable debug module
         }
 
-        Err(DebugProbeError::InterfaceNotAvailable { .. }) => {
-            tracing::debug!("No RISC-V interface available, skipping detection.");
-        }
-
         Err(error) => {
             tracing::debug!("Error during RISC-V chip detection: {error}");
         }
@@ -229,6 +230,11 @@ fn try_detect_riscv_chip(registry: &Registry, probe: &mut Probe) -> Result<Optio
 
 fn try_detect_xtensa_chip(registry: &Registry, probe: &mut Probe) -> Result<Option<Target>, Error> {
     let mut found_target = None;
+
+    if !probe.has_xtensa_interface() {
+        tracing::debug!("No Xtensa interface available, skipping detection.");
+        return Ok(None);
+    }
 
     if let Some(probe) = probe.try_as_jtag_probe() {
         _ = probe.select_target(0);
@@ -260,10 +266,6 @@ fn try_detect_xtensa_chip(registry: &Registry, probe: &mut Probe) -> Result<Opti
             }
 
             interface.leave_debug_mode()?;
-        }
-
-        Err(DebugProbeError::InterfaceNotAvailable { .. }) => {
-            tracing::debug!("No Xtensa interface available, skipping detection.");
         }
 
         Err(error) => {


### PR DESCRIPTION
Kinda-sorta extracted (the idea) from #3000