### PR TITLE
Add a Glasgow Interface Explorer probe driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,7 +997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2888,7 +2897,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
 dependencies = [
- "cobs",
+ "cobs 0.2.3",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "heapless 0.7.17",
@@ -2971,6 +2980,7 @@ dependencies = [
  "bitfield",
  "bitvec",
  "clap",
+ "cobs 0.3.0",
  "docsplay",
  "dunce",
  "env_logger",

--- a/changelog/added-glasgow-interface-explorer-support.md
+++ b/changelog/added-glasgow-interface-explorer-support.md
@@ -1,0 +1,1 @@
+Added Glasgow Interface Explorer support (SWD only).

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -62,6 +62,7 @@ uf2-decode = "0.2"
 espflash = { version = "3", default-features = false }
 parking_lot = "0.12.2"
 zerocopy = { version = "0.8.0", features = ["derive"] }
+cobs = "0.3"
 
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -7,6 +7,7 @@ pub mod cmsisdap;
 pub mod espusbjtag;
 pub mod fake_probe;
 pub mod ftdi;
+pub mod glasgow;
 pub mod jlink;
 pub mod list;
 pub mod sifliuart;

--- a/probe-rs/src/probe/glasgow/mod.rs
+++ b/probe-rs/src/probe/glasgow/mod.rs
@@ -1,0 +1,378 @@
+//! Glasgow Interface Explorer probe implementation.
+//!
+//! This implementation is compatible with the `probe-rs` applet. The Glasgow toolkit must first
+//! be used to build the bitstream and configure the device; probe-rs cannot do that itself.
+
+use std::sync::Arc;
+
+use crate::architecture::arm::{
+    ArmCommunicationInterface, ArmError, ArmProbeInterface, DapError, RawDapAccess,
+    RegisterAddress,
+    communication_interface::DapProbe,
+    dp::{DpRegister, RdBuff},
+    sequences::ArmDebugSequence,
+};
+
+use super::{
+    DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeFactory, WireProtocol,
+};
+
+mod mux;
+mod net;
+mod proto;
+mod usb;
+
+use mux::GlasgowDevice;
+use proto::Target;
+
+/// A factory for creating [`Glasgow`] probes.
+#[derive(Debug)]
+pub struct GlasgowFactory;
+
+impl std::fmt::Display for GlasgowFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Glasgow")
+    }
+}
+
+impl ProbeFactory for GlasgowFactory {
+    fn open(&self, selector: &DebugProbeSelector) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
+        tracing::debug!("open({selector:?}");
+        Glasgow::new_from_device(GlasgowDevice::new_from_selector(selector)?)
+            .map(Box::new)
+            .map(DebugProbe::into_probe)
+    }
+
+    fn list_probes(&self) -> Vec<DebugProbeInfo> {
+        // Don't return anything; we don't know whether any given device is running a compatible
+        // bitstream, and there is no way for us to know which interfaces are bound to the probe-rs
+        // applet. These parameters must be specified by the user.
+        Vec::new()
+    }
+
+    fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+        // Return exactly the specified probe, if it has the option string (which is referred to
+        // here as the serial number).
+        if let Some(DebugProbeSelector {
+            vendor_id: vendor_id @ 0x20b7,
+            product_id: product_id @ 0x9db1,
+            serial_number: serial_number @ Some(_),
+        }) = selector
+        {
+            vec![DebugProbeInfo {
+                identifier: "Glasgow".to_owned(),
+                vendor_id: *vendor_id,
+                product_id: *product_id,
+                serial_number: serial_number.clone(),
+                hid_interface: None,
+                probe_factory: &Self,
+            }]
+        } else {
+            vec![]
+        }
+    }
+}
+
+/// A Glasgow Interface Explorer device.
+pub struct Glasgow {
+    device: GlasgowDevice,
+    divisor: u16,
+}
+
+impl std::fmt::Debug for Glasgow {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Glasgow").finish()
+    }
+}
+
+impl Glasgow {
+    fn new_from_device(device: GlasgowDevice) -> Result<Self, DebugProbeError> {
+        Ok(Glasgow { device, divisor: 0 })
+    }
+
+    fn identify(&mut self) -> Result<(), DebugProbeError> {
+        self.device.send(Target::Root, &[proto::root::CMD_IDENTIFY]);
+        let identifier = self
+            .device
+            .recv(Target::Root, proto::root::IDENTIFIER.len())?;
+        let utf8_identifier = String::from_utf8_lossy(&identifier);
+        tracing::debug!("identify(): {utf8_identifier}");
+        if identifier == proto::root::IDENTIFIER {
+            Ok(())
+        } else {
+            Err(DebugProbeError::Other(format!(
+                "unsupported probe: {utf8_identifier:?}"
+            )))?
+        }
+    }
+
+    fn get_divisor(&mut self) -> Result<u16, DebugProbeError> {
+        self.device
+            .send(Target::Root, &[proto::root::CMD_GET_DIVISOR]);
+        Ok(u16::from_le_bytes(
+            self.device.recv(Target::Root, 2)?.try_into().unwrap(),
+        ))
+    }
+
+    fn set_divisor(&mut self, divisor: u16) -> Result<(), DebugProbeError> {
+        self.device
+            .send(Target::Root, &[proto::root::CMD_SET_DIVISOR]);
+        self.device.send(Target::Root, &u16::to_le_bytes(divisor));
+        Ok(())
+    }
+
+    fn assert_reset(&mut self) -> Result<(), DebugProbeError> {
+        self.device
+            .send(Target::Root, &[proto::root::CMD_ASSERT_RESET]);
+        self.device.recv(Target::Root, 0)?;
+        Ok(())
+    }
+
+    fn clear_reset(&mut self) -> Result<(), DebugProbeError> {
+        self.device
+            .send(Target::Root, &[proto::root::CMD_CLEAR_RESET]);
+        self.device.recv(Target::Root, 0)?;
+        Ok(())
+    }
+
+    fn swd_sequence(&mut self, len: u8, bits: u32) -> Result<(), DebugProbeError> {
+        assert!(len > 0 && len <= 32);
+        self.device.send(
+            Target::Swd,
+            &[proto::swd::CMD_SEQUENCE | (len & proto::swd::SEQ_LEN_MASK)],
+        );
+        self.device.send(Target::Swd, &bits.to_le_bytes()[..]);
+        self.device.recv(Target::Swd, 0)?;
+        Ok(())
+    }
+
+    fn swd_batch_cmd(&mut self, addr: RegisterAddress, data: Option<u32>) -> Result<(), ArmError> {
+        self.device.send(
+            Target::Swd,
+            &[proto::swd::CMD_TRANSFER
+                | (addr.is_ap() as u8)
+                | (data.is_none() as u8) << 1
+                | (addr.lsb() & 0b1100)],
+        );
+        if let Some(data) = data {
+            self.device.send(Target::Swd, &data.to_le_bytes()[..]);
+        }
+        Ok(())
+    }
+
+    fn swd_batch_ack(&mut self) -> Result<Option<u32>, ArmError> {
+        let response = self.device.recv(Target::Swd, 1)?[0];
+        if response & proto::swd::RSP_TYPE_MASK == proto::swd::RSP_TYPE_DATA {
+            Ok(Some(u32::from_le_bytes(
+                self.device.recv(Target::Swd, 4)?.try_into().unwrap(),
+            )))
+        } else if response & proto::swd::RSP_TYPE_MASK == proto::swd::RSP_TYPE_NO_DATA {
+            if response & proto::swd::RSP_ACK_MASK == proto::swd::RSP_ACK_OK {
+                Ok(None)
+            } else if response & proto::swd::RSP_ACK_MASK == proto::swd::RSP_ACK_WAIT {
+                Err(DapError::WaitResponse)?
+            } else if response & proto::swd::RSP_ACK_MASK == proto::swd::RSP_ACK_FAULT {
+                Err(DapError::FaultResponse)?
+            } else {
+                unreachable!()
+            }
+        } else if response & proto::swd::RSP_TYPE_MASK == proto::swd::RSP_TYPE_ERROR {
+            Err(DapError::Protocol(WireProtocol::Swd))?
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+impl DebugProbe for Glasgow {
+    fn get_name(&self) -> &str {
+        "Glasgow Interface Explorer"
+    }
+
+    fn speed_khz(&self) -> u32 {
+        proto::root::divisor_to_frequency(self.divisor) / 1000
+    }
+
+    fn set_speed(&mut self, speed_khz: u32) -> Result<u32, DebugProbeError> {
+        tracing::debug!("set_speed({speed_khz})");
+        let divisor = proto::root::frequency_to_divisor(speed_khz * 1000);
+        self.set_divisor(divisor)?;
+        self.divisor = self.get_divisor()?;
+        Ok(self.speed_khz())
+    }
+
+    fn attach(&mut self) -> Result<(), DebugProbeError> {
+        tracing::debug!("attach()");
+        self.identify()
+    }
+
+    fn detach(&mut self) -> Result<(), crate::Error> {
+        tracing::debug!("detach()");
+        Ok(())
+    }
+
+    fn target_reset(&mut self) -> Result<(), DebugProbeError> {
+        tracing::debug!("target_reset()");
+        Err(DebugProbeError::CommandNotSupportedByProbe {
+            command_name: "target_reset",
+        })
+    }
+
+    fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
+        tracing::debug!("target_reset_assert()");
+        self.assert_reset()
+    }
+
+    fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {
+        tracing::debug!("target_reset_deassert()");
+        self.clear_reset()
+    }
+
+    fn active_protocol(&self) -> Option<super::WireProtocol> {
+        Some(WireProtocol::Swd)
+    }
+
+    fn select_protocol(&mut self, protocol: super::WireProtocol) -> Result<(), DebugProbeError> {
+        tracing::debug!("select_protocol({protocol})");
+        match protocol {
+            WireProtocol::Swd => Ok(()),
+            _ => Err(DebugProbeError::UnsupportedProtocol(protocol)),
+        }
+    }
+
+    fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
+    }
+
+    fn try_as_dap_probe(&mut self) -> Option<&mut dyn DapProbe> {
+        Some(self)
+    }
+
+    fn has_arm_interface(&self) -> bool {
+        true
+    }
+
+    fn try_get_arm_interface<'probe>(
+        self: Box<Self>,
+        sequence: Arc<dyn ArmDebugSequence>,
+    ) -> Result<Box<dyn ArmProbeInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
+        // The Glasgow applet handles FAULT/WAIT states promptly.
+        Ok(ArmCommunicationInterface::create(
+            self, sequence, /*use_overrun_detect=*/ false,
+        ))
+    }
+}
+
+impl DapProbe for Glasgow {}
+
+impl RawDapAccess for Glasgow {
+    fn raw_read_register(&mut self, address: RegisterAddress) -> Result<u32, ArmError> {
+        if address.is_ap() {
+            let mut value = 0;
+            self.raw_read_block(address, std::slice::from_mut(&mut value))?;
+            Ok(value)
+        } else {
+            self.swd_batch_cmd(address, None)?;
+            let value = self.swd_batch_ack()?.expect("expected data");
+            tracing::debug!("raw_read_register({address:x?}) -> {value:x}");
+            Ok(value)
+        }
+    }
+
+    fn raw_read_block(
+        &mut self,
+        address: RegisterAddress,
+        values: &mut [u32],
+    ) -> Result<(), ArmError> {
+        assert!(address.is_ap());
+        for _ in 0..values.len() {
+            self.swd_batch_cmd(address, None)?;
+        }
+        self.swd_batch_cmd(RegisterAddress::DpRegister(RdBuff::ADDRESS), None)?;
+        let _ = self.swd_batch_ack()?.expect("expected data");
+        for value in values.iter_mut() {
+            *value = self.swd_batch_ack()?.expect("expected data");
+        }
+        tracing::debug!(
+            "raw_read_block({address:x?}, {}) -> {values:x?}",
+            values.len()
+        );
+        Ok(())
+    }
+
+    fn raw_write_register(&mut self, address: RegisterAddress, value: u32) -> Result<(), ArmError> {
+        tracing::debug!("raw_write_register({address:x?}, {value:x})");
+        self.swd_batch_cmd(address, Some(value))?;
+        let response = self.swd_batch_ack()?;
+        assert!(response.is_none(), "unexpected data");
+        Ok(())
+    }
+
+    fn raw_write_block(
+        &mut self,
+        address: RegisterAddress,
+        values: &[u32],
+    ) -> Result<(), ArmError> {
+        tracing::debug!("raw_write_block({address:x?}, {values:x?})");
+        assert!(address.is_ap());
+        for value in values {
+            self.swd_batch_cmd(address, Some(*value))?;
+        }
+        for _ in 0..values.len() {
+            let response = self.swd_batch_ack()?;
+            assert!(response.is_none(), "unexpected data");
+        }
+        Ok(())
+    }
+
+    fn jtag_sequence(&mut self, cycles: u8, tms: bool, tdi: u64) -> Result<(), DebugProbeError> {
+        tracing::debug!("jtag_sequence({cycles}, {tms}, {tdi})");
+        Err(DebugProbeError::CommandNotSupportedByProbe {
+            command_name: "jtag_sequence",
+        })
+    }
+
+    fn swj_sequence(&mut self, len: u8, bits: u64) -> Result<(), DebugProbeError> {
+        tracing::debug!("swj_sequence({len}, {bits:#x})");
+        if len > 0 {
+            self.swd_sequence(len.min(32), bits as u32)?;
+        }
+        if len > 32 {
+            self.swd_sequence(len - 32, (bits >> 32) as u32)?;
+        }
+        Ok(())
+    }
+
+    fn swj_pins(
+        &mut self,
+        pin_out: u32,
+        pin_select: u32,
+        pin_wait: u32,
+    ) -> Result<u32, DebugProbeError> {
+        tracing::debug!("swj_pins({pin_out:#010b}, {pin_select:#010b}, {pin_wait:#010b})");
+        const PIN_NSRST: u32 = 0x80;
+        if pin_select != PIN_NSRST || pin_wait != 0 {
+            Err(DebugProbeError::CommandNotSupportedByProbe {
+                command_name: "swj_pins",
+            })
+        } else {
+            if pin_out & PIN_NSRST == 0 {
+                self.assert_reset()?;
+            } else {
+                self.clear_reset()?;
+            }
+            Ok(0)
+        }
+    }
+
+    fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
+    }
+
+    fn core_status_notification(
+        &mut self,
+        _state: crate::CoreStatus,
+    ) -> Result<(), DebugProbeError> {
+        Ok(())
+    }
+}

--- a/probe-rs/src/probe/glasgow/mux.rs
+++ b/probe-rs/src/probe/glasgow/mux.rs
@@ -1,0 +1,179 @@
+use std::{cell::RefCell, collections::BTreeMap, io};
+
+use crate::probe::{DebugProbeError, DebugProbeSelector, ProbeError};
+
+use super::{net::GlasgowNetDevice, proto::Target, usb::GlasgowUsbDevice};
+
+#[derive(Debug, thiserror::Error)]
+pub enum DiscoveryError {
+    #[error(
+        "Serial number format is \"<device serial>:<IN interface>:<OUT interface>\" or \"tcp:<host>:<port>\"."
+    )]
+    InvalidFormat,
+
+    #[error("Specified USB interfaces are invalid.")]
+    InvalidInterfaces,
+
+    #[error("Could not connect to remote host: {0}.")]
+    ConnectionFailed(#[from] io::Error),
+}
+
+impl ProbeError for DiscoveryError {}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PacketDecodeError {
+    #[error("COBS decode error: {0}.")]
+    CobsDecodeError(#[from] cobs::DecodeError),
+
+    #[error("Packet too short.")]
+    PacketTooShort,
+
+    #[error("Packet destination does not exist.")]
+    NoDestination,
+}
+
+impl ProbeError for PacketDecodeError {}
+
+fn packet_encode(target: Target, mut data: Vec<u8>) -> Vec<u8> {
+    assert!(!data.is_empty());
+    data.insert(0, target as u8);
+    let mut result = vec![0; cobs::max_encoding_length(data.len())];
+    let result_len = cobs::encode(&data, &mut result);
+    result.truncate(result_len);
+    result
+}
+
+fn packet_decode(packet: &mut [u8]) -> Result<(Target, &[u8]), PacketDecodeError> {
+    let result_len = cobs::decode_in_place(packet).map_err(PacketDecodeError::CobsDecodeError)?;
+    let packet = &packet[..result_len];
+    let target = *packet.first().ok_or(PacketDecodeError::PacketTooShort)?;
+    let target = Target::try_from(target).map_err(|_| PacketDecodeError::NoDestination)?;
+    Ok((target, &packet[1..]))
+}
+
+enum GlasgowDeviceInner {
+    Usb(GlasgowUsbDevice),
+    Net(GlasgowNetDevice),
+}
+
+impl GlasgowDeviceInner {
+    fn transfer(
+        &mut self,
+        output: Vec<u8>,
+        input: impl FnMut(Vec<u8>) -> Result<bool, DebugProbeError>,
+    ) -> Result<(), DebugProbeError> {
+        match self {
+            GlasgowDeviceInner::Usb(usb_device) => usb_device.transfer(output, input),
+            GlasgowDeviceInner::Net(tcp_device) => tcp_device.transfer(output, input),
+        }
+    }
+}
+
+pub struct GlasgowDevice {
+    inner: RefCell<GlasgowDeviceInner>,
+    in_queue: RefCell<Vec<u8>>,
+    in_buffers: RefCell<BTreeMap<Target, Vec<u8>>>,
+    out_buffers: RefCell<BTreeMap<Target, Vec<u8>>>,
+}
+
+impl GlasgowDevice {
+    fn new(inner: GlasgowDeviceInner) -> Self {
+        Self {
+            inner: RefCell::new(inner),
+            in_queue: RefCell::new(Vec::new()),
+            in_buffers: RefCell::new(BTreeMap::from_iter([
+                (Target::Root, Vec::new()),
+                (Target::Swd, Vec::new()),
+            ])),
+            out_buffers: RefCell::new(BTreeMap::from_iter([
+                (Target::Root, Vec::new()),
+                (Target::Swd, Vec::new()),
+            ])),
+        }
+    }
+
+    pub fn new_from_selector(selector: &DebugProbeSelector) -> Result<Self, DebugProbeError> {
+        let Some(ref serial) = selector.serial_number else {
+            unreachable!()
+        };
+        if serial.starts_with("tcp:") || serial.starts_with("unix:") {
+            Ok(Self::new(GlasgowDeviceInner::Net(
+                GlasgowNetDevice::new_from_selector(selector)?,
+            )))
+        } else {
+            Ok(Self::new(GlasgowDeviceInner::Usb(
+                GlasgowUsbDevice::new_from_selector(selector)?,
+            )))
+        }
+    }
+
+    fn collect_out_data(&self) -> Vec<u8> {
+        let mut out_buffers = self.out_buffers.borrow_mut();
+        // The (lack of) scheduling in this function has the potential for head-of-line blocking.
+        // Right now the use model is straightforward enough this isn't an issue, though.
+        let mut output = Vec::new();
+        for (&target, buffer) in out_buffers.iter_mut() {
+            if !buffer.is_empty() {
+                output.extend(packet_encode(target, std::mem::take(buffer)));
+                output.push(0x00);
+            }
+        }
+        output
+    }
+
+    fn dispatch_in_data(&self, input: Vec<u8>) -> Result<(), PacketDecodeError> {
+        let mut in_buffers = self.in_buffers.borrow_mut();
+        let mut in_queue = self.in_queue.borrow_mut();
+        in_queue.extend(input);
+        let mut chunks = in_queue.split_mut(|b| *b == 0x00).collect::<Vec<_>>();
+        let chunks_len = chunks.len();
+        for chunk in &mut chunks[..chunks_len - 1] {
+            let (target, packet) = packet_decode(chunk)?;
+            in_buffers
+                .get_mut(&target)
+                .expect("IN buffer not found")
+                .extend(packet);
+        }
+        *in_queue = chunks[chunks_len - 1].to_vec();
+        Ok(())
+    }
+
+    pub fn send(&mut self, target: Target, data: &[u8]) {
+        tracing::trace!("send({target:?}, {})", hexdump(data));
+        self.out_buffers
+            .borrow_mut()
+            .get_mut(&target)
+            .expect("OUT buffer not found")
+            .extend(data);
+    }
+
+    pub fn recv(&mut self, target: Target, size: usize) -> Result<Vec<u8>, DebugProbeError> {
+        tracing::trace!("recv({target:?}, {size}) -> ...");
+        let out_transfer = self.collect_out_data();
+        self.inner
+            .borrow_mut()
+            .transfer(out_transfer, |in_transfer| {
+                self.dispatch_in_data(in_transfer)?;
+                let in_buffers = self.in_buffers.borrow_mut();
+                Ok(in_buffers.get(&target).expect("IN buffer not found").len() >= size)
+            })?;
+        let mut in_buffers = self.in_buffers.borrow_mut();
+        let in_buffer = in_buffers.get_mut(&target).expect("IN buffer not found");
+        let mut data = in_buffer.split_off(size);
+        std::mem::swap(&mut data, in_buffer);
+        tracing::trace!("recv({target:?}, {size}) -> {}", hexdump(&data));
+        Ok(data)
+    }
+}
+
+pub(super) fn hexdump(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+
+    let mut result = String::new();
+    result.push('<');
+    for byte in bytes {
+        write!(&mut result, "{byte:02x}").unwrap();
+    }
+    result.push('>');
+    result
+}

--- a/probe-rs/src/probe/glasgow/net.rs
+++ b/probe-rs/src/probe/glasgow/net.rs
@@ -1,0 +1,59 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
+
+use crate::probe::{
+    DebugProbeError, DebugProbeSelector, ProbeCreationError,
+    glasgow::mux::{DiscoveryError, hexdump},
+};
+
+trait ReadWrite: Read + Write {}
+
+impl ReadWrite for TcpStream {}
+#[cfg(unix)]
+impl ReadWrite for UnixStream {}
+
+pub struct GlasgowNetDevice(Box<dyn ReadWrite + Send>);
+
+impl GlasgowNetDevice {
+    pub fn new_from_selector(selector: &DebugProbeSelector) -> Result<Self, ProbeCreationError> {
+        let Some(qual_addr) = selector.serial_number.clone() else {
+            Err(ProbeCreationError::NotFound)?
+        };
+        let stream: Box<dyn ReadWrite + Send> = match *qual_addr.splitn(2, ":").collect::<Vec<_>>()
+        {
+            ["tcp", addr] => {
+                Box::new(TcpStream::connect(addr).map_err(DiscoveryError::ConnectionFailed)?)
+            }
+            #[cfg(unix)]
+            ["unix", addr] => {
+                Box::new(UnixStream::connect(addr).map_err(DiscoveryError::ConnectionFailed)?)
+            }
+            #[cfg(not(unix))]
+            ["unix", _addr] => Err(ProbeCreationError::NotFound)?,
+            _ => Err(DiscoveryError::InvalidFormat)?,
+        };
+        tracing::info!("opened Glasgow Interface Explorer ({qual_addr})");
+        Ok(Self(stream))
+    }
+
+    pub fn transfer(
+        &mut self,
+        output: Vec<u8>,
+        mut input: impl FnMut(Vec<u8>) -> Result<bool, DebugProbeError>,
+    ) -> Result<(), DebugProbeError> {
+        if !output.is_empty() {
+            tracing::trace!("send: {}", hexdump(&output));
+            self.0.write(&output).map_err(DebugProbeError::Usb)?;
+        }
+        let mut buffer = Vec::new();
+        while !input(buffer)? {
+            buffer = vec![0; 65536];
+            let buffer_len = self.0.read(&mut buffer[..]).map_err(DebugProbeError::Usb)?;
+            buffer.truncate(buffer_len);
+            tracing::trace!("recv: {}", hexdump(&buffer));
+        }
+        Ok(())
+    }
+}

--- a/probe-rs/src/probe/glasgow/proto.rs
+++ b/probe-rs/src/probe/glasgow/proto.rs
@@ -1,0 +1,67 @@
+//! Protocol definitions. These constants correspond to the implementation of the `probe-rs` and
+//! `swd-probe` applets, sometimes in a non-obvious way. They must be changed in sync with
+//! the applets.
+//!
+//! The `probe-rs` applet is composite: it contains multiple endpoints that can be accessed
+//! independently, using COBS as a framing method. The first byte of each packet is the target
+//! address (corresponding to the [`Target`] enum), the rest is the packet data. The endpoints are
+//! not aware of packet boundaries: two 1-byte and one 2-byte (with the same values) packets are
+//! processed exactly the same aside from timing.
+//!
+#![allow(unused)]
+
+/// Target address. The numeric values correspond to packet header bytes for that target.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Target {
+    Root = 0x00,
+    Swd = 0x01,
+}
+
+pub mod root {
+    pub const IDENTIFIER: &[u8; 12] = b"probe-rs,v00";
+
+    pub const CMD_IDENTIFY: u8 = 0x00;
+    pub const CMD_GET_DIVISOR: u8 = 0x10;
+    pub const CMD_SET_DIVISOR: u8 = 0x20;
+    pub const CMD_ASSERT_RESET: u8 = 0x30;
+    pub const CMD_CLEAR_RESET: u8 = 0x31;
+
+    pub const REF_CLK_FREQUENCY: u32 = 24_000_000;
+
+    pub fn divisor_to_frequency(divisor: u16) -> u32 {
+        REF_CLK_FREQUENCY / (divisor as u32 + 1)
+    }
+
+    pub fn frequency_to_divisor(frequency: u32) -> u16 {
+        (REF_CLK_FREQUENCY.div_ceil(frequency) - 1) as u16
+    }
+}
+
+pub mod swd {
+    pub const CMD_TRANSFER: u8 = 0x00;
+    pub const CMD_SEQUENCE: u8 = 0x20;
+
+    pub const SEQ_LEN_MASK: u8 = 0x1f;
+
+    pub const RSP_ACK_MASK: u8 = 0x07;
+    pub const RSP_ACK_OK: u8 = 0b001;
+    pub const RSP_ACK_WAIT: u8 = 0b010;
+    pub const RSP_ACK_FAULT: u8 = 0b100;
+
+    pub const RSP_TYPE_MASK: u8 = 0x30;
+    pub const RSP_TYPE_DATA: u8 = 0x00;
+    pub const RSP_TYPE_NO_DATA: u8 = 0x10;
+    pub const RSP_TYPE_ERROR: u8 = 0x20;
+}
+
+impl TryFrom<u8> for Target {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Root),
+            1 => Ok(Self::Swd),
+            _ => Err(()),
+        }
+    }
+}

--- a/probe-rs/src/probe/glasgow/usb.rs
+++ b/probe-rs/src/probe/glasgow/usb.rs
@@ -1,0 +1,141 @@
+use std::io;
+
+use async_io::block_on;
+use futures_lite::future;
+use nusb::{
+    Interface,
+    transfer::{Direction, RequestBuffer},
+};
+
+use crate::probe::{
+    DebugProbeError, DebugProbeSelector, ProbeCreationError,
+    glasgow::mux::{DiscoveryError, hexdump},
+};
+
+pub struct GlasgowUsbDevice {
+    out_iface: Interface,
+    in_iface: Interface,
+    out_ep_num: u8,
+    in_ep_num: u8,
+}
+
+impl GlasgowUsbDevice {
+    pub fn new_from_selector(selector: &DebugProbeSelector) -> Result<Self, ProbeCreationError> {
+        let Some(serial) = selector.serial_number.clone() else {
+            Err(ProbeCreationError::NotFound)?
+        };
+        let parts = serial.split(":").collect::<Vec<_>>();
+        let [serial, in_iface_num, out_iface_num] = parts[..] else {
+            Err(DiscoveryError::InvalidFormat)?
+        };
+        let in_iface_num: u8 = in_iface_num
+            .parse()
+            .map_err(|_| DiscoveryError::InvalidFormat)?;
+        let out_iface_num: u8 = out_iface_num
+            .parse()
+            .map_err(|_| DiscoveryError::InvalidFormat)?;
+
+        let selector = DebugProbeSelector {
+            serial_number: Some(serial.to_owned()),
+            ..selector.clone()
+        };
+        let device_info = nusb::list_devices()
+            .map_err(ProbeCreationError::Usb)?
+            .find(|device| selector.matches(device))
+            .ok_or(ProbeCreationError::NotFound)?;
+        let device = device_info.open().map_err(ProbeCreationError::Usb)?;
+
+        let mut in_ep_num = None;
+        let mut out_ep_num = None;
+        if let Ok(config) = device.active_configuration() {
+            if let Some(interface) = config.interfaces().nth(in_iface_num as usize) {
+                if let Some(altsetting) = interface.alt_settings().nth(1) {
+                    if let Some(endpoint) = altsetting.endpoints().next() {
+                        if endpoint.direction() == Direction::In {
+                            in_ep_num = Some(endpoint.address());
+                        }
+                    }
+                }
+            }
+            if let Some(interface) = config.interfaces().nth(out_iface_num as usize) {
+                if let Some(altsetting) = interface.alt_settings().nth(1) {
+                    if let Some(endpoint) = altsetting.endpoints().next() {
+                        if endpoint.direction() == Direction::Out {
+                            out_ep_num = Some(endpoint.address());
+                        }
+                    }
+                }
+            }
+        }
+
+        let (Some(in_ep_num), Some(out_ep_num)) = (in_ep_num, out_ep_num) else {
+            Err(DiscoveryError::InvalidInterfaces)?
+        };
+        tracing::info!(
+            "opened Glasgow Interface Explorer (IN {in_iface_num}/{in_ep_num:#04x}, OUT {out_iface_num}/{out_ep_num:#04x})"
+        );
+
+        // This makes our endpoints available for use.
+        let out_iface = device
+            .claim_interface(out_iface_num)
+            .map_err(ProbeCreationError::Usb)?;
+        let in_iface = device
+            .claim_interface(in_iface_num)
+            .map_err(ProbeCreationError::Usb)?;
+
+        // This takes the applet out of reset.
+        out_iface
+            .set_alt_setting(1)
+            .map_err(ProbeCreationError::Usb)?;
+        in_iface
+            .set_alt_setting(1)
+            .map_err(ProbeCreationError::Usb)?;
+
+        Ok(Self {
+            out_iface,
+            in_iface,
+            out_ep_num,
+            in_ep_num,
+        })
+    }
+
+    pub fn transfer(
+        &mut self,
+        output: Vec<u8>,
+        mut input: impl FnMut(Vec<u8>) -> Result<bool, DebugProbeError>,
+    ) -> Result<(), DebugProbeError> {
+        block_on(async {
+            let out_fut = async {
+                if !output.is_empty() {
+                    tracing::trace!("OUT URB: {}", hexdump(&output));
+                    let out_buffer_len = output.len();
+                    let out_completion = self.out_iface.bulk_out(self.out_ep_num, output).await;
+                    out_completion
+                        .status
+                        .map_err(io::Error::other)
+                        .map_err(DebugProbeError::Usb)?;
+                    assert!(out_completion.data.actual_length() == out_buffer_len);
+                }
+                Ok(())
+            };
+            let in_fut = async {
+                let mut buffer = Vec::new();
+                while !input(buffer)? {
+                    let in_completion = self
+                        .in_iface
+                        .bulk_in(self.in_ep_num, RequestBuffer::new(65536))
+                        .await;
+                    in_completion
+                        .status
+                        .map_err(io::Error::other)
+                        .map_err(DebugProbeError::Usb)?;
+                    tracing::trace!("IN URB: {}", hexdump(in_completion.data.as_slice()));
+                    buffer = in_completion.data;
+                }
+                Ok::<(), DebugProbeError>(())
+            };
+            let (out_result, in_result) = future::zip(out_fut, in_fut).await;
+            out_result.and(in_result)
+        })
+    }
+}

--- a/probe-rs/src/probe/list.rs
+++ b/probe-rs/src/probe/list.rs
@@ -4,7 +4,7 @@ use crate::probe::{
     DebugProbeError, DebugProbeInfo, DebugProbeSelector, Probe, ProbeCreationError, ProbeFactory,
 };
 
-use super::{blackmagic, cmsisdap, espusbjtag, ftdi, jlink, sifliuart, stlink, wlink};
+use super::{blackmagic, cmsisdap, espusbjtag, ftdi, glasgow, jlink, sifliuart, stlink, wlink};
 
 /// Struct to list all attached debug probes
 #[derive(Debug)]
@@ -120,6 +120,7 @@ impl AllProbesLister {
         &espusbjtag::EspUsbJtagFactory,
         &wlink::WchLinkFactory,
         &sifliuart::SifliUartFactory,
+        &glasgow::GlasgowFactory,
     ];
 
     /// Create a new lister with all built-in probe drivers.


### PR DESCRIPTION
The corresponding Glasgow PR is [#866](https://github.com/GlasgowEmbedded/glasgow/pull/866). 

This driver works in concert with the `probe-rs` applet and the Glasgow Python framework; it is not able to function standalone.

I would consider this implementation feature-complete within the scope of "supports SWD only". It has acceptable performance (~100 KB/s when loading a small ELF on an IMXRT1052 with maximum 24 MHz SWCLK), supports all of the features you would expect from an SWD debugger (~~except perhaps for hardware SRST#~~ this is implemented now), and is flexible enough to be extended with support for FPGA-accelerated algorithms and JTAG later.

This driver supports three transports (USB, TCP, and Unix domain sockets) equally and with a similar level of performance. The USB transport is novel for Glasgow (this is the first applet where I considered exposing the raw USB BULK endpoints to any third-party software), so I've added the infrastructure required to make the Python toolkit and probe-rs work together in any feasible configuration (the network transports are needed, among other reasons, because there will not always be a free BULK EP pair). While I wouldn't consider the wire protocol stable, there is an identification/version field so any mismatches will be detected.

I would like to get a review for this PR but not merge it just yet; I'm going to test it a bit more in real-world conditions. I also encourage anyone else who has a revC device to do so!