### PR TITLE
cortex-m: fix step() erroring with "timeout" on lockup.

### DIFF
--- a/changelog/fixed-step-lockup
+++ b/changelog/fixed-step-lockup
@@ -1,0 +1,1 @@
+Fixed cortex-m `step()` erroring with "Timeout" if the single-step causes a lock-up. This fixes "timeout" errors trying to attach to certain chips with blank flash(no firmware).

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -458,14 +458,15 @@ impl<'probe> Armv6m<'probe> {
     fn set_core_status(&mut self, new_status: CoreStatus) {
         super::update_core_status(&mut self.memory, &mut self.state.current_state, new_status);
     }
-}
 
-impl CoreInterface for Armv6m<'_> {
-    fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error> {
-        // Wait until halted state is active again.
+    fn wait_for_status(
+        &mut self,
+        timeout: Duration,
+        predicate: impl Fn(CoreStatus) -> bool,
+    ) -> Result<(), Error> {
         let start = Instant::now();
 
-        while !self.core_halted()? {
+        while !predicate(self.status()?) {
             if start.elapsed() >= timeout {
                 return Err(Error::Arm(ArmError::Timeout));
             }
@@ -474,6 +475,13 @@ impl CoreInterface for Armv6m<'_> {
         }
 
         Ok(())
+    }
+}
+
+impl CoreInterface for Armv6m<'_> {
+    fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error> {
+        // Wait until halted state is active again.
+        self.wait_for_status(timeout, |s| s.is_halted())
     }
 
     fn core_halted(&mut self) -> Result<bool, Error> {
@@ -685,7 +693,15 @@ impl CoreInterface for Armv6m<'_> {
             .write_word_32(Dhcsr::get_mmio_address(), value.into())?;
         self.memory.flush()?;
 
-        self.wait_for_core_halted(Duration::from_millis(100))?;
+        // The single-step might put the core in lockup state. Lockup isn't considered "halted"
+        // so we can't use `wait_for_core_halted` here.
+        // So we wait for halted OR lockup, and if we entered lockup we halt.
+        self.wait_for_status(Duration::from_millis(100), |s| {
+            matches!(s, CoreStatus::Halted(_) | CoreStatus::LockedUp)
+        })?;
+        if self.status()? == CoreStatus::LockedUp {
+            self.halt(Duration::from_millis(100))?;
+        }
 
         // Try to read the new program counter.
         let mut pc_after_step = self.read_core_reg(self.program_counter().into())?;

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -82,14 +82,15 @@ impl<'probe> Armv8m<'probe> {
     fn set_core_status(&mut self, new_status: CoreStatus) {
         super::update_core_status(&mut self.memory, &mut self.state.current_state, new_status);
     }
-}
 
-impl CoreInterface for Armv8m<'_> {
-    fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error> {
-        // Wait until halted state is active again.
+    fn wait_for_status(
+        &mut self,
+        timeout: Duration,
+        predicate: impl Fn(CoreStatus) -> bool,
+    ) -> Result<(), Error> {
         let start = Instant::now();
 
-        while !self.core_halted()? {
+        while !predicate(self.status()?) {
             if start.elapsed() >= timeout {
                 return Err(Error::Arm(ArmError::Timeout));
             }
@@ -98,6 +99,13 @@ impl CoreInterface for Armv8m<'_> {
         }
 
         Ok(())
+    }
+}
+
+impl CoreInterface for Armv8m<'_> {
+    fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error> {
+        // Wait until halted state is active again.
+        self.wait_for_status(timeout, |s| s.is_halted())
     }
 
     fn core_halted(&mut self) -> Result<bool, Error> {
@@ -309,7 +317,15 @@ impl CoreInterface for Armv8m<'_> {
             .write_word_32(Dhcsr::get_mmio_address(), value.into())?;
         self.memory.flush()?;
 
-        self.wait_for_core_halted(Duration::from_millis(100))?;
+        // The single-step might put the core in lockup state. Lockup isn't considered "halted"
+        // so we can't use `wait_for_core_halted` here.
+        // So we wait for halted OR lockup, and if we entered lockup we halt.
+        self.wait_for_status(Duration::from_millis(100), |s| {
+            matches!(s, CoreStatus::Halted(_) | CoreStatus::LockedUp)
+        })?;
+        if self.status()? == CoreStatus::LockedUp {
+            self.halt(Duration::from_millis(100))?;
+        }
 
         // Try to read the new program counter.
         let mut pc_after_step = self.read_core_reg(self.program_counter().into())?;


### PR DESCRIPTION
This fixes `step()` erroring with "Timeout" if executing the single-step causes the core to enter lockup. It sets some flag which normally would cause the core to run a single instruction and then halt again, but if that instruction causes the core to enter lockup it goes to lockup instead, which is not considered "halted".

Because attaching calls `run()` which then calls `step()`, this had the unfortunate consequence of making it impossible to attach to blank chips (because the very first instruction causes a lockup). How to repro:

- Grab a stm32f103 board
- `probe-rs erase`
- Power cycle it
- Try to `probe-rs download`,  `probe-rs erase`,  `probe-rs reset`. Nothing works.

This is the stack trace I was seeing (in v0.29, inserting a panic in wait_for_core_halted timeout to be able to get the whole stack trace):

```
   0: rust_begin_unwind
             at /rustc/6650252439d4e03368b305c42a10006e36f1545e/library/std/src/panicking.rs:695:5
   1: core::panicking::panic_fmt
             at /rustc/6650252439d4e03368b305c42a10006e36f1545e/library/core/src/panicking.rs:75:14
   2: <probe_rs::architecture::arm::core::armv7m::Armv7m as probe_rs::core::CoreInterface>::wait_for_core_halted
             at /home/dirbaio/probe-rs/probe-rs/src/architecture/arm/core/armv7m.rs:655:17
   3: <probe_rs::architecture::arm::core::armv7m::Armv7m as probe_rs::core::CoreInterface>::step
             at /home/dirbaio/probe-rs/probe-rs/src/architecture/arm/core/armv7m.rs:891:9
   4: <probe_rs::architecture::arm::core::armv7m::Armv7m as probe_rs::core::CoreInterface>::run
             at /home/dirbaio/probe-rs/probe-rs/src/architecture/arm/core/armv7m.rs:773:9
   5: probe_rs::core::Core::run
             at /home/dirbaio/probe-rs/probe-rs/src/core.rs:290:9
   6: probe_rs::session::Session::halted_access
             at /home/dirbaio/probe-rs/probe-rs/src/session.rs:524:13
   7: probe_rs::session::Session::clear_all_hw_breakpoints
             at /home/dirbaio/probe-rs/probe-rs/src/session.rs:858:9
   8: probe_rs::session::Session::new
             at /home/dirbaio/probe-rs/probe-rs/src/session.rs:183:9
   9: probe_rs::probe::Probe::attach_with_registry
             at /home/dirbaio/probe-rs/probe-rs/src/probe.rs:349:9
  10: probe_rs::probe::Probe::attach
             at /home/dirbaio/probe-rs/probe-rs/src/probe.rs:334:9
  11: flasher::main
             at ./src/main.rs:75:20
```
