### PR TITLE
ARMv8: Allow memory write fast path on AArch32

### DIFF
--- a/changelog/added-armv8a-fast-writes-for-aarch32.md
+++ b/changelog/added-armv8a-fast-writes-for-aarch32.md
@@ -1,0 +1,1 @@
+Added ARMv8 fast memory writes for AArch32 mode

--- a/probe-rs/src/architecture/arm/core/instructions.rs
+++ b/probe-rs/src/architecture/arm/core/instructions.rs
@@ -312,16 +312,6 @@ pub(crate) mod aarch64 {
         ret
     }
 
-    pub(crate) fn build_strb(reg_target: u16, reg_source: u16, imm: u16) -> u32 {
-        let mut ret = 0b0011_1000_0000_0000_0000_0100_0000_0000;
-
-        ret |= (imm as u32) << 12;
-        ret |= (reg_source as u32) << 5;
-        ret |= reg_target as u32;
-
-        ret
-    }
-
     pub(crate) fn build_ins_fp_to_gp(reg_target: u16, reg_source: u16, index: u16) -> u32 {
         let mut ret = 0b0100_1110_0000_1000_0011_1100_0000_0000;
 


### PR DESCRIPTION
MA fast memory access works almost identical in AArch32 mode so there is no need to gate this on 64-bit state.

However, `write_cpu_memory_aarch64_bytes`, used to handle unaligned prefix/suffix, is AArch64 specific, but can be replaced by the regular `write_word8`, thereby simplifying the differences between AArch32 and AArch64. (`write_word8` does a RMW for byte-access but that's an orthogonal optimization.)

This further fixes a bug where r1 was not clobbered; but it is set UNKNOWN based on the pseudo-code of `shared/debug/dccanditr/DBGDTRRX_EL0`:

```
[...]
R[1] = bits(32) UNKNOWN;
[...]
```

This previously corrupted r1 when there was no unaligned part.