### PR TITLE
blackmagic: fix panic for sequences

### DIFF
--- a/changelog/fixed-bmp-sequences.md
+++ b/changelog/fixed-bmp-sequences.md
@@ -1,0 +1,1 @@
+Fixed panic in BlackMagicProbe introduced by 49ef7eb960e8a7148ed7a8d23a0c5b5c0cac9e26

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -934,7 +934,7 @@ impl BlackMagicProbe {
             if dir != self.swd_direction
                 || accumulator_length >= core::mem::size_of_val(&accumulator) * 8
             {
-                // Inputs are off-by-one due to how J-Link is built. Remove one bit
+                // Inputs are off-by-one due to input latency. Remove one bit
                 // from the accumulator and store the turnaround bit at the end of
                 // the transaction.
                 if self.swd_direction == SwdDirection::Input && dir == SwdDirection::Output {
@@ -955,7 +955,7 @@ impl BlackMagicProbe {
                 accumulator_length = 0;
             }
             self.swd_direction = dir;
-            accumulator |= if swdio.try_into().unwrap_or(false) {
+            accumulator |= if let IoSequenceItem::Output(true) = swdio {
                 1 << accumulator_length
             } else {
                 0


### PR DESCRIPTION
Fix a panic during initialization sequences for BlackMagicProbe that was introduced in 49ef7eb960e8a7148ed7a8d23a0c5b5c0cac9e26