### PR TITLE
Feature gate cmsisdap

### DIFF
--- a/changelog/changed-cmsisdap-feature.md
+++ b/changelog/changed-cmsisdap-feature.md
@@ -1,0 +1,1 @@
+cmsisdap: V1 is now behind a feature gate `cmsisdap_v1`, making the `hidapi` dependency optional.

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -20,10 +20,11 @@ license.workspace = true
 exclude = ["tests/"]
 
 [features]
-default = ["builtin-targets"]
+default = ["builtin-targets", "cmsisdap_v1"]
 
 # Enable all built in targets.
 builtin-targets = ["dep:bincode", "dep:serde_yaml", "dep:probe-rs-target"]
+cmsisdap_v1 = ["dep:hidapi"]
 
 # Enable helpers for testing
 test = []
@@ -41,7 +42,7 @@ bitfield = "0.19.0"
 bitvec = "1"
 hidapi = { version = "2", default-features = false, features = [
     "linux-native",
-] }
+], optional = true }
 ihex = "3.0"
 itertools = "0.14"
 jep106 = "0.3"

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -246,6 +246,7 @@ pub enum ProbeCreationError {
     CouldNotOpen,
 
     /// An HID API occurred.
+    #[cfg(feature = "cmsisdap_v1")]
     HidApi(#[from] hidapi::HidError),
 
     /// A USB error occurred.


### PR DESCRIPTION
Putting cmsisdap behind a feature gate allows us to make hidapi an optional dependency, which makes it much easier (or even possible?) to build for Android. With this change I was able to compile my custom toolchain for Android, run it as root, and flash some devices.

Related discussion: #3274