### PR TITLE
blackmagic: don't turn off target power on init

### DIFF
--- a/changelog/fixed-dont-reset-blackmagic-power-on-init.md
+++ b/changelog/fixed-dont-reset-blackmagic-power-on-init.md
@@ -1,0 +1,1 @@
+Fixed an issue where the Black Magic Probe would always disable target power on reset rather than leaving it alone.

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -699,7 +699,6 @@ impl BlackMagicProbe {
             swd_direction: SwdDirection::Output,
         };
 
-        probe.command(RemoteCommand::SetPower(false)).ok();
         probe.command(RemoteCommand::SetNrst(false)).ok();
         probe.command(RemoteCommand::GetVoltage).ok();
         probe.command(RemoteCommand::SetSpeedHz(400_0000)).ok();


### PR DESCRIPTION
Don't reset the target's power on Black Magic Probes. If the target is currently being powered by the probe (e.g. with `blackmagic -p` or `mon tpwr en`), then the target will continue to be powered.