### PR TITLE
Allow target filtering and begin support for network targets.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -742,7 +742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -751,7 +751,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1023,7 +1023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2993,8 +2993,7 @@ dependencies = [
 [[package]]
 name = "postcard-rpc"
 version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af390b4b4c1a3a187293bfef773157c75a06f935eeae147c981ee1d958652ea"
+source = "git+https://github.com/rslawson/postcard-rpc?branch=main-no-ng#596c6caa1559313363c306095801823bd1cf2794"
 dependencies = [
  "heapless 0.8.0",
  "maitake-sync",
@@ -3054,6 +3053,7 @@ dependencies = [
  "bincode",
  "bitfield",
  "bitvec",
+ "cfg-if",
  "clap",
  "cobs 0.3.0",
  "docsplay",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,8 @@ debug = "line-tables-only"
 [profile.dev.package.zip]
 # Set the default for zip in development mode so the creation of the zip does not take forever
 opt-level = 3
+
+[patch.crates-io.postcard-rpc]
+git = "https://github.com/rslawson/postcard-rpc"
+branch = "main-no-ng"
+features = ["use-std"]

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -124,7 +124,7 @@ axum-extra = { version = "0.10", features = ["typed-header"], optional = true }
 tempfile = { version = "3.0", optional = true }
 postcard = { version = "1.0", features = ["use-std"] }
 postcard-rpc = { version = "0.11.8", features = ["use-std"] }
-postcard-schema = { version = "0.2.0", features = ["use-std", "derive"] }
+postcard-schema = { version = "0.2.2", features = ["use-std", "derive", "core-net"] }
 sha2 = "0.10"
 
 # gdb server

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -27,7 +27,7 @@ pub struct Config {
     pub general: General,
     pub flashing: Flashing,
     pub reset: Reset,
-    pub probe: Probe,
+    pub probe: Probe, // Should I replace this? I think yes, but I'm uncertain.
     pub rtt: Rtt,
     pub gdb: Gdb,
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -9,6 +9,7 @@ use colored::Colorize;
 use parking_lot::FairMutex;
 use probe_rs::config::Registry;
 use probe_rs::flashing::{BootInfo, FormatKind};
+use probe_rs::probe::UsbFilters;
 use probe_rs::probe::list::Lister;
 use probe_rs::rtt::ScanRegion;
 use probe_rs::{Session, probe::DebugProbeSelector};
@@ -183,10 +184,14 @@ async fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
         Some(selector)
     } else {
         match (config.probe.usb_vid.as_ref(), config.probe.usb_pid.as_ref()) {
-            (Some(vid), Some(pid)) => Some(DebugProbeSelector {
+            (Some(vid), Some(pid)) => Some(DebugProbeSelector::Usb {
                 vendor_id: u16::from_str_radix(vid, 16)?,
                 product_id: u16::from_str_radix(pid, 16)?,
-                serial_number: config.probe.serial.clone(),
+                filters: UsbFilters {
+                    // If `Probe` is replaced, then I can fix this up some.
+                    serial_number: config.probe.serial.clone(),
+                    ..Default::default()
+                },
             }),
             (vid, pid) => {
                 if vid.is_some() {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
@@ -140,14 +140,9 @@ pub async fn list_probes(lister: &Lister, starts_with: &str) -> Result<String> {
         if probe.identifier.starts_with(starts_with) {
             writeln!(
                 &mut output,
-                "{vid:04x}\\:{pid:04x}{sn}B[{id}B]",
-                vid = probe.vendor_id,
-                pid = probe.product_id,
-                sn = probe
-                    .serial_number
-                    .clone()
-                    .map_or("".to_owned(), |v| format!("\\:{}", v)),
+                "{id}: {kind}",
                 id = probe.identifier,
+                kind = probe.kind,
             )?;
         }
     }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -893,8 +893,8 @@ mod test {
         architecture::arm::FullyQualifiedApAddress,
         integration::{FakeProbe, Operation},
         probe::{
-            DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeFactory,
-            list::Lister,
+            DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeKind, DebugProbeSelector,
+            ProbeFactory, UsbFilters, list::Lister,
         },
     };
     use serde_json::json;
@@ -1275,11 +1275,15 @@ mod test {
     fn fake_probe() -> (DebugProbeInfo, FakeProbe) {
         let probe_info = DebugProbeInfo::new(
             "Mock probe",
-            0x12,
-            0x23,
-            Some("mock_serial".to_owned()),
+            DebugProbeKind::Usb {
+                vendor_id: 0x12,
+                product_id: 0x23,
+                filters: UsbFilters {
+                    serial_number: Some("mock_serial".to_owned()),
+                    ..Default::default()
+                },
+            },
             &MockProbeFactory,
-            None,
         );
 
         let fake_probe = FakeProbe::with_mocked_core_and_binary(program_binary().as_path());

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/test.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/test.rs
@@ -20,11 +20,12 @@ impl TestLister {
 #[async_trait::async_trait]
 impl ProbeLister for TestLister {
     async fn open(&self, selector: &DebugProbeSelector) -> Result<Probe, DebugProbeError> {
-        let probe_index = self.probes.lock().await.iter().position(|(info, _)| {
-            info.product_id == selector.product_id
-                && info.vendor_id == selector.vendor_id
-                && info.serial_number == selector.serial_number
-        });
+        let probe_index = self
+            .probes
+            .lock()
+            .await
+            .iter()
+            .position(|(info, _)| selector.matches_probe(info));
 
         if let Some(index) = probe_index {
             let (_info, probe) = self.probes.lock().await.swap_remove(index);

--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -55,7 +55,7 @@ impl Cmd {
             vec![WireProtocol::Jtag, WireProtocol::Swd]
         };
 
-        let probe = select_probe(&client, self.common.probe.map(Into::into)).await?;
+        let probe = select_probe(&client, self.common.probe).await?;
 
         for protocol in protocols {
             let msg = format!("Probing target via {protocol}");

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -12,7 +12,7 @@ use postcard_rpc::{
     host_client::{HostClient, HostClientConfig, HostErr, IoClosed, SubscribeError, Subscription},
 };
 use postcard_schema::Schema;
-use probe_rs::{Session, config::Registry, flashing::FlashLoader};
+use probe_rs::{Session, config::Registry, flashing::FlashLoader, probe::DebugProbeSelector};
 use serde::{Serialize, de::DeserializeOwned};
 use tokio::sync::{Mutex, MutexGuard};
 
@@ -47,8 +47,8 @@ use crate::{
             memory::{ReadMemoryRequest, WriteMemoryRequest},
             monitor::{MonitorExitReason, MonitorMode, MonitorOptions, MonitorRequest},
             probe::{
-                AttachRequest, AttachResult, DebugProbeEntry, DebugProbeSelector,
-                ListProbesRequest, SelectProbeRequest, SelectProbeResult,
+                AttachRequest, AttachResult, DebugProbeEntry, ListProbesRequest,
+                SelectProbeRequest, SelectProbeResult,
             },
             reset::ResetCoreRequest,
             resume::ResumeAllCoresRequest,
@@ -363,8 +363,10 @@ impl RpcClient {
         &self,
         selector: Option<DebugProbeSelector>,
     ) -> anyhow::Result<SelectProbeResult> {
-        self.send_resp::<SelectProbeEndpoint, _>(&SelectProbeRequest { probe: selector })
-            .await
+        self.send_resp::<SelectProbeEndpoint, _>(&SelectProbeRequest {
+            probe: selector.map(Into::into),
+        })
+        .await
     }
 
     pub async fn info(

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -39,6 +39,7 @@ probe-rs-target.workspace = true
 bincode = { version = "2", features = ["serde"], optional = true }
 bitfield = "0.19.0"
 bitvec = "1"
+cfg-if = "1.0"
 hidapi = { version = "2", default-features = false, features = [
     "linux-native",
 ] }
@@ -61,6 +62,7 @@ tracing = "0.1"
 uf2-decode = "0.2"
 espflash = { version = "3", default-features = false }
 parking_lot = "0.12.2"
+
 zerocopy = { version = "0.8.0", features = ["derive"] }
 cobs = "0.3"
 

--- a/probe-rs/src/probe/glasgow/mod.rs
+++ b/probe-rs/src/probe/glasgow/mod.rs
@@ -53,25 +53,20 @@ impl ProbeFactory for GlasgowFactory {
     fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
         // Return exactly the specified probe, if it has the option string (which is referred to
         // here as the serial number).
-        if let Some(DebugProbeSelector {
-            vendor_id,
-            product_id,
-            serial_number: serial_number @ Some(_),
-        }) = selector
-        {
-            if *vendor_id == usb::VID_QIHW && *product_id == usb::PID_GLASGOW {
-                return vec![DebugProbeInfo {
-                    identifier: "Glasgow".to_owned(),
-                    vendor_id: *vendor_id,
-                    product_id: *product_id,
-                    serial_number: serial_number.clone(),
-                    hid_interface: None,
-                    probe_factory: &Self,
-                }];
-            }
+        match selector {
+            Some(
+                selector @ DebugProbeSelector::Usb {
+                    vendor_id: 0x20b7,
+                    product_id: 0x9db1,
+                    ..
+                },
+            ) => vec![DebugProbeInfo {
+                identifier: "Glasgow".to_owned(),
+                kind: selector.into(),
+                probe_factory: &Self,
+            }],
+            _ => vec![],
         }
-
-        vec![]
     }
 }
 

--- a/probe-rs/src/probe/glasgow/mux.rs
+++ b/probe-rs/src/probe/glasgow/mux.rs
@@ -93,17 +93,17 @@ impl GlasgowDevice {
     }
 
     pub fn new_from_selector(selector: &DebugProbeSelector) -> Result<Self, DebugProbeError> {
-        let Some(ref serial) = selector.serial_number else {
-            unreachable!()
-        };
-        if serial.starts_with("tcp:") || serial.starts_with("unix:") {
-            Ok(Self::new(GlasgowDeviceInner::Net(
-                GlasgowNetDevice::new_from_selector(selector)?,
-            )))
-        } else {
-            Ok(Self::new(GlasgowDeviceInner::Usb(
+        match selector {
+            DebugProbeSelector::Usb { .. } => Ok(Self::new(GlasgowDeviceInner::Usb(
                 GlasgowUsbDevice::new_from_selector(selector)?,
-            )))
+            ))),
+            DebugProbeSelector::SocketAddr(_) => Ok(Self::new(GlasgowDeviceInner::Net(
+                GlasgowNetDevice::new_from_selector(selector)?,
+            ))),
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            DebugProbeSelector::UnixSocketAddr(_) => Ok(Self::new(GlasgowDeviceInner::Net(
+                GlasgowNetDevice::new_from_selector(selector)?,
+            ))),
         }
     }
 

--- a/rtthost/src/main.rs
+++ b/rtthost/src/main.rs
@@ -248,17 +248,7 @@ fn list_probes(mut stream: impl std::io::Write, probes: &[DebugProbeInfo]) {
     writeln!(stream, "Available probes:").unwrap();
 
     for (i, probe) in probes.iter().enumerate() {
-        writeln!(
-            stream,
-            "  {}: {} {}",
-            i,
-            probe.identifier,
-            probe
-                .serial_number
-                .as_deref()
-                .unwrap_or("(no serial number)")
-        )
-        .unwrap();
+        writeln!(stream, "  {}: {}{}", i, probe.identifier, probe.kind,).unwrap();
     }
 }
 


### PR DESCRIPTION
This PR enables specifying device targets in a few new ways in order to facilitate targeting a particular device, rather than just the first device that matches the first VID and PID (and optional serial number). The new formats are:

 - `usb=VID:PID:SERIAL`: This is identical to the old format, just with `usb=` in front.
 - `device=VID:PID:/path/to/device` (Linux): this targets the device at the specified path with the given VID and PID.
 - `device=VID:PID:PARENTID.ID.PORT.DRIVER` (Windows): this targets the device with the given parent ID, ID, port, and driver (driver is optional).
 - `device=VID:PID:RID,LID` (MacOS): this targets the device with the given register ID and location ID.
 - `net=ADDR`: this targets the device specified at the address, in the format of an IPv4/IPv6 address with a port number (e.g. `127.0.0.1:6666`, `[::1]:6666`).
 - `socket=/path/to/socket` (*nix): this targets the device with the given Unix socket path.

I'm making this a draft PR since there's still much work to be done that I'm already aware of at time of writing this, not limited to but including:

 - Making it actually work (there seems to be a problem with `postcard_rpc` things currently)
 - Testing with more hardware than I currently have access to
 - Documentation cleanup
 - More refactors? There might be some chances for code deduplication or rewriting better that I missed.
 - Writing the changelog entry/entries