### PR TITLE
Deduplicate flash regions for GDB memory map

### DIFF
--- a/changelog/fixed-deduplicate-gdb-memory-regions.md
+++ b/changelog/fixed-deduplicate-gdb-memory-regions.md
@@ -1,0 +1,1 @@
+gdb: Deduplicate flash regions in memory map before passing them to gdb


### PR DESCRIPTION
If a chip has multiple flash algorithms targeting the same memory region - like for example the MIMXRT685SFVKB - GDB will warn that there are overlapping regions, but it will also not list any memory regions in `info mem`. This causes problems when trying to set breakpoints since GDB assumes all memory is now RAM and will try to use soft breakpoints which in turn will fail in flash regions. 

This PR deduplicates the  flash regions before handing them to GDB. I'm not sure if this is the best place to do this, or if there is a more general function that could handle this.

cc: @Wassasin 