### PR TITLE
Generic deferred result handling

### DIFF
--- a/probe-rs/src/architecture/arm/traits/polyfill.rs
+++ b/probe-rs/src/architecture/arm/traits/polyfill.rs
@@ -14,7 +14,7 @@ use crate::{
         dp::{Abort, Ctrl, DPIDR, DebugPortError, DpRegister, RdBuff},
     },
     probe::{
-        CommandResult, DebugProbe, DebugProbeError, IoSequenceItem, JtagAccess, JtagCommandQueue,
+        CommandQueue, CommandResult, DebugProbe, DebugProbeError, IoSequenceItem, JtagAccess,
         JtagSequence, JtagWriteCommand, RawSwdIo, WireProtocol, common::bits_to_byte,
     },
 };
@@ -120,7 +120,7 @@ fn perform_jtag_transfers<P: JtagAccess + RawSwdIo>(
     transfers: &mut [DapTransfer],
 ) -> Result<(), DebugProbeError> {
     // Set up the command queue.
-    let mut queue = JtagCommandQueue::new();
+    let mut queue = CommandQueue::new();
 
     let mut results = vec![];
 

--- a/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
@@ -22,7 +22,7 @@ use crate::probe::{DebugProbeError, ShiftDrCommand};
 #[derive(Debug, Default)]
 struct DtmState {
     queued_commands: CommandQueue<JtagCommand>,
-    jtag_results: DeferredResultSet,
+    jtag_results: DeferredResultSet<CommandResult>,
 
     /// Number of address bits in the DMI register
     abits: u32,

--- a/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
@@ -14,14 +14,14 @@ use crate::architecture::riscv::communication_interface::{
 use crate::architecture::riscv::dtm::dtm_access::DtmAccess;
 use crate::error::Error;
 use crate::probe::{
-    CommandResult, DeferredResultIndex, DeferredResultSet, JtagAccess, JtagCommandQueue,
+    CommandQueue, CommandResult, DeferredResultIndex, DeferredResultSet, JtagAccess, JtagCommand,
     JtagWriteCommand,
 };
 use crate::probe::{DebugProbeError, ShiftDrCommand};
 
 #[derive(Debug, Default)]
 struct DtmState {
-    queued_commands: JtagCommandQueue,
+    queued_commands: CommandQueue<JtagCommand>,
     jtag_results: DeferredResultSet,
 
     /// Number of address bits in the DMI register

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -134,7 +134,7 @@ pub struct XdmState {
     queue: CommandQueue<JtagCommand>,
 
     /// The results of the reads in the already executed batched JTAG commands.
-    jtag_results: DeferredResultSet,
+    jtag_results: DeferredResultSet<CommandResult>,
 
     /// Read handles for accesses that need to force capturing their bits.
     ///

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -9,8 +9,8 @@ use crate::{
     Error as ProbeRsError,
     architecture::xtensa::arch::instruction::{Instruction, InstructionEncoding},
     probe::{
-        CommandResult, DeferredResultIndex, DeferredResultSet, JtagAccess, JtagCommandQueue,
-        JtagWriteCommand, ShiftDrCommand,
+        CommandQueue, CommandResult, DeferredResultIndex, DeferredResultSet, JtagAccess,
+        JtagCommand, JtagWriteCommand, ShiftDrCommand,
     },
 };
 
@@ -131,7 +131,7 @@ pub struct XdmState {
 
     /// The command queue for the current batch. JTAG accesses are batched to reduce the number of
     /// IO operations.
-    queue: JtagCommandQueue,
+    queue: CommandQueue<JtagCommand>,
 
     /// The results of the reads in the already executed batched JTAG commands.
     jtag_results: DeferredResultSet,
@@ -166,7 +166,7 @@ impl<'probe> Xdm<'probe> {
 
     #[tracing::instrument(skip(self))]
     pub(crate) fn enter_debug_mode(&mut self) -> Result<(), XtensaError> {
-        self.state.queue = JtagCommandQueue::new();
+        self.state.queue = CommandQueue::new();
         self.state.jtag_results = DeferredResultSet::new();
 
         self.probe.tap_reset()?;

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -7,8 +7,8 @@ use bitvec::prelude::*;
 use probe_rs_target::ScanChainElement;
 
 use crate::probe::{
-    AutoImplementJtagAccess, BatchExecutionError, ChainParams, CommandResult, DebugProbeError,
-    DeferredResultSet, JtagAccess, JtagCommand, JtagCommandQueue, JtagSequence, RawJtagIo,
+    AutoImplementJtagAccess, BatchExecutionError, ChainParams, CommandQueue, CommandResult,
+    DebugProbeError, DeferredResultSet, JtagAccess, JtagCommand, JtagSequence, RawJtagIo,
 };
 
 pub(crate) fn bits_to_byte(bits: impl IntoIterator<Item = bool>) -> u32 {
@@ -709,7 +709,7 @@ impl<Probe: AutoImplementJtagAccess> JtagAccess for Probe {
     #[tracing::instrument(skip(self, writes))]
     fn write_register_batch(
         &mut self,
-        writes: &JtagCommandQueue,
+        writes: &CommandQueue<JtagCommand>,
     ) -> Result<DeferredResultSet, BatchExecutionError> {
         let mut bits = Vec::with_capacity(writes.len());
         let t1 = std::time::Instant::now();

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -710,7 +710,7 @@ impl<Probe: AutoImplementJtagAccess> JtagAccess for Probe {
     fn write_register_batch(
         &mut self,
         writes: &CommandQueue<JtagCommand>,
-    ) -> Result<DeferredResultSet, BatchExecutionError> {
+    ) -> Result<DeferredResultSet<CommandResult>, BatchExecutionError> {
         let mut bits = Vec::with_capacity(writes.len());
         let t1 = std::time::Instant::now();
         tracing::debug!("Preparing {} writes...", writes.len());


### PR DESCRIPTION
I'm trying to get debugging of a mixed architecture chip working, by implementing the `DtmAccess` backed by the `ArmMemoryInterface`.

This is a small part, making the `CommandQueue` generic makes it easier to create an implementation of a DTM not based on JTAG.

