### PR TITLE
call `enable_arm_debug` sequence after srst deassertion

### DIFF
--- a/changelog/changed-arm-reset-deassert-before-core-debug.md
+++ b/changelog/changed-arm-reset-deassert-before-core-debug.md
@@ -1,0 +1,1 @@
+De-assert reset before `enable_arm_debug` to support chips that power down cores under SRST assertion.

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -264,11 +264,6 @@ impl Session {
             Err(e) => return Err(Error::Arm(e)),
         }
 
-        // For each core, setup debugging
-        for core in &cores {
-            core.enable_arm_debug(&mut *interface)?;
-        }
-
         if attach_method == AttachMethod::UnderReset {
             {
                 for core in &cores {
@@ -291,6 +286,12 @@ impl Session {
                     return Err(e.into());
                 }
                 drop(reset_hardware_deassert);
+            }
+
+            // Now that hardware reset is de-asserted, for each core, setup debugging.
+            // (Some chips keep cores in power-down under hardware-reset.)
+            for core in &cores {
+                core.enable_arm_debug(&mut *interface)?;
             }
 
             let mut session = Session {
@@ -316,6 +317,11 @@ impl Session {
 
             Ok(session)
         } else {
+            // For each core, setup debugging
+            for core in &cores {
+                core.enable_arm_debug(&mut *interface)?;
+            }
+
             Ok(Session {
                 target,
                 interfaces: ArchitectureInterface::Arm(interface),


### PR DESCRIPTION
This change is a bit intrusive, so some more explanation:

The (non-normative) explanation of Debug Access Sequences on https://developer.arm.com/documentation/ka002249/latest/ describes the following sequence for "Connect under Reset", which is also what `probe-rs` implements: (Slightly simplified here)

- ResetHardwareAssert
- DebugPortSetup
- DebugPortStart
- DebugDeviceUnlock
- DebugCoreStart
- ResetCatchSet
- ResetHardwareDeassert

(`probe-rs` swaps the order of ResetCatchSet and DebugCoreStart)

What we observed is that on some chips (ST SR6G7 with Cortex-R52+), with SRST asserted, the core is not powered up (PRSR consistently reads as 2, i.e. powered down). EDECR (especially RCE) can still be accessed, but e.g. access to EDLAR and OSLAR will fail. (It is a bit unclear what the exact status of the cores are - PRSR reads 2, and PRCR.DBGNOPWRDWN=1 does not modify this behavior. Similarly, neither of the power request bits in the DP - `csyspwrupreq` and `cdbgpwrupreq` - change this behavior. Explanation from chip vendor is that the chip does not move towards a specific change in the reset sequence while SRST is being asserted, but no more internal details are known.)

This makes these chips incompatible with the prescribed debug sequence (and probe-rs). (Connection without hardware reset will work, but relies on a working DP to execute a functional reset, but this does not work in all cases.)

By moving `DebugCoreStart` to after `ResetHardwareDeassert`, the sequence is changed so that only the reset catch is enabled with reset asserted; any other core configuration is done after releasing SRST. This is fine, since reset catch was enabled - the core will not start running code even after releasing SRST. This fixes the `DebugCoreStart` step on these platforms.

For comparison:

OpenOCD implements the equivalent of "DebugCoreStart" in aarch64_init_debug_access. In `aarch64_deassert_reset`, this is specifically called [_after_ SRST is deasserted](https://github.com/openocd-org/openocd/blob/cbc32c3831e39fd07f5fe0dc1cfb9a7be77ffa86/src/target/aarch64.c#L2023).
