### PR TITLE
Support gdb load command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,7 +733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -742,7 +742,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1014,7 +1014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1275,7 +1275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1370,7 +1370,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1528,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "gdbstub"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8062b93565ea9fe2e60a0dd3c252f0d48c27cf223dad7ead028e361181a2c1a5"
+checksum = "71d66e32caf5dd59f561be0143e413e01d651bd8498eb9aa0be8c482c81c8d31"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -3277,7 +3277,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3569,7 +3569,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3582,7 +3582,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4265,7 +4265,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/changelog/added-gdb-load-command-support.md
+++ b/changelog/added-gdb-load-command-support.md
@@ -1,0 +1,1 @@
+Added support for the gdb load command

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -128,7 +128,7 @@ postcard-schema = { version = "0.2.0", features = ["use-std", "derive"] }
 sha2 = "0.10"
 
 # gdb server
-gdbstub = "0.7"
+gdbstub = "0.7.6"
 
 [build-dependencies]
 git-version = "0.3"

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/flash.rs
@@ -24,6 +24,9 @@ impl Flash for RuntimeTarget<'_> {
         _start_addr: <Self::Arch as Arch>::Usize,
         _length: <Self::Arch as Arch>::Usize,
     ) -> gdbstub::target::TargetResult<(), Self> {
+        // We drop the flash_loader to ensure a fresh start in case
+        // flash_write returns an error and flash_done is not called.
+        let _drop = self.flash_loader.take();
         Ok(())
     }
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/flash.rs
@@ -1,0 +1,55 @@
+use gdbstub::{
+    arch::Arch,
+    target::{TargetError, ext::flash::Flash},
+};
+use probe_rs::flashing::DownloadOptions;
+
+use super::RuntimeTarget;
+
+// The GDB "load" command works as follow:
+// - flash_erase is called first to erase all involved sectors. GDB uses the blocksize
+//   defined in the memory map to provide sector-aligned addresses and lengths.
+// - One flash_write command is issued for each object file section (e.g., .vector_table, .text, etc.)
+//   that needs to be written to flash.
+// - Finally, flash_done is called to indicate that flash programming operation is complete.
+//   According to the GDB documentation, we are allowed to delay and batch all the erase/write
+//   operations until flash_done is invoked.
+
+// In our implementation, we collect all the write operations in the FlashLoader
+// and ignore the flash_erase command, as the FlashLoader will handle everything
+// when we commit during the flash_done command.
+impl Flash for RuntimeTarget<'_> {
+    fn flash_erase(
+        &mut self,
+        _start_addr: <Self::Arch as Arch>::Usize,
+        _length: <Self::Arch as Arch>::Usize,
+    ) -> gdbstub::target::TargetResult<(), Self> {
+        Ok(())
+    }
+
+    fn flash_write(
+        &mut self,
+        start_addr: <Self::Arch as Arch>::Usize,
+        data: &[u8],
+    ) -> gdbstub::target::TargetResult<(), Self> {
+        let flash_loader = self
+            .flash_loader
+            .get_or_insert_with(|| self.session.lock().target().flash_loader());
+
+        flash_loader
+            .add_data(start_addr, data)
+            .map_err(|_e| TargetError::NonFatal)?;
+        Ok(())
+    }
+
+    fn flash_done(&mut self) -> gdbstub::target::TargetResult<(), Self> {
+        let flash_loader = self.flash_loader.as_mut().ok_or(TargetError::NonFatal)?;
+        let mut session = self.session.lock();
+        flash_loader
+            .commit(&mut session, DownloadOptions::default())
+            .map_err(|_e| TargetError::NonFatal)?;
+
+        let _drop = self.flash_loader.take();
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #1057

Currently marked as draft because the flash operations extension in gdbstub PR is not merget yet:
(https://github.com/daniel5151/gdbstub/pull/172)
Maybe someone who's interested could test it meanwhile.

Some notes:
- I don't know if it make sense to reset after flash is done. Usually a `monitor reset` is necessary anyways.
- For the board I test flash sector info are wrong for OTP, option bytes etc.. That's not a problem for the load use case, but I wonder if there's some way to filter out those non-suited-for-exec-binary regions.