### PR TITLE
Export dapprobe and jtagdtmbuilder

### DIFF
--- a/changelog/added-export-of-arm-dapprobe.md
+++ b/changelog/added-export-of-arm-dapprobe.md
@@ -1,0 +1,1 @@
+Added an export of `arm::communication_interface::DapProbe` so external software can implement `ArmDebugSequence` trait functions that require that type

--- a/changelog/added-export-of-riscv-jtag-dtm-builder.md
+++ b/changelog/added-export-of-riscv-jtag-dtm-builder.md
@@ -1,0 +1,1 @@
+Added an export of `riscv::dtm::JtagDtmBuilder` so external software can implement `DebugProbe::try_get_riscv_interface_builder()`

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     probe::DebugProbeError,
 };
 pub use communication_interface::{
-    ArmChipInfo, ArmCommunicationInterface, ArmDebugInterface, DapError,
+    ArmChipInfo, ArmCommunicationInterface, ArmDebugInterface, DapError, DapProbe,
 };
 pub use swo::{SwoAccess, SwoConfig, SwoMode, SwoReader};
 pub use traits::*;

--- a/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
@@ -28,9 +28,12 @@ struct DtmState {
     abits: u32,
 }
 
+/// Object that can be used to build a RISC-V DTM interface
+/// from a JTAG transport.
 pub struct JtagDtmBuilder<'f>(&'f mut dyn JtagAccess);
 
 impl<'f> JtagDtmBuilder<'f> {
+    /// Create a new DTM Builder via a JTAG transport.
     pub fn new(probe: &'f mut dyn JtagAccess) -> Self {
         Self(probe)
     }

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -29,6 +29,8 @@ pub mod communication_interface;
 pub(crate) mod dtm;
 pub mod sequences;
 
+pub use dtm::jtag_dtm::JtagDtmBuilder;
+
 /// An interface to operate a RISC-V core.
 pub struct Riscv32<'state> {
     interface: RiscvCommunicationInterface<'state>,


### PR DESCRIPTION
Export `arm::communications_interface::DapProbe` to enable creating Sequences that require this struct in their arguments.

Similarly, export `riscv::dtm::JtagDtmBuilder` to enable creating RISC-V probes by implementing `DebugProbe::try_get_riscv_interface_builder()`