### PR TITLE
Fix setting PC value on ARMv8 in AArch32 mode

### DIFF
--- a/changelog/fixed-armv8-aarch32-pc-update.md
+++ b/changelog/fixed-armv8-aarch32-pc-update.md
@@ -1,0 +1,1 @@
+Fixed setting the Program Counter on ARMV8 in AArch32 mode

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -270,8 +270,14 @@ impl<'probe> Armv8a<'probe> {
 
                             self.execute_instruction_with_input_32(instruction, val.try_into()?)?;
 
-                            // Write to DLR
-                            let instruction = build_mrc(15, 3, 0, 4, 5, 1);
+                            // Arm A-profile Architecture Registers
+                            //   AArch32 Registers
+                            //     DLR, Debug Link Register
+                            //
+                            // In Debug state, holds the address to restart from.
+                            //
+                            // https://developer.arm.com/documentation/ddi0601/2025-03/AArch32-Registers/DLR--Debug-Link-Register
+                            let instruction = build_mcr(15, 3, 0, 4, 5, 1);
                             self.execute_instruction(instruction)?;
                         }
                         17..=48 => {


### PR DESCRIPTION
Fix updating the PC value on ARMv8 in AArch32 mode via the Debug Link Register by using the `mcr` 
instruction instead of `mrc`.