### PR TITLE
cortex-m: do not log errors on lockup.

### DIFF
--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -490,7 +490,7 @@ impl CoreInterface for Armv6m<'_> {
         let dhcsr = Dhcsr(self.memory.read_word_32(Dhcsr::get_mmio_address())?);
 
         if dhcsr.s_lockup() {
-            tracing::warn!(
+            tracing::debug!(
                 "The core is in locked up status as a result of an unrecoverable exception"
             );
 

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -669,7 +669,7 @@ impl CoreInterface for Armv7m<'_> {
         let dhcsr = Dhcsr(self.memory.read_word_32(Dhcsr::get_mmio_address())?);
 
         if dhcsr.s_lockup() {
-            tracing::error!(
+            tracing::debug!(
                 "The core is in locked up status as a result of an unrecoverable exception"
             );
 

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -109,7 +109,7 @@ impl CoreInterface for Armv8m<'_> {
         let dhcsr = Dhcsr(self.memory.read_word_32(Dhcsr::get_mmio_address())?);
 
         if dhcsr.s_lockup() {
-            tracing::warn!(
+            tracing::debug!(
                 "The core is in locked up status as a result of an unrecoverable exception"
             );
 


### PR DESCRIPTION
These error messages are unconditionally visible, and look scary to the user, suggesting
something's wrong that they should fix, while in fact it's perfectly normal to see a locked up
core in some situations (for example when flashing a blank chip). I've seen a few people misled by
this on Matrix already.

IMO it should be higher-level tools (the debugger, `probe-rs` run) that inform the user of lockup,
not the low-level ARM arch code. They know when lockup is expected or not (for example it's expected
before flashing, unexpected after).
