### PR TITLE
cargo-embed: Halt after reset even when flashing

### DIFF
--- a/changelog/fixed-cargo-embed-reset-after-halt.md
+++ b/changelog/fixed-cargo-embed-reset-after-halt.md
@@ -1,0 +1,1 @@
+* cargo-embed: Respect halt after reset even when flashing

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -393,7 +393,7 @@ async fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
 }
 
 fn should_resume_core(config: &config::Config) -> bool {
-    if config.flashing.enabled {
+    if config.flashing.enabled && !config.reset.halt_afterwards {
         true
     } else {
         !(config.reset.enabled && config.reset.halt_afterwards)


### PR DESCRIPTION
Even when we flash something, we should still respect the setting to halt after the reset.

Fixes #3438