### PR TITLE
armv8a: mark the cpu core as Running after reset()

### DIFF
--- a/changelog/fixed-armv8-state-after-reset.md
+++ b/changelog/fixed-armv8-state-after-reset.md
@@ -1,0 +1,1 @@
+Fixed ARMv8 cpu core state detection after reset()

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -1174,6 +1174,10 @@ impl CoreInterface for Armv8a<'_> {
         // Reset our cached values
         self.reset_register_cache();
 
+        // Recompute / verify current state
+        self.set_core_status(CoreStatus::Running);
+        let _ = self.status()?;
+
         Ok(())
     }
 


### PR DESCRIPTION
This mirrors #3387 for ARMv8:

After resetting the core, the current state needs to be re-evaluated.
