### PR TITLE
flashing: change erase, blank_check to work with address ranges.

### DIFF
--- a/changelog/changed-erase-blankcheck.md
+++ b/changelog/changed-erase-blankcheck.md
@@ -1,0 +1,1 @@
+Changed `flashing::{erase,blank_check}` to work with address ranges instead of sector numbers. Renamed `erase_sectors` to `erase`.


### PR DESCRIPTION
The previous code operated with sector indices, which is ambiguous
if the chip has multiple algos. What's worse, it'd erase that
sector index range on *every* algo, which is never what you want.

Changing it to use addresses makes it non-ambiguous and consistent
with FlashLoader.
