### PR TITLE
Fix serialport dep version

### DIFF
--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -54,7 +54,7 @@ object = { version = "0.37", default-features = false, features = [
 nusb = "0.1.12"
 futures-lite = { version = "2", default-features = false }
 scroll = "0.13"
-serialport = { version = "4.6.0", default-features = false, features = [
+serialport = { version = "4.7.0", default-features = false, features = [
     "usbportinfo-interface",
 ] }
 tracing = "0.1"


### PR DESCRIPTION
The SifliUart implementation uses the `dtr_on_open` function on the `SerialPortBuilder`, which was added in version 4.7.0, so depending on an earlier version is wrong.

https://github.com/probe-rs/probe-rs/blob/6e4b7bdc552c2ec518b0959e40cd59045a90e57b/probe-rs/src/probe/sifliuart/mod.rs#L414