### PR TITLE
Add, expand all FlexRAM regions on MIMXRT targets

### DIFF
--- a/changelog/added-mimxrt-flexrams.md
+++ b/changelog/added-mimxrt-flexrams.md
@@ -1,0 +1,1 @@
+Expand MIMXRT target memory maps to include all possible memory regions. Note that, based on your target's FlexRAM configuration, you may not be able to access all regions.

--- a/probe-rs/targets/MIMXRT1010.yaml
+++ b/probe-rs/targets/MIMXRT1010.yaml
@@ -33,6 +33,13 @@ variants:
     - main
     access:
       boot: true
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x00000000
+      end:   0x00020000
+    cores:
+      - main
   flash_algorithms:
   - mimxrt1011_quadspi_4kb_sec
 flash_algorithms:

--- a/probe-rs/targets/MIMXRT1020.yaml
+++ b/probe-rs/targets/MIMXRT1020.yaml
@@ -14,7 +14,7 @@ variants:
     name: OCRAM
     range:
       start: 0x20200000
-      end: 0x20220000
+      end:   0x20240000
     cores:
     - main
   - !Nvm
@@ -26,6 +26,20 @@ variants:
     - main
     access:
       boot: true
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x00000000
+      end:   0x00040000
+    cores:
+    - main
+  - !Ram
+    name: DTCM
+    range:
+      start: 0x20000000
+      end:   0x20040000
+    cores:
+    - main
   flash_algorithms:
   - mimxrt1021_quadspi_4kb_sec
 flash_algorithms:

--- a/probe-rs/targets/MIMXRT1040.yaml
+++ b/probe-rs/targets/MIMXRT1040.yaml
@@ -14,7 +14,7 @@ variants:
     name: OCRAM
     range:
       start: 0x20200000
-      end:   0x20240000
+      end:   0x20280000
     cores:
     - main
   - !Nvm
@@ -28,14 +28,14 @@ variants:
     name: ITCM
     range:
       start: 0x00000000
-      end:   0x00020000
+      end:   0x00080000
     cores:
     - main
   - !Ram
     name: DTCM
     range:
       start: 0x20000000
-      end:   0x20020000
+      end:   0x20080000
     cores:
     - main
   flash_algorithms:

--- a/probe-rs/targets/MIMXRT1050.yaml
+++ b/probe-rs/targets/MIMXRT1050.yaml
@@ -14,7 +14,7 @@ variants:
     name: OCRAM
     range:
       start: 0x20200000
-      end: 0x20240000
+      end:   0x20280000
     cores:
     - main
   - !Nvm
@@ -26,6 +26,20 @@ variants:
     - main
     access:
       boot: true
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x00000000
+      end:   0x00080000
+    cores:
+    - main
+  - !Ram
+    name: DTCM
+    range:
+      start: 0x20000000
+      end:   0x20080000
+    cores:
+    - main
   flash_algorithms:
   - mimxrt105x_hyper_256kb_sec
 - name: MIMXRT1050_quadspi
@@ -39,7 +53,7 @@ variants:
     name: OCRAM
     range:
       start: 0x20200000
-      end: 0x20240000
+      end:   0x20280000
     cores:
     - main
   - !Nvm
@@ -51,6 +65,20 @@ variants:
     - main
     access:
       boot: true
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x00000000
+      end:   0x00080000
+    cores:
+    - main
+  - !Ram
+    name: DTCM
+    range:
+      start: 0x20000000
+      end:   0x20080000
+    cores:
+    - main
   flash_algorithms:
   - mimxrt105x_quadspi_4kb_sec
 flash_algorithms:

--- a/probe-rs/targets/MIMXRT1060.yaml
+++ b/probe-rs/targets/MIMXRT1060.yaml
@@ -18,10 +18,10 @@ variants:
     cores:
     - main
   - !Ram
-    name: OCRAM2
+    name: OCRAM
     range:
       start: 0x20200000
-      end: 0x202c0000
+      end:   0x20300000
     cores:
     - main
   - !Nvm
@@ -33,6 +33,20 @@ variants:
     - main
     access:
       boot: true
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x00000000
+      end:   0x00080000
+    cores:
+    - main
+  - !Ram
+    name: DTCM
+    range:
+      start: 0x20000000
+      end:   0x20080000
+    cores:
+    - main
   flash_algorithms:
   - mimxrt106x_qspi_4kb_sec
 flash_algorithms:

--- a/probe-rs/targets/MIMXRT1064.yaml
+++ b/probe-rs/targets/MIMXRT1064.yaml
@@ -11,10 +11,10 @@ variants:
       ap: !v1 0
   memory_map:
   - !Ram
-    name: OCRAM2
+    name: OCRAM
     range:
       start: 0x20200000
-      end: 0x202c0000
+      end:   0x20300000
     cores:
     - main
   - !Nvm
@@ -26,6 +26,20 @@ variants:
     - main
     access:
       boot: true
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x00000000
+      end:   0x00080000
+    cores:
+    - main
+  - !Ram
+    name: DTCM
+    range:
+      start: 0x20000000
+      end:   0x20080000
+    cores:
+    - main
   flash_algorithms:
   - mimxrt1064_qspi_4kb_sec
 flash_algorithms:

--- a/probe-rs/targets/MIMXRT1160.yaml
+++ b/probe-rs/targets/MIMXRT1160.yaml
@@ -15,9 +15,10 @@ variants:
     range:
       # OCRAM1 and OCRAM2 aliases when ECC is disabled,
       # plus the ECC region (usable as RAM when ECC is
-      # disabled).
+      # disabled), plus the FlexRAM region (assuming
+      # all FlexRAM is allocated.)
       start: 0x20340000
-      end:   0x20380000
+      end:   0x20800000
     cores:
     - cm7
   - !Nvm
@@ -31,14 +32,14 @@ variants:
     name: ITCM
     range:
       start: 0x00000000
-      end:   0x00040000
+      end:   0x00080000
     cores:
     - cm7
   - !Ram
     name: DTCM
     range:
       start: 0x20000000
-      end:   0x20040000
+      end:   0x20080000
     cores:
     - cm7
   flash_algorithms:

--- a/probe-rs/targets/MIMXRT1170.yaml
+++ b/probe-rs/targets/MIMXRT1170.yaml
@@ -13,8 +13,10 @@ variants:
   - !Ram
     name: OCRAM
     range:
+      # OCRAM1 and OCRAM2, plus the two ECC regions,
+      # plus the FlexRAM allocation.
       start: 0x20240000
-      end: 0x20380000
+      end:   0x20400000
     cores:
     - cm7
   - !Nvm
@@ -22,6 +24,20 @@ variants:
     range:
       start: 0x30000000
       end: 0x31000000
+    cores:
+    - cm7
+  - !Ram
+    name: ITCM
+    range:
+      start: 0x00000000
+      end:   0x00080000
+    cores:
+    - cm7
+  - !Ram
+    name: DTCM
+    range:
+      start: 0x20000000
+      end:   0x20080000
     cores:
     - cm7
   flash_algorithms:


### PR DESCRIPTION
A follow-up on https://github.com/probe-rs/probe-rs/pull/3475. I'm adding TCM regions if they were missing. The bounds of each region represent the maximum-possible size. Note that users may not be able to actually access all of this memory; it depends on the application's FlexRAM configuration.