### PR TITLE
Clear pending AP access on connect

### DIFF
--- a/changelog/added-abort-ap-access-on-connect
+++ b/changelog/added-abort-ap-access-on-connect
@@ -1,0 +1,1 @@
+On ARM DAP, abort AP transaction to un-stuck DP when there is a stuck AP transaction.

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -1012,6 +1012,10 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
         abort.set_wderrclr(true);
         abort.set_stkerrclr(true);
         abort.set_stkcmpclr(true);
+        // There might be a stuck AP access, which would hang the `RDBUFF` read
+        // on `.raw_flush` (reading `RDBUFF` would respond `Wait` forever.)
+        // Abort the current AP transaction (if there is any).
+        abort.set_dapabort(true);
 
         // DPBANKSEL does not matter for ABORT
         interface.raw_write_register(Abort::ADDRESS.into(), abort.0)?;


### PR DESCRIPTION
It's possible to connect to a target - especially when not connecting under reset - with a pending AP access, for example because a prior debug session ended with some MEM-AP being stuck (i.e. returning `Wait` forever). 

When this happens, the initial `RDBUFF` - from `raw_flush`, intended to observe pending DP faults; no new AP transaction was enqueued yet - keeps returning `Wait` (from the prior AP transaction that is stuck), so we can never make progress post the very initial step of connecting to the DP:

Pseudo-code based on what is observed on SWD, without this change:
```
    swd.line_reset();
    dp.read_reg(Dpidr); // Ok(4c013477)
    dp.write_reg(Abort); // Ok(0000001e)
    dp.read_reg(Rdbuff); // Wait
    dp.read_reg(Rdbuff); // Wait
    dp.read_reg(Rdbuff); // Wait
    dp.read_reg(Rdbuff); // Wait
    dp.read_reg(Rdbuff); // Wait
```
[...never finishes]

By aborting a potentially pending AP read, DP access (and access to unaffected APs) is possible (it will clear the pending fault), and `reset_system` will hopefully un-stuck the AP:

With the change:
```
    swd.line_reset();
    dp.read_reg(Dpidr); // Ok(4c013477)
    dp.write_reg(Abort); // Ok(0000001f)  << [0]=1 i.e. DAPABORT=1 
    dp.read_reg(Rdbuff); // Wait
    dp.read_reg(Rdbuff); // Fault
    dp.read_reg(CtrlStat); // Ok(f0000020)
    dp.write_reg(Abort); // Ok(00000004)
    dp.write_reg(Abort); // Ok(0000001f)
```
