### PR TITLE
rp235x: add reset sequence

### DIFF
--- a/changelog/added-rp235x-reset-sequence copy.md
+++ b/changelog/added-rp235x-reset-sequence copy.md
@@ -1,0 +1,1 @@
+Added a Sequence to reset a Raspberry Pi RP235x using the Rescue DP.

--- a/probe-rs/src/vendor/raspberrypi/mod.rs
+++ b/probe-rs/src/vendor/raspberrypi/mod.rs
@@ -1,6 +1,7 @@
 //! RaspberryPi microcontroller support
 use crate::{config::DebugSequence, vendor::Vendor};
 use probe_rs_target::Chip;
+use sequences::rp235x::Rp235x;
 use sequences::rp2040::Rp2040;
 
 pub mod sequences;
@@ -13,6 +14,8 @@ impl Vendor for RaspberyPi {
     fn try_create_debug_sequence(&self, chip: &Chip) -> Option<DebugSequence> {
         let sequence = if chip.name.starts_with("RP2040") {
             DebugSequence::Arm(Rp2040::create())
+        } else if chip.name.starts_with("RP235") {
+            DebugSequence::Arm(Rp235x::create())
         } else {
             return None;
         };

--- a/probe-rs/src/vendor/raspberrypi/sequences/mod.rs
+++ b/probe-rs/src/vendor/raspberrypi/sequences/mod.rs
@@ -1,3 +1,4 @@
 //! Debug sequences for Raspberry Pi chips
 
 pub mod rp2040;
+pub mod rp235x;

--- a/probe-rs/src/vendor/raspberrypi/sequences/rp235x.rs
+++ b/probe-rs/src/vendor/raspberrypi/sequences/rp235x.rs
@@ -1,0 +1,129 @@
+//! Implement chip-specific dual-core reset for RP235x
+
+use crate::MemoryMappedRegister;
+use crate::architecture::arm::armv6m::{Aircr, Demcr};
+use crate::architecture::arm::dp::{Ctrl, DpAddress, DpRegister};
+use crate::architecture::arm::memory::ArmMemoryInterface;
+use crate::architecture::arm::sequences::{ArmDebugSequence, cortex_m_wait_for_reset};
+use crate::architecture::arm::{ApV2Address, ArmError, FullyQualifiedApAddress};
+use std::sync::Arc;
+
+const SIO_CPUID_OFFSET: u64 = 0xd000_0000;
+const RP_AP: FullyQualifiedApAddress =
+    FullyQualifiedApAddress::v2_with_dp(DpAddress::Default, ApV2Address(Some(0x80000)));
+
+/// Debug implementation for RP235x
+#[derive(Debug)]
+pub struct Rp235x {}
+
+impl Rp235x {
+    /// Create a debug sequencer for a Raspberry Pi RP235x
+    pub fn create() -> Arc<Self> {
+        Arc::new(Rp235x {})
+    }
+
+    fn perform_reset(
+        &self,
+        core: &mut dyn ArmMemoryInterface,
+        core_type: crate::CoreType,
+        debug_base: Option<u64>,
+        should_catch_reset: bool,
+    ) -> Result<(), ArmError> {
+        let ap = core.fully_qualified_address();
+        let arm_interface = core.get_arm_debug_interface()?;
+
+        // Take note of the existing values for CTRL. We will need to restore these after entering
+        // rescue mode.
+        let existing_core_0 = arm_interface.read_raw_dp_register(ap.dp(), Ctrl::ADDRESS)?;
+        tracing::trace!("Core 0 DP_CTRL: {existing_core_0:08x}");
+
+        // Put the SoC in rescue reset as the datasheet.
+        //
+        // This process consists of setting a flag in the CTRL register of
+        // the RP-AP, which causes a flag to be set in POWMAN CHIP_RESET
+        // (RESCUE) and the SoC to reset. The BootROM checks for the RESCUE
+        // flag, and if set, halts the system. We then attach as usual.
+        //
+        // See: 'RP2350 Datasheet', sections:
+        //   3.5.8: Rescue Reset
+        //   3.5.10.1: RP-AP list of registers
+
+        // CTRL register offset within RP-AP.
+        const CTRL: u64 = 0;
+        const RESCUE_RESTART: u32 = 0x8000_0000;
+
+        // Poke 1 to CTRL.RESCUE_RESTART.
+        let ctrl = arm_interface.read_raw_ap_register(&RP_AP, CTRL)?;
+        arm_interface.write_raw_ap_register(&RP_AP, CTRL, ctrl | RESCUE_RESTART)?;
+        // Poke 0 to CTRL.RESCUE_RESTART.
+        let ctrl = arm_interface.read_raw_ap_register(&RP_AP, CTRL)?;
+        arm_interface.write_raw_ap_register(&RP_AP, CTRL, ctrl & !RESCUE_RESTART)?;
+
+        let new_core_0 = arm_interface.read_raw_dp_register(ap.dp(), Ctrl::ADDRESS)?;
+        tracing::trace!("new core 0 CTRL: {new_core_0:08x}");
+
+        // Start the debug core back up which brings it out of Rescue Mode
+        self.debug_core_start(arm_interface, &ap, core_type, debug_base, None)?;
+
+        // Restore the ctrl values
+        tracing::trace!("Restoring ctrl values");
+        arm_interface.write_raw_dp_register(ap.dp(), Ctrl::ADDRESS, existing_core_0)?;
+
+        // If we were set to catch the reset before, set it up again
+        if should_catch_reset {
+            tracing::trace!("Re-setting reset catch");
+            self.reset_catch_set(core, core_type, debug_base)?
+        }
+
+        // Perform a reset to get out of Rescue Mode by poking AIRCR.
+        let mut aircr = Aircr(0);
+        aircr.vectkey();
+        aircr.set_sysresetreq(true);
+        core.write_word_32(Aircr::get_mmio_address(), aircr.into())?;
+
+        // Wait for the core to finish resetting
+        cortex_m_wait_for_reset(core)?;
+
+        core.read_word_32(0x2000_0000)
+            .map(|_| ())
+            .inspect_err(|e| tracing::error!("Reset failed -- trying again: {e}"))
+    }
+}
+
+impl ArmDebugSequence for Rp235x {
+    fn reset_system(
+        &self,
+        core: &mut dyn ArmMemoryInterface,
+        core_type: crate::CoreType,
+        debug_base: Option<u64>,
+    ) -> Result<(), ArmError> {
+        tracing::trace!("reset_system(interface, {core_type:?}, {debug_base:x?})");
+        // Only perform a system reset from core 0
+        let core_id = core.read_word_32(SIO_CPUID_OFFSET)?;
+        if core_id != 0 {
+            tracing::error!("Skipping reset of core {core_id}");
+            return Ok(());
+        }
+
+        // Since we're resetting the core, the catch_reset flag will get lost.
+        // Note whether we should re-set it after entering Rescue Mode.
+        let should_catch_reset =
+            Demcr(core.read_word_32(Demcr::get_mmio_address())?).vc_corereset();
+
+        // Reset seems to get stuck in a state where RAM is inaccessible. A second reset
+        // fixes this about 20% of the time. Perform multiple resets to try and get the
+        // board into a state where it's functioning. Note that a full reset is required
+        // in this case -- simply resetting the core does not get it into a functioning
+        // state.
+        let mut result;
+        for _ in 0..10 {
+            result = self.perform_reset(core, core_type, debug_base, should_catch_reset);
+            if result.is_ok() {
+                break;
+            }
+        }
+
+        tracing::trace!("Finished RP235x reset sequence");
+        Ok(())
+    }
+}


### PR DESCRIPTION
Add a sequence for the RP235x family of parts. This pokes the Rescue DP core on these parts to initiate a reset.