### PR TITLE
armv7a: mark the cpu core as Running after reset()

### DIFF
--- a/changelog/fixed-update-armv7a-core-status-on-reset.md
+++ b/changelog/fixed-update-armv7a-core-status-on-reset.md
@@ -1,0 +1,1 @@
+Fixed the core status of ARMv7A when issuing a `reset()` so that the status is now updated to `Running` rather than staying at `Halted`.

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -726,6 +726,10 @@ impl CoreInterface for Armv7a<'_> {
         // Reset our cached values
         self.reset_register_cache();
 
+        // Recompute / verify current state
+        self.set_core_status(CoreStatus::Running);
+        let _ = self.status()?;
+
         Ok(())
     }
 


### PR DESCRIPTION
When issuing a `reset()`, ensure the core state is updated to `Running` rather than leaving it in its current state of `Halted(_)`.