### PR TITLE
Add dtcm memory address range to mimxrt1010 map

### DIFF
--- a/changelog/fixed-mimxrt1010-memory-map
+++ b/changelog/fixed-mimxrt1010-memory-map
@@ -1,0 +1,1 @@
+Fixed MIMXRT1010 memory map: Added DTCM region, correct OCRAM region size.

--- a/probe-rs/targets/MIMXRT1010.yaml
+++ b/probe-rs/targets/MIMXRT1010.yaml
@@ -11,10 +11,17 @@ variants:
       ap: !v1 0
   memory_map:
   - !Ram
+    name: DTCM
+    range:
+      start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
     name: OCRAM
     range:
       start: 0x20200000
-      end: 0x20210000
+      end: 0x20220000
     cores:
     - main
   - !Nvm


### PR DESCRIPTION
Previous memory map did not contain the dtcm range and cut short the potential OCRAM range according to the reference manual.

ITCM is not added but perhaps should be, however it overlaps with Flash at 0x0.