### PR TITLE
Remove code rejecting --format

### DIFF
--- a/changelog/changed-format-reject.md
+++ b/changelog/changed-format-reject.md
@@ -1,0 +1,1 @@
+probe-rs no longer warns for potentially unintended `--format` use

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -447,8 +447,6 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    reject_format_arg(&args)?;
-
     let config = load_config().context("Failed to load configuration.")?;
 
     // Parse the commandline options.
@@ -568,23 +566,6 @@ fn apply_config_preset(
     }
 
     Ok(args_modified)
-}
-
-fn reject_format_arg(args: &[OsString]) -> anyhow::Result<()> {
-    if let Some(format_arg_pos) = args.iter().position(|arg| arg == "--format") {
-        if let Some(format_arg) = args.get(format_arg_pos + 1) {
-            if let Some(format_arg) = format_arg.to_str() {
-                if FormatKind::from_str(format_arg).is_ok() {
-                    anyhow::bail!(
-                        "--format has been renamed to --binary-format. Please use --binary-format {0} instead of --format {0}",
-                        format_arg
-                    );
-                }
-            }
-        }
-    }
-
-    Ok(())
 }
 
 fn compile_report(


### PR DESCRIPTION
Closes #3441 I think. The `--binary-format` change is old enough at this point, and while we could add logic to make the function rejecting `--format` more accurate, I'm just not sure we need it any more.