### PR TITLE
Add `--semihosting-file` command line option

### DIFF
--- a/changelog/added-semihosting-file-option.md
+++ b/changelog/added-semihosting-file-option.md
@@ -1,0 +1,1 @@
+Added `--semihosting-file` command line option.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
@@ -2,7 +2,7 @@ use time::UtcOffset;
 
 use crate::rpc::client::RpcClient;
 use crate::rpc::functions::monitor::{MonitorMode, MonitorOptions};
-use crate::util::cli::{self, connect_target_output_files, rtt_client};
+use crate::util::cli::{self, connect_target_output_files, parse_semihosting_options, rtt_client};
 
 #[derive(clap::Parser)]
 #[group(skip)]
@@ -32,6 +32,9 @@ impl Cmd {
         let mut target_output_files =
             connect_target_output_files(self.run.shared_options.target_output_file).await?;
 
+        let semihosting_options =
+            parse_semihosting_options(self.run.shared_options.semihosting_file)?;
+
         let client_handle = rtt_client.handle();
 
         cli::monitor(
@@ -43,6 +46,7 @@ impl Cmd {
                 catch_reset: !self.run.run_options.no_catch_reset,
                 catch_hardfault: !self.run.run_options.no_catch_hardfault,
                 rtt_client: Some(client_handle),
+                semihosting_options,
             },
             self.run.shared_options.always_print_stacktrace,
             &mut target_output_files,

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -60,6 +60,7 @@ use crate::{
             test::{ListTestsRequest, RunTestRequest, Test, TestResult, Tests},
         },
         transport::memory::{PostcardReceiver, PostcardSender, WireRx, WireTx},
+        utils::semihosting::SemihostingOptions,
     },
     util::{
         cli::MonitorEvent,
@@ -531,6 +532,7 @@ impl SessionInterface {
         &self,
         boot_info: BootInfo,
         rtt_client: Option<Key<RttClient>>,
+        semihosting_options: SemihostingOptions,
         on_msg: impl AsyncFnMut(MonitorEvent),
     ) -> anyhow::Result<Tests> {
         self.client
@@ -539,6 +541,7 @@ impl SessionInterface {
                     sessid: self.sessid,
                     boot_info,
                     rtt_client,
+                    semihosting_options,
                 },
                 on_msg,
             )
@@ -549,6 +552,7 @@ impl SessionInterface {
         &self,
         test: Test,
         rtt_client: Option<Key<RttClient>>,
+        semihosting_options: SemihostingOptions,
         on_msg: impl AsyncFnMut(MonitorEvent),
     ) -> anyhow::Result<TestResult> {
         self.client
@@ -557,6 +561,7 @@ impl SessionInterface {
                     sessid: self.sessid,
                     test,
                     rtt_client,
+                    semihosting_options,
                 },
                 on_msg,
             )

--- a/probe-rs-tools/src/bin/probe-rs/rpc/utils.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/utils.rs
@@ -1,2 +1,2 @@
 pub mod run_loop;
-pub mod semihosting_file_manager;
+pub mod semihosting;

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -15,6 +15,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::cmd::run::EmbeddedTestElfInfo;
 use crate::rpc::functions::monitor::MonitorExitReason;
+use crate::rpc::utils::semihosting::SemihostingOptions;
 use crate::{
     FormatOptions,
     rpc::{
@@ -243,6 +244,35 @@ pub(crate) async fn connect_target_output_files(
         map.insert(key, value);
     }
     Ok(map)
+}
+
+pub(crate) fn parse_semihosting_options(arg: Vec<String>) -> anyhow::Result<SemihostingOptions> {
+    let mut options = SemihostingOptions::new();
+    for component in arg {
+        let parts: Vec<&str> = component.splitn(2, "=").collect();
+        match parts[..] {
+            // Tolerating empty entries in particular makes a trailing comma tolerated.
+            [] => continue,
+            [single] => {
+                if single.ends_with('/') {
+                    options.add_file_prefix(single.into(), single.into())?;
+                } else {
+                    options.add_file(single.into(), single.into())?;
+                }
+            }
+            [first, second] => {
+                if first.starts_with('^') && first.ends_with('$') {
+                    options.add_file_regex(first.into(), second.into())?;
+                } else if first.ends_with('/') {
+                    options.add_file_prefix(first.into(), second.into())?;
+                } else {
+                    options.add_file(first.into(), second.into())?;
+                }
+            }
+            _ => unreachable!("splitn produces at most 2 items."),
+        }
+    }
+    Ok(options)
 }
 
 pub async fn rtt_client(
@@ -517,6 +547,7 @@ pub async fn test(
     path: &Path,
     mut rtt_client: Option<CliRttClient>,
     target_output_files: &mut TargetOutputFiles,
+    semihosting_options: SemihostingOptions,
 ) -> anyhow::Result<()> {
     tracing::info!("libtest args {:?}", libtest_args);
     let token = CancellationToken::new();
@@ -528,7 +559,12 @@ pub async fn test(
         let tests = if elf_info.version == 0 {
             // In embedded test < 0.7, we have to query the tests from the target via semihosting
             session
-                .list_tests(boot_info, rtt_handle, async |msg| sender.send(msg).unwrap())
+                .list_tests(
+                    boot_info,
+                    rtt_handle,
+                    semihosting_options.clone(),
+                    async |msg| sender.send(msg).unwrap(),
+                )
                 .await?
                 .tests
         } else {
@@ -542,7 +578,17 @@ pub async fn test(
 
         let tests = tests
             .into_iter()
-            .map(|test| create_trial(session, path, rtt_handle, sender.clone(), &token, test))
+            .map(|test| {
+                create_trial(
+                    session,
+                    path,
+                    rtt_handle,
+                    semihosting_options.clone(),
+                    sender.clone(),
+                    &token,
+                    test,
+                )
+            })
             .collect::<Vec<_>>();
 
         tokio::task::spawn_blocking(move || {
@@ -586,6 +632,7 @@ fn create_trial(
     session: &SessionInterface,
     path: &Path,
     rtt_client: Option<Key<RttClient>>,
+    semihosting_options: SemihostingOptions,
     sender: UnboundedSender<MonitorEvent>,
     token: &CancellationToken,
     test: Test,
@@ -606,7 +653,9 @@ fn create_trial(
 
             let handle = tokio::spawn(async move {
                 match session
-                    .run_test(test, rtt_client, async move |msg| sender.send(msg).unwrap())
+                    .run_test(test, rtt_client, semihosting_options, async move |msg| {
+                        sender.send(msg).unwrap()
+                    })
                     .await
                 {
                     Ok(TestResult::Success) => Ok(()),


### PR DESCRIPTION
@bugadani This is the follow up to https://github.com/probe-rs/probe-rs/pull/3527 that replaces the environment variable with proper command line options.