### PR TITLE
rp2040: read back value of rescue dp after writing it

### DIFF
--- a/probe-rs/src/vendor/raspberrypi/sequences/rp2040.rs
+++ b/probe-rs/src/vendor/raspberrypi/sequences/rp2040.rs
@@ -22,12 +22,6 @@ const RESCUE_DP: DpAddress = DpAddress::Multidrop(0xf100_2927);
 // specify the core 1 DP address.
 const CORE_1_DP: DpAddress = DpAddress::Multidrop(0x1100_2927);
 
-/// An empty struct that implements the default [ArmDebugSequence] methods
-/// to allow us to call default implementations from our derived function.
-#[derive(Debug)]
-struct DefaultArmDebugSequence;
-impl ArmDebugSequence for DefaultArmDebugSequence {}
-
 /// Debug implementation for RP2040
 #[derive(Debug)]
 pub struct Rp2040 {}
@@ -40,26 +34,6 @@ impl Rp2040 {
 }
 
 impl ArmDebugSequence for Rp2040 {
-    fn debug_port_setup(
-        &self,
-        interface: &mut dyn crate::architecture::arm::communication_interface::DapProbe,
-        dp: DpAddress,
-    ) -> Result<(), ArmError> {
-        // Before we set up the requested DP, start and then stop the Default DP.
-        // This works around an issue where the multidrop DP becomes unavailable.
-        if DefaultArmDebugSequence
-            .debug_port_setup(interface, DpAddress::Default)
-            .is_err()
-        {
-            tracing::error!("Unable to connect to default address");
-        }
-        self.debug_port_stop(interface, DpAddress::Default)?;
-
-        // Delegate actual debug port setup to the default implementation.
-        DefaultArmDebugSequence.debug_port_setup(interface, dp)?;
-        Ok(())
-    }
-
     fn reset_system(
         &self,
         core: &mut dyn ArmMemoryInterface,
@@ -99,6 +73,9 @@ impl ArmDebugSequence for Rp2040 {
         tracing::trace!(
             "Existing values core0: {existing_core_0:08x}  core1: {existing_core_1:08x}"
         );
+        // We need to read the value back to work around an issue where the WCH-Link probe
+        // stops working otherwise (#3480).
+        let _val = arm_interface.read_raw_dp_register(RESCUE_DP, Ctrl::ADDRESS)?;
 
         // The debug port is reset as well. Set it up again by sending the attention sequence again
         let dap_probe = arm_interface.try_dap_probe_mut().unwrap();


### PR DESCRIPTION
Read back the value of the RESCUE_DP after writing it. This works around an issue on WCH-Link probes where not doing this causes the probe to lock up.

Additionally, it was discovered that the `debug_port_setup()` implementation was breaking things on this probe. The comment said "This works around an issue where the multidrop DP becomes unavailable.", however it didn't say what the issues were. If the problem resurfaces, this code will be brought back and the comment will be updated with the actual issue it solves.

Closes #3480.