### PR TITLE
Check core name on algorithm selection

### DIFF
--- a/changelog/fixed-flashing-with-multiple-different-cores.md
+++ b/changelog/fixed-flashing-with-multiple-different-cores.md
@@ -1,0 +1,1 @@
+Fixed flashing devices such as STM32WL with multiple cores where the algorithm wasn't correctly selected

--- a/probe-rs/src/flashing/erase.rs
+++ b/probe-rs/src/flashing/erase.rs
@@ -50,7 +50,7 @@ pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), F
 
         let target = session.target();
         let core = target.core_index_by_name(core_name).unwrap();
-        let algo = FlashLoader::get_flash_algorithm_for_region(&region, target)?;
+        let algo = FlashLoader::get_flash_algorithm_for_region(&region, target, core_name)?;
 
         tracing::debug!("     -- using algorithm: {}", algo.name);
         if let Some(entry) = algos.iter_mut().find(|entry| {
@@ -188,13 +188,14 @@ pub fn erase_sectors(
             region.range.end - region.range.start
         );
 
-        let algo = FlashLoader::get_flash_algorithm_for_region(region, session.target())?;
-
         // Get the first core that can access the region
         let core_name = region
             .cores
             .first()
             .ok_or_else(|| FlashError::NoNvmCoreAccess(region.clone()))?;
+
+        let algo =
+            FlashLoader::get_flash_algorithm_for_region(region, session.target(), core_name)?;
 
         let entry = algos
             .entry((algo.name.clone(), core_name.clone()))
@@ -275,13 +276,14 @@ pub fn run_blank_check(
             region.range.end - region.range.start
         );
 
-        let algo = FlashLoader::get_flash_algorithm_for_region(region, session.target())?;
-
         // Get the first core that can access the region
         let core_name = region
             .cores
             .first()
             .ok_or_else(|| FlashError::NoNvmCoreAccess(region.clone()))?;
+
+        let algo =
+            FlashLoader::get_flash_algorithm_for_region(region, session.target(), core_name)?;
 
         let entry = algos
             .entry((algo.name.clone(), core_name.clone()))

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -693,7 +693,7 @@ impl FlashLoader {
 
             let target = session.target();
             let core = target.core_index_by_name(core_name).unwrap();
-            let algo = Self::get_flash_algorithm_for_region(&region, target)?;
+            let algo = Self::get_flash_algorithm_for_region(&region, target, core_name)?;
 
             // We don't usually have more than a handful of regions, linear search should be fine.
             tracing::debug!("     -- using algorithm: {}", algo.name);
@@ -820,6 +820,7 @@ impl FlashLoader {
     pub(crate) fn get_flash_algorithm_for_region<'a>(
         region: &NvmRegion,
         target: &'a Target,
+        core_name: &String,
     ) -> Result<&'a RawFlashAlgorithm, FlashError> {
         let algorithms = target
             .flash_algorithms
@@ -829,6 +830,7 @@ impl FlashLoader {
                 fa.flash_properties
                     .address_range
                     .contains_range(&region.range)
+                    && (fa.cores.is_empty() || fa.cores.contains(core_name))
             })
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
For targets such as stm32wl, multiple algorithms are present. The code does not know how to deal with this, and prints an error:

```
$ probe-rs run --chip STM32WL55JCIx test.elf
Error: An error with the flashing procedure has occurred.

Caused by:
    Trying to write flash, but found more than one suitable flash loader algorithim marked as default for
NvmRegion { name: Some("BANK_1"), range: 134217728..134479872, cores: ["cm4", "cm0p"], is_alias: false,
access: Some(MemoryAccess { read: true, write: false, execute: true, boot: true }) }.
$
```
Algorithms can specify which core they support, but this is not currently
being checked. Add a check that the core name matches a given algorithm.

This patch fixes flashing on STM32WL55.
