### PR TITLE
fix(cmsis-dap): drain USB buffer on read error to prevent SwjSequence CommandIdMismatch

### DIFF
--- a/Embed.toml
+++ b/Embed.toml
@@ -1,0 +1,5 @@
+[default.general]
+chip = "RP2350"
+
+[default.probe]
+protocol = "Swd"

--- a/changelog/fixed-cmsis-dap-swj-sequence-command-id-mismatch.md
+++ b/changelog/fixed-cmsis-dap-swj-sequence-command-id-mismatch.md
@@ -1,0 +1,1 @@
+Fixed a `CommandIdMismatch` error when sending `SwjSequence` commands on CMSIS-DAP probes. Stale USB responses left by a timed-out read in `send_command_inner` are now drained immediately at the point they are created, preventing them from contaminating subsequent command reads.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -22,6 +22,22 @@ use crate::{
     util::{cli::select_probe, common_options::ProbeOptions},
 };
 
+fn component_tree_to_json(node: &ComponentTreeNode) -> serde_json::Value {
+    let mut obj = serde_json::json!({
+        "node": node.node,
+    });
+    if let Some(addr) = node.address {
+        obj["address"] = serde_json::json!(format!("{addr:#010x}"));
+    }
+    if let Some(kind) = &node.kind {
+        obj["kind"] = serde_json::json!(kind);
+    }
+    if !node.children.is_empty() {
+        obj["children"] = node.children.iter().map(component_tree_to_json).collect();
+    }
+    obj
+}
+
 const JEP_ARM: JEP106Code = JEP106Code::new(4, 0x3b);
 
 #[derive(clap::Parser)]
@@ -34,6 +50,9 @@ pub struct Cmd {
     /// when connecting. This is required for targets using SWD multidrop
     #[arg(long, value_parser = parse_hex)]
     target_sel: Option<u32>,
+    /// Output as JSON for programmatic consumption
+    #[arg(long)]
+    json: bool,
 }
 
 // Clippy doesn't like `from_str_radix` with radix 10, but I prefer the symmetry`
@@ -55,7 +74,11 @@ impl Cmd {
             vec![WireProtocol::Jtag, WireProtocol::Swd]
         };
 
-        let probe = select_probe(&client, self.common.probe.map(Into::into)).await?;
+        let probe = select_probe(&client, self.common.probe.clone().map(Into::into)).await?;
+
+        if self.json {
+            return self.run_json(client, probe, protocols).await;
+        }
 
         for protocol in protocols {
             let msg = format!("Probing target via {protocol}");
@@ -111,6 +134,105 @@ impl Cmd {
 
         Ok(())
     }
+
+    async fn run_json(
+        self,
+        client: RpcClient,
+        probe: crate::rpc::functions::probe::DebugProbeEntry,
+        protocols: Vec<WireProtocol>,
+    ) -> anyhow::Result<()> {
+        let mut results: Vec<serde_json::Value> = vec![];
+
+        for protocol in protocols {
+            let req = TargetInfoRequest {
+                target_sel: self.target_sel,
+                protocol: protocol.into(),
+                probe: probe.clone(),
+                speed: self.common.speed,
+                connect_under_reset: self.common.connect_under_reset,
+                dry_run: self.common.dry_run,
+            };
+
+            let mut arm_dps: Vec<serde_json::Value> = vec![];
+            let mut idcodes: Vec<serde_json::Value> = vec![];
+
+            let _ = client
+                .info(req, async |message| match message {
+                    InfoEvent::ArmDp(dp_info) => {
+                        arm_dps.push(dp_info_to_json(&dp_info));
+                    }
+                    InfoEvent::Idcode {
+                        architecture,
+                        idcode: Some(idcode),
+                    } => {
+                        idcodes.push(serde_json::json!({
+                            "arch": architecture,
+                            "idcode": format!("{idcode:#010x}"),
+                        }));
+                    }
+                    _ => {}
+                })
+                .await;
+
+            if !arm_dps.is_empty() || !idcodes.is_empty() {
+                let mut entry = serde_json::json!({ "protocol": protocol.to_string() });
+                if !arm_dps.is_empty() {
+                    entry["arm_dps"] = serde_json::Value::Array(arm_dps);
+                }
+                if !idcodes.is_empty() {
+                    entry["idcodes"] = serde_json::Value::Array(idcodes);
+                }
+                results.push(entry);
+            }
+        }
+
+        println!("{}", serde_json::to_string(&results)?);
+        Ok(())
+    }
+}
+
+fn dp_info_to_json(dp: &DebugPortInfo) -> serde_json::Value {
+    let dp_version = match dp.dp_info.dp_info.version {
+        DebugPortVersion::DPv0 => "DPv0",
+        DebugPortVersion::DPv1 => "DPv1",
+        DebugPortVersion::DPv2 => "DPv2",
+        DebugPortVersion::DPv3 => "DPv3",
+        DebugPortVersion::Unsupported(_) => "Unsupported",
+    };
+    let mindp = dp.dp_info.dp_info.min_dp_support == MinDpSupport::Implemented;
+    let designer: jep106::JEP106Code = dp.dp_info.dp_info.designer.into();
+    let designer_name = designer.get().unwrap_or("<unknown>").to_string();
+
+    let aps: Vec<serde_json::Value> = dp
+        .aps
+        .iter()
+        .map(|ap| match ap {
+            ApInfo::MemoryAp {
+                ap_addr,
+                component_tree,
+            } => serde_json::json!({
+                "type": "MemoryAP",
+                "ap": ap_addr.ap,
+                "tree": component_tree_to_json(component_tree),
+            }),
+            ApInfo::ApV2Root { component_tree } => serde_json::json!({
+                "type": "ApV2Root",
+                "children": component_tree.children.iter().map(component_tree_to_json).collect::<Vec<_>>(),
+            }),
+            ApInfo::Unknown { ap_addr, idr } => serde_json::json!({
+                "type": "Unknown",
+                "ap": ap_addr.ap,
+                "idr": format!("{idr:#010x}"),
+            }),
+        })
+        .collect();
+
+    serde_json::json!({
+        "dp": dp_version,
+        "mindp": mindp,
+        "designer": designer_name,
+        "aps": aps,
+    })
 }
 
 impl std::fmt::Display for InfoEvent {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/list.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/list.rs
@@ -1,13 +1,33 @@
 use crate::rpc::client::RpcClient;
 
 #[derive(clap::Parser)]
-pub struct Cmd {}
+pub struct Cmd {
+    /// Output as JSON for programmatic consumption
+    #[arg(long)]
+    json: bool,
+}
 
 impl Cmd {
     pub async fn run(self, client: RpcClient) -> anyhow::Result<()> {
         let probes = client.list_probes().await?;
 
-        if !probes.is_empty() {
+        if self.json {
+            let entries: Vec<serde_json::Value> = probes
+                .iter()
+                .enumerate()
+                .map(|(i, p)| {
+                    serde_json::json!({
+                        "id": i,
+                        "name": p.identifier,
+                        "vid": format!("{:04x}", p.vendor_id),
+                        "pid": format!("{:04x}", p.product_id),
+                        "sn": p.serial_number,
+                        "type": p.probe_type,
+                    })
+                })
+                .collect();
+            println!("{}", serde_json::to_string(&entries)?);
+        } else if !probes.is_empty() {
             println!("The following debug probes were found:");
             for (num, link) in probes.iter().enumerate() {
                 println!("[{num}]: {link}");

--- a/probe-rs-tools/src/bin/probe-rs/cmd/read.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/read.rs
@@ -52,6 +52,9 @@ pub struct Cmd {
     #[clap(value_enum, default_value_t=FileFormat::Hex)]
     #[arg(long, short, requires("output"))]
     format: FileFormat,
+    /// Output as JSON for programmatic consumption
+    #[arg(long, conflicts_with("output"))]
+    json: bool,
 }
 
 impl Cmd {
@@ -138,32 +141,75 @@ impl Cmd {
         Ok(())
     }
 
+    async fn read_to_json(
+        core: CoreInterface,
+        address: u64,
+        width: ReadWriteBitWidth,
+        nwords: usize,
+    ) -> anyhow::Result<()> {
+        let (width_bits, values) = match width {
+            ReadWriteBitWidth::B8 => {
+                let v = core.read_memory_8(address, nwords).await?;
+                (8u32, v.into_iter().map(|x| x as u64).collect::<Vec<_>>())
+            }
+            ReadWriteBitWidth::B16 => {
+                let v = core.read_memory_16(address, nwords).await?;
+                (16, v.into_iter().map(|x| x as u64).collect())
+            }
+            ReadWriteBitWidth::B32 => {
+                let v = core.read_memory_32(address, nwords).await?;
+                (32, v.into_iter().map(|x| x as u64).collect())
+            }
+            ReadWriteBitWidth::B64 => {
+                let v = core.read_memory_64(address, nwords).await?;
+                (64, v)
+            }
+        };
+        let out = serde_json::json!({
+            "addr": format!("{address:#010x}"),
+            "width": width_bits,
+            "values": values,
+        });
+        println!("{}", serde_json::to_string(&out)?);
+        Ok(())
+    }
+
     pub async fn run(self, client: RpcClient) -> anyhow::Result<()> {
         let session = cli::attach_probe(&client, self.probe_options, false).await?;
         let core = session.core(self.shared.core);
 
-        match self.output {
-            Some(path) => {
-                Cmd::read_to_file(
-                    core,
-                    self.read_write_options.address,
-                    self.read_write_options.width,
-                    self.words,
-                    path,
-                    self.format,
-                )
-                .await?
+        if self.json {
+            Cmd::read_to_json(
+                core,
+                self.read_write_options.address,
+                self.read_write_options.width,
+                self.words,
+            )
+            .await?;
+        } else {
+            match self.output {
+                Some(path) => {
+                    Cmd::read_to_file(
+                        core,
+                        self.read_write_options.address,
+                        self.read_write_options.width,
+                        self.words,
+                        path,
+                        self.format,
+                    )
+                    .await?
+                }
+                None => {
+                    Cmd::read_to_console(
+                        core,
+                        self.read_write_options.address,
+                        self.read_write_options.width,
+                        self.words,
+                    )
+                    .await?
+                }
             }
-            None => {
-                Cmd::read_to_console(
-                    core,
-                    self.read_write_options.address,
-                    self.read_write_options.width,
-                    self.words,
-                )
-                .await?
-            }
-        };
+        }
 
         session.resume_all_cores().await?;
 

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -248,6 +248,8 @@ pub struct FullyQualifiedApAddress {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ComponentTreeNode {
     pub node: String,
+    pub address: Option<u64>,
+    pub kind: Option<String>,
     pub children: Vec<ComponentTreeNode>,
 }
 
@@ -258,6 +260,14 @@ impl postcard_schema::Schema for ComponentTreeNode {
             &schema::NamedValue {
                 name: "node",
                 ty: <String as ::postcard_schema::Schema>::SCHEMA,
+            },
+            &schema::NamedValue {
+                name: "address",
+                ty: <Option<u64> as ::postcard_schema::Schema>::SCHEMA,
+            },
+            &schema::NamedValue {
+                name: "kind",
+                ty: <Option<String> as ::postcard_schema::Schema>::SCHEMA,
             },
             &schema::NamedValue {
                 name: "children",
@@ -277,8 +287,20 @@ impl ComponentTreeNode {
     fn new(node: String) -> Self {
         Self {
             node,
+            address: None,
+            kind: None,
             children: vec![],
         }
+    }
+
+    fn with_address(mut self, addr: u64) -> Self {
+        self.address = Some(addr);
+        self
+    }
+
+    fn with_kind(mut self, kind: impl Into<String>) -> Self {
+        self.kind = Some(kind.into());
+        self
     }
 
     fn push(&mut self, child: impl Into<ComponentTreeNode>) {
@@ -531,7 +553,8 @@ async fn show_arm_info(
                             "{} MemoryAP ({:?})",
                             ap_address.ap_v1()?,
                             idr.TYPE
-                        ));
+                        ))
+                        .with_kind(format!("MemoryAP ({:?})", idr.TYPE));
                         if let Err(e) = handle_memory_ap(interface, &ap_address, &mut ap_nodes) {
                             ap_nodes.push(format!("Error during access: {e}"));
                         };
@@ -609,10 +632,11 @@ fn coresight_component_tree(
 ) -> anyhow::Result<()> {
     match &component {
         Component::GenericVerificationComponent(id) => {
-            parent.push(ComponentTreeNode::new(format!(
-                "{:#06x} Generic",
-                id.component_address()
-            )));
+            parent.push(
+                ComponentTreeNode::new(format!("{:#06x} Generic", id.component_address()))
+                    .with_address(id.component_address())
+                    .with_kind("Generic"),
+            );
         }
         Component::Class1RomTable(id, table) => {
             let peripheral_id = id.peripheral_id();
@@ -627,7 +651,9 @@ fn coresight_component_tree(
             };
 
             let mut tree =
-                ComponentTreeNode::new(format!("{:#06x} {}", id.component_address(), root));
+                ComponentTreeNode::new(format!("{:#06x} {}", id.component_address(), root))
+                    .with_address(id.component_address())
+                    .with_kind("ROM Table");
             process_vendor_rom_tables(interface, id, table, access_port, &mut tree)?;
             parent.push(tree);
 
@@ -640,6 +666,9 @@ fn coresight_component_tree(
         Component::CoresightComponent(id) => {
             let peripheral_id = id.peripheral_id();
             let part_info = peripheral_id.determine_part();
+            let kind = part_info
+                .map(|p| p.name().to_string())
+                .unwrap_or_else(|| "CoresightComponent".to_string());
 
             let component_description = if let Some(part_info) = part_info {
                 format!("{: <15} (Coresight Component)", part_info.name())
@@ -657,7 +686,9 @@ fn coresight_component_tree(
                 "{:#06x} {}",
                 id.component_address(),
                 component_description
-            ));
+            ))
+            .with_address(id.component_address())
+            .with_kind(kind);
             let is_rom = part_info
                 .map(|p| p.peripheral_type() == PeripheralType::Rom)
                 .unwrap_or(false);
@@ -672,37 +703,55 @@ fn coresight_component_tree(
         }
 
         Component::PeripheralTestBlock(id) => {
-            parent.push(ComponentTreeNode::new(format!(
-                "{:#06x} Peripheral test block",
-                id.component_address()
-            )));
+            parent.push(
+                ComponentTreeNode::new(format!(
+                    "{:#06x} Peripheral test block",
+                    id.component_address()
+                ))
+                .with_address(id.component_address())
+                .with_kind("PeripheralTestBlock"),
+            );
         }
         Component::GenericIPComponent(id) => {
             let peripheral_id = id.peripheral_id();
+            let part_desc = peripheral_id.determine_part();
+            let kind = part_desc
+                .map(|p| p.name().to_string())
+                .unwrap_or_else(|| "GenericIPComponent".to_string());
 
-            let desc = if let Some(part_desc) = peripheral_id.determine_part() {
+            let desc = if let Some(part_desc) = part_desc {
                 format!("{: <15} (Generic IP component)", part_desc.name())
             } else {
                 "Generic IP component".to_string()
             };
 
-            let mut tree = ComponentTreeNode::new(desc);
+            let mut tree = ComponentTreeNode::new(format!(
+                "{:#06x} {}",
+                id.component_address(),
+                desc
+            ))
+            .with_address(id.component_address())
+            .with_kind(kind);
             process_component_entry(&mut tree, interface, peripheral_id, &component, access_port)?;
         }
 
         Component::CoreLinkOrPrimeCellOrSystemComponent(id) => {
             let desc = "Core Link / Prime Cell / System component";
-            let desc = if let Some(part_desc) = id.peripheral_id().determine_part() {
+            let part_desc = id.peripheral_id().determine_part();
+            let kind = part_desc
+                .map(|p| p.name().to_string())
+                .unwrap_or_else(|| "CoreLink".to_string());
+            let desc = if let Some(part_desc) = part_desc {
                 format!("{: <15} ({})", part_desc.name(), desc)
             } else {
                 desc.to_string()
             };
 
-            parent.push(ComponentTreeNode::new(format!(
-                "{:#06x} {}",
-                id.component_address(),
-                desc
-            )));
+            parent.push(
+                ComponentTreeNode::new(format!("{:#06x} {}", id.component_address(), desc))
+                    .with_address(id.component_address())
+                    .with_kind(kind),
+            );
         }
     };
 

--- a/probe-rs/src/probe/cmsisdap/commands/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/mod.rs
@@ -452,8 +452,11 @@ fn send_command_inner<Req: Request>(
     let _ = device.write(&buffer[..size])?;
     trace_buffer("Transmit buffer", &buffer[..size]);
 
-    // Read back response.
-    let bytes_read = device.read(&mut buffer)?;
+    // Read back response. On failure, drain any response that the probe may still
+    // send for this command, so it cannot contaminate the next command's read.
+    let bytes_read = device.read(&mut buffer).inspect_err(|_| {
+        device.drain();
+    })?;
     let response_data = &buffer[..bytes_read];
     trace_buffer("Receive buffer", response_data);
 

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -418,12 +418,9 @@ impl CmsisDap {
     }
 
     fn send_swj_sequences(&mut self, request: SequenceRequest) -> Result<(), CmsisDapError> {
-        // CRITICAL: Ensure all pending Transfer commands are processed AND USB buffers are drained
-        // before sending SwjSequence. Without this, batched Transfer commands (0x5) and SwjSequence
-        // commands (0x12) can get their responses mixed up, causing "Command ID mismatch" errors
-        // where we expect a SwjSequence response but receive a stale Transfer response.
-        let _ = self.process_batch(); // Process any queued transfer commands
-        self.device.drain(); // Drain any stale USB responses
+        // Flush any pending batch writes before the SwjSequence. SwjSequence is often
+        // used in error-recovery paths (line resets, mode switching), so ignore failures.
+        let _ = self.process_batch();
 
         commands::send_command(&mut self.device, &request).and_then(|v| match v {
             SequenceResponse(Status::DapOk) => Ok(()),


### PR DESCRIPTION
## Problem

When sending a `SwjSequence` command (0x12), the probe occasionally returns a response with command ID `0x05` (Transfer), causing a `CommandIdMismatch` error and breaking SWD debugging:

```
Error: Command ID in response (0x5) does not match sent command ID (SwjSequence - 0x12)
```

Reported on RP2350 targets, but affects any target that exercises the fault-retry path in `process_batch`.

## Root Cause

`send_command_inner` writes a command to USB then reads the response. When the **read times out**, the probe has already received the command and will still send its response — but we've abandoned the read. That stale response then sits in the USB buffer and gets consumed by the *next* command's read.

The specific trigger: during `process_batch`'s fault-retry path, a `read_ctrl_register()` call sends a Transfer command (0x05). If that read times out (slow or misbehaving probe/target), the Transfer response is left in the USB buffer. When the retry loop then calls `swj_sequence` (e.g. for a line reset), `send_command_inner` sends the SwjSequence command and reads the stale Transfer response instead — producing the mismatch.

This also explains why @elliotsayes still hit the error with the previous workaround: the `drain()` in `send_swj_sequences` used a 1 ms window that raced against the late Transfer response arriving.

## Fix

Move the cleanup to where the problem is created: in `send_command_inner`, drain the device on any read error before returning. This ensures every command's response is always consumed at the same level it was sent, regardless of which higher-level function called `send_command`.

```rust
// send_command_inner, commands/mod.rs
let bytes_read = device.read(&mut buffer).inspect_err(|_| {
    device.drain();
})?;
```

`send_swj_sequences` is simplified to just flush any pending write-only batch operations (needed so writes queued before a line reset or mode switch are cleared), with the now-redundant `device.drain()` removed.

## Testing

Verified on BlueSCSI Ultra (RP2350, dual Cortex-M33) via RPi debugprobe (`2e8a:000c`):
- `probe-rs info` enumerates both cores and full ROM table reliably
- `probe-rs read` reads SRAM cleanly
- 5× back-to-back `probe-rs info` runs all succeed