### PR TITLE
Fix unwinding on thumb targets for functions that never return

### DIFF
--- a/changelog/fixed-thumb-unwinding.md
+++ b/changelog/fixed-thumb-unwinding.md
@@ -1,0 +1,1 @@
+Fix unwinding on thumb targets for functions that never return

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -1351,8 +1351,9 @@ fn unwind_program_counter_register(
                     //
                     // We have to clear the last bit to ensure the PC is half-word aligned. (on ARM architecture,
                     // when in Thumb state for certain instruction types will set the LSB to 1)
-                    *register_rule_string = "PC=(unwound LR & !0b1) (dwarf Undefined)".to_string();
-                    Some(RegisterValue::U32(return_address & !0b1))
+                    *register_rule_string =
+                        "PC=(unwound (LR - 2) & !0b1) (dwarf Undefined)".to_string();
+                    Some(RegisterValue::U32((return_address - 2) & !0b1))
                 }
                 Some(InstructionSet::RV32C) => {
                     *register_rule_string = "PC=(unwound x1 - 2) (dwarf Undefined)".to_string();

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -1709,7 +1709,7 @@ mod test {
             "__cortex_m_rt_SVCall_trampoline".to_string()
         );
 
-        assert_eq!(frames[1].pc, RegisterValue::U32(0x0000018A)); // <-- This is the instruction *after* the jump into the topmost frame.
+        assert_eq!(frames[1].pc, RegisterValue::U32(0x00000188)); // <-- This is the instruction for the jump into the topmost frame.
 
         // The PC value in the exception data
         // depends on the exception type, and for some exceptions, it will

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_full_unwind.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_full_unwind.snap
@@ -391,7 +391,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268465166
+        U32: 268465164
     - core_register:
         id: 17
         roles:
@@ -430,7 +430,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268465166
+    U32: 268465164
   frame_base: 536883320
   is_inlined: false
   local_variables:
@@ -616,7 +616,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268465166
+        U32: 268465164
     - core_register:
         id: 17
         roles:
@@ -655,7 +655,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268465166
+    U32: 268465164
   frame_base: 536883464
   is_inlined: false
   local_variables:
@@ -841,7 +841,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268465166
+        U32: 268465164
     - core_register:
         id: 17
         roles:
@@ -880,7 +880,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268465166
+    U32: 268465164
   frame_base: 536883608
   is_inlined: false
   local_variables:
@@ -1066,7 +1066,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268465166
+        U32: 268465164
     - core_register:
         id: 17
         roles:
@@ -1105,7 +1105,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268465166
+    U32: 268465164
   frame_base: 536883752
   is_inlined: false
   local_variables:
@@ -1291,7 +1291,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268465166
+        U32: 268465164
     - core_register:
         id: 17
         roles:
@@ -1330,7 +1330,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268465166
+    U32: 268465164
   frame_base: 536883896
   is_inlined: false
   local_variables:
@@ -1516,7 +1516,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268464920
+        U32: 268464918
     - core_register:
         id: 17
         roles:
@@ -1555,7 +1555,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268464920
+    U32: 268464918
   frame_base: 536886960
   is_inlined: false
   local_variables:
@@ -4654,7 +4654,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268436110
+        U32: 268436108
     - core_register:
         id: 17
         roles:
@@ -4693,7 +4693,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268436110
+    U32: 268436108
   frame_base: 536887280
   is_inlined: false
   local_variables:
@@ -5307,12 +5307,13 @@ expression: stack_frames
                         Base: u32
                       value: "46875"
   canonical_frame_address: 536887288
-- function_name: __cortex_m_rt_main
+- function_name: "__cortex_m_rt_main_trampoline : ERROR: UNWIND: Failed to read value for register R14/LR from address 0x0000000020003ffc (4 bytes): The coredump does not include the memory for address 0x20003ffc of size 0x4"
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
-    line: 22
-    column: LeftEdge
-    address: 268435972
+    line: 21
+    column:
+      Column: 1
+    address: 268435968
   registers:
     - core_register:
         id: 0
@@ -5462,7 +5463,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268435972
+        U32: 268435970
     - core_register:
         id: 17
         roles:
@@ -5501,7 +5502,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268435972
+    U32: 268435970
   frame_base: 536887288
   is_inlined: false
   local_variables:
@@ -5509,4 +5510,4 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-  canonical_frame_address: 536887288
+  canonical_frame_address: 536887296

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_svcall.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_svcall.snap
@@ -431,8 +431,8 @@ expression: stack_frames
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
     line: 114
     column:
-      Column: 13
-    address: 268437110
+      Column: 1
+    address: 268437106
   registers:
     - core_register:
         id: 0
@@ -582,7 +582,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268437110
+        U32: 268437108
     - core_register:
         id: 17
         roles:
@@ -621,7 +621,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268437110
+    U32: 268437108
   frame_base: 536886920
   is_inlined: false
   local_variables:
@@ -1040,10 +1040,10 @@ expression: stack_frames
 - function_name: __cortex_m_rt_main
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
-    line: 55
+    line: 52
     column:
-      Column: 54
-    address: 268436890
+      Column: 5
+    address: 268436886
   registers:
     - core_register:
         id: 0
@@ -1193,7 +1193,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268436890
+        U32: 268436888
     - core_register:
         id: 17
         roles:
@@ -1232,7 +1232,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268436890
+    U32: 268436888
   frame_base: 536887280
   is_inlined: false
   local_variables:
@@ -1846,12 +1846,13 @@ expression: stack_frames
                         Base: u32
                       value: "46875"
   canonical_frame_address: 536887288
-- function_name: __cortex_m_rt_main
+- function_name: "__cortex_m_rt_main_trampoline : ERROR: UNWIND: Failed to read value for register R14/LR from address 0x0000000020003ffc (4 bytes): The coredump does not include the memory for address 0x20003ffc of size 0x4"
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
-    line: 22
-    column: LeftEdge
-    address: 268436752
+    line: 21
+    column:
+      Column: 1
+    address: 268436748
   registers:
     - core_register:
         id: 0
@@ -2001,7 +2002,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268436752
+        U32: 268436750
     - core_register:
         id: 17
         roles:
@@ -2040,7 +2041,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268436752
+    U32: 268436750
   frame_base: 536887288
   is_inlined: false
   local_variables:
@@ -2048,4 +2049,4 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-  canonical_frame_address: 536887288
+  canonical_frame_address: 536887296

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_systick.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_systick.snap
@@ -431,8 +431,8 @@ expression: stack_frames
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
     line: 97
     column:
-      Column: 13
-    address: 268436672
+      Column: 1
+    address: 268436668
   registers:
     - core_register:
         id: 0
@@ -582,7 +582,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268436672
+        U32: 268436670
     - core_register:
         id: 17
         roles:
@@ -621,7 +621,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268436672
+    U32: 268436670
   frame_base: 536886880
   is_inlined: false
   local_variables:
@@ -1423,7 +1423,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268436312
+        U32: 268436310
     - core_register:
         id: 17
         roles:
@@ -1462,7 +1462,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268436312
+    U32: 268436310
   frame_base: 536886960
   is_inlined: false
   local_variables:
@@ -1656,10 +1656,10 @@ expression: stack_frames
 - function_name: __cortex_m_rt_main
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
-    line: 55
+    line: 43
     column:
-      Column: 54
-    address: 268436470
+      Column: 5
+    address: 268436466
   registers:
     - core_register:
         id: 0
@@ -1809,7 +1809,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268436470
+        U32: 268436468
     - core_register:
         id: 17
         roles:
@@ -1848,7 +1848,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268436470
+    U32: 268436468
   frame_base: 536887280
   is_inlined: false
   local_variables:
@@ -2462,12 +2462,13 @@ expression: stack_frames
                         Base: u32
                       value: "46875"
   canonical_frame_address: 536887288
-- function_name: __cortex_m_rt_main
+- function_name: "__cortex_m_rt_main_trampoline : ERROR: UNWIND: Failed to read value for register R14/LR from address 0x0000000020003ffc (4 bytes): The coredump does not include the memory for address 0x20003ffc of size 0x4"
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/RP2040.rs
-    line: 22
-    column: LeftEdge
-    address: 268436332
+    line: 21
+    column:
+      Column: 1
+    address: 268436328
   registers:
     - core_register:
         id: 0
@@ -2617,7 +2618,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 268436332
+        U32: 268436330
     - core_register:
         id: 17
         roles:
@@ -2656,7 +2657,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 268436332
+    U32: 268436330
   frame_base: 536887288
   is_inlined: false
   local_variables:
@@ -2664,4 +2665,4 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-  canonical_frame_address: 536887288
+  canonical_frame_address: 536887296

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__atsamd51p19a.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__atsamd51p19a.snap
@@ -252,10 +252,10 @@ expression: stack_frames
 - function_name: print_pointers
   source_location:
     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
-    line: 94
+    line: 93
     column:
-      Column: 1
-    address: 5340
+      Column: 5
+    address: 5336
   registers:
     - core_register:
         id: 0
@@ -405,7 +405,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 5340
+        U32: 5338
     - core_register:
         id: 17
         roles:
@@ -444,7 +444,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 5340
+    U32: 5338
   frame_base: 536875104
   is_inlined: false
   local_variables:
@@ -481,10 +481,10 @@ expression: stack_frames
 - function_name: main
   source_location:
     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\main.c"
-    line: 111
+    line: 110
     column:
       Column: 9
-    address: 5434
+    address: 5430
   registers:
     - core_register:
         id: 0
@@ -634,7 +634,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 5434
+        U32: 5432
     - core_register:
         id: 17
         roles:
@@ -673,7 +673,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 5434
+    U32: 5432
   frame_base: 536875112
   is_inlined: false
   local_variables:
@@ -705,10 +705,10 @@ expression: stack_frames
 - function_name: Reset_Handler
   source_location:
     path: "C:\\_Hobby\\probe-rs-test-c-firmware\\Atmel\\Device_Startup\\startup_samd51.c"
-    line: 536
+    line: 533
     column:
-      Column: 15
-    address: 2426
+      Column: 9
+    address: 2422
   registers:
     - core_register:
         id: 0
@@ -858,7 +858,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 2426
+        U32: 2424
     - core_register:
         id: 17
         roles:
@@ -897,7 +897,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 2426
+    U32: 2424
   frame_base: 536875128
   is_inlined: false
   local_variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_full_unwind.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_full_unwind.snap
@@ -391,7 +391,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 6150
+        U32: 6148
     - core_register:
         id: 17
         roles:
@@ -430,7 +430,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 6150
+    U32: 6148
   frame_base: 536883608
   is_inlined: false
   local_variables:
@@ -616,7 +616,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 6150
+        U32: 6148
     - core_register:
         id: 17
         roles:
@@ -655,7 +655,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 6150
+    U32: 6148
   frame_base: 536883752
   is_inlined: false
   local_variables:
@@ -841,7 +841,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 6150
+        U32: 6148
     - core_register:
         id: 17
         roles:
@@ -880,7 +880,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 6150
+    U32: 6148
   frame_base: 536883896
   is_inlined: false
   local_variables:
@@ -1066,7 +1066,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 6150
+        U32: 6148
     - core_register:
         id: 17
         roles:
@@ -1105,7 +1105,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 6150
+    U32: 6148
   frame_base: 536884040
   is_inlined: false
   local_variables:
@@ -1291,7 +1291,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 6150
+        U32: 6148
     - core_register:
         id: 17
         roles:
@@ -1330,7 +1330,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 6150
+    U32: 6148
   frame_base: 536884184
   is_inlined: false
   local_variables:
@@ -1516,7 +1516,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 5990
+        U32: 5988
     - core_register:
         id: 17
         roles:
@@ -1555,7 +1555,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 5990
+    U32: 5988
   frame_base: 536887128
   is_inlined: false
   local_variables:
@@ -4503,8 +4503,8 @@ expression: stack_frames
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 38
     column:
-      Column: 10
-    address: 766
+      Column: 54
+    address: 762
   registers:
     - core_register:
         id: 0
@@ -4655,7 +4655,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 766
+        U32: 764
     - core_register:
         id: 17
         roles:
@@ -4694,7 +4694,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 766
+    U32: 764
   frame_base: 536887280
   is_inlined: false
   local_variables:
@@ -5177,12 +5177,13 @@ expression: stack_frames
                 Struct: CLOCK
               value: CLOCK @ 0x20003F76
   canonical_frame_address: 536887288
-- function_name: __cortex_m_rt_main
+- function_name: "__cortex_m_rt_main_trampoline : ERROR: UNWIND: Failed to read value for register R14/LR from address 0x0000000020003ffc (4 bytes): The coredump does not include the memory for address 0x20003ffc of size 0x4"
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
-    line: 19
-    column: LeftEdge
-    address: 688
+    line: 18
+    column:
+      Column: 1
+    address: 684
   registers:
     - core_register:
         id: 0
@@ -5332,7 +5333,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 688
+        U32: 686
     - core_register:
         id: 17
         roles:
@@ -5371,7 +5372,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 688
+    U32: 686
   frame_base: 536887288
   is_inlined: false
   local_variables:
@@ -5379,4 +5380,4 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-  canonical_frame_address: 536887288
+  canonical_frame_address: 536887296

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_from_busfault.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_from_busfault.snap
@@ -853,10 +853,10 @@ expression: stack_frames
 - function_name: trigger_hardfault_from_busfault
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
-    line: 51
+    line: 49
     column:
-      Column: 2
-    address: 360
+      Column: 9
+    address: 356
   registers:
     - core_register:
         id: 0
@@ -1006,7 +1006,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 360
+        U32: 358
     - core_register:
         id: 17
         roles:
@@ -1045,7 +1045,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 360
+    U32: 358
   frame_base: 536887128
   is_inlined: false
   local_variables:
@@ -1057,10 +1057,10 @@ expression: stack_frames
 - function_name: __cortex_m_rt_main
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
-    line: 38
+    line: 32
     column:
-      Column: 54
-    address: 448
+      Column: 5
+    address: 444
   registers:
     - core_register:
         id: 0
@@ -1210,7 +1210,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 448
+        U32: 446
     - core_register:
         id: 17
         roles:
@@ -1249,7 +1249,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 448
+    U32: 446
   frame_base: 536887280
   is_inlined: false
   local_variables:
@@ -1732,12 +1732,13 @@ expression: stack_frames
                 Struct: CLOCK
               value: CLOCK @ 0x20003F76
   canonical_frame_address: 536887288
-- function_name: __cortex_m_rt_main
+- function_name: "__cortex_m_rt_main_trampoline : ERROR: UNWIND: Failed to read value for register R14/LR from address 0x0000000020003ffc (4 bytes): The coredump does not include the memory for address 0x20003ffc of size 0x4"
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
-    line: 19
-    column: LeftEdge
-    address: 370
+    line: 18
+    column:
+      Column: 1
+    address: 366
   registers:
     - core_register:
         id: 0
@@ -1887,7 +1888,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 370
+        U32: 368
     - core_register:
         id: 17
         roles:
@@ -1926,7 +1927,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 370
+    U32: 368
   frame_base: 536887288
   is_inlined: false
   local_variables:
@@ -1934,4 +1935,4 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-  canonical_frame_address: 536887288
+  canonical_frame_address: 536887296

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
@@ -1041,12 +1041,13 @@ expression: stack_frames
       type_name: Unknown
       value: "<unknown>"
   canonical_frame_address: 536887128
-- function_name: __cortex_m_rt_main_trampoline
+- function_name: "trigger_hardfault_from_usagefault : ERROR: UNWIND: Failed to read value for register R14/LR from address 0x0000000020003f5c (4 bytes): The coredump does not include the memory for address 0x20003f5c of size 0x4"
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
-    line: 18
-    column: LeftEdge
-    address: 390
+    line: 55
+    column:
+      Column: 5
+    address: 386
   registers:
     - core_register:
         id: 0
@@ -1196,7 +1197,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 390
+        U32: 388
     - core_register:
         id: 17
         roles:
@@ -1235,7 +1236,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 390
+    U32: 388
   frame_base: 536887128
   is_inlined: false
   local_variables:
@@ -1243,4 +1244,4 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-  canonical_frame_address: 536887128
+  canonical_frame_address: 536887136

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
@@ -853,10 +853,10 @@ expression: stack_frames
 - function_name: trigger_hardfault_from_busfault
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
-    line: 51
+    line: 49
     column:
-      Column: 2
-    address: 588
+      Column: 9
+    address: 584
   registers:
     - core_register:
         id: 0
@@ -1007,7 +1007,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 588
+        U32: 586
     - core_register:
         id: 17
         roles:
@@ -1046,7 +1046,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 588
+    U32: 586
   frame_base: 536887032
   is_inlined: false
   local_variables:
@@ -1055,217 +1055,13 @@ expression: stack_frames
       type_name: Unknown
       value: "<unknown>"
   canonical_frame_address: 536887040
-- function_name: software_breakpoint
-  source_location:
-    path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/lib.rs
-    line: 371
-    column:
-      Column: 9
-    address: 958
-  registers:
-    - core_register:
-        id: 0
-        roles:
-          - Core: R0
-          - Argument: a1
-          - Return: r1
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 0
-      value: ~
-    - core_register:
-        id: 1
-        roles:
-          - Core: R1
-          - Argument: a2
-          - Return: r2
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 1
-      value: ~
-    - core_register:
-        id: 2
-        roles:
-          - Core: R2
-          - Argument: a3
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 2
-      value: ~
-    - core_register:
-        id: 3
-        roles:
-          - Core: R3
-          - Argument: a4
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 3
-      value: ~
-    - core_register:
-        id: 4
-        roles:
-          - Core: R4
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 4
-      value:
-        U32: 1073741820
-    - core_register:
-        id: 5
-        roles:
-          - Core: R5
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 5
-      value:
-        U32: 1073741820
-    - core_register:
-        id: 6
-        roles:
-          - Core: R6
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 6
-      value:
-        U32: 2263
-    - core_register:
-        id: 7
-        roles:
-          - Core: R7
-          - FramePointer
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 7
-      value:
-        U32: 536887040
-    - core_register:
-        id: 8
-        roles:
-          - Core: R8
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 8
-      value:
-        U32: 2191
-    - core_register:
-        id: 9
-        roles:
-          - Core: R9
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 9
-      value: ~
-    - core_register:
-        id: 10
-        roles:
-          - Core: R10
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 10
-      value:
-        U32: 16777231
-    - core_register:
-        id: 11
-        roles:
-          - Core: R11
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 11
-      value:
-        U32: 3758153752
-    - core_register:
-        id: 12
-        roles:
-          - Core: R12
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 12
-      value:
-        U32: 0
-    - core_register:
-        id: 13
-        roles:
-          - Core: R13
-          - StackPointer
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 13
-      value:
-        U32: 536887040
-    - core_register:
-        id: 14
-        roles:
-          - Core: R14
-          - ReturnAddress
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 14
-      value:
-        U32: 959
-    - core_register:
-        id: 15
-        roles:
-          - Core: R15
-          - ProgramCounter
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 15
-      value:
-        U32: 958
-    - core_register:
-        id: 17
-        roles:
-          - Core: MSP
-          - MainStackPointer
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 16
-      value: ~
-    - core_register:
-        id: 18
-        roles:
-          - Core: PSP
-          - ProcessStackPointer
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 17
-      value: ~
-    - core_register:
-        id: 16
-        roles:
-          - Core: XPSR
-          - ProcessorStatus
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 18
-      value:
-        U32: 16777231
-    - core_register:
-        id: 20
-        roles:
-          - Core: EXTRA
-          - Other: EXTRA
-        data_type:
-          UnsignedInteger: 32
-      dwarf_id: 19
-      value: ~
-  pc:
-    U32: 958
-  frame_base: 536887040
-  is_inlined: true
-  local_variables:
-    Child Variables:
-      name: LocalScopeRoot
-      type_name: Unknown
-      value: "<unknown>"
-  canonical_frame_address: 536887048
 - function_name: __cortex_m_rt_SysTick
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
-    line: 84
+    line: 83
     column:
       Column: 5
-    address: 958
+    address: 954
   registers:
     - core_register:
         id: 0
@@ -1415,7 +1211,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 958
+        U32: 956
     - core_register:
         id: 17
         roles:
@@ -1454,7 +1250,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 958
+    U32: 956
   frame_base: 536887040
   is_inlined: false
   local_variables:
@@ -1468,8 +1264,8 @@ expression: stack_frames
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 80
     column:
-      Column: 13
-    address: 948
+      Column: 1
+    address: 944
   registers:
     - core_register:
         id: 0
@@ -1619,7 +1415,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 948
+        U32: 946
     - core_register:
         id: 17
         roles:
@@ -1658,7 +1454,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 948
+    U32: 946
   frame_base: 536887048
   is_inlined: false
   local_variables:
@@ -2470,7 +2266,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 664
+        U32: 662
     - core_register:
         id: 17
         roles:
@@ -2509,7 +2305,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 664
+    U32: 662
   frame_base: 536887128
   is_inlined: false
   local_variables:
@@ -2703,10 +2499,10 @@ expression: stack_frames
 - function_name: __cortex_m_rt_main
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
-    line: 32
+    line: 26
     column:
       Column: 5
-    address: 752
+    address: 748
   registers:
     - core_register:
         id: 0
@@ -2856,7 +2652,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 752
+        U32: 750
     - core_register:
         id: 17
         roles:
@@ -2895,7 +2691,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 752
+    U32: 750
   frame_base: 536887280
   is_inlined: false
   local_variables:
@@ -3378,12 +3174,13 @@ expression: stack_frames
                 Struct: CLOCK
               value: CLOCK @ 0x20003F76
   canonical_frame_address: 536887288
-- function_name: __cortex_m_rt_main
+- function_name: "__cortex_m_rt_main_trampoline : ERROR: UNWIND: Failed to read value for register R14/LR from address 0x0000000020003ffc (4 bytes): The coredump does not include the memory for address 0x20003ffc of size 0x4"
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
-    line: 19
-    column: LeftEdge
-    address: 674
+    line: 18
+    column:
+      Column: 1
+    address: 670
   registers:
     - core_register:
         id: 0
@@ -3533,7 +3330,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 674
+        U32: 672
     - core_register:
         id: 17
         roles:
@@ -3572,7 +3369,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 674
+    U32: 672
   frame_base: 536887288
   is_inlined: false
   local_variables:
@@ -3580,4 +3377,4 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-  canonical_frame_address: 536887288
+  canonical_frame_address: 536887296

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_svcall.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_svcall.snap
@@ -431,8 +431,8 @@ expression: stack_frames
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 97
     column:
-      Column: 13
-    address: 1236
+      Column: 1
+    address: 1232
   registers:
     - core_register:
         id: 0
@@ -582,7 +582,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 1236
+        U32: 1234
     - core_register:
         id: 17
         roles:
@@ -621,7 +621,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 1236
+    U32: 1234
   frame_base: 536887088
   is_inlined: false
   local_variables:
@@ -1040,10 +1040,10 @@ expression: stack_frames
 - function_name: __cortex_m_rt_main
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
-    line: 38
+    line: 35
     column:
-      Column: 54
-    address: 1026
+      Column: 5
+    address: 1022
   registers:
     - core_register:
         id: 0
@@ -1193,7 +1193,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 1026
+        U32: 1024
     - core_register:
         id: 17
         roles:
@@ -1232,7 +1232,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 1026
+    U32: 1024
   frame_base: 536887280
   is_inlined: false
   local_variables:
@@ -1715,12 +1715,13 @@ expression: stack_frames
                 Struct: CLOCK
               value: CLOCK @ 0x20003F76
   canonical_frame_address: 536887288
-- function_name: __cortex_m_rt_main
+- function_name: "__cortex_m_rt_main_trampoline : ERROR: UNWIND: Failed to read value for register R14/LR from address 0x0000000020003ffc (4 bytes): The coredump does not include the memory for address 0x20003ffc of size 0x4"
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
-    line: 19
-    column: LeftEdge
-    address: 948
+    line: 18
+    column:
+      Column: 1
+    address: 944
   registers:
     - core_register:
         id: 0
@@ -1870,7 +1871,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 948
+        U32: 946
     - core_register:
         id: 17
         roles:
@@ -1909,7 +1910,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 948
+    U32: 946
   frame_base: 536887288
   is_inlined: false
   local_variables:
@@ -1917,4 +1918,4 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-  canonical_frame_address: 536887288
+  canonical_frame_address: 536887296

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_systick.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_systick.snap
@@ -431,8 +431,8 @@ expression: stack_frames
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
     line: 80
     column:
-      Column: 13
-    address: 1260
+      Column: 1
+    address: 1256
   registers:
     - core_register:
         id: 0
@@ -582,7 +582,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 1260
+        U32: 1258
     - core_register:
         id: 17
         roles:
@@ -621,7 +621,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 1260
+    U32: 1258
   frame_base: 536887048
   is_inlined: false
   local_variables:
@@ -1433,7 +1433,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 980
+        U32: 978
     - core_register:
         id: 17
         roles:
@@ -1472,7 +1472,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 980
+    U32: 978
   frame_base: 536887128
   is_inlined: false
   local_variables:
@@ -1666,10 +1666,10 @@ expression: stack_frames
 - function_name: __cortex_m_rt_main
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
-    line: 38
+    line: 26
     column:
-      Column: 54
-    address: 1068
+      Column: 5
+    address: 1064
   registers:
     - core_register:
         id: 0
@@ -1819,7 +1819,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 1068
+        U32: 1066
     - core_register:
         id: 17
         roles:
@@ -1858,7 +1858,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 1068
+    U32: 1066
   frame_base: 536887280
   is_inlined: false
   local_variables:
@@ -2341,12 +2341,13 @@ expression: stack_frames
                 Struct: CLOCK
               value: CLOCK @ 0x20003F76
   canonical_frame_address: 536887288
-- function_name: __cortex_m_rt_main
+- function_name: "__cortex_m_rt_main_trampoline : ERROR: UNWIND: Failed to read value for register R14/LR from address 0x0000000020003ffc (4 bytes): The coredump does not include the memory for address 0x20003ffc of size 0x4"
   source_location:
     path: /Users/jacknoppe/dev/debug/probe-rs-debugger-test/src/bin/nRF52833_xxAA.rs
-    line: 19
-    column: LeftEdge
-    address: 990
+    line: 18
+    column:
+      Column: 1
+    address: 986
   registers:
     - core_register:
         id: 0
@@ -2496,7 +2497,7 @@ expression: stack_frames
           UnsignedInteger: 32
       dwarf_id: 15
       value:
-        U32: 990
+        U32: 988
     - core_register:
         id: 17
         roles:
@@ -2535,7 +2536,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U32: 990
+    U32: 988
   frame_base: 536887288
   is_inlined: false
   local_variables:
@@ -2543,4 +2544,4 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: "<unknown>"
-  canonical_frame_address: 536887288
+  canonical_frame_address: 536887296

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__print_stacktrace.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__print_stacktrace.snap
@@ -34,22 +34,22 @@ Frame:
  function:        delay_us<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
  source_location:
   path: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs
-  line: Some(325)
-  column: Some(Column(6))
+  line: Some(324)
+  column: Some(Column(9))
  frame_base:      Some(20003f88)
 Frame:
  function:        delay_ms<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
  source_location:
   path: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs
-  line: Some(298)
-  column: Some(Column(6))
+  line: Some(297)
+  column: Some(Column(9))
  frame_base:      Some(20003fa8)
 Frame:
  function:        delay_ms<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
  source_location:
   path: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs
-  line: Some(307)
-  column: Some(Column(6))
+  line: Some(306)
+  column: Some(Column(9))
  frame_base:      Some(20003fc0)
 Frame:
  function:        __cortex_m_rt_main
@@ -66,7 +66,7 @@ Frame:
   column: Some(Column(1))
  frame_base:      Some(20003ff8)
 Frame:
- function:        Reset @ 0x000000ce> : ERROR: UNWIND: Failed to read value for register R7/FP from address 0x0000000000000000 (4 bytes): The coredump does not include the memory for address 0x0 of size 0x4
+ function:        Reset @ 0x000000cc> : ERROR: UNWIND: Failed to read value for register R7/FP from address 0x0000000000000000 (4 bytes): The coredump does not include the memory for address 0x0 of size 0x4
  source_location:
 None
  frame_base:      None

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_in_exception_handler.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_in_exception_handler.snap
@@ -36,7 +36,12 @@ Frame:
   column: Some(Column(1))
  frame_base:      Some(2001fff8)
 Frame:
- function:        Reset @ 0x0000013c>
+ function:        Reset @ 0x0000013a>
+ source_location:
+None
+ frame_base:      None
+Frame:
+ function:        Reset @ 0x0000013a>
  source_location:
 None
  frame_base:      None

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_in_exception_trampoline.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_in_exception_trampoline.snap
@@ -29,7 +29,12 @@ Frame:
   column: Some(Column(1))
  frame_base:      Some(2001fff8)
 Frame:
- function:        Reset @ 0x0000013c>
+ function:        Reset @ 0x0000013a>
+ source_location:
+None
+ frame_base:      None
+Frame:
+ function:        Reset @ 0x0000013a>
  source_location:
 None
  frame_base:      None

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_inlined.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__unwinding_inlined.snap
@@ -52,7 +52,12 @@ Frame:
   column: Some(Column(1))
  frame_base:      Some(20003ff8)
 Frame:
- function:        Reset @ 0x0000013c>
+ function:        Reset @ 0x0000013a>
+ source_location:
+None
+ frame_base:      None
+Frame:
+ function:        Reset @ 0x0000013a>
  source_location:
 None
  frame_base:      None


### PR DESCRIPTION
By -2 of the LR, we get the address of the branch instruction, rather than the next instruction, which might not be part of the function (in particular for fns where the compiler has realised they will never return, the next instruction is [unreachable](https://www.nmichaels.org/musings/d4d4/d4d4/), and doesn't end up in the unwind info so unwinding gives up)

one example of a before/after
<img width="1083" height="300" alt="image" src="https://github.com/user-attachments/assets/fc10d400-c15c-403f-8e1c-782de4d7cbd9" />

<img width="1084" height="515" alt="image" src="https://github.com/user-attachments/assets/e3e71a4f-c181-4508-800d-64a1b6a09ada" />

unreachable instr in question
<img width="1203" height="158" alt="image" src="https://github.com/user-attachments/assets/5e47776f-1651-47c3-affb-a2c9d08f59dc" />

