### PR TITLE
Remove panicking From impls

### DIFF
--- a/changelog/removed-panicking-conversions.md
+++ b/changelog/removed-panicking-conversions.md
@@ -1,0 +1,1 @@
+Removed the panicking From implementations from IoSequenceItem.

--- a/probe-rs/src/architecture/arm/traits/polyfill.rs
+++ b/probe-rs/src/architecture/arm/traits/polyfill.rs
@@ -1153,7 +1153,7 @@ fn send_sequence<P: RawSwdIo + JtagAccess>(
                 }
 
                 probe.shift_raw_sequence(JtagSequence {
-                    tms: first.into(),
+                    tms: first.into_output().unwrap(),
                     data: bitvec![0; count],
                     tdo_capture: false,
                 })?;

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -1119,20 +1119,11 @@ pub(crate) enum IoSequenceItem {
     Input,
 }
 
-impl From<IoSequenceItem> for bool {
-    fn from(item: IoSequenceItem) -> Self {
-        match item {
-            IoSequenceItem::Output(b) => b,
-            IoSequenceItem::Input => panic!("Input type is not supposed to hold a value!"),
-        }
-    }
-}
-
-impl From<IoSequenceItem> for u8 {
-    fn from(value: IoSequenceItem) -> Self {
-        match value {
-            IoSequenceItem::Output(b) => b as u8,
-            IoSequenceItem::Input => panic!("Input type is not supposed to hold a value!"),
+impl IoSequenceItem {
+    pub fn into_output(&self) -> Option<bool> {
+        match self {
+            IoSequenceItem::Output(b) => Some(*b),
+            IoSequenceItem::Input => None,
         }
     }
 }


### PR DESCRIPTION
From implies an implementation of TryFrom, and TryFrom panicking is a really bad footgun.