### PR TITLE
arm axi3/4 mem-ap: Add large data support

### DIFF
--- a/changelog/added-large-data-support-for-axi34-memap.md
+++ b/changelog/added-large-data-support-for-axi34-memap.md
@@ -1,0 +1,1 @@
+Added large data support for AXI3/AXI4 MEM-APs.


### PR DESCRIPTION
This adds support for the Large Data Extension to natively write U64, U128 or U256 (depending on chip support) over AXI MEM-APs.

Tested with 64-bit writes on Stellar SR6G7.
