### PR TITLE
Fix printing stacktrace on ctrl-c

### DIFF
--- a/changelog/fixed-ctrl-c-trace.md
+++ b/changelog/fixed-ctrl-c-trace.md
@@ -1,0 +1,1 @@
+Fixed printing stack trace on ctrl-c

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
@@ -67,6 +67,7 @@ pub struct MonitorRequest {
 #[derive(Serialize, Deserialize, Schema)]
 pub enum MonitorExitReason {
     Success,
+    UserExit,
     SemihostingExit(Result<(), SemihostingExitError>),
     UnexpectedExit(String),
 }
@@ -222,7 +223,7 @@ fn monitor_impl(
     match exit_reason {
         ReturnReason::Predicate(reason) => Ok(reason),
         ReturnReason::Timeout => anyhow::bail!("Run loop exited due to an unexpected timeout"),
-        ReturnReason::Cancelled => anyhow::bail!("Exited due to user request"),
+        ReturnReason::Cancelled => Ok(MonitorExitReason::UserExit),
         ReturnReason::LockedUp => anyhow::bail!("Run loop exited due to a locked up core"),
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -447,7 +447,11 @@ pub async fn monitor(
     let print_stack_trace = match &result {
         Ok(MonitorExitReason::Success | MonitorExitReason::SemihostingExit(Ok(_))) => {
             println!("Firmware exited successfully");
-            print_stack_trace // On success, we only printi the user asked for it.
+            print_stack_trace // On success, we only print if the user asked for it.
+        }
+        Ok(MonitorExitReason::UserExit) => {
+            println!("Exited by user request");
+            print_stack_trace // On ctrl-c, we only print if the user asked for it.
         }
         Ok(MonitorExitReason::UnexpectedExit(reason)) => {
             println!("Firmware exited unexpectedly: {reason}");


### PR DESCRIPTION
Ctrl-C was considered a type of error that prevented printing stack traces for some reason.