### PR TITLE
Change page size of MIMXRT685S to 4K to speed up flashing

### DIFF
--- a/probe-rs/targets/MIMXRT685S.yaml
+++ b/probe-rs/targets/MIMXRT685S.yaml
@@ -1,3 +1,6 @@
+# This file has been changed compared to the version as generated from the cmsispack.
+# * changed flash algorithm page_size to 4K to speed up flashing.
+
 name: MIMXRT685S Series
 manufacturer:
   id: 0x15
@@ -484,7 +487,7 @@ flash_algorithms:
     address_range:
       start: 0x8000000
       end: 0xc000000
-    page_size: 0x100
+    page_size: 0x1000 # Changed to 4K from 256 bytes to speed up flashing
     erased_byte_value: 0xff
     program_page_timeout: 3000
     erase_sector_timeout: 3000
@@ -506,7 +509,7 @@ flash_algorithms:
     address_range:
       start: 0x18000000
       end: 0x1c000000
-    page_size: 0x100
+    page_size: 0x1000 # Changed to 4K from 256 bytes to speed up flashing
     erased_byte_value: 0xff
     program_page_timeout: 300
     erase_sector_timeout: 3000
@@ -527,7 +530,7 @@ flash_algorithms:
     address_range:
       start: 0x8000000
       end: 0xc000000
-    page_size: 0x100
+    page_size: 0x1000 # Changed to 4K from 256 bytes to speed up flashing
     erased_byte_value: 0xff
     program_page_timeout: 3000
     erase_sector_timeout: 3000
@@ -548,7 +551,7 @@ flash_algorithms:
     address_range:
       start: 0x18000000
       end: 0x1c000000
-    page_size: 0x100
+    page_size: 0x1000 # Changed to 4K from 256 bytes to speed up flashing
     erased_byte_value: 0xff
     program_page_timeout: 300
     erase_sector_timeout: 3000


### PR DESCRIPTION
When flashing a large binary on MIMXRT685S the process is slow:
```
      Erasing ✔ 100% [####################] 860.00 KiB @  55.48 KiB/s (took 16s)
  Programming ⠦   6% [##------------------]  51.25 KiB @   4.13 KiB/s (ETA 3m)
    Verifying ⠦   0% [--------------------] 
```

Checking NXP LinkServer we can see that it uses 16KiB blocks to flash the device:
```
Ps: ( 99) at 080D0000: 16384 bytes - 868352/877088
Ps: (100) at 080D4000: 16384 bytes - 884736/877088
Nc: 080D8000 done 100% (884736 out of 877088)
Nc: Sectors written: 14, unchanged: 0, total: 14
Nc: Closing flash driver MIMXRT600_FlexSPI_B_MXIC_OPI.cfx
Pb: (100) Finished writing Flash successfully.
Nt: Loaded 0xD5A20 bytes in 9739ms (about 89kB/s)
```

The CMSISpack flash algorithm is quite different to the one LinkServer is using, at least superficially. For one the LinkServer implementation does not have symbols at all.

However, when changing the `page_size` to 4K (same as sector size) in the probe-rs generated yaml file we can already notice a considerable speedup:

```
      Erasing ✔ 100% [####################] 860.00 KiB @  54.83 KiB/s (took 16s)
  Programming ⠈  18% [####----------------] 152.00 KiB @  32.85 KiB/s (ETA 22s)
    Verifying ⠈   0% [--------------------] 
```

Because this will likely not break anything (it also verifies the downloaded binary correctly), I have here made a PR to change it to 4K. Changing it to 16K gains us some more speed to 53.61 KiB/s. The actual EVK flash page size is 256 bytes. The sector size is 4K.

This will break from the generated CMSISpack yaml. If desireable we could also consider implementing our own flash algo in Rust.

Let me know what you think.
