### PR TITLE
RPC: Use `src_path` directly if `canonicalize()` fails

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -327,7 +327,11 @@ impl RpcClient {
     pub async fn upload_file(&self, src_path: impl AsRef<Path>) -> anyhow::Result<PathBuf> {
         use anyhow::Context as _;
 
-        let src_path = src_path.as_ref().canonicalize()?;
+        let src_path = src_path
+            .as_ref()
+            .canonicalize()
+            .unwrap_or_else(|_| src_path.as_ref().to_path_buf());
+
         if self.is_localhost {
             return Ok(src_path);
         }


### PR DESCRIPTION
Adding this call to `canonicalize()` somewhere between v0.27 and v0.28 broke using probe-rs with memfd files and other "unreal" file paths.

As discussed on matrix, we can try calling `canonicalize()` and if it fails we fall back to using the `src_path` directly.