### PR TITLE
Adds support for file access via semihosting

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
@@ -433,7 +433,7 @@ impl SemihostingReader {
     }
 
     fn handle_close(&mut self, core: &mut Core<'_>, request: CloseRequest) -> anyhow::Result<()> {
-        let handle = request.file_handle(core)?;
+        let handle = request.file_handle();
         if handle == Self::STDOUT.get() {
             self.stdout_open = false;
             request.success(core)?;

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
@@ -340,6 +340,10 @@ impl<F: FnMut(SemihostingEvent)> MonitorEventHandler<F> {
                 );
                 Ok(None) // Continue running
             }
+            SemihostingCommand::Time(request) => {
+                request.write_current_time(core)?;
+                Ok(None)
+            }
             SemihostingCommand::Errno(_) => Ok(None),
             other if SemihostingFileManager::can_handle(other) => {
                 self.semihosting_file_manager

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroU32, time::Duration};
+use std::time::Duration;
 
 use crate::{
     rpc::{
@@ -7,17 +7,17 @@ use crate::{
             MonitorEndpoint, MultiTopicPublisher, MultiTopicWriter, RpcResult, RpcSpawnContext,
             RttTopic, SemihostingTopic, WireTxImpl, flash::BootInfo,
         },
-        utils::run_loop::{ReturnReason, RunLoop, RunLoopPoller},
+        utils::{
+            run_loop::{ReturnReason, RunLoop, RunLoopPoller},
+            semihosting_file_manager::SemihostingFileManager,
+        },
     },
     util::rtt::client::RttClient,
 };
 use anyhow::Context;
 use postcard_rpc::{header::VarHeader, server::Sender};
 use postcard_schema::Schema;
-use probe_rs::{
-    BreakpointCause, Core, HaltReason, Session,
-    semihosting::{CloseRequest, OpenRequest, SemihostingCommand, WriteRequest},
-};
+use probe_rs::{BreakpointCause, Core, HaltReason, Session, semihosting::SemihostingCommand};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{self, error::SendError};
 use tokio_util::sync::CancellationToken;
@@ -295,14 +295,14 @@ where
 
 struct MonitorEventHandler<F: FnMut(SemihostingEvent)> {
     sender: F,
-    semihosting_reader: SemihostingReader,
+    semihosting_file_manager: SemihostingFileManager,
 }
 
 impl<F: FnMut(SemihostingEvent)> MonitorEventHandler<F> {
     pub fn new(sender: F) -> Self {
         Self {
             sender,
-            semihosting_reader: SemihostingReader::new(),
+            semihosting_file_manager: SemihostingFileManager::new(),
         }
     }
 
@@ -341,10 +341,9 @@ impl<F: FnMut(SemihostingEvent)> MonitorEventHandler<F> {
                 Ok(None) // Continue running
             }
             SemihostingCommand::Errno(_) => Ok(None),
-            other if SemihostingReader::is_io(other) => {
-                if let Some((stream, data)) = self.semihosting_reader.handle(other, core)? {
-                    (self.sender)(SemihostingEvent::Output { stream, data });
-                }
+            other if SemihostingFileManager::can_handle(other) => {
+                self.semihosting_file_manager
+                    .handle(other, core, &mut self.sender)?;
                 Ok(None)
             }
             other => Ok(Some(MonitorExitReason::UnexpectedExit(format!(
@@ -352,133 +351,4 @@ impl<F: FnMut(SemihostingEvent)> MonitorEventHandler<F> {
             )))),
         }
     }
-}
-
-pub struct SemihostingReader {
-    stdout_open: bool,
-    stderr_open: bool,
-}
-
-impl SemihostingReader {
-    const STDOUT: NonZeroU32 = NonZeroU32::new(1).unwrap();
-    const STDERR: NonZeroU32 = NonZeroU32::new(2).unwrap();
-
-    pub fn new() -> Self {
-        Self {
-            stdout_open: false,
-            stderr_open: false,
-        }
-    }
-
-    pub fn is_io(other: SemihostingCommand) -> bool {
-        matches!(
-            other,
-            SemihostingCommand::Open(_)
-                | SemihostingCommand::Close(_)
-                | SemihostingCommand::WriteConsole(_)
-                | SemihostingCommand::Write(_)
-        )
-    }
-
-    pub fn handle(
-        &mut self,
-        command: SemihostingCommand,
-        core: &mut Core<'_>,
-    ) -> anyhow::Result<Option<(String, String)>> {
-        let out = match command {
-            SemihostingCommand::Open(request) => {
-                self.handle_open(core, request)?;
-                None
-            }
-            SemihostingCommand::Close(request) => {
-                self.handle_close(core, request)?;
-                None
-            }
-            SemihostingCommand::Write(request) => self.handle_write(core, request)?,
-            SemihostingCommand::WriteConsole(request) => {
-                let str = request.read(core)?;
-                Some((String::from("stdout"), str))
-            }
-
-            _ => None,
-        };
-
-        Ok(out)
-    }
-
-    fn handle_open(&mut self, core: &mut Core<'_>, request: OpenRequest) -> anyhow::Result<()> {
-        let path = request.path(core)?;
-        if path != ":tt" {
-            tracing::warn!(
-                "Target wanted to open file {path}, but probe-rs does not support this operation yet. Continuing..."
-            );
-            return Ok(());
-        }
-
-        match request.mode().as_bytes()[0] {
-            b'w' => {
-                self.stdout_open = true;
-                request.respond_with_handle(core, Self::STDOUT)?;
-            }
-            b'a' => {
-                self.stderr_open = true;
-                request.respond_with_handle(core, Self::STDERR)?;
-            }
-            mode => tracing::warn!(
-                "Target wanted to open file {path} with mode {mode}, but probe-rs does not support this operation yet. Continuing..."
-            ),
-        }
-
-        Ok(())
-    }
-
-    fn handle_close(&mut self, core: &mut Core<'_>, request: CloseRequest) -> anyhow::Result<()> {
-        let handle = request.file_handle();
-        if handle == Self::STDOUT.get() {
-            self.stdout_open = false;
-            request.success(core)?;
-        } else if handle == Self::STDERR.get() {
-            self.stderr_open = false;
-            request.success(core)?;
-        } else {
-            tracing::warn!(
-                "Target wanted to close file handle {handle}, but probe-rs does not support this operation yet. Continuing..."
-            );
-        }
-
-        Ok(())
-    }
-
-    fn handle_write(
-        &mut self,
-        core: &mut Core<'_>,
-        request: WriteRequest,
-    ) -> anyhow::Result<Option<(String, String)>> {
-        match request.file_handle() {
-            handle if handle == Self::STDOUT.get() => {
-                if self.stdout_open {
-                    let string = read_written_string(core, request)?;
-                    return Ok(Some((String::from("stdout"), string)));
-                }
-            }
-            handle if handle == Self::STDERR.get() => {
-                if self.stderr_open {
-                    let string = read_written_string(core, request)?;
-                    return Ok(Some((String::from("stderr"), string)));
-                }
-            }
-            other => tracing::warn!(
-                "Target wanted to write to file handle {other}, but probe-rs does not support this operation yet. Continuing...",
-            ),
-        }
-
-        Ok(None)
-    }
-}
-
-fn read_written_string(core: &mut Core<'_>, request: WriteRequest) -> anyhow::Result<String> {
-    let bytes = request.read(core)?;
-    let str = String::from_utf8_lossy(&bytes);
-    request.write_status(core, 0)?;
-    Ok(str.to_string())
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
@@ -330,6 +330,10 @@ impl<F: FnMut(SemihostingEvent)> ListEventHandler<F> {
                     .handle(other, core, &mut self.sender)?;
                 Ok(None)
             }
+            SemihostingCommand::Time(request) => {
+                request.write_current_time(core)?;
+                Ok(None)
+            }
             SemihostingCommand::Errno(_) => Ok(None),
             other => anyhow::bail!(
                 "Unexpected semihosting command {:?} cmdline_requested: {:?}",
@@ -406,6 +410,10 @@ impl<F: FnMut(SemihostingEvent)> RunEventHandler<F> {
             other if SemihostingFileManager::can_handle(other) => {
                 self.semihosting_file_manager
                     .handle(other, core, &mut self.sender)?;
+                Ok(None)
+            }
+            SemihostingCommand::Time(request) => {
+                request.write_current_time(core)?;
                 Ok(None)
             }
             SemihostingCommand::Errno(_) => Ok(None),

--- a/probe-rs-tools/src/bin/probe-rs/rpc/utils.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/utils.rs
@@ -1,1 +1,2 @@
 pub mod run_loop;
+pub mod semihosting_file_manager;

--- a/probe-rs-tools/src/bin/probe-rs/rpc/utils/semihosting_file_manager.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/utils/semihosting_file_manager.rs
@@ -1,0 +1,157 @@
+use crate::rpc::functions::monitor::SemihostingEvent;
+use probe_rs::{
+    Core,
+    semihosting::{CloseRequest, OpenRequest, SemihostingCommand, WriteRequest},
+};
+use std::num::NonZeroU32;
+
+enum FileHandle {
+    Stdout,
+    Stderr,
+}
+
+pub struct SemihostingFileManager {
+    file_handles: Vec<Option<FileHandle>>,
+}
+
+impl SemihostingFileManager {
+    pub fn new() -> Self {
+        Self {
+            file_handles: vec![],
+        }
+    }
+
+    pub fn can_handle(other: SemihostingCommand) -> bool {
+        matches!(
+            other,
+            SemihostingCommand::Open(_)
+                | SemihostingCommand::Close(_)
+                | SemihostingCommand::WriteConsole(_)
+                | SemihostingCommand::Write(_)
+        )
+    }
+
+    pub fn handle(
+        &mut self,
+        command: SemihostingCommand,
+        core: &mut Core<'_>,
+        send: &mut impl FnMut(SemihostingEvent),
+    ) -> anyhow::Result<()> {
+        let mut send_output = |stream: &str, data: String| {
+            send(SemihostingEvent::Output {
+                stream: stream.into(),
+                data,
+            });
+        };
+
+        match command {
+            SemihostingCommand::Open(request) => self.handle_open(core, request),
+            SemihostingCommand::Close(request) => self.handle_close(core, request),
+            SemihostingCommand::Write(request) => self.handle_write(core, request, send_output),
+            SemihostingCommand::WriteConsole(request) => {
+                send_output("stdout", request.read(core)?);
+                Ok(())
+            }
+
+            _ => Ok(()),
+        }
+    }
+
+    fn open_tt(&self, mode: &str) -> Option<FileHandle> {
+        match mode.as_bytes()[0] {
+            b'w' => Some(FileHandle::Stdout),
+            b'a' => Some(FileHandle::Stderr),
+            mode => {
+                tracing::warn!(
+                    "Target wanted to open file :tt with mode {mode}, \
+                    but probe-rs does not support this operation yet. Continuing..."
+                );
+                None
+            }
+        }
+    }
+
+    fn handle_open(&mut self, core: &mut Core<'_>, request: OpenRequest) -> anyhow::Result<()> {
+        let path = request.path(core)?;
+
+        let f = if path == ":tt" {
+            self.open_tt(request.mode())
+        } else {
+            None
+        };
+
+        if let Some(f) = f {
+            self.file_handles.push(Some(f));
+            request.respond_with_handle(
+                core,
+                NonZeroU32::new(self.file_handles.len() as u32).unwrap(),
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn handle_close(&mut self, core: &mut Core<'_>, request: CloseRequest) -> anyhow::Result<()> {
+        let handle = request.file_handle();
+        if self.take_file_handle(handle).is_some() {
+            self.trim_file_handles();
+            request.success(core)?;
+        } else {
+            tracing::warn!("Target wanted to close invalid file handle {handle}. Continuing...");
+        }
+
+        Ok(())
+    }
+
+    fn handle_write(
+        &mut self,
+        core: &mut Core<'_>,
+        request: WriteRequest,
+        mut send_output: impl FnMut(&str, String),
+    ) -> anyhow::Result<()> {
+        let Some(f) = self.get_file_handle("write to", request.file_handle()) else {
+            return Ok(());
+        };
+
+        let buf = request.read(core)?;
+        let len = match f {
+            FileHandle::Stdout => {
+                send_output("stdout", String::from_utf8_lossy(&buf).into());
+                Some(buf.len())
+            }
+            FileHandle::Stderr => {
+                send_output("stderr", String::from_utf8_lossy(&buf).into());
+                Some(buf.len())
+            }
+        };
+        if let Some(len) = len {
+            request.write_status(core, (buf.len() - len) as i32)?;
+        }
+
+        Ok(())
+    }
+
+    fn get_file_handle_entry(&mut self, handle: u32) -> Option<&mut Option<FileHandle>> {
+        self.file_handles.get_mut(handle as usize - 1)
+    }
+
+    fn take_file_handle(&mut self, handle: u32) -> Option<FileHandle> {
+        self.get_file_handle_entry(handle)
+            .and_then(|inner| inner.take())
+    }
+
+    fn get_file_handle(&mut self, action: &'static str, handle: u32) -> Option<&mut FileHandle> {
+        let Some(Some(file_handle)) = self.get_file_handle_entry(handle) else {
+            tracing::warn!("Target wanted to {action} invalid file handle {handle}. Continuing...");
+            return None;
+        };
+
+        Some(file_handle)
+    }
+
+    fn trim_file_handles(&mut self) {
+        while let Some(None) = self.file_handles.last() {
+            self.file_handles.pop();
+        }
+    }
+}


### PR DESCRIPTION
This makes all function of the the [`semihosting` crate](https://docs.rs/semihosting/) work with `probe-rs`.

The function needs enabled by setting the `PROBE_RS_SEMIHOSTING_ALLOW_FILE_ACCESS` environment variable, to avoid giving the target to much power over the host. Maybe there is a better way to achieve this or we don't want it at all. It only affects the last commit.