### PR TITLE
verify: Use correct core_index

### DIFF
--- a/changelog/fixed-verify-use-correct-core.md
+++ b/changelog/fixed-verify-use-correct-core.md
@@ -1,0 +1,1 @@
+Use the correct core when verifying flash content, do not always use the core with index 0.

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -591,7 +591,7 @@ impl Flasher {
             } else {
                 // Not using a flash algorithm function, so there's no need to go
                 // through ActiveFlasher.
-                let mut core = session.core(0).map_err(FlashError::Core)?;
+                let mut core = session.core(self.core_index).map_err(FlashError::Core)?;
                 compare_flash(&self.regions, progress, ignore_filled, |address, data| {
                     core.read(address, data).map_err(FlashError::Core)
                 })


### PR DESCRIPTION
Otherwise verifying fails e.g. for the network core on the nRF5340.