### PR TITLE
Reject ADI MEM-AP components without P bit set

### DIFF
--- a/changelog/fixed-mem-aps-without-base-p-bit-set.md
+++ b/changelog/fixed-mem-aps-without-base-p-bit-set.md
@@ -1,0 +1,1 @@
+Fixed an issue where a MEM-AP whose BASE register did not have Present bit set (no ROM tables) would cause probe-rs to issue invalid memory accesses. This was discovered on an STM32H743.

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -95,6 +95,9 @@ pub trait MemoryApType:
     /// The base address of this AP which is used to then access all relative control registers.
     fn base_address<I: ApAccess>(&self, interface: &mut I) -> Result<u64, ArmError> {
         let base_register: BASE = interface.read_ap_register(self)?;
+        if !base_register.present {
+            return Err(ArmError::Other("debug entry not present".to_string()));
+        }
 
         let mut base_address = if BaseAddrFormat::ADIv5 == base_register.Format {
             let base2: BASE2 = interface.read_ap_register(self)?;


### PR DESCRIPTION
This fixes `probe-rs info` for STM32H743.

Before:

```
Probing target via JTAG
-----------------------

Error while probing target: The protocol 'JTAG' could not be selected.

Caused by:
    The probe does not support the JTAG protocol.
Probing target via SWD
----------------------

ERROR probe_rs::architecture::arm::memory::romtable:    Failed to read component information at 0x0.
ARM Chip with debug port Default:
```

After:

```
Probing target via JTAG
-----------------------

Error while probing target: The protocol 'JTAG' could not be selected.

Caused by:
    The probe does not support the JTAG protocol.
Probing target via SWD
----------------------

ARM Chip with debug port Default:

Debug Port: DPv2, Designer: STMicroelectronics, Part: 0x4500, Revision: 0x0, Instance: 0x00
├── V1(0) MemoryAP
│   └── 0 MemoryAP (AmbaAhb3)
│       ├── 0xe00fe000 ROM Table (Class 1), Designer: STMicroelectronics
│       ├── 0xe00ff000 ROM Table (Class 1), Designer: ARM Ltd
│       ├── 0xe0041000 ETM architecture (Coresight Component)
│       └── 0xe0043000 Coresight Component, Part: 0x0906, Devtype: 0x14, Archid: 0x0000, Designer: ARM Ltd
├── V1(1) MemoryAP
│   └── 1 MemoryAP (AmbaAhb3)
│       └── Error during access: Another ARM error occurred: ROM tables not present
└── V1(2) MemoryAP
    └── 2 MemoryAP (AmbaApb2Apb3)
        ├── 0xe00e0000 ROM Table (Class 1), Designer: STMicroelectronics
        ├── 0xe00e3000 Generic
        ├── 0xe00e4000 Generic
        └── 0xe00e5000 System TSGEN    (Core Link / Prime Cell / System component)
```

