### PR TITLE
Cleanup some ARM related code

### DIFF
--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,0 +1,17 @@
+// Project-local debug tasks
+//
+// For more documentation on how to configure debug tasks,
+// see: https://zed.dev/docs/debugger
+[
+  {
+    "label": "Debug DAP server",
+    "adapter": "CodeLLDB",
+    "program": "target/debug/probe-rs",
+    "request": "launch",
+    "args": ["dap-server", "--single-session", "--port", "50000"],
+    "build": {
+      "command": "cargo",
+      "args": ["build", "--bin", "probe-rs"]
+    }
+  }
+]

--- a/changelog/changed-renamed-arm-probe-interface.md
+++ b/changelog/changed-renamed-arm-probe-interface.md
@@ -1,0 +1,1 @@
+BREAKING: Rename the `ArmProbeInterface` trait to `ArmDebugInterface`.

--- a/changelog/removed-arm-memory-itnerface-functions.md
+++ b/changelog/removed-arm-memory-itnerface-functions.md
@@ -1,0 +1,1 @@
+BREAKING: Removed the `get_dap_access` and `get_swd_sequence` functions from the `ArmMemoryInterface` trait. Calls to these functions can be replaced by `ArmMemoryInterface::get_arm_debug_interface`

--- a/probe-rs-target/src/chip_family.rs
+++ b/probe-rs-target/src/chip_family.rs
@@ -77,6 +77,15 @@ impl CoreType {
                 | CoreType::Armv8m
         )
     }
+
+    /// Returns the parent architecture family of this core type.
+    pub fn architecture(&self) -> Architecture {
+        match self {
+            CoreType::Riscv => Architecture::Riscv,
+            CoreType::Xtensa => Architecture::Xtensa,
+            _ => Architecture::Arm,
+        }
+    }
 }
 
 /// The architecture family of a specific [`CoreType`].
@@ -88,17 +97,6 @@ pub enum Architecture {
     Riscv,
     /// An Xtensa core.
     Xtensa,
-}
-
-impl CoreType {
-    /// Returns the parent architecture family of this core type.
-    pub fn architecture(&self) -> Architecture {
-        match self {
-            CoreType::Riscv => Architecture::Riscv,
-            CoreType::Xtensa => Architecture::Xtensa,
-            _ => Architecture::Arm,
-        }
-    }
 }
 
 /// Instruction set used by a core

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -8,7 +8,7 @@ use postcard_schema::{Schema, schema};
 use probe_rs::{
     architecture::{
         arm::{
-            self, ApAddress, ApV2Address, ArmProbeInterface,
+            self, ApAddress, ApV2Address, ArmDebugInterface,
             ap::{ApClass, ApRegister, IDR},
             component::Scs,
             dp::{self, Ctrl, DLPIDR, DPIDR, DpRegister, TARGETID},
@@ -457,7 +457,7 @@ async fn try_show_arm_dp_info(
     tracing::debug!("Trying to show ARM chip information");
 
     let mut interface = match probe
-        .try_into_arm_interface(DefaultArmSequence::create())
+        .try_into_arm_debug_interface(DefaultArmSequence::create())
         .map_err(|(iface, e)| (iface, anyhow!(e)))
     {
         Ok(interface) => interface,
@@ -477,7 +477,7 @@ async fn try_show_arm_dp_info(
 /// Returns the version of the DP.
 async fn show_arm_info(
     ctx: &mut RpcContext,
-    interface: &mut dyn ArmProbeInterface,
+    interface: &mut dyn ArmDebugInterface,
     dp: dp::DpAddress,
 ) -> anyhow::Result<dp::DebugPortVersion> {
     let dp_info = interface.read_raw_dp_register(dp, DPIDR::ADDRESS)?;
@@ -579,7 +579,7 @@ async fn show_arm_info(
 }
 
 fn handle_memory_ap(
-    interface: &mut dyn ArmProbeInterface,
+    interface: &mut dyn ArmDebugInterface,
     access_port: &arm::FullyQualifiedApAddress,
     parent: &mut ComponentTreeNode,
 ) -> anyhow::Result<()> {
@@ -602,7 +602,7 @@ fn handle_memory_ap(
 }
 
 fn coresight_component_tree(
-    interface: &mut dyn ArmProbeInterface,
+    interface: &mut dyn ArmDebugInterface,
     component: Component,
     access_port: &arm::FullyQualifiedApAddress,
     parent: &mut ComponentTreeNode,
@@ -714,7 +714,7 @@ fn coresight_component_tree(
 /// Some manufacturer-specific ROM tables contain more than just entries. This function tries
 /// to make sense of these tables.
 fn process_vendor_rom_tables(
-    interface: &mut dyn ArmProbeInterface,
+    interface: &mut dyn ArmDebugInterface,
     id: &ComponentId,
     _table: &RomTable,
     access_port: &arm::FullyQualifiedApAddress,
@@ -744,7 +744,7 @@ fn process_vendor_rom_tables(
 /// Processes ROM table entries and adds them to the tree.
 fn process_component_entry(
     tree: &mut ComponentTreeNode,
-    interface: &mut dyn ArmProbeInterface,
+    interface: &mut dyn ArmDebugInterface,
     peripheral_id: &PeripheralID,
     component: &Component,
     access_port: &arm::FullyQualifiedApAddress,

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -301,7 +301,7 @@ async fn try_show_info(
         probe.attach_to_unspecified()?;
     }
 
-    if probe.has_arm_interface() {
+    if probe.has_arm_debug_interface() {
         let dp_addr = if let Some(target_sel) = target_sel {
             vec![dp::DpAddress::Multidrop(target_sel)]
         } else {

--- a/probe-rs/examples/multidrop_raw.rs
+++ b/probe-rs/examples/multidrop_raw.rs
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
         probe.set_speed(100)?;
         probe.attach_to_unspecified()?;
         let mut iface = probe
-            .try_into_arm_interface(DefaultArmSequence::create())
+            .try_into_arm_debug_interface(DefaultArmSequence::create())
             .map_err(|(_probe, err)| err)?;
 
         iface.select_debug_port(core0)?;

--- a/probe-rs/examples/nrf53_recover.rs
+++ b/probe-rs/examples/nrf53_recover.rs
@@ -25,7 +25,7 @@ fn main() -> Result<()> {
 
         probe.attach_to_unspecified()?;
         let mut iface = probe
-            .try_into_arm_interface(DefaultArmSequence::create())
+            .try_into_arm_debug_interface(DefaultArmSequence::create())
             .unwrap();
 
         iface.select_debug_port(DpAddress::Default).unwrap();

--- a/probe-rs/examples/raw_dap_access.rs
+++ b/probe-rs/examples/raw_dap_access.rs
@@ -20,7 +20,7 @@ fn main() -> Result<()> {
 
         probe.attach_to_unspecified()?;
         let mut iface = probe
-            .try_into_arm_interface(DefaultArmSequence::create())
+            .try_into_arm_debug_interface(DefaultArmSequence::create())
             .unwrap();
 
         iface.select_debug_port(DpAddress::Default)?;

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -4,7 +4,7 @@ use crate::architecture::arm::{
         AddressIncrement, ApClass, ApRegister, ApType, CFG, DRW, DataSize, IDR, TAR,
         memory_ap::amba_ahb3::CSW,
     },
-    communication_interface::{DapProbe, FlushableArmAccess},
+    communication_interface::DapProbe,
     dp::{DpAddress, DpRegisterAddress},
 };
 use std::collections::HashMap;
@@ -48,12 +48,6 @@ impl MockMemoryAp {
             memory: std::iter::repeat(1..=255).flatten().take(size).collect(),
             store,
         }
-    }
-}
-
-impl FlushableArmAccess for MockMemoryAp {
-    fn flush(&mut self) -> Result<(), ArmError> {
-        Ok(())
     }
 }
 

--- a/probe-rs/src/architecture/arm/ap/v2/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/v2/mod.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeSet;
 
 use crate::architecture::arm::{
-    ApAddress, ApV2Address, ArmCommunicationInterface, ArmError, ArmProbeInterface,
+    ApAddress, ApV2Address, ArmCommunicationInterface, ArmDebugInterface, ArmError,
     FullyQualifiedApAddress,
     dp::DpAddress,
     memory::{
@@ -16,7 +16,7 @@ mod root_memory_interface;
 use root_memory_interface::RootMemoryInterface;
 
 /// Deeply scans the debug port and returns a list of the addresses the memory access points discovered.
-pub fn enumerate_access_ports<API: ArmProbeInterface>(
+pub fn enumerate_access_ports<API: ArmDebugInterface>(
     probe: &mut API,
     dp: DpAddress,
 ) -> Result<BTreeSet<FullyQualifiedApAddress>, ArmError> {
@@ -36,7 +36,7 @@ pub fn enumerate_access_ports<API: ArmProbeInterface>(
         .collect())
 }
 
-fn process_root_component<API: ArmProbeInterface>(
+fn process_root_component<API: ArmDebugInterface>(
     iface: &mut RootMemoryInterface<API>,
     component: &Component,
 ) -> Result<BTreeSet<ApV2Address>, ArmError> {

--- a/probe-rs/src/architecture/arm/ap/v2/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/v2/mod.rs
@@ -16,8 +16,8 @@ mod root_memory_interface;
 use root_memory_interface::RootMemoryInterface;
 
 /// Deeply scans the debug port and returns a list of the addresses the memory access points discovered.
-pub fn enumerate_access_ports<API: ArmDebugInterface>(
-    probe: &mut API,
+pub fn enumerate_access_ports<ADI: ArmDebugInterface>(
+    probe: &mut ADI,
     dp: DpAddress,
 ) -> Result<BTreeSet<FullyQualifiedApAddress>, ArmError> {
     let mut root_interface = RootMemoryInterface::new(probe, dp)?;
@@ -36,8 +36,8 @@ pub fn enumerate_access_ports<API: ArmDebugInterface>(
         .collect())
 }
 
-fn process_root_component<API: ArmDebugInterface>(
-    iface: &mut RootMemoryInterface<API>,
+fn process_root_component<ADI: ArmDebugInterface>(
+    iface: &mut RootMemoryInterface<ADI>,
     component: &Component,
 ) -> Result<BTreeSet<ApV2Address>, ArmError> {
     let mut result = BTreeSet::new();

--- a/probe-rs/src/architecture/arm/ap/v2/root_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/ap/v2/root_memory_interface.rs
@@ -3,7 +3,7 @@
 use crate::{
     MemoryInterface,
     architecture::arm::{
-        ApV2Address, ArmError, ArmProbeInterface, DapAccess, FullyQualifiedApAddress,
+        ApV2Address, ArmError, ArmDebugInterface, DapAccess, FullyQualifiedApAddress,
         communication_interface::SwdSequence,
         dp::{BASEPTR0, BASEPTR1, DpAccess, DpAddress},
         memory::ArmMemoryInterface,
@@ -18,13 +18,13 @@ pub struct RootMemoryInterface<'iface, API> {
     iface: &'iface mut API,
     dp: DpAddress,
 }
-impl<'iface, API: ArmProbeInterface> RootMemoryInterface<'iface, API> {
+impl<'iface, API: ArmDebugInterface> RootMemoryInterface<'iface, API> {
     pub fn new(iface: &'iface mut API, dp: DpAddress) -> Result<Self, ArmError> {
         Ok(Self { iface, dp })
     }
 }
 
-impl<API: ArmProbeInterface> MemoryInterface<ArmError> for RootMemoryInterface<'_, API> {
+impl<API: ArmDebugInterface> MemoryInterface<ArmError> for RootMemoryInterface<'_, API> {
     fn supports_native_64bit_access(&mut self) -> bool {
         false
     }
@@ -83,7 +83,7 @@ impl<API: ArmProbeInterface> MemoryInterface<ArmError> for RootMemoryInterface<'
         Ok(())
     }
 }
-impl<API: ArmProbeInterface> ArmMemoryInterface for RootMemoryInterface<'_, API> {
+impl<API: ArmDebugInterface> ArmMemoryInterface for RootMemoryInterface<'_, API> {
     fn fully_qualified_address(&self) -> FullyQualifiedApAddress {
         FullyQualifiedApAddress::v2_with_dp(self.dp, ApV2Address::root())
     }
@@ -103,7 +103,7 @@ impl<API: ArmProbeInterface> ArmMemoryInterface for RootMemoryInterface<'_, API>
         Ok(self.iface)
     }
 
-    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmProbeInterface, DebugProbeError> {
+    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
         Ok(self.iface)
     }
 

--- a/probe-rs/src/architecture/arm/ap/v2/root_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/ap/v2/root_memory_interface.rs
@@ -17,13 +17,13 @@ pub struct RootMemoryInterface<'iface, API> {
     iface: &'iface mut API,
     dp: DpAddress,
 }
-impl<'iface, API: ArmDebugInterface> RootMemoryInterface<'iface, API> {
-    pub fn new(iface: &'iface mut API, dp: DpAddress) -> Result<Self, ArmError> {
+impl<'iface, ADI: ArmDebugInterface> RootMemoryInterface<'iface, ADI> {
+    pub fn new(iface: &'iface mut ADI, dp: DpAddress) -> Result<Self, ArmError> {
         Ok(Self { iface, dp })
     }
 }
 
-impl<API: ArmDebugInterface> MemoryInterface<ArmError> for RootMemoryInterface<'_, API> {
+impl<ADI: ArmDebugInterface> MemoryInterface<ArmError> for RootMemoryInterface<'_, ADI> {
     fn supports_native_64bit_access(&mut self) -> bool {
         false
     }
@@ -82,7 +82,7 @@ impl<API: ArmDebugInterface> MemoryInterface<ArmError> for RootMemoryInterface<'
         Ok(())
     }
 }
-impl<API: ArmDebugInterface> ArmMemoryInterface for RootMemoryInterface<'_, API> {
+impl<ADI: ArmDebugInterface> ArmMemoryInterface for RootMemoryInterface<'_, ADI> {
     fn fully_qualified_address(&self) -> FullyQualifiedApAddress {
         FullyQualifiedApAddress::v2_with_dp(self.dp, ApV2Address::root())
     }

--- a/probe-rs/src/architecture/arm/ap/v2/root_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/ap/v2/root_memory_interface.rs
@@ -3,8 +3,7 @@
 use crate::{
     MemoryInterface,
     architecture::arm::{
-        ApV2Address, ArmError, ArmDebugInterface, DapAccess, FullyQualifiedApAddress,
-        communication_interface::SwdSequence,
+        ApV2Address, ArmDebugInterface, ArmError, FullyQualifiedApAddress,
         dp::{BASEPTR0, BASEPTR1, DpAccess, DpAddress},
         memory::ArmMemoryInterface,
     },
@@ -99,15 +98,7 @@ impl<API: ArmDebugInterface> ArmMemoryInterface for RootMemoryInterface<'_, API>
         Ok(base)
     }
 
-    fn get_swd_sequence(&mut self) -> Result<&mut dyn SwdSequence, DebugProbeError> {
-        Ok(self.iface)
-    }
-
-    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
-        Ok(self.iface)
-    }
-
-    fn get_dap_access(&mut self) -> Result<&mut dyn DapAccess, DebugProbeError> {
+    fn get_arm_debug_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
         Ok(self.iface)
     }
 

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -492,12 +492,6 @@ impl ArmCommunicationInterface {
     }
 }
 
-impl FlushableArmAccess for ArmCommunicationInterface {
-    fn flush(&mut self) -> Result<(), ArmError> {
-        self.probe_mut().raw_flush()
-    }
-}
-
 impl SwoAccess for ArmCommunicationInterface {
     fn enable_swo(&mut self, config: &SwoConfig) -> Result<(), ArmError> {
         match self.probe_mut().get_swo_interface_mut() {
@@ -638,10 +632,4 @@ impl std::fmt::Display for ArmChipInfo {
         };
         write!(f, "{} 0x{:04x}", manu, self.part)
     }
-}
-
-/// A helper trait to get more specific interfaces.
-pub trait FlushableArmAccess {
-    /// Flush all remaining commands if the target driver implements batching.
-    fn flush(&mut self) -> Result<(), ArmError>;
 }

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -42,8 +42,8 @@ pub enum DapError {
     IncorrectParity,
 }
 
-/// To be implemented by debug probe drivers that support debugging ARM cores.
-pub trait ArmProbeInterface: DapAccess + SwdSequence + SwoAccess + Send {
+/// To be implemented by debug probe drivers that support the ARM debug interface.
+pub trait ArmDebugInterface: DapAccess + SwdSequence + SwoAccess + Send {
     /// Reinitialize the communication interface (in place).
     ///
     /// Some chip-specific reset sequences may disable the debug port. `reinitialize` allows
@@ -90,7 +90,7 @@ pub trait ArmProbeInterface: DapAccess + SwdSequence + SwoAccess + Send {
 
 /// Read chip information from the ROM tables
 pub fn read_chip_info_from_rom_table(
-    probe: &mut dyn ArmProbeInterface,
+    probe: &mut dyn ArmDebugInterface,
     dp: DpAddress,
 ) -> Result<Option<ArmChipInfo>, ArmError> {
     for ap in probe.access_ports(dp)? {
@@ -237,7 +237,7 @@ impl ArmCommunicationInterface {
 /// struct itself.
 pub trait DapProbe: RawDapAccess + DebugProbe {}
 
-impl ArmProbeInterface for ArmCommunicationInterface {
+impl ArmDebugInterface for ArmCommunicationInterface {
     fn reinitialize(&mut self) -> Result<(), ArmError> {
         let current_dp = self.current_dp;
 
@@ -318,7 +318,7 @@ impl ArmCommunicationInterface {
         probe: Box<dyn DapProbe>,
         sequence: Arc<dyn ArmDebugSequence>,
         use_overrun_detect: bool,
-    ) -> Box<dyn ArmProbeInterface> {
+    ) -> Box<dyn ArmDebugInterface> {
         let interface = ArmCommunicationInterface {
             probe: Some(probe),
             current_dp: None,

--- a/probe-rs/src/architecture/arm/component/dwt.rs
+++ b/probe-rs/src/architecture/arm/component/dwt.rs
@@ -8,7 +8,7 @@
 
 use super::super::memory::romtable::CoresightComponent;
 use super::DebugComponentInterface;
-use crate::architecture::arm::{ArmError, ArmDebugInterface};
+use crate::architecture::arm::{ArmDebugInterface, ArmError};
 use crate::{Error, memory_mapped_bitfield_register};
 
 /// A struct representing a DWT unit on target.

--- a/probe-rs/src/architecture/arm/component/dwt.rs
+++ b/probe-rs/src/architecture/arm/component/dwt.rs
@@ -8,19 +8,19 @@
 
 use super::super::memory::romtable::CoresightComponent;
 use super::DebugComponentInterface;
-use crate::architecture::arm::{ArmError, ArmProbeInterface};
+use crate::architecture::arm::{ArmError, ArmDebugInterface};
 use crate::{Error, memory_mapped_bitfield_register};
 
 /// A struct representing a DWT unit on target.
 pub struct Dwt<'a> {
     component: &'a CoresightComponent,
-    interface: &'a mut dyn ArmProbeInterface,
+    interface: &'a mut dyn ArmDebugInterface,
 }
 
 impl<'a> Dwt<'a> {
     /// Creates a new DWT component representation.
     pub fn new(
-        interface: &'a mut dyn ArmProbeInterface,
+        interface: &'a mut dyn ArmDebugInterface,
         component: &'a CoresightComponent,
     ) -> Self {
         Dwt {

--- a/probe-rs/src/architecture/arm/component/itm.rs
+++ b/probe-rs/src/architecture/arm/component/itm.rs
@@ -4,7 +4,7 @@
 
 use super::super::memory::romtable::CoresightComponent;
 use super::DebugComponentInterface;
-use crate::architecture::arm::ArmProbeInterface;
+use crate::architecture::arm::ArmDebugInterface;
 use crate::{Error, MemoryMappedRegister};
 
 pub const _ITM_PID: [u8; 8] = [0x1, 0xB0, 0x3b, 0x0, 0x4, 0x0, 0x0, 0x0];
@@ -26,7 +26,7 @@ pub const _ITM_PID: [u8; 8] = [0x1, 0xB0, 0x3b, 0x0, 0x4, 0x0, 0x0, 0x0];
 ///   The same count value can be used to insert timestamps in the ETM trace stream, allowing coarse-grain correlation.
 pub struct Itm<'a> {
     component: &'a CoresightComponent,
-    interface: &'a mut dyn ArmProbeInterface,
+    interface: &'a mut dyn ArmDebugInterface,
 }
 
 const _REGISTER_OFFSET_ITM_TPR: u32 = 0xE40;
@@ -35,7 +35,7 @@ const REGISTER_OFFSET_ACCESS: u32 = 0xFB0;
 impl<'a> Itm<'a> {
     /// Create a new ITM interface from a probe and a ROM table component.
     pub fn new(
-        interface: &'a mut dyn ArmProbeInterface,
+        interface: &'a mut dyn ArmDebugInterface,
         component: &'a CoresightComponent,
     ) -> Self {
         Itm {
@@ -149,7 +149,7 @@ impl<'a> Itm<'a> {
         Ok(())
     }
 
-    /// Enable synchronization packet transmission.  
+    /// Enable synchronization packet transmission.
     pub fn enable_sync_pulses(&mut self) -> Result<(), Error> {
         let mut tcr = register::ITM_TCR::load(self.component, self.interface)?;
         tcr.set_syncena(true);
@@ -158,7 +158,7 @@ impl<'a> Itm<'a> {
         Ok(())
     }
 
-    /// Disable synchronization packet transmission.  
+    /// Disable synchronization packet transmission.
     pub fn disable_sync_pulses(&mut self) -> Result<(), Error> {
         let mut tcr = register::ITM_TCR::load(self.component, self.interface)?;
         tcr.set_syncena(false);

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -11,7 +11,7 @@ mod trace_funnel;
 use crate::{
     Core, Error, MemoryInterface, MemoryMappedRegister,
     architecture::arm::{
-        ArmError, ArmProbeInterface, SwoConfig, SwoMode,
+        ArmDebugInterface, ArmError, SwoConfig, SwoMode,
         core::armv6m::Demcr,
         dp::DpAddress,
         memory::romtable::{CoresightComponent, PeripheralType, RomTableError},
@@ -59,7 +59,7 @@ pub trait DebugComponentInterface:
     /// Loads the register value from the given debug component via the given core.
     fn load(
         component: &CoresightComponent,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
     ) -> Result<Self, ArmError> {
         Ok(Self::from(
             component.read_reg(interface, Self::ADDRESS_OFFSET as u32)?,
@@ -69,7 +69,7 @@ pub trait DebugComponentInterface:
     /// Loads the register value from the given component in given unit via the given core.
     fn load_unit(
         component: &CoresightComponent,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         unit: usize,
     ) -> Result<Self, ArmError> {
         Ok(Self::from(component.read_reg(
@@ -82,7 +82,7 @@ pub trait DebugComponentInterface:
     fn store(
         &self,
         component: &CoresightComponent,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
     ) -> Result<(), ArmError> {
         component.write_reg(interface, Self::ADDRESS_OFFSET as u32, self.clone().into())
     }
@@ -91,7 +91,7 @@ pub trait DebugComponentInterface:
     fn store_unit(
         &self,
         component: &CoresightComponent,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         unit: usize,
     ) -> Result<(), ArmError> {
         component.write_reg(
@@ -107,7 +107,7 @@ pub trait DebugComponentInterface:
 /// This will recursively parse the Romtable of the attached target
 /// and create a list of all the contained components.
 pub fn get_arm_components(
-    interface: &mut dyn ArmProbeInterface,
+    interface: &mut dyn ArmDebugInterface,
     dp: DpAddress,
 ) -> Result<Vec<CoresightComponent>, ArmError> {
     let mut components = Vec::new();
@@ -165,7 +165,7 @@ pub fn find_component(
 /// * `component` - The TPIU CoreSight component found.
 /// * `config` - The SWO pin configuration to use.
 fn configure_tpiu(
-    interface: &mut dyn ArmProbeInterface,
+    interface: &mut dyn ArmDebugInterface,
     component: &CoresightComponent,
     config: &SwoConfig,
 ) -> Result<(), Error> {
@@ -195,7 +195,7 @@ fn configure_tpiu(
 ///
 /// Expects to be given a list of all ROM table `components` as the second argument.
 pub(crate) fn setup_tracing(
-    interface: &mut dyn ArmProbeInterface,
+    interface: &mut dyn ArmDebugInterface,
     components: &[CoresightComponent],
     sink: &TraceSink,
 ) -> Result<(), Error> {
@@ -278,7 +278,7 @@ pub(crate) fn setup_tracing(
 /// # Returns
 /// All data stored in trace memory, with an upper bound at the size of internal trace memory.
 pub(crate) fn read_trace_memory(
-    interface: &mut dyn ArmProbeInterface,
+    interface: &mut dyn ArmDebugInterface,
     components: &[CoresightComponent],
 ) -> Result<Vec<u8>, ArmError> {
     let mut tmc =
@@ -342,7 +342,7 @@ pub(crate) fn read_trace_memory(
 ///
 /// Expects to be given a list of all ROM table `components` as the second argument.
 pub(crate) fn add_swv_data_trace(
-    interface: &mut dyn ArmProbeInterface,
+    interface: &mut dyn ArmDebugInterface,
     components: &[CoresightComponent],
     unit: usize,
     address: u32,
@@ -356,7 +356,7 @@ pub(crate) fn add_swv_data_trace(
 ///
 /// Expects to be given a list of all ROM table `components` as the second argument.
 pub fn remove_swv_data_trace(
-    interface: &mut dyn ArmProbeInterface,
+    interface: &mut dyn ArmDebugInterface,
     components: &[CoresightComponent],
     unit: usize,
 ) -> Result<(), ArmError> {

--- a/probe-rs/src/architecture/arm/component/scs.rs
+++ b/probe-rs/src/architecture/arm/component/scs.rs
@@ -7,19 +7,19 @@ use self::register::CPUID;
 use super::super::memory::romtable::CoresightComponent;
 use crate::{
     MemoryMappedRegister,
-    architecture::arm::{ArmError, ArmProbeInterface},
+    architecture::arm::{ArmError, ArmDebugInterface},
 };
 
 /// An interface to control the SCS (System Control Space) of a MCU.
 pub struct Scs<'a> {
     component: &'a CoresightComponent,
-    interface: &'a mut dyn ArmProbeInterface,
+    interface: &'a mut dyn ArmDebugInterface,
 }
 
 impl<'a> Scs<'a> {
     /// Create a new SCS interface from a probe and a ROM table component.
     pub fn new(
-        interface: &'a mut dyn ArmProbeInterface,
+        interface: &'a mut dyn ArmDebugInterface,
         component: &'a CoresightComponent,
     ) -> Self {
         Scs {

--- a/probe-rs/src/architecture/arm/component/scs.rs
+++ b/probe-rs/src/architecture/arm/component/scs.rs
@@ -7,7 +7,7 @@ use self::register::CPUID;
 use super::super::memory::romtable::CoresightComponent;
 use crate::{
     MemoryMappedRegister,
-    architecture::arm::{ArmError, ArmDebugInterface},
+    architecture::arm::{ArmDebugInterface, ArmError},
 };
 
 /// An interface to control the SCS (System Control Space) of a MCU.

--- a/probe-rs/src/architecture/arm/component/swo.rs
+++ b/probe-rs/src/architecture/arm/component/swo.rs
@@ -4,7 +4,7 @@
 //! This module provides access and control of the SWO CoreSight component block.
 use super::super::memory::romtable::CoresightComponent;
 use crate::Error;
-use crate::architecture::arm::ArmProbeInterface;
+use crate::architecture::arm::ArmDebugInterface;
 
 const REGISTER_OFFSET_SWO_CODR: u32 = 0x10;
 const REGISTER_OFFSET_SWO_SPPR: u32 = 0xF0;
@@ -15,13 +15,13 @@ const REGISTER_OFFSET_ACCESS: u32 = 0xFB0;
 /// Serial Wire Output unit.
 pub struct Swo<'a> {
     component: &'a CoresightComponent,
-    interface: &'a mut dyn ArmProbeInterface,
+    interface: &'a mut dyn ArmDebugInterface,
 }
 
 impl<'a> Swo<'a> {
     /// Construct a new SWO component.
     pub fn new(
-        interface: &'a mut dyn ArmProbeInterface,
+        interface: &'a mut dyn ArmDebugInterface,
         component: &'a CoresightComponent,
     ) -> Self {
         Swo {

--- a/probe-rs/src/architecture/arm/component/tmc.rs
+++ b/probe-rs/src/architecture/arm/component/tmc.rs
@@ -6,7 +6,7 @@
 use crate::{
     Error,
     architecture::arm::{
-        ArmError, ArmProbeInterface, component::DebugComponentInterface, memory::CoresightComponent,
+        ArmDebugInterface, ArmError, component::DebugComponentInterface, memory::CoresightComponent,
     },
     memory_mapped_bitfield_register,
 };
@@ -35,13 +35,13 @@ pub enum Mode {
 /// The embedded trace memory controller.
 pub struct TraceMemoryController<'a> {
     component: &'a CoresightComponent,
-    interface: &'a mut dyn ArmProbeInterface,
+    interface: &'a mut dyn ArmDebugInterface,
 }
 
 impl<'a> TraceMemoryController<'a> {
     /// Construct a new embedded trace fifo controller.
     pub fn new(
-        interface: &'a mut dyn ArmProbeInterface,
+        interface: &'a mut dyn ArmDebugInterface,
         component: &'a CoresightComponent,
     ) -> Self {
         Self {

--- a/probe-rs/src/architecture/arm/component/tpiu.rs
+++ b/probe-rs/src/architecture/arm/component/tpiu.rs
@@ -1,6 +1,6 @@
 use super::super::memory::romtable::CoresightComponent;
 use crate::Error;
-use crate::architecture::arm::ArmProbeInterface;
+use crate::architecture::arm::ArmDebugInterface;
 
 pub const _TPIU_PID: [u8; 8] = [0xA1, 0xB9, 0x0B, 0x0, 0x4, 0x0, 0x0, 0x0];
 
@@ -15,13 +15,13 @@ const REGISTER_OFFSET_TPIU_FFCR: u32 = 0x304;
 /// Trace port interface unit unit.
 pub struct Tpiu<'a> {
     component: &'a CoresightComponent,
-    interface: &'a mut dyn ArmProbeInterface,
+    interface: &'a mut dyn ArmDebugInterface,
 }
 
 impl<'a> Tpiu<'a> {
     /// Create a new TPIU interface from a probe and a ROM table component.
     pub fn new(
-        interface: &'a mut dyn ArmProbeInterface,
+        interface: &'a mut dyn ArmDebugInterface,
         component: &'a CoresightComponent,
     ) -> Self {
         Tpiu {

--- a/probe-rs/src/architecture/arm/component/trace_funnel.rs
+++ b/probe-rs/src/architecture/arm/component/trace_funnel.rs
@@ -4,7 +4,7 @@
 //! This module provides access and control of the trace funnel CoreSight component block.
 use super::DebugComponentInterface;
 use crate::architecture::arm::memory::romtable::CoresightComponent;
-use crate::architecture::arm::{ArmError, ArmProbeInterface};
+use crate::architecture::arm::{ArmError, ArmDebugInterface};
 use crate::memory_mapped_bitfield_register;
 
 const REGISTER_OFFSET_ACCESS: u32 = 0xFB0;
@@ -12,13 +12,13 @@ const REGISTER_OFFSET_ACCESS: u32 = 0xFB0;
 /// Trace funnel unit
 pub struct TraceFunnel<'a> {
     component: &'a CoresightComponent,
-    interface: &'a mut dyn ArmProbeInterface,
+    interface: &'a mut dyn ArmDebugInterface,
 }
 
 impl<'a> TraceFunnel<'a> {
     /// Construct a new TraceFunnel component.
     pub fn new(
-        interface: &'a mut dyn ArmProbeInterface,
+        interface: &'a mut dyn ArmDebugInterface,
         component: &'a CoresightComponent,
     ) -> Self {
         TraceFunnel {

--- a/probe-rs/src/architecture/arm/component/trace_funnel.rs
+++ b/probe-rs/src/architecture/arm/component/trace_funnel.rs
@@ -4,7 +4,7 @@
 //! This module provides access and control of the trace funnel CoreSight component block.
 use super::DebugComponentInterface;
 use crate::architecture::arm::memory::romtable::CoresightComponent;
-use crate::architecture::arm::{ArmError, ArmDebugInterface};
+use crate::architecture::arm::{ArmDebugInterface, ArmError};
 use crate::memory_mapped_bitfield_register;
 
 const REGISTER_OFFSET_ACCESS: u32 = 0xFB0;

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -1690,7 +1690,7 @@ mod test {
 
         fn get_arm_probe_interface(
             &mut self,
-        ) -> Result<&mut dyn crate::architecture::arm::ArmProbeInterface, DebugProbeError> {
+        ) -> Result<&mut dyn crate::architecture::arm::ArmDebugInterface, DebugProbeError> {
             Err(DebugProbeError::NotImplemented {
                 function_name: "get_arm_probe_interface",
             })

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -381,7 +381,7 @@ impl<'probe> Armv7a<'probe> {
         let address = Dbgdtrtx::get_mmio_address_from_base(self.base_address)?;
         let ap = self.memory.fully_qualified_address();
         let is_64_bit = self.is_64_bit();
-        let interface = self.memory.get_dap_access()?;
+        let interface = self.memory.get_arm_debug_interface()?;
 
         if is_64_bit {
             interface.write_raw_ap_register(&ap, TAR2::ADDRESS, (address >> 32) as u32)?;
@@ -1682,25 +1682,11 @@ mod test {
             todo!()
         }
 
-        fn get_swd_sequence(&mut self) -> Result<&mut dyn SwdSequence, DebugProbeError> {
-            Err(DebugProbeError::NotImplemented {
-                function_name: "get_swd_sequence",
-            })
-        }
-
-        fn get_arm_probe_interface(
+        fn get_arm_debug_interface(
             &mut self,
         ) -> Result<&mut dyn crate::architecture::arm::ArmDebugInterface, DebugProbeError> {
             Err(DebugProbeError::NotImplemented {
-                function_name: "get_arm_probe_interface",
-            })
-        }
-
-        fn get_dap_access(
-            &mut self,
-        ) -> Result<&mut dyn crate::architecture::arm::DapAccess, DebugProbeError> {
-            Err(DebugProbeError::NotImplemented {
-                function_name: "get_dap_access",
+                function_name: "get_arm_debug_interface",
             })
         }
 

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -1839,7 +1839,7 @@ mod test {
 
         fn get_arm_probe_interface(
             &mut self,
-        ) -> Result<&mut dyn crate::architecture::arm::ArmProbeInterface, DebugProbeError> {
+        ) -> Result<&mut dyn crate::architecture::arm::ArmDebugInterface, DebugProbeError> {
             Err(DebugProbeError::NotImplemented {
                 function_name: "get_arm_probe_interface",
             })

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -1837,25 +1837,11 @@ mod test {
             todo!()
         }
 
-        fn get_arm_probe_interface(
+        fn get_arm_debug_interface(
             &mut self,
         ) -> Result<&mut dyn crate::architecture::arm::ArmDebugInterface, DebugProbeError> {
             Err(DebugProbeError::NotImplemented {
-                function_name: "get_arm_probe_interface",
-            })
-        }
-
-        fn get_swd_sequence(&mut self) -> Result<&mut dyn SwdSequence, DebugProbeError> {
-            Err(DebugProbeError::NotImplemented {
-                function_name: "get_swd_sequence",
-            })
-        }
-
-        fn get_dap_access(
-            &mut self,
-        ) -> Result<&mut dyn crate::architecture::arm::DapAccess, DebugProbeError> {
-            Err(DebugProbeError::NotImplemented {
-                function_name: "get_dap_access",
+                function_name: "get_arm_debug_interface",
             })
         }
 

--- a/probe-rs/src/architecture/arm/memory/adi_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_memory_interface.rs
@@ -5,7 +5,7 @@ use zerocopy::IntoBytes;
 use crate::{
     CoreStatus, MemoryInterface,
     architecture::arm::{
-        ArmCommunicationInterface, ArmError, ArmProbeInterface, DapAccess, FullyQualifiedApAddress,
+        ArmCommunicationInterface, ArmError, ArmDebugInterface, DapAccess, FullyQualifiedApAddress,
         ap::{
             AccessPortType, ApAccess, CSW, DataSize,
             memory_ap::{MemoryAp, MemoryApType},
@@ -513,7 +513,7 @@ where
 
 impl<APA> ArmMemoryInterface for ADIMemoryInterface<'_, APA>
 where
-    APA: std::any::Any + FlushableArmAccess + ApAccess + DpAccess + ArmProbeInterface,
+    APA: std::any::Any + FlushableArmAccess + ApAccess + DpAccess + ArmDebugInterface,
 {
     fn base_address(&mut self) -> Result<u64, ArmError> {
         self.memory_ap.base_address(self.interface)
@@ -534,7 +534,7 @@ where
 
     fn get_arm_probe_interface(
         &mut self,
-    ) -> Result<&mut dyn crate::architecture::arm::ArmProbeInterface, DebugProbeError> {
+    ) -> Result<&mut dyn crate::architecture::arm::ArmDebugInterface, DebugProbeError> {
         Ok(self.interface)
     }
 

--- a/probe-rs/src/architecture/arm/memory/adi_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_memory_interface.rs
@@ -1,17 +1,13 @@
-use std::any::Any;
-
 use zerocopy::IntoBytes;
 
 use crate::{
     CoreStatus, MemoryInterface,
     architecture::arm::{
-        ArmCommunicationInterface, ArmDebugInterface, ArmError, DapAccess, FullyQualifiedApAddress,
+        ArmDebugInterface, ArmError, DapAccess, FullyQualifiedApAddress,
         ap::{
             AccessPortType, ApAccess, CSW, DataSize,
             memory_ap::{MemoryAp, MemoryApType},
         },
-        communication_interface::FlushableArmAccess,
-        dp::DpAccess,
         memory::ArmMemoryInterface,
     },
     probe::DebugProbeError,
@@ -33,7 +29,7 @@ pub(crate) struct ADIMemoryInterface<'interface, APA> {
 
 impl<'interface, APA> ADIMemoryInterface<'interface, APA>
 where
-    APA: ApAccess + DapAccess,
+    APA: DapAccess,
 {
     /// Creates a new MemoryInterface for given AccessPort.
     pub fn new(
@@ -48,11 +44,9 @@ where
     }
 }
 
-impl<APA> ADIMemoryInterface<'_, APA> where APA: ApAccess {}
-
 impl<AP> MemoryInterface<ArmError> for ADIMemoryInterface<'_, AP>
 where
-    AP: FlushableArmAccess + ApAccess + DpAccess,
+    AP: DapAccess,
 {
     /// Read a block of 64 bit words at `address`.
     ///
@@ -513,7 +507,7 @@ where
 
 impl<APA> ArmMemoryInterface for ADIMemoryInterface<'_, APA>
 where
-    APA: std::any::Any + FlushableArmAccess + ApAccess + DpAccess + ArmDebugInterface,
+    APA: ApAccess + ArmDebugInterface,
 {
     fn base_address(&mut self) -> Result<u64, ArmError> {
         self.memory_ap.base_address(self.interface)
@@ -523,36 +517,19 @@ where
         self.memory_ap.ap_address().clone()
     }
 
-    fn get_arm_debug_interface(
-        &mut self,
-    ) -> Result<&mut dyn crate::architecture::arm::ArmDebugInterface, DebugProbeError> {
+    fn get_arm_debug_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
         Ok(self.interface)
     }
 
     fn generic_status(&mut self) -> Result<CSW, ArmError> {
-        // TODO: This assumes that the base type is `ArmCommunicationInterface`,
-        // which will fail if something else implements `ADIMemoryInterface`.
-        let Some(iface) =
-            (self.interface as &mut dyn Any).downcast_mut::<ArmCommunicationInterface>()
-        else {
-            return Err(ArmError::Probe(DebugProbeError::Other(
-                "Not an ArmCommunicationInterface".to_string(),
-            )));
-        };
-
-        self.memory_ap.generic_status(iface)
+        self.memory_ap.generic_status(self.interface)
     }
 
     fn update_core_status(&mut self, state: CoreStatus) {
-        // TODO: This assumes that the base type is `ArmCommunicationInterface`,
-        // which will fail if something else implements `ADIMemoryInterface`.
-        let Some(iface) =
-            (self.interface as &mut dyn Any).downcast_mut::<ArmCommunicationInterface>()
-        else {
-            return;
-        };
-
-        iface.probe_mut().core_status_notification(state).ok();
+        if let Some(probe) = self.interface.try_dap_probe_mut() {
+            // Ignore errors setting the core status
+            let _ = probe.core_status_notification(state);
+        }
     }
 }
 

--- a/probe-rs/src/architecture/arm/memory/adi_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_memory_interface.rs
@@ -5,7 +5,7 @@ use zerocopy::IntoBytes;
 use crate::{
     CoreStatus, MemoryInterface,
     architecture::arm::{
-        ArmCommunicationInterface, ArmError, ArmDebugInterface, DapAccess, FullyQualifiedApAddress,
+        ArmCommunicationInterface, ArmDebugInterface, ArmError, DapAccess, FullyQualifiedApAddress,
         ap::{
             AccessPortType, ApAccess, CSW, DataSize,
             memory_ap::{MemoryAp, MemoryApType},
@@ -523,22 +523,9 @@ where
         self.memory_ap.ap_address().clone()
     }
 
-    fn get_swd_sequence(
-        &mut self,
-    ) -> Result<
-        &mut dyn crate::architecture::arm::communication_interface::SwdSequence,
-        DebugProbeError,
-    > {
-        Ok(self.interface)
-    }
-
-    fn get_arm_probe_interface(
+    fn get_arm_debug_interface(
         &mut self,
     ) -> Result<&mut dyn crate::architecture::arm::ArmDebugInterface, DebugProbeError> {
-        Ok(self.interface)
-    }
-
-    fn get_dap_access(&mut self) -> Result<&mut dyn DapAccess, DebugProbeError> {
         Ok(self.interface)
     }
 

--- a/probe-rs/src/architecture/arm/memory/mod.rs
+++ b/probe-rs/src/architecture/arm/memory/mod.rs
@@ -7,13 +7,11 @@ pub(crate) use adi_memory_interface::ADIMemoryInterface;
 
 use crate::{CoreStatus, memory::MemoryInterface, probe::DebugProbeError};
 
-use super::{
-    ArmError, ArmDebugInterface, DapAccess, FullyQualifiedApAddress,
-    communication_interface::SwdSequence,
-};
+use super::{ArmDebugInterface, ArmError, FullyQualifiedApAddress};
 pub use romtable::{Component, ComponentId, CoresightComponent, PeripheralType, RomTable};
 
-/// An ArmMemoryInterface (ArmProbeInterface + MemoryAp)
+/// Trait for accessing memory behind a memory access port,
+/// as defined in the ARM Debug Interface Specification.
 pub trait ArmMemoryInterface: MemoryInterface<ArmError> {
     /// The underlying MemoryAp address.
     fn fully_qualified_address(&self) -> FullyQualifiedApAddress;
@@ -21,14 +19,8 @@ pub trait ArmMemoryInterface: MemoryInterface<ArmError> {
     /// The underlying memory AP’s base address.
     fn base_address(&mut self) -> Result<u64, ArmError>;
 
-    /// Get this interface as a SwdSequence object.
-    fn get_swd_sequence(&mut self) -> Result<&mut dyn SwdSequence, DebugProbeError>;
-
-    /// Get this interface as a [`ArmProbeInterface`] object.
-    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError>;
-
-    /// Get this interface as a [`DapAccess`] object.
-    fn get_dap_access(&mut self) -> Result<&mut dyn DapAccess, DebugProbeError>;
+    /// Get this interface as a [`ArmDebugInterface`] object.
+    fn get_arm_debug_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError>;
 
     /// Get the current value of the CSW reflected in this probe.
     fn generic_status(&mut self) -> Result<crate::architecture::arm::ap::CSW, ArmError>;

--- a/probe-rs/src/architecture/arm/memory/mod.rs
+++ b/probe-rs/src/architecture/arm/memory/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use adi_memory_interface::ADIMemoryInterface;
 use crate::{CoreStatus, memory::MemoryInterface, probe::DebugProbeError};
 
 use super::{
-    ArmError, ArmProbeInterface, DapAccess, FullyQualifiedApAddress,
+    ArmError, ArmDebugInterface, DapAccess, FullyQualifiedApAddress,
     communication_interface::SwdSequence,
 };
 pub use romtable::{Component, ComponentId, CoresightComponent, PeripheralType, RomTable};
@@ -25,7 +25,7 @@ pub trait ArmMemoryInterface: MemoryInterface<ArmError> {
     fn get_swd_sequence(&mut self) -> Result<&mut dyn SwdSequence, DebugProbeError>;
 
     /// Get this interface as a [`ArmProbeInterface`] object.
-    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmProbeInterface, DebugProbeError>;
+    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError>;
 
     /// Get this interface as a [`DapAccess`] object.
     fn get_dap_access(&mut self) -> Result<&mut dyn DapAccess, DebugProbeError>;

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -2,7 +2,7 @@
 
 use crate::architecture::arm::{
     ArmError, FullyQualifiedApAddress, ap::AccessPortError,
-    communication_interface::ArmProbeInterface, memory::ArmMemoryInterface,
+    communication_interface::ArmDebugInterface, memory::ArmMemoryInterface,
 };
 
 /// The ARCHID associated with all CoreSight ROM tables.
@@ -529,7 +529,7 @@ impl CoresightComponent {
     /// Reads a register of the component pointed to by this romtable entry.
     pub fn read_reg(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         offset: u32,
     ) -> Result<u32, ArmError> {
         let mut memory = interface.memory_interface(&self.ap_address)?;
@@ -540,7 +540,7 @@ impl CoresightComponent {
     /// Writes a register of the component pointed to by this romtable entry.
     pub fn write_reg(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         offset: u32,
         value: u32,
     ) -> Result<(), ArmError> {

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     probe::DebugProbeError,
 };
 pub use communication_interface::{
-    ArmChipInfo, ArmCommunicationInterface, ArmProbeInterface, DapError,
+    ArmChipInfo, ArmCommunicationInterface, ArmDebugInterface, DapError,
 };
 pub use swo::{SwoAccess, SwoConfig, SwoMode, SwoReader};
 pub use traits::*;

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -13,7 +13,7 @@ use probe_rs_target::CoreType;
 use crate::{
     MemoryInterface, MemoryMappedRegister, Session,
     architecture::arm::{
-        ArmProbeInterface, DapError, RegisterAddress,
+        ArmDebugInterface, DapError, RegisterAddress,
         core::registers::cortex_m::{PC, SP},
         dp::{Ctrl, DLPIDR, DebugPortError, DpRegister, TARGETID},
     },
@@ -456,7 +456,7 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
     #[doc(alias = "ResetHardwareDeassert")]
     fn reset_hardware_deassert(
         &self,
-        probe: &mut dyn ArmProbeInterface,
+        probe: &mut dyn ArmDebugInterface,
         _default_ap: &FullyQualifiedApAddress,
     ) -> Result<(), ArmError> {
         let mut n_reset = Pins(0);
@@ -721,7 +721,7 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
     #[doc(alias = "DebugCoreStart")]
     fn debug_core_start(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         core_ap: &FullyQualifiedApAddress,
         core_type: CoreType,
         debug_base: Option<u64>,
@@ -797,7 +797,7 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
     /// [ARM SVD Debug Description]: https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/debug_description.html#traceStart
     fn trace_start(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         components: &[CoresightComponent],
         _sink: &TraceSink,
     ) -> Result<(), ArmError> {
@@ -848,7 +848,7 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
     #[doc(alias = "DebugDeviceUnlock")]
     fn debug_device_unlock(
         &self,
-        _interface: &mut dyn ArmProbeInterface,
+        _interface: &mut dyn ArmDebugInterface,
         _default_ap: &FullyQualifiedApAddress,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
@@ -1136,7 +1136,7 @@ pub trait DebugEraseSequence: Send + Sync {
     /// May fail if the device is e.g. permanently locked or due to communication issues with the device.
     /// Some devices require the probe to be disconnected and re-attached after a successful chip-erase in
     /// which case it will return `Error::Probe(DebugProbeError::ReAttachRequired)`
-    fn erase_all(&self, _interface: &mut dyn ArmProbeInterface) -> Result<(), ArmError> {
+    fn erase_all(&self, _interface: &mut dyn ArmDebugInterface) -> Result<(), ArmError> {
         Err(ArmError::NotImplemented("erase_all"))
     }
 }

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -408,7 +408,7 @@ pub(crate) fn cortex_m_wait_for_reset(
                 {
                     // On PSOC 6, a system reset resets the SWD interface as well,
                     // so we have to reinitialize.
-                    if let Ok(probe) = interface.get_arm_probe_interface() {
+                    if let Ok(probe) = interface.get_arm_debug_interface() {
                         probe.reinitialize()?;
                     }
                 }

--- a/probe-rs/src/architecture/arm/swo/mod.rs
+++ b/probe-rs/src/architecture/arm/swo/mod.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use crate::architecture::arm::communication_interface::ArmProbeInterface;
+use crate::architecture::arm::communication_interface::ArmDebugInterface;
 
 use super::ArmError;
 
@@ -168,12 +168,12 @@ pub(crate) fn poll_interval_from_buf_size(config: &SwoConfig, buf_size: usize) -
 
 /// A reader interface to pull SWO data from the underlying driver.
 pub struct SwoReader<'a> {
-    interface: &'a mut dyn ArmProbeInterface,
+    interface: &'a mut dyn ArmDebugInterface,
     buf: Vec<u8>,
 }
 
 impl<'a> SwoReader<'a> {
-    pub(crate) fn new(interface: &'a mut dyn ArmProbeInterface) -> Self {
+    pub(crate) fn new(interface: &'a mut dyn ArmDebugInterface) -> Self {
         Self {
             interface,
             buf: Vec::new(),

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -2,7 +2,7 @@ use crate::{
     Core, CoreType, Error, Target,
     architecture::{
         arm::{
-            ApV2Address, ArmProbeInterface, FullyQualifiedApAddress,
+            ApV2Address, ArmDebugInterface, FullyQualifiedApAddress,
             core::{CortexAState, CortexMState},
             dp::DpAddress,
         },
@@ -41,7 +41,7 @@ impl CombinedCoreState {
     pub(crate) fn attach_arm<'probe>(
         &'probe mut self,
         target: &'probe Target,
-        arm_interface: &'probe mut Box<dyn ArmProbeInterface>,
+        arm_interface: &'probe mut Box<dyn ArmDebugInterface>,
     ) -> Result<Core<'probe>, Error> {
         let name = &target.cores[self.id].name;
 
@@ -109,7 +109,7 @@ impl CombinedCoreState {
 
     pub(crate) fn enable_arm_debug(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
     ) -> Result<(), Error> {
         let ResolvedCoreOptions::Arm { sequence, options } = &self.core_state.core_access_options
         else {
@@ -135,7 +135,7 @@ impl CombinedCoreState {
 
     pub(crate) fn arm_reset_catch_set(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
     ) -> Result<(), Error> {
         let ResolvedCoreOptions::Arm { sequence, options } = &self.core_state.core_access_options
         else {

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -524,7 +524,7 @@ impl Probe {
 
     /// Checks if the probe supports connecting to chips
     /// using the Arm Debug Interface.
-    pub fn has_arm_interface(&self) -> bool {
+    pub fn has_arm_debug_interface(&self) -> bool {
         self.inner.has_arm_interface()
     }
 

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -16,7 +16,7 @@ pub mod stlink;
 pub mod wlink;
 
 use crate::architecture::arm::sequences::{ArmDebugSequence, DefaultArmSequence};
-use crate::architecture::arm::{ArmError, ArmProbeInterface, DapError};
+use crate::architecture::arm::{ArmDebugInterface, ArmError, DapError};
 use crate::architecture::arm::{RegisterAddress, SwoAccess, communication_interface::DapProbe};
 use crate::architecture::riscv::communication_interface::{RiscvError, RiscvInterfaceBuilder};
 use crate::architecture::xtensa::communication_interface::{
@@ -528,19 +528,19 @@ impl Probe {
         self.inner.has_arm_interface()
     }
 
-    /// Try to get a trait object implementing `UninitializedArmProbe`, which can
-    /// can be used to communicate with chips using the ARM architecture.
+    /// Try to get a trait object implementing [`ArmDebugInterface`], which can
+    /// can be used to communicate with chips using the ARM debug interface.
     ///
     /// If an error occurs while trying to connect, the probe is returned.
-    pub fn try_into_arm_interface<'probe>(
+    pub fn try_into_arm_debug_interface<'probe>(
         self,
         sequence: Arc<dyn ArmDebugSequence>,
-    ) -> Result<Box<dyn ArmProbeInterface + 'probe>, (Self, ArmError)> {
+    ) -> Result<Box<dyn ArmDebugInterface + 'probe>, (Self, ArmError)> {
         if !self.attached {
             Err((self, DebugProbeError::NotAttached.into()))
         } else {
             self.inner
-                .try_get_arm_interface(sequence)
+                .try_get_arm_debug_interface(sequence)
                 .map_err(|(probe, err)| (Probe::from_attached_probe(probe), err))
         }
     }
@@ -702,10 +702,10 @@ pub trait DebugProbe: Any + Send + fmt::Debug {
 
     /// Get the dedicated interface to debug ARM chips. To check that the
     /// probe actually supports this, call [DebugProbe::has_arm_interface] first.
-    fn try_get_arm_interface<'probe>(
+    fn try_get_arm_debug_interface<'probe>(
         self: Box<Self>,
         _sequence: Arc<dyn ArmDebugSequence>,
-    ) -> Result<Box<dyn ArmProbeInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
+    ) -> Result<Box<dyn ArmDebugInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
         Err((
             self.into_probe(),
             DebugProbeError::InterfaceNotAvailable {

--- a/probe-rs/src/probe/blackmagic/arm.rs
+++ b/probe-rs/src/probe/blackmagic/arm.rs
@@ -638,15 +638,7 @@ impl ArmMemoryInterface for BlackMagicProbeMemoryInterface<'_> {
         self.current_ap.base_address(self.probe)
     }
 
-    fn get_swd_sequence(&mut self) -> Result<&mut dyn SwdSequence, DebugProbeError> {
-        Ok(self.probe)
-    }
-
-    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
-        Ok(self.probe)
-    }
-
-    fn get_dap_access(&mut self) -> Result<&mut dyn DapAccess, DebugProbeError> {
+    fn get_arm_debug_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
         Ok(self.probe)
     }
 

--- a/probe-rs/src/probe/blackmagic/arm.rs
+++ b/probe-rs/src/probe/blackmagic/arm.rs
@@ -1,6 +1,6 @@
 use crate::MemoryInterface;
 use crate::architecture::arm::{
-    ArmProbeInterface, DapAccess, FullyQualifiedApAddress, RawDapAccess, SwoAccess,
+    ArmDebugInterface, DapAccess, FullyQualifiedApAddress, RawDapAccess, SwoAccess,
     ap::{
         self, AccessPortType, AddressIncrement, CSW, DataSize,
         memory_ap::{MemoryAp, MemoryApType},
@@ -202,7 +202,7 @@ impl BlackMagicProbeArmDebug {
     }
 }
 
-impl ArmProbeInterface for BlackMagicProbeArmDebug {
+impl ArmDebugInterface for BlackMagicProbeArmDebug {
     fn access_ports(
         &mut self,
         dp: DpAddress,
@@ -642,7 +642,7 @@ impl ArmMemoryInterface for BlackMagicProbeMemoryInterface<'_> {
         Ok(self.probe)
     }
 
-    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmProbeInterface, DebugProbeError> {
+    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
         Ok(self.probe)
     }
 

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -10,7 +10,7 @@ use std::{
 use crate::{
     architecture::{
         arm::{
-            ArmCommunicationInterface, ArmError, ArmProbeInterface,
+            ArmCommunicationInterface, ArmDebugInterface, ArmError,
             communication_interface::DapProbe, sequences::ArmDebugSequence,
         },
         riscv::{
@@ -1147,10 +1147,10 @@ impl DebugProbe for BlackMagicProbe {
     }
 
     /// Turn this probe into an ARM probe
-    fn try_get_arm_interface<'probe>(
+    fn try_get_arm_debug_interface<'probe>(
         mut self: Box<Self>,
         sequence: Arc<dyn ArmDebugSequence>,
-    ) -> Result<Box<dyn ArmProbeInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
+    ) -> Result<Box<dyn ArmDebugInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
         let has_adiv5 = match self.remote_protocol {
             ProtocolVersion::V0 => false,
             ProtocolVersion::V0P

--- a/probe-rs/src/probe/ch347usbjtag/mod.rs
+++ b/probe-rs/src/probe/ch347usbjtag/mod.rs
@@ -187,11 +187,11 @@ impl DebugProbe for Ch347UsbJtag {
         true
     }
 
-    fn try_get_arm_interface<'probe>(
+    fn try_get_arm_debug_interface<'probe>(
         self: Box<Self>,
         sequence: std::sync::Arc<dyn crate::architecture::arm::sequences::ArmDebugSequence>,
     ) -> Result<
-        Box<dyn crate::architecture::arm::ArmProbeInterface + 'probe>,
+        Box<dyn crate::architecture::arm::ArmDebugInterface + 'probe>,
         (Box<dyn DebugProbe>, crate::architecture::arm::ArmError),
     > {
         Ok(ArmCommunicationInterface::create(self, sequence, true))

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     CoreStatus,
     architecture::{
         arm::{
-            ArmCommunicationInterface, ArmError, ArmProbeInterface, DapError, Pins, RawDapAccess,
+            ArmCommunicationInterface, ArmDebugInterface, ArmError, DapError, Pins, RawDapAccess,
             RegisterAddress, SwoAccess, SwoConfig, SwoMode,
             communication_interface::DapProbe,
             dp::{Abort, Ctrl, DpRegister},
@@ -932,10 +932,10 @@ impl DebugProbe for CmsisDap {
         Some(self as _)
     }
 
-    fn try_get_arm_interface<'probe>(
+    fn try_get_arm_debug_interface<'probe>(
         self: Box<Self>,
         sequence: Arc<dyn ArmDebugSequence>,
-    ) -> Result<Box<dyn ArmProbeInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
+    ) -> Result<Box<dyn ArmDebugInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
         Ok(ArmCommunicationInterface::create(self, sequence, false))
     }
 

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -2,7 +2,7 @@
 use crate::{
     MemoryInterface, MemoryMappedRegister,
     architecture::arm::{
-        ArmError, ArmProbeInterface, DapAccess, FullyQualifiedApAddress, RawDapAccess,
+        ArmDebugInterface, ArmError, DapAccess, FullyQualifiedApAddress, RawDapAccess,
         RegisterAddress, SwoAccess,
         ap::memory_ap::mock::MockMemoryAp,
         armv8m::Dhcsr,
@@ -272,7 +272,7 @@ impl ArmMemoryInterface for &mut MockCore {
         todo!()
     }
 
-    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmProbeInterface, DebugProbeError> {
+    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
         todo!()
     }
 
@@ -529,10 +529,10 @@ impl DebugProbe for FakeProbe {
         self
     }
 
-    fn try_get_arm_interface<'probe>(
+    fn try_get_arm_debug_interface<'probe>(
         self: Box<Self>,
         sequence: Arc<dyn ArmDebugSequence>,
-    ) -> Result<Box<dyn ArmProbeInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
+    ) -> Result<Box<dyn ArmDebugInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
         Ok(Box::new(FakeArmInterface::new(self, sequence)))
     }
 
@@ -622,7 +622,7 @@ impl crate::architecture::arm::communication_interface::FlushableArmAccess for F
     }
 }
 
-impl ArmProbeInterface for FakeArmInterface {
+impl ArmDebugInterface for FakeArmInterface {
     fn memory_interface(
         &mut self,
         access_port_address: &FullyQualifiedApAddress,

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -272,15 +272,7 @@ impl ArmMemoryInterface for &mut MockCore {
         todo!()
     }
 
-    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
-        todo!()
-    }
-
-    fn get_swd_sequence(&mut self) -> Result<&mut dyn SwdSequence, DebugProbeError> {
-        todo!()
-    }
-
-    fn get_dap_access(&mut self) -> Result<&mut dyn DapAccess, DebugProbeError> {
+    fn get_arm_debug_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
         todo!()
     }
 

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -608,12 +608,6 @@ impl SwdSequence for FakeArmInterface {
     }
 }
 
-impl crate::architecture::arm::communication_interface::FlushableArmAccess for FakeArmInterface {
-    fn flush(&mut self) -> Result<(), ArmError> {
-        todo!()
-    }
-}
-
 impl ArmDebugInterface for FakeArmInterface {
     fn memory_interface(
         &mut self,

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -2,7 +2,7 @@
 use crate::{
     architecture::{
         arm::{
-            ArmCommunicationInterface, ArmError, ArmProbeInterface,
+            ArmCommunicationInterface, ArmDebugInterface, ArmError,
             communication_interface::DapProbe, sequences::ArmDebugSequence,
         },
         riscv::{
@@ -393,10 +393,10 @@ impl DebugProbe for FtdiProbe {
         self
     }
 
-    fn try_get_arm_interface<'probe>(
+    fn try_get_arm_debug_interface<'probe>(
         self: Box<Self>,
         sequence: Arc<dyn ArmDebugSequence>,
-    ) -> Result<Box<dyn ArmProbeInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
+    ) -> Result<Box<dyn ArmDebugInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
         Ok(ArmCommunicationInterface::create(self, sequence, true))
     }
 

--- a/probe-rs/src/probe/glasgow/mod.rs
+++ b/probe-rs/src/probe/glasgow/mod.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use crate::architecture::arm::{
-    ArmCommunicationInterface, ArmError, ArmProbeInterface, DapError, RawDapAccess,
+    ArmCommunicationInterface, ArmDebugInterface, ArmError, DapError, RawDapAccess,
     RegisterAddress,
     communication_interface::DapProbe,
     dp::{DpRegister, RdBuff},
@@ -264,10 +264,10 @@ impl DebugProbe for Glasgow {
         true
     }
 
-    fn try_get_arm_interface<'probe>(
+    fn try_get_arm_debug_interface<'probe>(
         self: Box<Self>,
         sequence: Arc<dyn ArmDebugSequence>,
-    ) -> Result<Box<dyn ArmProbeInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
+    ) -> Result<Box<dyn ArmDebugInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
         // The Glasgow applet handles FAULT/WAIT states promptly.
         Ok(ArmCommunicationInterface::create(
             self, sequence, /*use_overrun_detect=*/ false,

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -26,7 +26,7 @@ use self::interface::{Interface, Interfaces};
 use self::speed::SpeedConfig;
 use self::swo::SwoMode;
 use crate::architecture::arm::sequences::ArmDebugSequence;
-use crate::architecture::arm::{ArmError, ArmProbeInterface, Pins};
+use crate::architecture::arm::{ArmDebugInterface, ArmError, Pins};
 use crate::architecture::riscv::communication_interface::RiscvError;
 use crate::architecture::xtensa::communication_interface::{
     XtensaCommunicationInterface, XtensaDebugInterfaceState, XtensaError,
@@ -1125,10 +1125,10 @@ impl DebugProbe for JLink {
         Some(self)
     }
 
-    fn try_get_arm_interface<'probe>(
+    fn try_get_arm_debug_interface<'probe>(
         self: Box<Self>,
         sequence: Arc<dyn ArmDebugSequence>,
-    ) -> Result<Box<dyn ArmProbeInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
+    ) -> Result<Box<dyn ArmDebugInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
         Ok(ArmCommunicationInterface::create(self, sequence, true))
     }
 

--- a/probe-rs/src/probe/sifliuart/arm.rs
+++ b/probe-rs/src/probe/sifliuart/arm.rs
@@ -8,7 +8,7 @@ use crate::architecture::arm::dp::{DpAddress, DpRegisterAddress};
 use crate::architecture::arm::memory::ArmMemoryInterface;
 use crate::architecture::arm::sequences::ArmDebugSequence;
 use crate::architecture::arm::{
-    ArmError, ArmProbeInterface, DapAccess, FullyQualifiedApAddress, SwoAccess, SwoConfig,
+    ArmError, ArmDebugInterface, DapAccess, FullyQualifiedApAddress, SwoAccess, SwoConfig,
 };
 use crate::probe::sifliuart::{SifliUart, SifliUartCommand, SifliUartResponse};
 use crate::probe::{DebugProbeError, Probe};
@@ -144,7 +144,7 @@ impl ArmMemoryInterface for SifliUartMemoryInterface<'_> {
         Ok(self.probe)
     }
 
-    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmProbeInterface, DebugProbeError> {
+    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
         Ok(self.probe)
     }
 
@@ -166,7 +166,7 @@ impl ArmMemoryInterface for SifliUartMemoryInterface<'_> {
     }
 }
 
-impl ArmProbeInterface for SifliUartArmDebug {
+impl ArmDebugInterface for SifliUartArmDebug {
     fn reinitialize(&mut self) -> Result<(), ArmError> {
         Ok(())
     }

--- a/probe-rs/src/probe/sifliuart/arm.rs
+++ b/probe-rs/src/probe/sifliuart/arm.rs
@@ -8,7 +8,7 @@ use crate::architecture::arm::dp::{DpAddress, DpRegisterAddress};
 use crate::architecture::arm::memory::ArmMemoryInterface;
 use crate::architecture::arm::sequences::ArmDebugSequence;
 use crate::architecture::arm::{
-    ArmError, ArmDebugInterface, DapAccess, FullyQualifiedApAddress, SwoAccess, SwoConfig,
+    ArmDebugInterface, ArmError, DapAccess, FullyQualifiedApAddress, SwoAccess, SwoConfig,
 };
 use crate::probe::sifliuart::{SifliUart, SifliUartCommand, SifliUartResponse};
 use crate::probe::{DebugProbeError, Probe};
@@ -140,15 +140,7 @@ impl ArmMemoryInterface for SifliUartMemoryInterface<'_> {
         self.current_ap.base_address(self.probe)
     }
 
-    fn get_swd_sequence(&mut self) -> Result<&mut dyn SwdSequence, DebugProbeError> {
-        Ok(self.probe)
-    }
-
-    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
-        Ok(self.probe)
-    }
-
-    fn get_dap_access(&mut self) -> Result<&mut dyn DapAccess, DebugProbeError> {
+    fn get_arm_debug_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
         Ok(self.probe)
     }
 

--- a/probe-rs/src/probe/sifliuart/mod.rs
+++ b/probe-rs/src/probe/sifliuart/mod.rs
@@ -5,7 +5,7 @@ mod arm;
 
 use crate::Error;
 use crate::architecture::arm::sequences::ArmDebugSequence;
-use crate::architecture::arm::{ArmError, ArmProbeInterface};
+use crate::architecture::arm::{ArmDebugInterface, ArmError};
 use crate::probe::sifliuart::arm::SifliUartArmDebug;
 use crate::probe::{
     DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeCreationError,
@@ -355,10 +355,10 @@ impl DebugProbe for SifliUart {
         true
     }
 
-    fn try_get_arm_interface<'probe>(
+    fn try_get_arm_debug_interface<'probe>(
         self: Box<Self>,
         sequence: Arc<dyn ArmDebugSequence>,
-    ) -> Result<Box<dyn ArmProbeInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
+    ) -> Result<Box<dyn ArmDebugInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
         Ok(Box::new(SifliUartArmDebug::new(self, sequence)))
     }
 

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1784,15 +1784,7 @@ impl ArmMemoryInterface for StLinkMemoryInterface<'_> {
         self.current_ap.ap_address().clone()
     }
 
-    fn get_swd_sequence(&mut self) -> Result<&mut dyn SwdSequence, DebugProbeError> {
-        Ok(self)
-    }
-
-    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
-        Ok(self.probe)
-    }
-
-    fn get_dap_access(&mut self) -> Result<&mut dyn DapAccess, DebugProbeError> {
+    fn get_arm_debug_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
         Ok(self.probe)
     }
 

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -13,7 +13,7 @@ use crate::{
             memory_ap::{MemoryAp, MemoryApType},
             v1::valid_access_ports,
         },
-        communication_interface::{ArmProbeInterface, DapProbe, SwdSequence},
+        communication_interface::{ArmDebugInterface, DapProbe, SwdSequence},
         dp::{DpAddress, DpRegisterAddress},
         memory::ArmMemoryInterface,
         sequences::ArmDebugSequence,
@@ -303,10 +303,10 @@ impl DebugProbe for StLink<StLinkUsbDevice> {
         self
     }
 
-    fn try_get_arm_interface<'probe>(
+    fn try_get_arm_debug_interface<'probe>(
         self: Box<Self>,
         _sequence: Arc<dyn ArmDebugSequence>,
-    ) -> Result<Box<dyn ArmProbeInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
+    ) -> Result<Box<dyn ArmDebugInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
         let interface = StlinkArmDebug::new(self);
 
         Ok(Box::new(interface))
@@ -1406,7 +1406,7 @@ impl DapAccess for StlinkArmDebug {
     }
 }
 
-impl ArmProbeInterface for StlinkArmDebug {
+impl ArmDebugInterface for StlinkArmDebug {
     fn memory_interface(
         &mut self,
         access_port: &FullyQualifiedApAddress,
@@ -1788,7 +1788,7 @@ impl ArmMemoryInterface for StLinkMemoryInterface<'_> {
         Ok(self)
     }
 
-    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmProbeInterface, DebugProbeError> {
+    fn get_arm_probe_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, DebugProbeError> {
         Ok(self.probe)
     }
 

--- a/probe-rs/src/vendor/infineon/mod.rs
+++ b/probe-rs/src/vendor/infineon/mod.rs
@@ -5,7 +5,7 @@ use probe_rs_target::{Chip, chip_detection::ChipDetectionMethod};
 
 use crate::{
     architecture::arm::{
-        ArmChipInfo, ArmError, ArmProbeInterface, FullyQualifiedApAddress,
+        ArmChipInfo, ArmError, ArmDebugInterface, FullyQualifiedApAddress,
         dp::{DpRegister, TARGETID},
         memory::ArmMemoryInterface,
     },
@@ -37,7 +37,7 @@ impl Vendor for Infineon {
     fn try_detect_arm_chip(
         &self,
         registry: &Registry,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         chip_info: ArmChipInfo,
     ) -> Result<Option<String>, Error> {
         if let Some(psoc) = try_detect_psoc(registry, interface, &chip_info)? {
@@ -50,7 +50,7 @@ impl Vendor for Infineon {
 
 fn try_detect_xmc4xxx(
     registry: &Registry,
-    interface: &mut dyn ArmProbeInterface,
+    interface: &mut dyn ArmDebugInterface,
     chip_info: &ArmChipInfo,
 ) -> Result<Option<String>, Error> {
     if chip_info.manufacturer != INFINEON {
@@ -153,7 +153,7 @@ fn probe_xmc4xxx_flash_size(start_addr: u32, memory: &mut dyn ArmMemoryInterface
 
 fn try_detect_psoc(
     registry: &Registry,
-    interface: &mut dyn ArmProbeInterface,
+    interface: &mut dyn ArmDebugInterface,
     chip_info: &ArmChipInfo,
 ) -> Result<Option<String>, Error> {
     if chip_info.manufacturer != INFINEON && chip_info.manufacturer != CYPRESS {

--- a/probe-rs/src/vendor/infineon/mod.rs
+++ b/probe-rs/src/vendor/infineon/mod.rs
@@ -5,7 +5,7 @@ use probe_rs_target::{Chip, chip_detection::ChipDetectionMethod};
 
 use crate::{
     architecture::arm::{
-        ArmChipInfo, ArmError, ArmDebugInterface, FullyQualifiedApAddress,
+        ArmChipInfo, ArmDebugInterface, ArmError, FullyQualifiedApAddress,
         dp::{DpRegister, TARGETID},
         memory::ArmMemoryInterface,
     },

--- a/probe-rs/src/vendor/infineon/sequences/xmc4000.rs
+++ b/probe-rs/src/vendor/infineon/sequences/xmc4000.rs
@@ -3,7 +3,7 @@
 use crate::architecture::arm::armv7m::{Aircr, Dhcsr, FpCtrl, FpRev1CompX, FpRev2CompX};
 use crate::architecture::arm::memory::ArmMemoryInterface;
 use crate::architecture::arm::sequences::{ArmDebugSequence, ArmDebugSequenceError};
-use crate::architecture::arm::{ArmError, ArmDebugInterface, FullyQualifiedApAddress};
+use crate::architecture::arm::{ArmDebugInterface, ArmError, FullyQualifiedApAddress};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread;

--- a/probe-rs/src/vendor/infineon/sequences/xmc4000.rs
+++ b/probe-rs/src/vendor/infineon/sequences/xmc4000.rs
@@ -3,7 +3,7 @@
 use crate::architecture::arm::armv7m::{Aircr, Dhcsr, FpCtrl, FpRev1CompX, FpRev2CompX};
 use crate::architecture::arm::memory::ArmMemoryInterface;
 use crate::architecture::arm::sequences::{ArmDebugSequence, ArmDebugSequenceError};
-use crate::architecture::arm::{ArmError, ArmProbeInterface, FullyQualifiedApAddress};
+use crate::architecture::arm::{ArmError, ArmDebugInterface, FullyQualifiedApAddress};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread;
@@ -418,7 +418,7 @@ impl ArmDebugSequence for XMC4000 {
 
     fn reset_hardware_deassert(
         &self,
-        probe: &mut dyn ArmProbeInterface,
+        probe: &mut dyn ArmDebugInterface,
         default_ap: &FullyQualifiedApAddress,
     ) -> Result<(), ArmError> {
         tracing::trace!("performing XMC4000 ResetHardwareDeassert");

--- a/probe-rs/src/vendor/microchip/mod.rs
+++ b/probe-rs/src/vendor/microchip/mod.rs
@@ -4,7 +4,7 @@ use probe_rs_target::{Chip, chip_detection::ChipDetectionMethod};
 
 use crate::{
     Error,
-    architecture::arm::{ArmChipInfo, ArmProbeInterface, FullyQualifiedApAddress},
+    architecture::arm::{ArmChipInfo, ArmDebugInterface, FullyQualifiedApAddress},
     config::{DebugSequence, Registry},
     vendor::{
         Vendor,
@@ -42,7 +42,7 @@ impl Vendor for Microchip {
     fn try_detect_arm_chip(
         &self,
         registry: &Registry,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         chip_info: ArmChipInfo,
     ) -> Result<Option<String>, Error> {
         if chip_info.manufacturer.get() != Some("Atmel") || chip_info.part != 0xCD0 {

--- a/probe-rs/src/vendor/microchip/sequences/atsam.rs
+++ b/probe-rs/src/vendor/microchip/sequences/atsam.rs
@@ -3,7 +3,7 @@
 use crate::{
     MemoryMappedRegister, Permissions,
     architecture::arm::{
-        ArmError, ArmProbeInterface, FullyQualifiedApAddress, Pins,
+        ArmError, ArmDebugInterface, FullyQualifiedApAddress, Pins,
         armv7m::Dhcsr,
         communication_interface::{DapProbe, SwdSequence},
         memory::ArmMemoryInterface,
@@ -460,7 +460,7 @@ impl AtSAM {
 impl ArmDebugSequence for AtSAM {
     fn debug_core_start(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         core_ap: &FullyQualifiedApAddress,
         _core_type: CoreType,
         _debug_base: Option<u64>,
@@ -488,7 +488,7 @@ impl ArmDebugSequence for AtSAM {
     /// the device is released from Reset Extension.
     fn reset_hardware_deassert(
         &self,
-        probe: &mut dyn ArmProbeInterface,
+        probe: &mut dyn ArmDebugInterface,
         default_ap: &FullyQualifiedApAddress,
     ) -> Result<(), ArmError> {
         let mut pins = Pins(0);
@@ -519,7 +519,7 @@ impl ArmDebugSequence for AtSAM {
     ///   to signal that a probe re-attach is required before the new `unlocked` status takes effect.
     fn debug_device_unlock(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         default_ap: &FullyQualifiedApAddress,
         permissions: &Permissions,
     ) -> Result<(), ArmError> {
@@ -541,7 +541,7 @@ impl ArmDebugSequence for AtSAM {
 }
 
 impl DebugEraseSequence for AtSAM {
-    fn erase_all(&self, interface: &mut dyn ArmProbeInterface) -> Result<(), ArmError> {
+    fn erase_all(&self, interface: &mut dyn ArmDebugInterface) -> Result<(), ArmError> {
         let mem_ap = &FullyQualifiedApAddress::v1_with_default_dp(0);
 
         let mut memory = interface.memory_interface(mem_ap)?;

--- a/probe-rs/src/vendor/microchip/sequences/atsam.rs
+++ b/probe-rs/src/vendor/microchip/sequences/atsam.rs
@@ -3,7 +3,7 @@
 use crate::{
     MemoryMappedRegister, Permissions,
     architecture::arm::{
-        ArmError, ArmDebugInterface, FullyQualifiedApAddress, Pins,
+        ArmDebugInterface, ArmError, FullyQualifiedApAddress, Pins,
         armv7m::Dhcsr,
         communication_interface::{DapProbe, SwdSequence},
         memory::ArmMemoryInterface,
@@ -311,7 +311,7 @@ impl AtSAM {
             let current_dsu_statusa = DsuStatusA::from(memory.read_word_8(DsuStatusA::ADDRESS)?);
             if current_dsu_statusa.done() {
                 tracing::info!("Chip-Erase complete");
-                let interface = memory.get_swd_sequence()?;
+                let interface = memory.get_arm_debug_interface()?;
 
                 // If the device was in Reset Extension when we started put it back into Reset Extension
                 let result = if dsu_status_a.crstext() {

--- a/probe-rs/src/vendor/microchip/sequences/mec17xx.rs
+++ b/probe-rs/src/vendor/microchip/sequences/mec17xx.rs
@@ -140,7 +140,7 @@ impl ArmDebugSequence for Mec172x {
         // The ARM communication interface knows how to re-initialize the debug port.
         // Re-initializing the core(s) is on us.
         let ap = memory.fully_qualified_address();
-        let interface = memory.get_arm_probe_interface()?;
+        let interface = memory.get_arm_debug_interface()?;
         interface.reinitialize()?;
 
         assert!(debug_base.is_none());

--- a/probe-rs/src/vendor/microchip/sequences/mec17xx.rs
+++ b/probe-rs/src/vendor/microchip/sequences/mec17xx.rs
@@ -4,7 +4,7 @@ use crate::architecture::arm::armv7m::Demcr;
 use crate::{
     MemoryMappedRegister,
     architecture::arm::{
-        ArmError, ArmProbeInterface, FullyQualifiedApAddress, armv7m::Dhcsr,
+        ArmDebugInterface, ArmError, FullyQualifiedApAddress, armv7m::Dhcsr,
         memory::ArmMemoryInterface, sequences::ArmDebugSequence,
     },
 };
@@ -108,7 +108,7 @@ impl Mec172x {
 impl ArmDebugSequence for Mec172x {
     fn debug_core_start(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         core_ap: &FullyQualifiedApAddress,
         _core_type: CoreType,
         _debug_base: Option<u64>,

--- a/probe-rs/src/vendor/mod.rs
+++ b/probe-rs/src/vendor/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     Error, Target,
     architecture::{
         arm::{
-            ArmChipInfo, ArmProbeInterface, communication_interface::read_chip_info_from_rom_table,
+            ArmChipInfo, ArmDebugInterface, communication_interface::read_chip_info_from_rom_table,
             dp::DpAddress, sequences::DefaultArmSequence,
         },
         riscv::communication_interface::RiscvCommunicationInterface,
@@ -41,7 +41,7 @@ pub trait Vendor: Send + Sync + std::fmt::Display {
     fn try_detect_arm_chip(
         &self,
         _registry: &Registry,
-        _probe: &mut dyn ArmProbeInterface,
+        _probe: &mut dyn ArmDebugInterface,
         _chip_info: ArmChipInfo,
     ) -> Result<Option<String>, Error> {
         Ok(None)
@@ -130,7 +130,7 @@ fn try_detect_arm_chip(
 
     for dp_address in dp_addresses {
         // TODO: do not consume probe
-        match probe.try_into_arm_interface(sequence.clone()) {
+        match probe.try_into_arm_debug_interface(sequence.clone()) {
             Ok(mut interface) => {
                 if let Err(error) = interface.select_debug_port(dp_address) {
                     probe = interface.close();

--- a/probe-rs/src/vendor/mod.rs
+++ b/probe-rs/src/vendor/mod.rs
@@ -114,7 +114,7 @@ fn try_detect_arm_chip(
 ) -> Result<(Probe, Option<Target>), Error> {
     let mut found_target = None;
 
-    if !probe.has_arm_interface() {
+    if !probe.has_arm_debug_interface() {
         // No ARM interface available.
         tracing::debug!("No ARM interface available, skipping detection.");
         return Ok((probe, None));

--- a/probe-rs/src/vendor/nordicsemi/mod.rs
+++ b/probe-rs/src/vendor/nordicsemi/mod.rs
@@ -11,7 +11,7 @@ use sequences::nrf54l::Nrf54L;
 use crate::{
     Error,
     architecture::arm::{
-        ArmChipInfo, ArmProbeInterface, FullyQualifiedApAddress, memory::ArmMemoryInterface,
+        ArmChipInfo, ArmDebugInterface, FullyQualifiedApAddress, memory::ArmMemoryInterface,
     },
     config::{DebugSequence, Registry},
     vendor::{
@@ -46,7 +46,7 @@ impl Vendor for NordicSemi {
     fn try_detect_arm_chip(
         &self,
         registry: &Registry,
-        probe: &mut dyn ArmProbeInterface,
+        probe: &mut dyn ArmDebugInterface,
         chip_info: ArmChipInfo,
     ) -> Result<Option<String>, Error> {
         if chip_info.manufacturer.get() != Some("Nordic VLSI ASA") {

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     architecture::arm::{
-        ArmError, ArmProbeInterface, FullyQualifiedApAddress,
+        ArmError, ArmDebugInterface, FullyQualifiedApAddress,
         dp::DpAddress,
         memory::ArmMemoryInterface,
         sequences::{ArmDebugSequence, ArmDebugSequenceError},
@@ -21,7 +21,7 @@ pub trait Nrf: Sync + Send + Debug {
     /// Returns true when the core is unlocked and false when it is locked.
     fn is_core_unlocked(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         ahb_ap_address: &FullyQualifiedApAddress,
         ctrl_ap_address: &FullyQualifiedApAddress,
     ) -> Result<bool, ArmError>;
@@ -43,7 +43,7 @@ const RELEASE_FORCEOFF: u32 = 0;
 /// Unlocks the core by performing an erase all procedure.
 /// The `ap_address` must be of the ctrl ap of the core.
 fn unlock_core(
-    arm_interface: &mut dyn ArmProbeInterface,
+    arm_interface: &mut dyn ArmDebugInterface,
     ap_address: &FullyQualifiedApAddress,
     permissions: &crate::Permissions,
 ) -> Result<(), ArmError> {
@@ -80,7 +80,7 @@ fn set_network_core_running(interface: &mut dyn ArmMemoryInterface) -> Result<()
 impl<T: Nrf> ArmDebugSequence for T {
     fn debug_device_unlock(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         default_ap: &FullyQualifiedApAddress,
         permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     architecture::arm::{
-        ArmError, ArmDebugInterface, FullyQualifiedApAddress,
+        ArmDebugInterface, ArmError, FullyQualifiedApAddress,
         dp::DpAddress,
         memory::ArmMemoryInterface,
         sequences::{ArmDebugSequence, ArmDebugSequenceError},

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf52.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf52.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use crate::architecture::arm::{
-    ArmError, ArmDebugInterface, FullyQualifiedApAddress,
+    ArmDebugInterface, ArmError, FullyQualifiedApAddress,
     component::TraceSink,
     memory::CoresightComponent,
     sequences::{ArmDebugSequence, ArmDebugSequenceError},

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf52.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf52.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use crate::architecture::arm::{
-    ArmError, ArmProbeInterface, FullyQualifiedApAddress,
+    ArmError, ArmDebugInterface, FullyQualifiedApAddress,
     component::TraceSink,
     memory::CoresightComponent,
     sequences::{ArmDebugSequence, ArmDebugSequenceError},
@@ -39,7 +39,7 @@ impl Nrf52 {
 
     fn is_core_unlocked(
         &self,
-        iface: &mut dyn ArmProbeInterface,
+        iface: &mut dyn ArmDebugInterface,
         ctrl_ap: &FullyQualifiedApAddress,
     ) -> Result<bool, ArmError> {
         let status = iface.read_raw_ap_register(ctrl_ap, APPROTECTSTATUS)?;
@@ -85,7 +85,7 @@ mod clock {
 impl ArmDebugSequence for Nrf52 {
     fn debug_device_unlock(
         &self,
-        iface: &mut dyn ArmProbeInterface,
+        iface: &mut dyn ArmDebugInterface,
         _default_ap: &FullyQualifiedApAddress,
         permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
@@ -125,7 +125,7 @@ impl ArmDebugSequence for Nrf52 {
 
     fn trace_start(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         components: &[CoresightComponent],
         sink: &TraceSink,
     ) -> Result<(), ArmError> {

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use super::nrf::Nrf;
 use crate::architecture::arm::{
-    ArmError, ArmProbeInterface, FullyQualifiedApAddress, ap::CSW, dp::DpAddress,
+    ArmError, ArmDebugInterface, FullyQualifiedApAddress, ap::CSW, dp::DpAddress,
     sequences::ArmDebugSequence,
 };
 
@@ -39,7 +39,7 @@ impl Nrf for Nrf5340 {
 
     fn is_core_unlocked(
         &self,
-        arm_interface: &mut dyn ArmProbeInterface,
+        arm_interface: &mut dyn ArmDebugInterface,
         ahb_ap_address: &FullyQualifiedApAddress,
         _ctrl_ap_address: &FullyQualifiedApAddress,
     ) -> Result<bool, ArmError> {

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use super::nrf::Nrf;
 use crate::architecture::arm::{
-    ArmError, ArmDebugInterface, FullyQualifiedApAddress, ap::CSW, dp::DpAddress,
+    ArmDebugInterface, ArmError, FullyQualifiedApAddress, ap::CSW, dp::DpAddress,
     sequences::ArmDebugSequence,
 };
 

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf54l.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf54l.rs
@@ -29,7 +29,7 @@ impl Nrf54L {
 impl ArmDebugSequence for Nrf54L {
     fn debug_device_unlock(
         &self,
-        interface: &mut dyn crate::architecture::arm::ArmProbeInterface,
+        interface: &mut dyn crate::architecture::arm::ArmDebugInterface,
         default_ap: &FullyQualifiedApAddress,
         permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf91.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf91.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use super::nrf::Nrf;
 use crate::architecture::arm::{
-    ArmError, ArmDebugInterface, FullyQualifiedApAddress, dp::DpAddress,
+    ArmDebugInterface, ArmError, FullyQualifiedApAddress, dp::DpAddress,
     sequences::ArmDebugSequence,
 };
 

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf91.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf91.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use super::nrf::Nrf;
 use crate::architecture::arm::{
-    ArmError, ArmProbeInterface, FullyQualifiedApAddress, dp::DpAddress,
+    ArmError, ArmDebugInterface, FullyQualifiedApAddress, dp::DpAddress,
     sequences::ArmDebugSequence,
 };
 
@@ -39,7 +39,7 @@ impl Nrf for Nrf9160 {
 
     fn is_core_unlocked(
         &self,
-        arm_interface: &mut dyn ArmProbeInterface,
+        arm_interface: &mut dyn ArmDebugInterface,
         _ahb_ap_address: &FullyQualifiedApAddress,
         ctrl_ap_address: &FullyQualifiedApAddress,
     ) -> Result<bool, ArmError> {

--- a/probe-rs/src/vendor/nxp/sequences/mcx.rs
+++ b/probe-rs/src/vendor/nxp/sequences/mcx.rs
@@ -13,7 +13,7 @@ use probe_rs_target::CoreType;
 use crate::{
     MemoryMappedRegister,
     architecture::arm::{
-        ArmError, ArmProbeInterface, DapAccess, FullyQualifiedApAddress, Pins,
+        ArmError, ArmDebugInterface, DapAccess, FullyQualifiedApAddress, Pins,
         ap::ApRegister,
         dp::{DpAccess, DpAddress, DpRegister},
         memory::ArmMemoryInterface,
@@ -410,7 +410,7 @@ impl ArmDebugSequence for MCX {
 
     fn reset_hardware_deassert(
         &self,
-        probe: &mut dyn ArmProbeInterface,
+        probe: &mut dyn ArmDebugInterface,
         _default_ap: &FullyQualifiedApAddress,
     ) -> Result<(), ArmError> {
         tracing::info!("reset hardware deassert");

--- a/probe-rs/src/vendor/nxp/sequences/mcx.rs
+++ b/probe-rs/src/vendor/nxp/sequences/mcx.rs
@@ -13,7 +13,7 @@ use probe_rs_target::CoreType;
 use crate::{
     MemoryMappedRegister,
     architecture::arm::{
-        ArmError, ArmDebugInterface, DapAccess, FullyQualifiedApAddress, Pins,
+        ArmDebugInterface, ArmError, DapAccess, FullyQualifiedApAddress, Pins,
         ap::ApRegister,
         dp::{DpAccess, DpAddress, DpRegister},
         memory::ArmMemoryInterface,
@@ -92,7 +92,7 @@ impl MCX {
         v.into_iter().any(|s| self.variant.starts_with(s))
     }
 
-    fn is_ap_enable(
+    fn is_ap_enabled(
         &self,
         interface: &mut dyn DapAccess,
         mem_ap: &FullyQualifiedApAddress,
@@ -178,10 +178,11 @@ impl MCX {
         let ap = interface.fully_qualified_address();
         let dp = ap.dp();
         let start = Instant::now();
-        while self.is_ap_enable(interface.get_dap_access()?, &ap)?
+
+        while self.is_ap_enabled(interface.get_arm_debug_interface()?, &ap)?
             && start.elapsed() < Duration::from_millis(300)
         {}
-        self.enable_debug_mailbox(interface.get_dap_access()?, dp)?;
+        self.enable_debug_mailbox(interface.get_arm_debug_interface()?, dp)?;
 
         // Halt the core in case it didn't stop at a breakpoint
         let mut dhcsr = Dhcsr(0);
@@ -295,7 +296,7 @@ impl ArmDebugSequence for MCX {
             }
 
             let ap = FullyQualifiedApAddress::v1_with_dp(dp, 0);
-            if !self.is_ap_enable(interface, &ap)? {
+            if !self.is_ap_enabled(interface, &ap)? {
                 self.enable_debug_mailbox(interface, dp)?;
             }
         }

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
@@ -469,7 +469,7 @@ impl ArmDebugSequence for MIMXRT11xx {
         // The ARM communication interface knows how to re-initialize the debug port.
         // Re-initializing the core(s) is on us.
         let ap = probe.fully_qualified_address();
-        let interface = probe.get_arm_probe_interface()?;
+        let interface = probe.get_arm_debug_interface()?;
         interface.reinitialize()?;
 
         assert!(debug_base.is_none());

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv8m.rs
@@ -9,7 +9,7 @@ use std::{
 
 use crate::{
     architecture::arm::{
-        ArmError, ArmProbeInterface, DapAccess, FullyQualifiedApAddress, Pins,
+        ArmError, ArmDebugInterface, DapAccess, FullyQualifiedApAddress, Pins,
         ap::{AccessPortError, AccessPortType, ApRegister, GenericAp, IDR},
         core::armv8m::{Aircr, Demcr, Dhcsr},
         dp::{Abort, Ctrl, DPIDR, DpAccess, DpAddress, DpRegister, SelectV1},
@@ -702,7 +702,7 @@ impl ArmDebugSequence for MIMXRT5xxS {
 
     fn reset_hardware_deassert(
         &self,
-        memory: &mut dyn ArmProbeInterface,
+        memory: &mut dyn ArmDebugInterface,
         _default_ap: &FullyQualifiedApAddress,
     ) -> Result<(), ArmError> {
         tracing::trace!("MIMXRT5xxS reset hardware deassert");

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv8m/ol23d0.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv8m/ol23d0.rs
@@ -9,7 +9,7 @@ use probe_rs_target::CoreType;
 use crate::{
     Error,
     architecture::arm::{
-        ArmError, ArmDebugInterface, FullyQualifiedApAddress,
+        ArmDebugInterface, ArmError, FullyQualifiedApAddress,
         armv8m::Aircr,
         core::armv8m::Dhcsr,
         memory::ArmMemoryInterface,

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv8m/ol23d0.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv8m/ol23d0.rs
@@ -9,7 +9,7 @@ use probe_rs_target::CoreType;
 use crate::{
     Error,
     architecture::arm::{
-        ArmError, ArmProbeInterface, FullyQualifiedApAddress,
+        ArmError, ArmDebugInterface, FullyQualifiedApAddress,
         armv8m::Aircr,
         core::armv8m::Dhcsr,
         memory::ArmMemoryInterface,
@@ -32,7 +32,7 @@ impl OL23D0 {
 impl ArmDebugSequence for OL23D0 {
     fn debug_core_start(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         core_ap: &FullyQualifiedApAddress,
         _core_type: CoreType,
         _debug_base: Option<u64>,

--- a/probe-rs/src/vendor/st/sequences/stm32_armv6.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32_armv6.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use probe_rs_target::CoreType;
 
 use crate::architecture::arm::{
-    ArmError, ArmProbeInterface, FullyQualifiedApAddress, memory::ArmMemoryInterface,
+    ArmError, ArmDebugInterface, FullyQualifiedApAddress, memory::ArmMemoryInterface,
     sequences::ArmDebugSequence,
 };
 
@@ -114,7 +114,7 @@ mod dbgmcu {
 impl ArmDebugSequence for Stm32Armv6 {
     fn debug_device_unlock(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         default_ap: &FullyQualifiedApAddress,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {

--- a/probe-rs/src/vendor/st/sequences/stm32_armv6.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32_armv6.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use probe_rs_target::CoreType;
 
 use crate::architecture::arm::{
-    ArmError, ArmDebugInterface, FullyQualifiedApAddress, memory::ArmMemoryInterface,
+    ArmDebugInterface, ArmError, FullyQualifiedApAddress, memory::ArmMemoryInterface,
     sequences::ArmDebugSequence,
 };
 

--- a/probe-rs/src/vendor/st/sequences/stm32_armv7.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32_armv7.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 use probe_rs_target::CoreType;
 
 use crate::architecture::arm::{
-    ArmError, ArmDebugInterface, FullyQualifiedApAddress,
+    ArmDebugInterface, ArmError, FullyQualifiedApAddress,
     component::TraceSink,
     memory::{ArmMemoryInterface, CoresightComponent},
     sequences::ArmDebugSequence,

--- a/probe-rs/src/vendor/st/sequences/stm32_armv7.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32_armv7.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 use probe_rs_target::CoreType;
 
 use crate::architecture::arm::{
-    ArmError, ArmProbeInterface, FullyQualifiedApAddress,
+    ArmError, ArmDebugInterface, FullyQualifiedApAddress,
     component::TraceSink,
     memory::{ArmMemoryInterface, CoresightComponent},
     sequences::ArmDebugSequence,
@@ -74,7 +74,7 @@ mod dbgmcu {
 impl ArmDebugSequence for Stm32Armv7 {
     fn debug_device_unlock(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         default_ap: &FullyQualifiedApAddress,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
@@ -105,7 +105,7 @@ impl ArmDebugSequence for Stm32Armv7 {
 
     fn trace_start(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         components: &[CoresightComponent],
         sink: &TraceSink,
     ) -> Result<(), ArmError> {

--- a/probe-rs/src/vendor/st/sequences/stm32_armv8.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32_armv8.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use probe_rs_target::CoreType;
 
 use crate::architecture::arm::{
-    ArmError, ArmProbeInterface, FullyQualifiedApAddress,
+    ArmError, ArmDebugInterface, FullyQualifiedApAddress,
     component::TraceSink,
     memory::{ArmMemoryInterface, CoresightComponent},
     sequences::ArmDebugSequence,
@@ -66,7 +66,7 @@ mod dbgmcu {
 impl ArmDebugSequence for Stm32Armv8 {
     fn debug_device_unlock(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         default_ap: &FullyQualifiedApAddress,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
@@ -94,7 +94,7 @@ impl ArmDebugSequence for Stm32Armv8 {
 
     fn trace_start(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         components: &[CoresightComponent],
         sink: &TraceSink,
     ) -> Result<(), ArmError> {

--- a/probe-rs/src/vendor/st/sequences/stm32_armv8.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32_armv8.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use probe_rs_target::CoreType;
 
 use crate::architecture::arm::{
-    ArmError, ArmDebugInterface, FullyQualifiedApAddress,
+    ArmDebugInterface, ArmError, FullyQualifiedApAddress,
     component::TraceSink,
     memory::{ArmMemoryInterface, CoresightComponent},
     sequences::ArmDebugSequence,

--- a/probe-rs/src/vendor/st/sequences/stm32h7.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32h7.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use probe_rs_target::CoreType;
 
 use crate::architecture::arm::{
-    ArmError, ArmDebugInterface, FullyQualifiedApAddress,
+    ArmDebugInterface, ArmError, FullyQualifiedApAddress,
     component::{TraceFunnel, TraceSink},
     memory::{ArmMemoryInterface, CoresightComponent, PeripheralType, romtable::RomTableError},
     sequences::ArmDebugSequence,

--- a/probe-rs/src/vendor/st/sequences/stm32h7.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32h7.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use probe_rs_target::CoreType;
 
 use crate::architecture::arm::{
-    ArmError, ArmProbeInterface, FullyQualifiedApAddress,
+    ArmError, ArmDebugInterface, FullyQualifiedApAddress,
     component::{TraceFunnel, TraceSink},
     memory::{ArmMemoryInterface, CoresightComponent, PeripheralType, romtable::RomTableError},
     sequences::ArmDebugSequence,
@@ -172,7 +172,7 @@ fn find_trace_funnel(
 impl ArmDebugSequence for Stm32h7 {
     fn debug_device_unlock(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         _default_ap: &FullyQualifiedApAddress,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
@@ -199,7 +199,7 @@ impl ArmDebugSequence for Stm32h7 {
 
     fn trace_start(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         components: &[CoresightComponent],
         sink: &TraceSink,
     ) -> Result<(), ArmError> {

--- a/probe-rs/src/vendor/ti/sequences/cc13xx_cc26xx.rs
+++ b/probe-rs/src/vendor/ti/sequences/cc13xx_cc26xx.rs
@@ -79,7 +79,7 @@ impl ArmDebugSequence for CC13xxCC26xx {
 
         // Re-initializing the core(s) is on us.
         let ap = probe.fully_qualified_address();
-        let interface = probe.get_arm_probe_interface()?;
+        let interface = probe.get_arm_debug_interface()?;
         interface.reinitialize()?;
 
         assert!(debug_base.is_none());

--- a/probe-rs/src/vendor/ti/sequences/cc23xx_cc27xx.rs
+++ b/probe-rs/src/vendor/ti/sequences/cc23xx_cc27xx.rs
@@ -7,7 +7,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::MemoryMappedRegister;
-use crate::architecture::arm::ArmProbeInterface;
+use crate::architecture::arm::ArmDebugInterface;
 use crate::architecture::arm::DapAccess;
 use crate::architecture::arm::armv6m::{Aircr, BpCtrl, Demcr, Dhcsr};
 use crate::architecture::arm::core::cortex_m;
@@ -341,7 +341,7 @@ impl ArmDebugSequence for CC23xxCC27xx {
 
     fn debug_core_start(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         core_ap: &FullyQualifiedApAddress,
         _core_type: CoreType,
         _debug_base: Option<u64>,

--- a/probe-rs/src/vendor/ti/sequences/cc23xx_cc27xx.rs
+++ b/probe-rs/src/vendor/ti/sequences/cc23xx_cc27xx.rs
@@ -227,7 +227,7 @@ impl ArmDebugSequence for CC23xxCC27xx {
 
         // Re-initializing the core(s) is on us.
         let ap = probe.fully_qualified_address();
-        let interface = probe.get_arm_probe_interface()?;
+        let interface = probe.get_arm_debug_interface()?;
 
         interface.reinitialize()?;
         self.debug_core_start(interface, &ap, core_type, debug_base, None)?;

--- a/probe-rs/src/vendor/ti/sequences/tms570.rs
+++ b/probe-rs/src/vendor/ti/sequences/tms570.rs
@@ -120,8 +120,8 @@ impl ArmDebugSequence for TMS570 {
         _core_type: probe_rs_target::CoreType,
         _debug_base: Option<u64>,
     ) -> Result<(), ArmError> {
-        let arm_probe = interface.get_arm_probe_interface()?;
-        let probe = arm_probe.try_dap_probe_mut().ok_or(ArmError::NoArmTarget)?;
+        let arm_debug = interface.get_arm_debug_interface()?;
+        let probe = arm_debug.try_dap_probe_mut().ok_or(ArmError::NoArmTarget)?;
         let mut icepick = Icepick::initialized(probe)?;
         icepick.sysreset()?;
         icepick.bypass()?;

--- a/probe-rs/src/vendor/vorago/sequences/va416xx.rs
+++ b/probe-rs/src/vendor/vorago/sequences/va416xx.rs
@@ -6,7 +6,7 @@ use probe_rs_target::CoreType;
 use crate::{
     MemoryMappedRegister,
     architecture::arm::{
-        ArmError, ArmDebugInterface, FullyQualifiedApAddress,
+        ArmDebugInterface, ArmError, FullyQualifiedApAddress,
         armv7m::Demcr,
         memory::ArmMemoryInterface,
         sequences::{ArmDebugSequence, cortex_m_core_start},
@@ -80,7 +80,7 @@ impl ArmDebugSequence for Va416xx {
         // Re-initializing the core(s) is on us.
         let ap = interface.fully_qualified_address();
 
-        let arm_interface = interface.get_arm_probe_interface()?;
+        let arm_interface = interface.get_arm_debug_interface()?;
         const NUM_RETRIES: u32 = 10;
         for i in 0..NUM_RETRIES {
             match arm_interface.reinitialize() {

--- a/probe-rs/src/vendor/vorago/sequences/va416xx.rs
+++ b/probe-rs/src/vendor/vorago/sequences/va416xx.rs
@@ -6,7 +6,7 @@ use probe_rs_target::CoreType;
 use crate::{
     MemoryMappedRegister,
     architecture::arm::{
-        ArmError, ArmProbeInterface, FullyQualifiedApAddress,
+        ArmError, ArmDebugInterface, FullyQualifiedApAddress,
         armv7m::Demcr,
         memory::ArmMemoryInterface,
         sequences::{ArmDebugSequence, cortex_m_core_start},
@@ -31,7 +31,7 @@ impl ArmDebugSequence for Va416xx {
     /// disabling the ROM protection and the watchdog.
     fn debug_core_start(
         &self,
-        interface: &mut dyn ArmProbeInterface,
+        interface: &mut dyn ArmDebugInterface,
         core_ap: &FullyQualifiedApAddress,
         _core_type: CoreType,
         _debug_base: Option<u64>,

--- a/probe-rs/targets/nRF54L_Series.yaml
+++ b/probe-rs/targets/nRF54L_Series.yaml
@@ -6,59 +6,59 @@ manufacturer:
   id: 0x44
   cc: 0x2
 chip_detection:
-- !NordicFicrInfo
-  part_address: 0xffc31c
-  variant_address: 0xffc320
-  part: 0x54B15
-  variants:
-    0x41414242: nRF54L15 # QFN48, engineering B
+  - !NordicFicrInfo
+    part_address: 0xffc31c
+    variant_address: 0xffc320
+    part: 0x54B15
+    variants:
+      0x41414242: nRF54L15 # QFN48, engineering B
 variants:
-- name: nRF54L15
-  cores:
-  - name: main
-    type: armv8m
-    core_access_options: !Arm
-      ap: !v1 0
-  memory_map:
-  - !Nvm
-    range:
-      start: 0x0
-      end: 0x180000
+  - name: nRF54L15
     cores:
-    - main
-    access:
-      boot: true
-  - !Ram
-    range:
-      start: 0x20000000
-      end: 0x20040000
-    cores:
-    - main
-  flash_algorithms:
-  - algorithm
+      - name: main
+        type: armv8m
+        core_access_options: !Arm
+          ap: !v1 0
+    memory_map:
+      - !Nvm
+        range:
+          start: 0x0
+          end: 0x180000
+        cores:
+          - main
+        access:
+          boot: true
+      - !Ram
+        range:
+          start: 0x20000000
+          end: 0x20040000
+        cores:
+          - main
+    flash_algorithms:
+      - algorithm
 
 flash_algorithms:
-- name: algorithm
-  description: nrf54l flash algorithm
-  default: true
-  instructions: QPKwEEvyAFHC8gAAxfIEAQN4C7EAIwtgAToDKj+/ACIKYAEhAXA8vwAgcEf+3kDysBHC8gABCHgBKBy/ASBwRwAgCHBL8gBRxfIEAQhgcEdA8rAQwvIAAAB4gPABAHBHC0ZA8rARwvIAAQl4ASkcvwEgcEfQtQKvS/IIBELyAQHF8gQExPj4FNT4+BPJB/vQEUYaRgDwevgBICBg1Pj4A8AH+9AAIMT4+ATU+PgDwAf70AAg0L1A8rAQwvIAAAF4ASABKRi/cEdL8gBBxfIEAcH4QAEIaMAH/NAAIHBH8LUDry3pAA8QKjXTQ0IT8AMEAOsEDAfQA0YORhb4AVsD+AFbY0X506LrBA4B6wQKLvADCAzrCANf6opyHtC48QEPJdsYIirwAwYC6soLT+rKAsLxAAkyaDUdCfAYBlX4BBsi+gvyAfoG9CJDTPgEKwpGnEXz0wvgA0YN4LjxAQ8G21JGUvgEG0z4BBucRfnTCusIAQ7wAwIysRpEEfgBawP4AWuTQvnTvegAD/C9//envwDU1NQ=
-  load_address: 0x20000020
-  pc_init: 0x1
-  pc_uninit: 0x2f
-  pc_program_page: 0x61
-  pc_erase_sector: 0x51
-  pc_erase_all: 0xb7
-  data_section_offset: 0x200001b4
-  flash_properties:
-    address_range:
-      start: 0x0
-      end: 0x180000
-    page_size: 0x1000
-    erased_byte_value: 0xff
-    program_page_timeout: 1000
-    erase_sector_timeout: 2000
-    sectors:
-    - size: 0x1000
-      address: 0x0
-  cores:
-  - main
+  - name: algorithm
+    description: nrf54l flash algorithm
+    default: true
+    instructions: QPKwEEvyAFHC8gAAxfIEAQN4C7EAIwtgAToDKj+/ACIKYAEhAXA8vwAgcEf+3kDysBHC8gABCHgBKBy/ASBwRwAgCHBL8gBRxfIEAQhgcEdA8rAQwvIAAAB4gPABAHBHC0ZA8rARwvIAAQl4ASkcvwEgcEfQtQKvS/IIBELyAQHF8gQExPj4FNT4+BPJB/vQEUYaRgDwevgBICBg1Pj4A8AH+9AAIMT4+ATU+PgDwAf70AAg0L1A8rAQwvIAAAF4ASABKRi/cEdL8gBBxfIEAcH4QAEIaMAH/NAAIHBH8LUDry3pAA8QKjXTQ0IT8AMEAOsEDAfQA0YORhb4AVsD+AFbY0X506LrBA4B6wQKLvADCAzrCANf6opyHtC48QEPJdsYIirwAwYC6soLT+rKAsLxAAkyaDUdCfAYBlX4BBsi+gvyAfoG9CJDTPgEKwpGnEXz0wvgA0YN4LjxAQ8G21JGUvgEG0z4BBucRfnTCusIAQ7wAwIysRpEEfgBawP4AWuTQvnTvegAD/C9//envwDU1NQ=
+    load_address: 0x20000020
+    pc_init: 0x1
+    pc_uninit: 0x2f
+    pc_program_page: 0x61
+    pc_erase_sector: 0x51
+    pc_erase_all: 0xb7
+    data_section_offset: 0x200001b4
+    flash_properties:
+      address_range:
+        start: 0x0
+        end: 0x180000
+      page_size: 0x1000
+      erased_byte_value: 0xff
+      program_page_timeout: 1000
+      erase_sector_timeout: 2000
+      sectors:
+        - size: 0x1000
+          address: 0x0
+    cores:
+      - main


### PR DESCRIPTION
Due to the rename, this is best reviewed commit by commit.

## Rename `ArmProbeInterface` to `ArmDebugInterface`

Rename the `ArmProbeInterface` to `ArmDebugInterface`. The relevant feature here is that we get access to chips using the Arm Debug Interface, it is not necessarily constrained to cores with an ARM architecture.

## Cleanup `ArmMemoryInterface`

The `get_dap_access` and `get_swd_sequence` functions are removed, the `get_arm_debug_interface` function gives access to a trait object implementing `ArmDebugInterface`, which can be used for the same purpose.