### PR TITLE
Add v8m registers for correct exception unwinding

### DIFF
--- a/probe-rs-debug/src/exception_handling/armv8m.rs
+++ b/probe-rs-debug/src/exception_handling/armv8m.rs
@@ -404,6 +404,7 @@ impl ExceptionInterface for ArmV8MExceptionHandler {
                 exc_return.stack_pointer_selection(),
             );
 
+            // TODO: with no security extension, we should use the old SP_main and SP_process values.
             let sp_reg_id = match stack_info {
                 (false, false) => 0b00011000, // non-secure, main stack pointer
                 (false, true) => 0b00011001,  // non-secure, process stack pointer
@@ -431,6 +432,8 @@ impl ExceptionInterface for ArmV8MExceptionHandler {
 
         memory_interface.read_32(sp_value, &mut calling_stack_registers)?;
         let mut calling_frame_registers = stackframe_registers.clone();
+        // TODO: v8m has "Additional State Context" registers that may be stacked
+        // not handled yet. don't think they're needed for unwind
         for (i, register_role) in EXCEPTION_STACK_REGISTERS.iter().enumerate() {
             calling_frame_registers
                 .get_register_mut_by_role(register_role)?

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -3,6 +3,10 @@
 use super::{
     CortexMState, Dfsr,
     cortex_m::{IdPfr1, Mvfr0},
+    registers::armv8m::{
+        V8M_BASE_SEC_FP_REGISTERS, V8M_BASE_SEC_REGISTERS, V8M_MAIN_FP_REGISTERS,
+        V8M_MAIN_REGISTERS, V8M_MAIN_SEC_FP_REGISTERS, V8M_MAIN_SEC_REGISTERS,
+    },
     registers::cortex_m::{
         CORTEX_M_CORE_REGISTERS, CORTEX_M_WITH_FP_CORE_REGISTERS, FP, PC, RA, SP,
     },
@@ -447,10 +451,19 @@ impl CoreInterface for Armv8m<'_> {
     }
 
     fn registers(&self) -> &'static CoreRegisters {
-        if self.state.fp_present {
-            &CORTEX_M_WITH_FP_CORE_REGISTERS
-        } else {
-            &CORTEX_M_CORE_REGISTERS
+        let main = true; //TODO
+        let security = true; //TODO
+        let fp = self.state.fp_present;
+
+        match (main, security, fp) {
+            (true, true, true) => &V8M_MAIN_SEC_FP_REGISTERS,
+            (true, true, false) => &V8M_MAIN_SEC_REGISTERS,
+            (true, false, true) => &V8M_MAIN_FP_REGISTERS,
+            (true, false, false) => &V8M_MAIN_REGISTERS,
+            (false, true, true) => &V8M_BASE_SEC_FP_REGISTERS,
+            (false, true, false) => &V8M_BASE_SEC_REGISTERS,
+            (false, false, true) => &CORTEX_M_WITH_FP_CORE_REGISTERS,
+            (false, false, false) => &CORTEX_M_CORE_REGISTERS,
         }
     }
 

--- a/probe-rs/src/architecture/arm/core/cortex_m.rs
+++ b/probe-rs/src/architecture/arm/core/cortex_m.rs
@@ -53,7 +53,8 @@ memory_mapped_bitfield_register! {
     impl From;
     pub _, set_regwnr: 16;
     // If the processor does not implement the FP extension the REGSEL field is bits `[4:0]`, and bits `[6:5]` are Reserved, SBZ.
-    pub _, set_regsel: 6,0;
+    // Increased to 7 bits on v8-M
+    pub _, set_regsel: 7,0;
 }
 
 memory_mapped_bitfield_register! {

--- a/probe-rs/src/architecture/arm/core/registers.rs
+++ b/probe-rs/src/architecture/arm/core/registers.rs
@@ -2,4 +2,5 @@
 
 pub mod aarch32;
 pub mod aarch64;
+pub mod armv8m;
 pub mod cortex_m;

--- a/probe-rs/src/architecture/arm/core/registers/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/registers/armv8m.rs
@@ -1,0 +1,165 @@
+//! General Cortex-M registers present on all Cortex-M cores.
+
+use std::sync::LazyLock;
+
+use super::cortex_m::{ARM32_COMMON_REGS_SET, CORTEX_M_COMMON_REGS_SET, CORTEX_M_WITH_FP_REGS_SET};
+use crate::{
+    CoreRegister, CoreRegisters, RegisterId,
+    core::{RegisterDataType, RegisterRole, UnwindRule},
+};
+/// v8M base + security
+pub static V8M_BASE_SEC_REGISTERS: LazyLock<CoreRegisters> = LazyLock::new(|| {
+    CoreRegisters::new(
+        ARM32_COMMON_REGS_SET
+            .iter()
+            .chain(CORTEX_M_COMMON_REGS_SET.iter())
+            .chain(V8M_SECURITY_REGS_SET.iter())
+            .collect(),
+    )
+});
+
+/// v8M base + security + FP
+pub static V8M_BASE_SEC_FP_REGISTERS: LazyLock<CoreRegisters> = LazyLock::new(|| {
+    CoreRegisters::new(
+        ARM32_COMMON_REGS_SET
+            .iter()
+            .chain(CORTEX_M_COMMON_REGS_SET.iter())
+            .chain(V8M_SECURITY_REGS_SET.iter())
+            .chain(CORTEX_M_WITH_FP_REGS_SET.iter())
+            .collect(),
+    )
+});
+
+/// v8M main
+pub static V8M_MAIN_REGISTERS: LazyLock<CoreRegisters> = LazyLock::new(|| {
+    CoreRegisters::new(
+        ARM32_COMMON_REGS_SET
+            .iter()
+            .chain(CORTEX_M_COMMON_REGS_SET.iter())
+            .chain(V8M_MAIN_REGS_SET.iter())
+            .collect(),
+    )
+});
+
+/// v8M main + FP
+pub static V8M_MAIN_FP_REGISTERS: LazyLock<CoreRegisters> = LazyLock::new(|| {
+    CoreRegisters::new(
+        ARM32_COMMON_REGS_SET
+            .iter()
+            .chain(CORTEX_M_COMMON_REGS_SET.iter())
+            .chain(V8M_MAIN_REGS_SET.iter())
+            .chain(CORTEX_M_WITH_FP_REGS_SET.iter())
+            .collect(),
+    )
+});
+
+/// v8M main + security
+pub static V8M_MAIN_SEC_REGISTERS: LazyLock<CoreRegisters> = LazyLock::new(|| {
+    CoreRegisters::new(
+        ARM32_COMMON_REGS_SET
+            .iter()
+            .chain(CORTEX_M_COMMON_REGS_SET.iter())
+            .chain(V8M_MAIN_REGS_SET.iter())
+            .chain(V8M_SECURITY_REGS_SET.iter())
+            .collect(),
+    )
+});
+
+/// v8M main + security + FP
+pub static V8M_MAIN_SEC_FP_REGISTERS: LazyLock<CoreRegisters> = LazyLock::new(|| {
+    CoreRegisters::new(
+        ARM32_COMMON_REGS_SET
+            .iter()
+            .chain(CORTEX_M_COMMON_REGS_SET.iter())
+            .chain(V8M_MAIN_REGS_SET.iter())
+            .chain(V8M_SECURITY_REGS_SET.iter())
+            .chain(CORTEX_M_WITH_FP_REGS_SET.iter())
+            .collect(),
+    )
+});
+
+static V8M_MAIN_REGS_SET: &[CoreRegister] = &[
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("MSPLIM_NS"),
+            RegisterRole::Other("MSPLIM_NS"),
+        ],
+        id: RegisterId(0b00011110),
+        data_type: RegisterDataType::UnsignedInteger(32),
+        unwind_rule: UnwindRule::SpecialRule,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("PSPLIM_NS"),
+            RegisterRole::Other("PSPLIM_NS"),
+        ],
+        id: RegisterId(0b00011111),
+        data_type: RegisterDataType::UnsignedInteger(32),
+        unwind_rule: UnwindRule::SpecialRule,
+    },
+];
+
+static V8M_SECURITY_REGS_SET: &[CoreRegister] = &[
+    CoreRegister {
+        roles: &[RegisterRole::Core("MSP_NS"), RegisterRole::Other("MSP_NS")],
+        id: RegisterId(0b00011000),
+        data_type: RegisterDataType::UnsignedInteger(32),
+        unwind_rule: UnwindRule::Preserve,
+    },
+    CoreRegister {
+        roles: &[RegisterRole::Core("PSP_NS"), RegisterRole::Other("PSP_NS")],
+        id: RegisterId(0b00011001),
+        data_type: RegisterDataType::UnsignedInteger(32),
+        unwind_rule: UnwindRule::Preserve,
+    },
+    CoreRegister {
+        roles: &[RegisterRole::Core("MSP_S"), RegisterRole::Other("MSP_S")],
+        id: RegisterId(0b00011010),
+        data_type: RegisterDataType::UnsignedInteger(32),
+        unwind_rule: UnwindRule::Preserve,
+    },
+    CoreRegister {
+        roles: &[RegisterRole::Core("PSP_S"), RegisterRole::Other("PSP_S")],
+        id: RegisterId(0b00011011),
+        data_type: RegisterDataType::UnsignedInteger(32),
+        unwind_rule: UnwindRule::Preserve,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("MSPLIM_S"),
+            RegisterRole::Other("MSPLIM_S"),
+        ],
+        id: RegisterId(0b00011100),
+        data_type: RegisterDataType::UnsignedInteger(32),
+        unwind_rule: UnwindRule::SpecialRule,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("PSPLIM_S"),
+            RegisterRole::Other("PSPLIM_S"),
+        ],
+        id: RegisterId(0b00011101),
+        data_type: RegisterDataType::UnsignedInteger(32),
+        unwind_rule: UnwindRule::SpecialRule,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("EXTRA_S"),
+            RegisterRole::Other("EXTRA_S"),
+        ],
+        id: RegisterId(0b00100010),
+        data_type: RegisterDataType::UnsignedInteger(32),
+        unwind_rule: UnwindRule::SpecialRule,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("EXTRA_NS"),
+            RegisterRole::Other("EXTRA_NS"),
+        ],
+        id: RegisterId(0b00100010),
+        data_type: RegisterDataType::UnsignedInteger(32),
+        unwind_rule: UnwindRule::SpecialRule,
+    },
+];
+
+//TODO: VPR (MVE), PACBTI

--- a/probe-rs/src/architecture/arm/core/registers/cortex_m.rs
+++ b/probe-rs/src/architecture/arm/core/registers/cortex_m.rs
@@ -155,7 +155,7 @@ pub(crate) static ARM32_COMMON_REGS_SET: &[CoreRegister] = &[
     PC,
 ];
 
-static CORTEX_M_COMMON_REGS_SET: &[CoreRegister] = &[
+pub(crate) static CORTEX_M_COMMON_REGS_SET: &[CoreRegister] = &[
     CoreRegister {
         roles: &[RegisterRole::Core("MSP"), RegisterRole::MainStackPointer],
         id: RegisterId(0b10001),
@@ -179,7 +179,7 @@ static CORTEX_M_COMMON_REGS_SET: &[CoreRegister] = &[
     },
 ];
 
-static CORTEX_M_WITH_FP_REGS_SET: &[CoreRegister] = &[
+pub(crate) static CORTEX_M_WITH_FP_REGS_SET: &[CoreRegister] = &[
     CoreRegister {
         roles: &[
             RegisterRole::Core("FPSCR"),


### PR DESCRIPTION
This ended up being more complicated than I was expecting 😅 The code that already existed for v8m exception handling uses the register IDs, which were perhaps passed straight through at some point, but now are used with CoreRegisters, so I've added the new registers there.
A few comments:
https://github.com/probe-rs/probe-rs/blob/139a7b775d7c68bbf8c7b66a97f8f0ea0ef1ff3f/probe-rs-debug/src/debug_info.rs#L1247-L1250
says registers might have their values set "later", but not exactly sure what that would entail. I just gave the new registers UnwindRule::Preserve which seems to give the correct behavior. Maybe a new RegisterRole? Also, I noticed that the "old style" MSP/PSP do have roles but are ignored also, but they aren't used:
https://github.com/probe-rs/probe-rs/blob/139a7b775d7c68bbf8c7b66a97f8f0ea0ef1ff3f/probe-rs-debug/src/exception_handling/armv6m_armv7m_shared.rs#L44-L45
a) as mentioned in the code, when the security extension isn't present you need to use the "old way" or perhaps as the code for v6/v7 currently does just look at R13. 
b) it occurs to me that I never actually checked if we got that same SP banking "help" in v8m as well... oops. I _think_ that Trustzone might be worried about "leaking" SP between thread S and exception NS (or vice versa) so maybe it is actually needed here? either way it can't hurt 🙃

WRT security extension: might be a good idea to cache extension details in `struct Armv8m`? also, not sure how detecting Security on a core without Main would work: the ARM says "In a PE with the Main Extension, support for the Security Extension is indicated in ID_PFR1.Security." so I guess in a Baseline core (like Cortex-M23 with Trustzone) you're just screwed? 🤷 not like anyone has those yet iirc.

WRT struct CoreRegisters: isn't fn registers returning &'static CoreRegisters kind of unneeded? Vec is already a smart pointer, so returning a reference is double indirection, and means dealing with the static lifetime. alternatively, since we can't even modify it without cloning it (& not &mut) maybe just make CoreRegisters have &'static [CoreRegister] and use Vec::leak or just do it all at compile time somehow.