### PR TITLE
Clean up unnecessary allow lints

### DIFF
--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -467,7 +467,7 @@ impl DebugInfo {
 
         // Handle last function, which contains no further inlined functions
         // `unwrap`: Checked at beginning of loop, functions must contain at least one value
-        #[allow(clippy::unwrap_used)]
+        #[expect(clippy::unwrap_used)]
         let last_function = functions.last().unwrap();
 
         let function_name = last_function

--- a/probe-rs-debug/src/language.rs
+++ b/probe-rs-debug/src/language.rs
@@ -75,7 +75,7 @@ pub trait ProgrammingLanguage {
     }
 
     // Post-process raw type representations for more user-friendly output.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn process_struct(
         &self,
         _unit_info: &UnitInfo,

--- a/probe-rs-debug/src/language/rust.rs
+++ b/probe-rs-debug/src/language/rust.rs
@@ -46,7 +46,7 @@ impl Rust {
     /// Replaces *const data pointer with *const [data; len] in slices.
     ///
     /// This function may return `Ok(())` even if it does not modify the variable.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn expand_slice(
         &self,
         unit_info: &UnitInfo,

--- a/probe-rs-debug/src/lib.rs
+++ b/probe-rs-debug/src/lib.rs
@@ -235,7 +235,7 @@ fn extract_line(attribute_value: AttributeValue<GimliReader>) -> Option<u64> {
     }
 }
 
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(clippy::unwrap_used)]
 pub(crate) fn _print_all_attributes(
     core: &mut Core<'_>,
     stackframe_cfa: Option<u64>,
@@ -280,7 +280,7 @@ pub(crate) fn _print_all_attributes(
     }
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 fn iterate(
     result: EvaluationResult<DwarfReader>,
     core: &mut Core,

--- a/probe-rs-debug/src/unit_info.rs
+++ b/probe-rs-debug/src/unit_info.rs
@@ -149,7 +149,7 @@ impl UnitInfo {
 
     /// Recurse the ELF structure below the `tree_node`,
     /// and updates the `cache` with the updated value of the `child_variable`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn process_tree_node_attributes(
         &self,
         debug_info: &DebugInfo,
@@ -417,7 +417,7 @@ impl UnitInfo {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn process_type_attribute(
         &self,
         attr: &gimli::Attribute<GimliReader>,
@@ -962,7 +962,7 @@ impl UnitInfo {
     ///
     /// [e]: Self::extract_type()
     /// [p]: Self::process_tree()
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn extract_type(
         &self,
         debug_info: &DebugInfo,
@@ -1252,7 +1252,7 @@ impl UnitInfo {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn extract_struct(
         &self,
         type_name: Option<String>,
@@ -1315,7 +1315,7 @@ impl UnitInfo {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn extract_array_type(
         &self,
         node: &DebuggingInformationEntry<GimliReader>,
@@ -1385,7 +1385,7 @@ impl UnitInfo {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn extract_enumeration_type(
         &self,
         child_variable: &mut Variable,
@@ -1500,7 +1500,7 @@ impl UnitInfo {
     }
 
     /// Create child variable entries to represent array members and their values.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn expand_array_members(
         &self,
         debug_info: &DebugInfo,
@@ -1598,7 +1598,6 @@ impl UnitInfo {
     }
 
     /// Process a memory location for a variable, by first evaluating the `byte_size`, and then calling the `self.extract_location`.
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn process_memory_location(
         &self,
         debug_info: &DebugInfo,

--- a/probe-rs-target/src/flash_properties.rs
+++ b/probe-rs-target/src/flash_properties.rs
@@ -29,7 +29,6 @@ pub struct FlashProperties {
 }
 
 impl Default for FlashProperties {
-    #[allow(clippy::reversed_empty_ranges)]
     fn default() -> Self {
         FlashProperties {
             address_range: 0..0,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/codec/decoder.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/codec/decoder.rs
@@ -108,8 +108,8 @@ pub(crate) fn get_content_len(header: &str) -> Option<usize> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
     use std::io::ErrorKind;
 
     use pretty_assertions::assert_eq;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/codec/encoder.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/codec/encoder.rs
@@ -19,8 +19,8 @@ impl<T: Serialize + for<'a> Deserialize<'a> + PartialEq> Encoder<Frame<T>> for D
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
 
     use pretty_assertions::assert_eq;
     use serde_json::json;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -539,7 +539,7 @@ impl CoreHandle<'_> {
                         // We will use the path as the key to store the handle.
                         // This way, we can reuse the same handle for the same path.
                         let handle = self.core_data.next_semihosting_handle;
-                        #[allow(
+                        #[expect(
                             clippy::unwrap_used,
                             reason = "Infallible because we start from 1024"
                         )]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -869,8 +869,8 @@ pub(crate) fn is_file_newer(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod test {
-    #![allow(clippy::unwrap_used, clippy::panic)]
 
     use crate::cmd::dap_server::{
         DebuggerError,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -347,7 +347,7 @@ impl SessionData {
                         suggest_delay_required = false;
                     }
                 } else {
-                    #[allow(clippy::unwrap_used)]
+                    #[expect(clippy::unwrap_used)]
                     if let Err(error) = target_core.attach_to_rtt(
                         debug_adapter,
                         core_config.program_binary.as_ref().unwrap(),

--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -38,7 +38,7 @@ pub struct Cmd {
 
 // Clippy doesn't like `from_str_radix` with radix 10, but I prefer the symmetry`
 // with the hex case.
-#[allow(clippy::from_str_radix_10)]
+#[expect(clippy::from_str_radix_10)]
 fn parse_hex(src: &str) -> Result<u32, std::num::ParseIntError> {
     if src.starts_with("0x") {
         u32::from_str_radix(src.trim_start_matches("0x"), 16)

--- a/probe-rs-tools/src/bin/probe-rs/rpc/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/mod.rs
@@ -70,7 +70,7 @@ impl<T> Key<T> {
         }
     }
 
-    #[allow(unused)]
+    #[cfg_attr(not(feature = "remote"), expect(unused))]
     pub unsafe fn cast<U>(&self) -> Key<U> {
         Key {
             key: self.key,
@@ -126,7 +126,6 @@ pub struct SessionState {
     registry: Arc<Mutex<Registry>>,
 }
 
-#[allow(unused)]
 impl SessionState {
     pub fn new() -> Self {
         Self {
@@ -138,10 +137,6 @@ impl SessionState {
 
     pub async fn store_object<T: Any + Send>(&mut self, obj: T) -> Key<T> {
         self.object_storage.lock().await.store_object(obj)
-    }
-
-    pub fn store_object_blocking<T: Any + Send>(&mut self, obj: T) -> Key<T> {
-        self.object_storage.blocking_lock().store_object(obj)
     }
 
     pub async fn object_mut<T: Any + Send>(

--- a/probe-rs-tools/src/bin/probe-rs/rpc/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/mod.rs
@@ -70,7 +70,7 @@ impl<T> Key<T> {
         }
     }
 
-    #[cfg_attr(not(feature = "remote"), expect(unused))]
+    #[cfg(feature = "remote")]
     pub unsafe fn cast<U>(&self) -> Key<U> {
         Key {
             key: self.key,

--- a/probe-rs-tools/src/bin/probe-rs/util/cargo.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cargo.rs
@@ -39,7 +39,7 @@ impl Artifact {
     }
 
     /// If `true`, then the artifact was unchanged during compilation.
-    #[allow(unused)]
+    #[expect(unused)]
     pub fn fresh(&self) -> bool {
         self.fresh
     }

--- a/probe-rs-tools/src/bin/probe-rs/util/cargo.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cargo.rs
@@ -29,19 +29,12 @@ pub enum ArtifactError {
 /// Represents compiled code that the compiler emitted during compilation.
 pub struct Artifact {
     path: PathBuf,
-    fresh: bool,
 }
 
 impl Artifact {
     /// Get the path of this output from the compiler.
     pub fn path(&self) -> &Path {
         &self.path
-    }
-
-    /// If `true`, then the artifact was unchanged during compilation.
-    #[expect(unused)]
-    pub fn fresh(&self) -> bool {
-        self.fresh
     }
 }
 
@@ -121,7 +114,6 @@ pub fn build_artifact(work_dir: &Path, args: &[String]) -> Result<Artifact, Arti
         // Unwrap is safe, we only store artifacts with an executable.
         Ok(Artifact {
             path: PathBuf::from(artifact.executable.unwrap().as_path()),
-            fresh: artifact.fresh,
         })
     } else {
         // We did not find a binary, so we should return an error.

--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -455,7 +455,6 @@ pub enum OperationError {
     NoProbesFound,
 
     #[error("Failed to open the ELF file '{path}' for flashing.")]
-    #[allow(dead_code)]
     FailedToOpenElf {
         #[source]
         source: std::io::Error,
@@ -463,7 +462,6 @@ pub enum OperationError {
     },
 
     #[error("Failed to load the ELF data.")]
-    #[allow(dead_code)]
     FailedToLoadElfData(#[source] FileDownloadError),
 
     #[error("Failed to open the debug probe.")]

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -327,7 +327,6 @@ impl ApClass {
 /// The type of AP defined in the [`ARM Debug Interface v5.2`](https://developer.arm.com/documentation/ihi0031/f/?lang=en) specification.
 /// You can find the details in the table C1-2 on page C1-146.
 /// The different types correspond to the different access/memory buses of ARM cores.
-#[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ApType {
     /// This is the most basic AP that is included in most MCUs and uses SWD or JTAG as an access bus.

--- a/probe-rs/src/architecture/arm/dp/register_generation.rs
+++ b/probe-rs/src/architecture/arm/dp/register_generation.rs
@@ -13,7 +13,7 @@ macro_rules! define_dp_register {
     )
     => {
         $(#[$outer])*
-        #[allow(non_snake_case)]
+        #[expect(non_snake_case)]
         #[derive(Debug, Default, Clone, Copy)]
         pub struct $name {
             $(pub $field: $type,)*

--- a/probe-rs/src/architecture/arm/dp/register_generation.rs
+++ b/probe-rs/src/architecture/arm/dp/register_generation.rs
@@ -13,7 +13,7 @@ macro_rules! define_dp_register {
     )
     => {
         $(#[$outer])*
-        #[expect(non_snake_case)]
+        #[allow(non_snake_case)]
         #[derive(Debug, Default, Clone, Copy)]
         pub struct $name {
             $(pub $field: $type,)*

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -289,7 +289,6 @@ impl<'probe: 'memory, 'memory> ComponentInformationReader<'probe, 'memory> {
     ///
     /// This function does a direct memory access and is meant for internal use only.
     fn component_class(&mut self) -> Result<RawComponent, RomTableError> {
-        #![allow(clippy::verbose_bit_mask)]
         let mut cidr = [0u32; 4];
 
         self.memory
@@ -640,7 +639,7 @@ enum ComponentModification {
 /// Peripheral ID information for a CoreSight component.
 ///
 /// Described in section D1.2.2 of the ADIv5.2 spec.
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PeripheralID {
     /// Indicates minor errata fixes by the component `designer`.

--- a/probe-rs/src/architecture/arm/traits/polyfill.rs
+++ b/probe-rs/src/architecture/arm/traits/polyfill.rs
@@ -1228,7 +1228,7 @@ mod test {
 
     use bitvec::prelude::*;
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     enum DapAcknowledge {
         Ok,
         Wait,

--- a/probe-rs/src/architecture/riscv/assembly.rs
+++ b/probe-rs/src/architecture/riscv/assembly.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::unusual_byte_groupings)]
+#![expect(clippy::unusual_byte_groupings)]
 
 /// RISC-V breakpoint instruction
 pub const EBREAK: u32 = 0b000000000001_00000_000_00000_1110011;

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -2318,7 +2318,7 @@ impl From<RiscvBusAccess> for u8 {
 ///
 /// The `AbstractCommand` method for memory access is not implemented.
 #[derive(Debug, Copy, Clone)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 enum MemoryAccessMethod {
     /// Memory access using the program buffer is supported
     ProgramBuffer,

--- a/probe-rs/src/architecture/xtensa/arch/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/mod.rs
@@ -279,7 +279,7 @@ impl From<SpecialRegister> for RegisterId {
     }
 }
 
-#[allow(non_upper_case_globals)] // Aliasses have same style as other register names
+#[expect(non_upper_case_globals)] // Aliasses have same style as other register names
 impl SpecialRegister {
     // Aliasses
     pub const MpuEnB: Self = Self::RAsid;

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -79,7 +79,7 @@ impl core::fmt::Display for ProtocolVersion {
     }
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(Debug)]
 enum RemoteCommand<'a> {
     Handshake(&'a mut [u8]),
@@ -281,7 +281,7 @@ impl RemoteCommand<'_> {
 
 // Implement `ToString` instead of `Display` as this is for generating
 // strings to send over the network, and is not meant for human consumption.
-#[allow(clippy::to_string_trait_impl)]
+#[expect(clippy::to_string_trait_impl)]
 impl std::string::ToString for RemoteCommand<'_> {
     fn to_string(&self) -> String {
         match self {

--- a/probe-rs/src/probe/cmsisdap/commands/general/host_status.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/host_status.rs
@@ -14,7 +14,6 @@ impl HostStatusRequest {
         }
     }
 
-    #[allow(dead_code)]
     pub fn running(running: bool) -> Self {
         HostStatusRequest {
             status_type: 1,

--- a/probe-rs/src/probe/cmsisdap/commands/jtag/idcode.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/jtag/idcode.rs
@@ -6,7 +6,7 @@ pub struct IdCodeRequest {
 }
 
 impl IdCodeRequest {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn new(index: u8) -> IdCodeRequest {
         IdCodeRequest { index }
     }
@@ -41,8 +41,8 @@ impl Request for IdCodeRequest {
 
 #[derive(Clone, Copy, Debug)]
 pub struct IDCODEResponse {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) status: Status,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) idcode: u32,
 }

--- a/probe-rs/src/probe/cmsisdap/commands/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/mod.rs
@@ -360,7 +360,7 @@ impl Status {
 /// The command ID is always sent as the first byte for every command,
 /// and also is the first byte of every response.
 #[derive(Debug, Clone, Copy)]
-#[allow(unused)]
+#[expect(unused)]
 pub enum CommandId {
     Info = 0x00,
     HostStatus = 0x01,

--- a/probe-rs/src/probe/cmsisdap/commands/swo.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swo.rs
@@ -3,7 +3,7 @@ use scroll::{LE, Pread};
 use super::{CommandId, Request, SendError, Status};
 
 #[repr(u8)]
-#[allow(unused)]
+#[expect(unused)]
 #[derive(Copy, Clone, Debug)]
 pub enum TransportRequest {
     NoTransport = 0,
@@ -34,7 +34,7 @@ pub struct TransportResponse {
 }
 
 #[repr(u8)]
-#[allow(unused)]
+#[expect(unused)]
 #[derive(Copy, Clone, Debug)]
 pub enum ModeRequest {
     Off = 0,

--- a/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
@@ -13,7 +13,7 @@ pub enum RW {
 }
 
 /// Contains information about requested access from host debugger.
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 #[derive(Clone, Debug)]
 struct InnerTransferRequest {
     /// 0 = Debug PortType (DP), 1 = Access PortType (AP).
@@ -80,7 +80,6 @@ impl InnerTransferRequest {
     }
 }
 /// Response to an InnerTransferRequest.
-#[allow(non_snake_case)]
 #[derive(Clone, Debug)]
 pub struct InnerTransferResponse {
     /// Test Domain Timestamp. Will be `Some` if `td_timestamp_request` was set on the request.
@@ -245,7 +244,7 @@ pub enum Ack {
     Ok = 1,
     Wait = 2,
     Fault = 4,
-    #[allow(clippy::enum_variant_names)]
+    #[expect(clippy::enum_variant_names)]
     NoAck = 7,
 }
 

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -713,7 +713,7 @@ impl CmsisDap {
     }
 
     /// Fetch current SWO trace status.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     fn get_swo_status(&mut self) -> Result<swo::StatusResponse, DebugProbeError> {
         Ok(commands::send_command(
             &mut self.device,
@@ -726,7 +726,7 @@ impl CmsisDap {
     /// request.request_status: request trace status
     /// request.request_count: request remaining bytes in trace buffer
     /// request.request_index: request sequence number and timestamp of next trace sequence
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     fn get_swo_extended_status(
         &mut self,
         request: swo::ExtendedStatusRequest,

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)] // Don't require docs for test code
+#![expect(missing_docs)] // Don't require docs for test code
 use crate::{
     MemoryInterface, MemoryMappedRegister,
     architecture::arm::{
@@ -28,7 +28,7 @@ use std::{
 };
 
 /// This is a mock probe which can be used for mocking things in tests or for dry runs.
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub struct FakeProbe {
     protocol: WireProtocol,
     speed: u32,

--- a/probe-rs/src/probe/ftdi/ftdaye/mod.rs
+++ b/probe-rs/src/probe/ftdi/ftdaye/mod.rs
@@ -26,7 +26,7 @@ pub enum ChipType {
 }
 
 #[repr(C)]
-#[allow(unused)]
+#[expect(unused)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum BitMode {
     Reset = 0,
@@ -41,7 +41,7 @@ pub enum BitMode {
 }
 
 #[repr(C)]
-#[allow(unused)]
+#[expect(unused)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Interface {
     A = 1,

--- a/probe-rs/src/probe/glasgow/proto.rs
+++ b/probe-rs/src/probe/glasgow/proto.rs
@@ -8,7 +8,6 @@
 //! not aware of packet boundaries: two 1-byte and one 2-byte (with the same values) packets are
 //! processed exactly the same aside from timing.
 //!
-#![allow(unused)]
 
 /// Target address. The numeric values correspond to packet header bytes for that target.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/probe-rs/src/probe/jlink/capabilities.rs
+++ b/probe-rs/src/probe/jlink/capabilities.rs
@@ -7,7 +7,7 @@ use std::fmt;
 /// Not many of these are actually used, and a lot of these have unknown meaning.
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Capability {
     Reserved0 = 0, // Reserved, seems to be always set
     GetHwVersion = 1,

--- a/probe-rs/src/probe/jlink/config.rs
+++ b/probe-rs/src/probe/jlink/config.rs
@@ -1,5 +1,5 @@
 #[derive(Default, Clone, Copy, Debug)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub struct JlinkConfig {
     pub usb_address: Option<u8>,
     pub kickstart_power: Option<bool>,

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -299,7 +299,7 @@ impl Drop for JLink {
 }
 
 #[repr(u8)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 enum Command {
     Version = 0x01,
     Register = 0x09,

--- a/probe-rs/src/probe/jlink/speed.rs
+++ b/probe-rs/src/probe/jlink/speed.rs
@@ -23,7 +23,7 @@ impl SpeedInfo {
     }
 
     /// Returns a `SpeedConfig` that configures the fastest supported speed.
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) fn max_speed_config(&self) -> SpeedConfig {
         let khz = cmp::min(self.max_speed_hz() / 1000, 0xFFFE);
         // khz is guaranteed to be in the range 1..=0xFFFE, so let's skip the constructor

--- a/probe-rs/src/probe/jlink/swo.rs
+++ b/probe-rs/src/probe/jlink/swo.rs
@@ -95,11 +95,11 @@ impl Deref for SwoData<'_> {
 pub struct SwoSpeedInfo {
     base_freq: u32,
     min_div: u32,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     max_div: u32,
 
     min_presc: u32,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     max_presc: u32,
 }
 

--- a/probe-rs/src/probe/sifliuart/arm.rs
+++ b/probe-rs/src/probe/sifliuart/arm.rs
@@ -329,7 +329,6 @@ impl SifliUartMemoryInterface<'_> {
     }
 }
 
-#[allow(unused)]
 impl MemoryInterface<ArmError> for SifliUartMemoryInterface<'_> {
     fn supports_native_64bit_access(&mut self) -> bool {
         true

--- a/probe-rs/src/probe/sifliuart/mod.rs
+++ b/probe-rs/src/probe/sifliuart/mod.rs
@@ -23,7 +23,6 @@ const DEFUALT_RECV_TIMEOUT: Duration = Duration::from_secs(3);
 
 const DEFUALT_UART_BAUD: u32 = 1000000;
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) enum SifliUartCommand<'a> {
     Enter,
@@ -81,7 +80,6 @@ impl fmt::Display for SifliUartResponse {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug, thiserror::Error)]
 enum CommandError {
     ParameterError(std::io::Error),
@@ -292,7 +290,6 @@ impl SifliUart {
     }
 }
 
-#[allow(unused)]
 impl DebugProbe for SifliUart {
     fn get_name(&self) -> &str {
         "Sifli UART Debug Probe"

--- a/probe-rs/src/probe/stlink/constants.rs
+++ b/probe-rs/src/probe/stlink/constants.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![expect(unused)]
 
 pub mod commands {
     // Common commands.

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -69,7 +69,6 @@ pub struct SessionConfig {
     pub protocol: Option<WireProtocol>,
 }
 
-#[allow(clippy::large_enum_variant)]
 enum JtagInterface {
     Riscv(RiscvDebugInterfaceState),
     Xtensa(XtensaDebugInterfaceState),

--- a/probe-rs/src/vendor/sifli/sequences/sf32lb52.rs
+++ b/probe-rs/src/vendor/sifli/sequences/sf32lb52.rs
@@ -14,7 +14,7 @@ impl Sf32lb52 {
     }
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 mod pmuc {
     use crate::architecture::arm::{ArmError, memory::ArmMemoryInterface};
     use bitfield::bitfield;

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -19,7 +19,7 @@ use xshell::{Shell, cmd};
 
 use crate::commands::elf::cmd_elf;
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn cmd_test(
     target_artifact: &Path,
     template_path: &Path,


### PR DESCRIPTION
This PR changes `allow` to `expect` so that the compiler starts warning when the lint is no longer necessary, and cleans up lints based on the generated warnings.