### PR TITLE
Allow to control timestamps for RTT channels using String format

### DIFF
--- a/changelog/added-option-no-timestamps.md
+++ b/changelog/added-option-no-timestamps.md
@@ -1,0 +1,1 @@
+Added option `--no-timestamps` to `probe-rs run` and `probe-rs attach` commands to suppress timestamps of String and Defmt messages.

--- a/changelog/fixed-show-timestamps-string.md
+++ b/changelog/fixed-show-timestamps-string.md
@@ -1,0 +1,1 @@
+Fixed an issue where the show_timestamps property for RTT channels was ignored when using the String format in both the DAP server and `cargo embed`.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
@@ -24,6 +24,7 @@ impl Cmd {
                 false => crate::rpc::functions::rtt_client::ScanRegion::Ranges(vec![]),
             },
             self.run.shared_options.log_format,
+            !self.run.shared_options.no_timestamps,
             !self.run.shared_options.no_location,
             Some(utc_offset),
         )

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -107,6 +107,9 @@ impl App {
                 DataFormat::String => RttDecoder::String {
                     timestamp_offset: Some(timestamp_offset),
                     last_line_done: false,
+                    show_timestamps: channel_config
+                        .show_timestamps
+                        .unwrap_or(default_channel_config.show_timestamps),
                 },
                 DataFormat::BinaryLE => RttDecoder::BinaryLE,
                 DataFormat::Defmt if defmt_data.is_none() => {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -240,6 +240,7 @@ impl CoreHandle<'_> {
                 DataFormat::String => RttDecoder::String {
                     timestamp_offset: Some(timestamp_offset),
                     last_line_done: false,
+                    show_timestamps,
                 },
                 DataFormat::BinaryLE => RttDecoder::BinaryLE,
                 DataFormat::Defmt => {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -153,6 +153,10 @@ pub struct SharedOptions {
     #[clap(long)]
     pub(crate) no_location: bool,
 
+    /// Suppress timestamps from the rtt log
+    #[clap(long)]
+    pub(crate) no_timestamps: bool,
+
     #[clap(flatten)]
     pub(crate) format_options: FormatOptions,
 
@@ -193,6 +197,7 @@ impl Cmd {
                 false => crate::rpc::functions::rtt_client::ScanRegion::Ranges(vec![]),
             },
             self.shared_options.log_format,
+            !self.shared_options.no_timestamps,
             !self.shared_options.no_location,
             Some(utc_offset),
         )

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -250,6 +250,7 @@ pub async fn rtt_client(
     path: &Path,
     mut scan_regions: ScanRegion,
     log_format: Option<String>,
+    show_timestamps: bool,
     show_location: bool,
     timestamp_offset: Option<UtcOffset>,
 ) -> anyhow::Result<CliRttClient> {
@@ -284,6 +285,7 @@ pub async fn rtt_client(
     Ok(CliRttClient {
         handle: rtt_client.handle,
         timestamp_offset,
+        show_timestamps,
         show_location,
         channel_processors: vec![],
         defmt_data,
@@ -684,6 +686,7 @@ pub struct CliRttClient {
 
     // Data necessary to create the channel processors once we know the channel names.
     log_format: Option<String>,
+    show_timestamps: bool,
     show_location: bool,
     timestamp_offset: Option<UtcOffset>,
     defmt_data: Option<DefmtState>,
@@ -708,7 +711,7 @@ impl CliRttClient {
                         RttDecoder::Defmt {
                             processor: DefmtProcessor::new(
                                 defmt_data,
-                                self.timestamp_offset.is_some(),
+                                self.show_timestamps,
                                 self.show_location,
                                 self.log_format.as_deref(),
                             ),
@@ -721,6 +724,7 @@ impl CliRttClient {
                     RttDecoder::String {
                         timestamp_offset: self.timestamp_offset,
                         last_line_done: false,
+                        show_timestamps: self.show_timestamps,
                     }
                 };
 


### PR DESCRIPTION
Fixes an issue where the show_timestamps property for RTT channels was ignored when using the String format in both the DAP server and `cargo embed`.

Adds an option `--no-timestamps` to `probe-rs run` and `probe-rs attach` commands to suppress timestamps of String and Defmt messages.