### PR TITLE
Update zip dependency to 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,21 +810,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,7 +988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 2.0.100",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1375,6 +1360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -2254,6 +2240,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
+name = "liblzma"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66352d7a8ac12d4877b6e6ea5a9b7650ee094257dc40889955bea5bc5b08c1d0"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5839bad90c3cc2e0b8c4ed8296b80e86040240f81d46b9c0e9bc8dd51ddd3af1"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2283,6 +2289,15 @@ checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2381,16 +2396,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown",
-]
-
-[[package]]
-name = "lzma-rs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
-dependencies = [
- "byteorder",
- "crc",
 ]
 
 [[package]]
@@ -5483,22 +5488,27 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.6.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
+checksum = "153a6fff49d264c4babdcfa6b4d534747f520e56e8f0f384f3b808c4b64cc1fd"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "crossbeam-utils",
  "deflate64",
  "flate2",
  "indexmap",
- "lzma-rs",
+ "liblzma",
  "memchr",
  "time",
  "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"
 
 [[package]]
 name = "zopfli"

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -99,7 +99,7 @@ parking_lot = "0.12.2"
 cargo-config2 = "0.1.26"
 clap_complete = "4.5.2"
 regex = "1.10.4"
-zip = { version = "2.0.0", default-features = false, features = [
+zip = { version = "4.0.0", default-features = false, features = [
     "deflate",
     "time",
 ] }

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -29,7 +29,7 @@ goblin = { version = "0.9.0", default-features = false, features = [
 scroll = "0.12.0"
 serde_yaml = "0.9"
 log = "0.4.21"
-zip = { version = "2.0.0", default-features = false, features = [
+zip = { version = "4.0.0", default-features = false, features = [
     "deflate64",
     "deflate",
     "lzma",


### PR DESCRIPTION
The `zip` crate has been causing some trouble lately:

- In late March/early April, `zip` v2.5 and v2.6 were published, both of which included semver-breaking changes.
- On April 7, probe-rs updated to `zip` v2.6.1 and adapted to the new API (#3210).
- On May 14, the `zip` maintainer yanked v2.5 and v2.6, republishing as v3.0: https://github.com/zip-rs/zip2/issues/337
- The `zip` maintainer added CI semver checks to prevent this breakage in the future; and on May 21, they released `zip` 4.0 with a minor breaking change to remove some unintentionally-exposed Cargo features (https://github.com/zip-rs/zip2/pull/357).

Currently, `probe-rs` declares a dependency on `zip` 2.0.0, but uses the new API from the versions that were yanked and republished. The only reason it successfully builds is because probe-rs's `Cargo.lock` locks `zip` to the yanked version 2.6.1. However, we use `target-gen` as a library (to generate target files enhanced with autodetection information); and since libraries don't use the lockfile, Cargo selects version 2.4.2 (the latest unyanked 2.x version), and `target-gen` fails to compile against the old API.

This PR bumps the `zip` dependency to v4.0.0 so that we can build against an unyanked crate version. This requires no code changes, as probe-rs already uses the new `zip` API.