### PR TITLE
Implement a tokio decoder codec

### DIFF
--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -110,7 +110,7 @@ svg = "0.18"
 
 # Server-only
 tokio = { version = "1.0", features = ["full"] }
-tokio-util = "0.7"
+tokio-util = { version = "0.7", features = ["codec"] }
 futures-util = { version = "0.3" }
 rustls = { version = "0.23", default-features = false, features = [
     "std",

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter.rs
@@ -1,3 +1,5 @@
+/// A codec to encode/decode the MS-DAP protocol frames.
+pub(crate) mod codec;
 /// Everything related to the MS DAP implementation.
 pub(crate) mod dap;
 /// Communication interfaces to connect the DAP client and probe-rs-debugger.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/codec.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/codec.rs
@@ -1,0 +1,11 @@
+use std::marker::PhantomData;
+
+use serde::{Deserialize, Serialize};
+
+pub(crate) mod decoder;
+
+pub(crate) struct DapCodec<T: Serialize + for<'a> Deserialize<'a>> {
+    length: Option<usize>,
+    header_received: bool,
+    _pd: PhantomData<T>,
+}

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/codec/decoder.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/codec/decoder.rs
@@ -1,0 +1,323 @@
+use std::{io::BufRead, marker::PhantomData};
+
+use serde::{Deserialize, Serialize};
+use tokio_util::{bytes::BytesMut, codec::Decoder};
+
+use super::DapCodec;
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct Frame<T: Serialize + for<'a> Deserialize<'a> + PartialEq> {
+    pub content: T,
+}
+
+impl<T: Serialize + for<'a> Deserialize<'a> + PartialEq> DapCodec<T> {
+    pub(crate) fn new() -> Self {
+        Self {
+            length: None,
+            header_received: false,
+            _pd: PhantomData,
+        }
+    }
+}
+
+impl<T: Serialize + for<'a> Deserialize<'a> + PartialEq> Decoder for DapCodec<T> {
+    type Item = Frame<T>;
+    type Error = std::io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        // We have not received the full header yet, so scan for more header entries.
+        if !self.header_received {
+            while let Some(line) = read_line(src) {
+                let line = line.inspect_err(|_| {
+                    // If we fail to parse the line, we need to remove the faulty line from the buffer before erroring.
+                    let _ = src.split_to((&src[..]).skip_until(b'\n').unwrap_or(0));
+                })?;
+
+                if line.is_empty() {
+                    // Make sure to also split off bytes at the end of the line.
+                    let _ = src.split_to(line.len() + b"\r\n".len());
+                    if self.length.is_some() {
+                        // The header is done parsing. Content start next line.
+                        self.header_received = true;
+                        // We can immediately go to parsing the content.
+                        break;
+                    }
+                    // We unfortunately got a header end without ever receiving a length.
+                    // Continue scanning through lines, flushing lines until a valid header is
+                    // encountered.
+                } else if let Some(length) = get_content_len(&line) {
+                    // We received a content length header, we keep looking for other headers.
+                    self.length = Some(length);
+                    // FIXME: This reservation does not account for possible additional headers.
+                    src.reserve(length + b"\r\n".len());
+                    // Make sure to also split off bytes at the end of the line.
+                    let _ = src.split_to(line.len() + b"\r\n".len());
+                } else {
+                    tracing::warn!("Unknown header payload: {line}");
+                    let _ = src.split_to(line.len() + b"\r\n".len());
+                }
+            }
+        }
+
+        if self.header_received {
+            let Some(length) = self.length else {
+                // We did not get a header length but we received the header end so we cannot continue.
+                // FIXME: How to flush?
+                return Ok(None);
+            };
+
+            // We have received the full header, so now look for the content.
+            if src.len() < length {
+                // Not enough content was received yet. Wait for more bytes.
+                return Ok(None);
+            }
+
+            // We need to clean up the decoder state for the next frame.
+            self.header_received = false;
+            self.length = None;
+
+            // Finally parse and return the frame.
+            return Ok(Some(Frame {
+                content: serde_json::from_slice::<T>(&src.split_to(length))?,
+            }));
+        }
+
+        Ok(None)
+    }
+}
+
+fn read_line(bytes: &mut BytesMut) -> Option<Result<String, std::io::Error>> {
+    let mut buf = String::new();
+    match (&bytes[..]).read_line(&mut buf) {
+        Ok(0) => None,
+        Ok(_n) => {
+            if buf.ends_with('\n') {
+                buf.pop();
+                if buf.ends_with('\r') {
+                    buf.pop();
+                }
+            } else {
+                // EOF terminated lines do not count as complete yet.
+                return None;
+            }
+            Some(Ok(buf))
+        }
+        Err(e) => Some(Err(e)),
+    }
+}
+
+/// Parses the Content-Length header.
+///
+/// Discards excess characters at the start of the header to recover faster (without flushing many
+/// lines) from previous malformed packets.
+pub(crate) fn get_content_len(header: &str) -> Option<usize> {
+    let mut parts = header.trim_end().split_ascii_whitespace();
+
+    let name = parts.next()?;
+
+    if name.ends_with("Content-Length:") {
+        parts.next()?.parse::<usize>().ok()
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use std::io::ErrorKind;
+
+    use pretty_assertions::assert_eq;
+    use serde_json::Value;
+    use serde_json::json;
+    use tokio_util::{bytes::BytesMut, codec::Decoder};
+
+    use crate::cmd::dap_server::debug_adapter::codec::decoder::Frame;
+
+    use super::DapCodec;
+    use super::get_content_len;
+
+    #[test]
+    fn good_single_empty_frame() {
+        let mut decoder = DapCodec::<Value>::new();
+        let mut buf = BytesMut::new();
+
+        let content = json!({"seq": 3, "type": "request", "command": "test"});
+        let payload = serde_json::to_string_pretty(&content).unwrap();
+        buf.extend_from_slice(format!("Content-Length: {}\r\n", payload.len()).as_bytes());
+        buf.extend_from_slice("\r\n".as_bytes());
+        buf.extend_from_slice(payload.as_bytes());
+
+        let result = decoder.decode(&mut buf);
+
+        assert_eq!(result.unwrap().unwrap(), Frame { content });
+        assert_eq!(buf.len(), 0)
+    }
+
+    #[test]
+    fn good_split_frame() {
+        let mut decoder = DapCodec::<Value>::new();
+        let mut buf = BytesMut::new();
+        let content = json!({"seq": 3, "type": "request", "command": "test"});
+        let payload = serde_json::to_string_pretty(&content).unwrap();
+        buf.extend_from_slice(format!("Content-Length: {}\r\n", payload.len()).as_bytes());
+        buf.extend_from_slice("\r\n".as_bytes());
+
+        // The frame is not ready yet.
+        let result = decoder.decode(&mut buf);
+        assert_eq!(result.unwrap(), None);
+
+        buf.extend_from_slice(payload.as_bytes());
+
+        // The frame should be ready now.
+        let result = decoder.decode(&mut buf);
+        assert_eq!(result.unwrap().unwrap(), Frame { content });
+        assert_eq!(buf.len(), 0)
+    }
+
+    #[test]
+    fn good_split_frame_2() {
+        let mut decoder = DapCodec::<Value>::new();
+        let mut buf = BytesMut::new();
+        let content = json!({"seq": 3, "type": "request", "command": "test"});
+        let payload = serde_json::to_string_pretty(&content).unwrap();
+        buf.extend_from_slice(format!("Content-Length: {}\r\n", payload.len()).as_bytes());
+        buf.extend_from_slice("\r\n".as_bytes());
+        buf.extend_from_slice(&payload.as_bytes()[..payload.len() / 2]);
+        // The frame is not ready yet.
+        let result = decoder.decode(&mut buf);
+        assert_eq!(result.unwrap(), None);
+
+        buf.extend_from_slice(&payload.as_bytes()[payload.len() / 2..]);
+
+        // The frame should be ready now.
+        let result = decoder.decode(&mut buf);
+        assert_eq!(result.unwrap().unwrap(), Frame { content });
+        assert_eq!(buf.len(), 0)
+    }
+
+    #[test]
+    fn bad_frame_wrong_length() {
+        let mut decoder = DapCodec::<Value>::new();
+        let mut buf = BytesMut::new();
+        let content = json!({"seq": 3, "type": "request", "command": "test"});
+        let payload = serde_json::to_string_pretty(&content).unwrap();
+        buf.extend_from_slice(format!("Content-Length: {}\r\n", payload.len() + 10).as_bytes());
+        buf.extend_from_slice("\r\n".as_bytes());
+        buf.extend_from_slice(payload.as_bytes());
+
+        let result = decoder.decode(&mut buf);
+
+        assert_eq!(result.unwrap(), None);
+        assert_eq!(buf.len(), 56)
+    }
+
+    #[test]
+    fn bad_frame_invalid_json() {
+        let mut decoder = DapCodec::<Value>::new();
+        let mut buf = BytesMut::new();
+        let payload = "{\"test:}";
+        buf.extend_from_slice(format!("Content-Length: {}\r\n", payload.len()).as_bytes());
+        buf.extend_from_slice("\r\n".as_bytes());
+        buf.extend_from_slice(payload.as_bytes());
+
+        let result = decoder.decode(&mut buf);
+
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::UnexpectedEof);
+        assert_eq!(buf.len(), 0)
+    }
+
+    #[test]
+    fn bad_frame_no_utf8() {
+        let mut decoder = DapCodec::<Value>::new();
+        let mut buf = BytesMut::new();
+        let payload = "";
+        buf.extend_from_slice(&[5, 189, 250, 130, 4, b'\r', b'\n']);
+        buf.extend_from_slice("\r\n".as_bytes());
+        buf.extend_from_slice(payload.as_bytes());
+
+        let result = decoder.decode(&mut buf);
+
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidData);
+        assert_eq!(buf.len(), 2);
+
+        // Flush the remainder of the bytes.
+        let result = decoder.decode(&mut buf);
+
+        assert_eq!(result.unwrap(), None);
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    fn bad_frame_no_length() {
+        let mut decoder = DapCodec::<Value>::new();
+        let mut buf = BytesMut::new();
+        let content = json!({"seq": 3, "type": "request", "command": "test"});
+        let payload = serde_json::to_string_pretty(&content).unwrap();
+        buf.extend_from_slice("\r\n".as_bytes());
+        buf.extend_from_slice(payload.as_bytes());
+
+        let result = decoder.decode(&mut buf);
+
+        assert_eq!(result.unwrap(), None);
+        assert_eq!(buf.len(), 0)
+    }
+
+    #[test]
+    fn recover_from_bad_frame() {
+        let mut decoder = DapCodec::<Value>::new();
+        let mut buf = BytesMut::new();
+        let content = json!({"seq": 3, "type": "request", "command": "test"});
+        let payload = serde_json::to_string_pretty(&content).unwrap();
+        // Send frame without length and expect second frame to arrive correctly.
+        buf.extend_from_slice("\r\n".as_bytes());
+        buf.extend_from_slice(payload.as_bytes());
+        buf.extend_from_slice(format!("Content-Length: {}\r\n", payload.len()).as_bytes());
+        buf.extend_from_slice("\r\n".as_bytes());
+        buf.extend_from_slice(payload.as_bytes());
+
+        let result = decoder.decode(&mut buf);
+
+        assert_eq!(result.unwrap().unwrap(), Frame { content });
+        assert_eq!(buf.len(), 0);
+
+        let result = decoder.decode(&mut buf);
+
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn parse_valid_length_header() {
+        let header = "Content-Length: 234\r\n";
+
+        assert_eq!(234, get_content_len(header).unwrap());
+    }
+
+    #[test]
+    fn parse_valid_length_header_with_prepended_data() {
+        let header = "asdasdContent-Length: 234\r\n";
+
+        assert_eq!(234, get_content_len(header).unwrap());
+    }
+
+    #[test]
+    fn parse_invalid_length_header_with_prepended_data() {
+        let header = "asdasd Content-Length: 234\r\n";
+
+        assert!(get_content_len(header).is_none());
+    }
+
+    #[test]
+    fn parse_valid_length_header_with_prepended_data_2() {
+        let header = "asdasd: Content-Length: 234\r\n";
+
+        assert!(get_content_len(header).is_none());
+    }
+
+    #[test]
+    fn parse_invalid_length_header() {
+        let header = "Content: 234\r\n";
+
+        assert!(get_content_len(header).is_none());
+    }
+}

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/protocol.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/protocol.rs
@@ -1,8 +1,8 @@
 use crate::cmd::dap_server::{
     DebuggerError,
     debug_adapter::dap::dap_types::{
-        ErrorResponseBody, Event, Message, MessageSeverity, OutputEventBody, ProtocolMessage,
-        Request, Response, ShowMessageEventBody,
+        ErrorResponseBody, Event, Message, MessageSeverity, OutputEventBody, Request, Response,
+        ShowMessageEventBody,
     },
     server::configuration::ConsoleLog,
 };
@@ -10,10 +10,13 @@ use anyhow::{Context, anyhow};
 use serde::Serialize;
 use std::{
     collections::{BTreeMap, HashMap},
-    io::{BufRead, BufReader, Read, Write},
+    io::{BufRead, BufReader, ErrorKind, Read, Write},
     str,
 };
+use tokio_util::{bytes::BytesMut, codec::Decoder};
 use tracing::instrument;
+
+use super::codec::{DapCodec, decoder::Frame};
 
 pub trait ProtocolAdapter {
     /// Listen for a request. This call should be non-blocking, and if not request is available, it should
@@ -202,6 +205,9 @@ pub struct DapAdapter<R: Read, W: Write> {
     seq: i64,
 
     pending_requests: HashMap<i64, String>,
+
+    codec: DapCodec<Request>,
+    input_buffer: BytesMut,
 }
 
 impl<R: Read, W: Write> DapAdapter<R, W> {
@@ -212,6 +218,9 @@ impl<R: Read, W: Write> DapAdapter<R, W> {
             seq: 1,
             console_log_level: ConsoleLog::Console,
             pending_requests: HashMap::new(),
+
+            codec: DapCodec::new(),
+            input_buffer: BytesMut::with_capacity(4096),
         }
     }
 
@@ -252,46 +261,26 @@ impl<R: Read, W: Write> DapAdapter<R, W> {
 
     /// Receive data from `self.input`. Data has to be in the format specified by the Debug Adapter Protocol (DAP).
     /// The returned data is the content part of the request, as raw bytes.
-    fn receive_data(&mut self) -> Result<Vec<u8>, DebuggerError> {
-        let mut header = String::new();
-
-        match self.input.read_line(&mut header) {
-            Ok(_data_length) => {}
-            Err(error) => {
-                // There is no data available, so do something else (like checking the probe status) or try again.
-                return Err(DebuggerError::NonBlockingReadError {
-                    original_error: error,
-                });
+    fn receive_data(&mut self) -> Result<Option<Frame<Request>>, DebuggerError> {
+        match self.input.fill_buf() {
+            Ok(data) => {
+                // New data is here. Shove it into the buffer.
+                self.input_buffer.extend_from_slice(data);
+                let consumed = data.len();
+                self.input.consume(consumed);
             }
-        }
+            Err(error) => match error.kind() {
+                // No new data is here and we also have nothing buffered, go back to polling.
+                ErrorKind::WouldBlock if self.input_buffer.is_empty() => return Ok(None),
+                // No new data is here but we have some buffered, so go to work the data and produce frames.
+                ErrorKind::WouldBlock if !self.input_buffer.is_empty() => {}
+                // An error ocurred, report it.
+                _ => return Err(error.into()),
+            },
+        };
 
-        // We should read an empty line here.
-        let mut buff = String::new();
-        match self.input.read_line(&mut buff) {
-            Ok(_data_length) => {}
-            Err(error) => {
-                // There is no data available, so do something else (like checking the probe status) or try again.
-                return Err(DebuggerError::NonBlockingReadError {
-                    original_error: error,
-                });
-            }
-        }
-
-        let data_length = get_content_len(&header).ok_or_else(|| {
-            DebuggerError::Other(anyhow!(
-                "Failed to read content length from header '{}'",
-                header
-            ))
-        })?;
-
-        let mut content = vec![0u8; data_length];
-        match self.input.read_exact(&mut content) {
-            Ok(_) => Ok(content),
-            Err(error) => Err(DebuggerError::Other(anyhow!(
-                "Failed to read the expected {} bytes from incoming data: {error}",
-                data_length
-            ))),
-        }
+        // Process the next message from the buffer.
+        Ok(self.codec.decode(&mut self.input_buffer)?)
     }
 
     fn listen_for_request_and_respond(&mut self) -> anyhow::Result<Option<Request>> {
@@ -332,42 +321,21 @@ impl<R: Read, W: Write> DapAdapter<R, W> {
 
     fn receive_msg_content(&mut self) -> Result<Option<Request>, DebuggerError> {
         match self.receive_data() {
-            Ok(message_content) => {
+            Ok(Some(frame)) => {
                 // Extract protocol message
-                match serde_json::from_slice::<ProtocolMessage>(&message_content) {
-                    Ok(protocol_message) if protocol_message.type_ == "request" => {
-                        match serde_json::from_slice::<Request>(&message_content) {
-                            Ok(request) => Ok(Some(request)),
-                            Err(error) => Err(DebuggerError::Other(anyhow!(
-                                "Error encoding ProtocolMessage to Request: {:?}",
-                                error
-                            ))),
-                        }
-                    }
-                    Ok(protocol_message) => Err(DebuggerError::Other(anyhow!(
+                if frame.content.type_ == "request" {
+                    Ok(Some(frame.content))
+                } else {
+                    Err(DebuggerError::Other(anyhow!(
                         "Received an unexpected message type: '{}'",
-                        protocol_message.type_
-                    ))),
-                    Err(error) => Err(DebuggerError::Other(anyhow!("{}", error))),
+                        frame.content.type_
+                    )))
                 }
             }
+            Ok(None) => Ok(None),
             Err(error) => {
-                match error {
-                    DebuggerError::NonBlockingReadError { original_error } => {
-                        if original_error.kind() == std::io::ErrorKind::WouldBlock {
-                            // Non-blocking read is waiting for incoming data that is not ready yet.
-                            // This is not a real error, so use this opportunity to check on probe status and notify the debug client if required.
-                            Ok(None)
-                        } else {
-                            // This is a legitimate error. Tell the client about it.
-                            Err(DebuggerError::StdIO(original_error))
-                        }
-                    }
-                    _ => {
-                        // This is a legitimate error. Tell the client about it.
-                        Err(DebuggerError::Other(anyhow!("{}", error)))
-                    }
-                }
+                // This is a legitimate error. Tell the client about it.
+                Err(DebuggerError::Other(anyhow!("{}", error)))
             }
         }
     }
@@ -434,19 +402,6 @@ impl<R: Read, W: Write> ProtocolAdapter for DapAdapter<R, W> {
     }
 }
 
-fn get_content_len(header: &str) -> Option<usize> {
-    let mut parts = header.trim_end().split_ascii_whitespace();
-
-    // discard first part
-    let first_part = parts.next()?;
-
-    if first_part == "Content-Length:" {
-        parts.next()?.parse::<usize>().ok()
-    } else {
-        None
-    }
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
@@ -490,24 +445,6 @@ mod test {
     }
 
     #[test]
-    fn receive_request_with_wrong_content_length() {
-        let content = "{ \"seq\": 3, \"type\": \"request\", \"command\": \"test\" }";
-
-        let input = format!("Content-Length: {}\r\n\r\n{}", content.len() + 10, content);
-
-        let mut output = Vec::new();
-
-        let mut adapter = DapAdapter::new(input.as_bytes(), &mut output);
-        adapter.console_log_level = super::ConsoleLog::Info;
-
-        let _request = adapter.listen_for_request().unwrap_err();
-
-        let output_str = String::from_utf8(output).unwrap();
-
-        insta::assert_snapshot!(output_str);
-    }
-
-    #[test]
     fn receive_request_with_invalid_json() {
         let content = "{ \"seq\": 3, \"type\": \"request\", \"command\": \"test }";
 
@@ -546,20 +483,6 @@ mod test {
         insta::assert_snapshot!(output_str);
 
         assert!(request.is_none());
-    }
-
-    #[test]
-    fn parse_valid_header() {
-        let header = "Content-Length: 234\r\n";
-
-        assert_eq!(234, get_content_len(header).unwrap());
-    }
-
-    #[test]
-    fn parse_invalid_header() {
-        let header = "Content: 234\r\n";
-
-        assert!(get_content_len(header).is_none());
     }
 
     struct FailingWriter {}

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/mod.rs
@@ -59,8 +59,6 @@ pub enum DebuggerError {
     UserMessage(String),
     #[error("Serialization error")]
     SerdeError(#[from] serde_json::Error),
-    #[error("IO error: '{original_error}'.")]
-    NonBlockingReadError { original_error: std::io::Error },
     #[error(transparent)]
     StdIO(#[from] std::io::Error),
     #[error("Unable to open probe{}", .0.map(|s| format!(": {s}")).as_deref().unwrap_or("."))]


### PR DESCRIPTION
This is a new implementation of the DAP decoder for the base protocol.

This is a first step towards using tower, using channels for progress updates and going fully async.

This impl features the same tests as before plus several more but it's not actually used in the server yet.