### PR TITLE
Use tokio::net::TcpStream in the DAP server

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/protocol.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/protocol.rs
@@ -235,7 +235,6 @@ pub struct DapAdapter<R> {
     output_thread: Option<std::thread::JoinHandle<Result<(), std::io::Error>>>,
 
     console_log_level: ConsoleLog,
-    seq: i64,
 
     pending_requests: HashMap<i64, String>,
 
@@ -292,7 +291,6 @@ impl<R: Read> DapAdapter<R> {
             input: BufReader::new(reader),
             output_tx: tx,
             output_thread: Some(output_thread),
-            seq: 0,
             console_log_level: ConsoleLog::Console,
             pending_requests: HashMap::new(),
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
@@ -77,7 +77,7 @@ impl DebuggerRttChannel {
         };
 
         match out.data {
-            Some(data) => debug_adapter.rtt_output(self.channel_number, data),
+            Some(data) => debug_adapter.rtt_output(self.channel_number, data).await,
             None => false,
         }
     }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -884,7 +884,7 @@ mod test {
                     ThreadsResponseBody,
                 },
             },
-            protocol::ProtocolAdapter,
+            protocol::{EventSender, ProtocolAdapter},
         },
         server::configuration::{ConsoleLog, CoreConfig, FlashingConfig, SessionConfig},
         test::TestLister,
@@ -1211,6 +1211,10 @@ mod test {
         fn get_next_seq(&mut self) -> i64 {
             self.sequence_number += 1;
             self.sequence_number
+        }
+
+        fn event_sender(&self) -> Box<dyn EventSender> {
+            todo!()
         }
     }
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/startup.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/startup.rs
@@ -77,7 +77,7 @@ pub async fn debug(
                     .context("Failed to establish a bi-directional Tcp connection.")?;
                 let writer = socket;
 
-                let dap_adapter = DapAdapter::new(reader, writer);
+                let dap_adapter = DapAdapter::new(reader, writer)?;
                 let mut debug_adapter = DebugAdapter::new(dap_adapter);
 
                 // Flush any pending log messages to the debug adapter Console Log.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
@@ -37,7 +37,7 @@ struct CliAdapter {
     console_log_level: ConsoleLog,
 }
 impl ProtocolAdapter for CliAdapter {
-    fn listen_for_request(&mut self) -> anyhow::Result<Option<Request>> {
+    async fn listen_for_request(&mut self) -> anyhow::Result<Option<Request>> {
         Ok(self.shared.borrow().next_request.clone())
     }
 
@@ -79,7 +79,7 @@ impl ProtocolAdapter for CliAdapter {
         Ok(())
     }
 
-    fn send_raw_response(&mut self, response: Response) -> anyhow::Result<()> {
+    async fn send_raw_response(&mut self, response: Response) -> anyhow::Result<()> {
         if !response.success {
             print_error(&response)?;
             return Ok(());
@@ -229,7 +229,7 @@ impl Cmd {
             seq: 0,
             type_: "request".to_string(),
         });
-        debugger.handle_initialize(&mut debug_adapter)?;
+        debugger.handle_initialize(&mut debug_adapter).await?;
 
         let attach_request = Request {
             command: "attach".to_string(),

--- a/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
@@ -124,6 +124,10 @@ impl ProtocolAdapter for CliAdapter {
         self.shared.borrow_mut().seq += 1;
         self.shared.borrow().seq
     }
+
+    fn event_sender(&self) -> Box<dyn super::dap_server::debug_adapter::protocol::EventSender> {
+        todo!()
+    }
 }
 
 fn print_error(response: &Response) -> anyhow::Result<()> {

--- a/probe-rs/src/flashing/progress.rs
+++ b/probe-rs/src/flashing/progress.rs
@@ -1,5 +1,8 @@
 use super::FlashLayout;
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 /// A structure to manage the flashing procedure progress reporting.
 ///
@@ -16,27 +19,27 @@ use std::{sync::Arc, time::Duration};
 /// ```
 #[derive(Clone)]
 pub struct FlashProgress<'a> {
-    handler: Arc<dyn Fn(ProgressEvent) + 'a>,
+    handler: Arc<Mutex<dyn FnMut(ProgressEvent) + 'a>>,
 }
 
 impl<'a> FlashProgress<'a> {
     /// Create a new `FlashProgress` structure with a given `handler` to be called on events.
-    pub fn new(handler: impl Fn(ProgressEvent) + 'a) -> Self {
+    pub fn new(handler: impl FnMut(ProgressEvent) + 'a) -> Self {
         Self {
-            handler: Arc::new(handler),
+            handler: Arc::new(Mutex::new(handler)),
         }
     }
 
     /// Create a new `FlashProgress` structure with an empty handler.
     pub fn empty() -> Self {
         Self {
-            handler: Arc::new(|_| {}),
+            handler: Arc::new(Mutex::new(|_| {})),
         }
     }
 
     /// Emit a flashing progress event.
     pub fn emit(&self, event: ProgressEvent) {
-        (self.handler)(event);
+        (self.handler.lock().unwrap())(event);
     }
 
     // --- Methods for emitting specific kinds of events.


### PR DESCRIPTION
Now that we're using tokio, it makes to also use async TCP in the DAP server.

Other than that, this PR changes the `FlashProgress` struct so that it uses a `FnMut`, which makes using it easier.

To simplify the progress handling, there is now also way to create an independent `EventSender`, which can be used to send events independently from the `DebugAdapter`.