### PR TITLE
jtag: don't halt cores on attach for non-ARM targets

### DIFF
--- a/changelog/removed-halt-jtag-cores-on-session-creation.md
+++ b/changelog/removed-halt-jtag-cores-on-session-creation.md
@@ -1,0 +1,1 @@
+Removed a step where all cores are halted when creating a Session for non-ARM targets.

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -410,19 +410,6 @@ impl Session {
             configured_trace_sink: None,
         };
 
-        // Wait for the cores to be halted.
-        for core_id in 0..session.cores.len() {
-            match session.core(core_id) {
-                Ok(mut core) => {
-                    if !core.core_halted()? {
-                        core.halt(Duration::from_millis(100))?;
-                    }
-                }
-                Err(Error::CoreDisabled(i)) => tracing::debug!("Core {i} is disabled"),
-                Err(error) => return Err(error),
-            }
-        }
-
         // Connect to the cores
         match session.target.debug_sequence.clone() {
             DebugSequence::Xtensa(_) => {}


### PR DESCRIPTION
When attaching to ARM targets, the target will stay running. However, when attaching to Xtensa or RISC-V targets all cores are halted. This can potentially interrupt the target if it's in the middle of processing. Additionally, it means that information about which cores were running is lost.

Remove the halt entirely, as it shouldn't be required.