### PR TITLE
ARMv8-A/R: Use HLT instead of BKPT

### DIFF
--- a/changelog/fixed-arm-breakpoint-instruction.md
+++ b/changelog/fixed-arm-breakpoint-instruction.md
@@ -1,0 +1,1 @@
+Fixed ARMv8 instruction for debug halt from `BKPT` to `HLT`.

--- a/probe-rs/src/architecture/arm/assembly.rs
+++ b/probe-rs/src/architecture/arm/assembly.rs
@@ -1,2 +1,4 @@
 /// ARM breakpoint instruction (x2)
-pub const BRKPT: u32 = 0xBE00_BE00;
+pub const BKPT: u32 = 0xBE00_BE00;
+/// ARM hlt instruction, Thumb2 (x2)
+pub const HLT: u32 = 0xBA80_BA80;


### PR DESCRIPTION
On ARMv8-R (and -A), `BKPT` instruction does not cause the CPU to enter debug state, but debug exception (for software debuggers). `HLT` must be used instead.

This fixes running flash algorithms on ARMv8-R.
