### PR TITLE
embedded test: read testcases directly from elf

### DIFF
--- a/changelog/added-embedded-test-v2.md
+++ b/changelog/added-embedded-test-v2.md
@@ -1,0 +1,1 @@
+Added support for reading embedded_test testcases directly from ELF file.

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
@@ -65,7 +65,7 @@ impl From<TestDefinition> for Test {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TestDefinition {
     pub name: String,
     #[serde(
@@ -75,6 +75,7 @@ pub struct TestDefinition {
     pub expected_outcome: TestOutcome,
     pub ignored: bool,
     pub timeout: Option<u32>,
+    pub address: Option<u32>,
 }
 
 fn outcome_from_should_panic<'de, D>(deserializer: D) -> Result<TestOutcome, D::Error>

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
@@ -385,7 +385,7 @@ impl<F: FnMut(SemihostingEvent)> RunEventHandler<F> {
         match cmd {
             SemihostingCommand::GetCommandLine(request) if !self.cmdline_requested => {
                 let cmdline = if let Some(address) = self.test.address {
-                    format!("run_addr {}", address)
+                    format!("run_addr {address}")
                 } else {
                     format!("run {}", self.test.name)
                 };

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -528,7 +528,8 @@ pub async fn test(
             // In embedded test < 0.7, we have to query the tests from the target via semihosting
             session
                 .list_tests(boot_info, rtt_handle, async |msg| sender.send(msg).unwrap())
-                .await?.tests
+                .await?
+                .tests
         } else {
             // Recent embedded test versions report the tests directly via the elf file
             elf_info.tests

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -507,6 +507,7 @@ pub async fn monitor(
     result.map(|_| ())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn test(
     session: &SessionInterface,
     boot_info: BootInfo,
@@ -524,15 +525,22 @@ pub async fn test(
 
     let rtt_handle = rtt_client.as_ref().map(|rtt| rtt.handle);
     let test = async {
-        let tests = if elf_info.version == 0 {
-            // In embedded test < 0.7, we have to query the tests from the target via semihosting
-            session
-                .list_tests(boot_info, rtt_handle, async |msg| sender.send(msg).unwrap())
-                .await?
-                .tests
-        } else {
-            // Recent embedded test versions report the tests directly via the elf file
-            elf_info.tests
+        let tests = match elf_info.version {
+            0 => {
+                // In embedded test < 0.7, we have to query the tests from the target via semihosting
+                session
+                    .list_tests(boot_info, rtt_handle, async |msg| sender.send(msg).unwrap())
+                    .await?
+                    .tests
+            }
+            1 => {
+                // Recent embedded test versions report the tests directly via the elf file
+                elf_info.tests
+            }
+            v => anyhow::bail!(
+                "Found embedded_test protocol version {}, which is not yet supported by probe-rs. Update probe-rs?",
+                v
+            ),
         };
 
         if token.is_cancelled() {

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -13,6 +13,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::{runtime::Handle, sync::mpsc::UnboundedSender};
 use tokio_util::sync::CancellationToken;
 
+use crate::cmd::run::EmbeddedTestElfInfo;
 use crate::rpc::functions::monitor::MonitorExitReason;
 use crate::{
     FormatOptions,
@@ -509,6 +510,7 @@ pub async fn monitor(
 pub async fn test(
     session: &SessionInterface,
     boot_info: BootInfo,
+    elf_info: EmbeddedTestElfInfo,
     libtest_args: libtest_mimic::Arguments,
     print_stack_trace: bool,
     path: &Path,
@@ -522,16 +524,21 @@ pub async fn test(
 
     let rtt_handle = rtt_client.as_ref().map(|rtt| rtt.handle);
     let test = async {
-        let tests = session
-            .list_tests(boot_info, rtt_handle, async |msg| sender.send(msg).unwrap())
-            .await?;
+        let tests = if elf_info.version == 0 {
+            // In embedded test < 0.7, we have to query the tests from the target via semihosting
+            session
+                .list_tests(boot_info, rtt_handle, async |msg| sender.send(msg).unwrap())
+                .await?.tests
+        } else {
+            // Recent embedded test versions report the tests directly via the elf file
+            elf_info.tests
+        };
 
         if token.is_cancelled() {
             return Ok(());
         }
 
         let tests = tests
-            .tests
             .into_iter()
             .map(|test| create_trial(session, path, rtt_handle, sender.clone(), &token, test))
             .collect::<Vec<_>>();


### PR DESCRIPTION
Host-side changes for the next version of embedded-test, which:
* reads the testcases directly from the ELF, instead of requesting them from the target via semihosting
* supports unit tests (apart from integration tests)

More Infos: https://github.com/probe-rs/embedded-test/issues/62


