### PR TITLE
Fixed minor issues with resetting mimxrt6xx and mcx.

### DIFF
--- a/changelog/fixed-mimxrt6-mcx-sequences.md
+++ b/changelog/fixed-mimxrt6-mcx-sequences.md
@@ -1,0 +1,1 @@
+Fixed minor issues with resetting mimxrt6xx and mcx.

--- a/probe-rs/src/vendor/nxp/sequences/mcx.rs
+++ b/probe-rs/src/vendor/nxp/sequences/mcx.rs
@@ -416,7 +416,7 @@ impl ArmDebugSequence for MCX {
         tracing::info!("reset hardware deassert");
         let n_reset = Pins(0x80).0 as u32;
 
-        let can_read_pins = probe.swj_pins(0, n_reset, 0)? != 0xFFFF_FFFF;
+        let can_read_pins = probe.swj_pins(n_reset, n_reset, 0)? != 0xFFFF_FFFF;
 
         thread::sleep(Duration::from_millis(50));
 

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
@@ -501,11 +501,12 @@ impl MIMXRT5xxS {
             interface.write_word_32(0x40004214, 0x130)?; // full drive and pullup
             interface.write_word_32(0x40102010, 1 << 5)?; // PIO4_5 is an output
             interface.write_word_32(0x40103214, 0)?; // PIO4_5 is driven low
-            thread::sleep(Duration::from_millis(100));
+            interface.flush()?;
+            thread::sleep(Duration::from_micros(100));
 
             interface.write_word_32(0x40102010, 0)?; // PIO4_5 is an input
             interface.flush()?;
-            thread::sleep(Duration::from_millis(100));
+            thread::sleep(Duration::from_micros(100));
         } else {
             tracing::trace!("MIMXRT685-EVK FlexSPI flash reset (pulse PIO2_12)");
 
@@ -515,16 +516,17 @@ impl MIMXRT5xxS {
             // generalize this so that the reset is configurable?
             //
             // See MIMX685-EVK schematics page 12 for details.
-            interface.write_word_32(0x40021044, 1 << 2)?; // enable HSGPIO2 clock
-            interface.write_word_32(0x40000074, 1 << 2)?; // take HSGPIO2 out of reset
             interface.write_word_32(0x40004130, 0x130)?; // full drive and pullup
+            interface.write_word_32(0x40021044, 1 << 2)?; // enable HSGPIO2 clock
+            interface.write_word_32(0x40020074, 1 << 2)?; // take HSGPIO2 out of reset
             interface.write_word_32(0x40102008, 1 << 12)?; // PIO2_12 is an output
             interface.write_word_32(0x40102288, 1 << 12)?; // PIO2_12 is driven low
+            interface.flush()?;
             thread::sleep(Duration::from_millis(100));
 
             interface.write_word_32(0x40102208, 1 << 12)?; // PIO2_12 is driven high
             interface.flush()?;
-            thread::sleep(Duration::from_millis(100));
+            thread::sleep(Duration::from_micros(100));
         }
 
         Ok(())
@@ -708,7 +710,7 @@ impl ArmDebugSequence for MIMXRT5xxS {
         tracing::trace!("MIMXRT5xxS reset hardware deassert");
         let n_reset = Pins(0x80).0 as u32;
 
-        let can_read_pins = memory.swj_pins(0, n_reset, 0)? != 0xffff_ffff;
+        let can_read_pins = memory.swj_pins(n_reset, n_reset, 0)? != 0xffff_ffff;
 
         thread::sleep(Duration::from_millis(50));
 


### PR DESCRIPTION
This PR fixes two minor issues in my search to fix #3248. It does not actually fix practical issues for the typical usecase.

* During `reset_hardware_deassert` the nreset pin would be toggled during the check whether the pins can be read. This was incorrectly copied from `reset_hardware` in the cmsispack to `reset_hardware_deassert` for both IMXRT6xx and MCX.
* The reset flash procedure would pull the RSTCTL0 SDIO0 `0x40000074 bit 2` out of reset instead of the RSTCTL1 HSGPIO2 `0x40020074 bit 2`. Flushing and ordering was incorrect as well. See the cmsispack implementation for reference, which we now follow exactly:

```
<sequence name='ResetFlash' Pname='cm33'>
          <block/>
          <control if='(__connection &amp; 0x01)'>
            <block>
              //  Reset external flash if connection for target debug
              Write32(0x40004130, 0x130U);
              Write32(0x40021044, 0x4U);
              Write32(0x40020074, 0x4U);
              Write32(0x40102008, 0x1000U);
              Write32(0x40102288, 0x1000U);
              DAP_Delay(100);
              Write32(0x40102208, 0x1000U);
            </block>
          </control>
</sequence>
```