### PR TITLE
Revert "Make the probe lister interface async (#3356)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,11 +173,11 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-io"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
@@ -186,29 +186,7 @@ dependencies = [
  "polling",
  "rustix 1.0.7",
  "slab",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -747,7 +725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -756,7 +734,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1020,7 +998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1152,7 +1130,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1336,27 +1314,6 @@ dependencies = [
  "sha2",
  "strum 0.27.1",
  "thiserror 2.0.16",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
-dependencies = [
- "event-listener",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -1759,9 +1716,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2919,17 +2876,16 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.2",
  "pin-project-lite",
- "rustix 0.38.44",
- "tracing",
- "windows-sys 0.59.0",
+ "rustix 1.0.7",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3031,7 +2987,6 @@ version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-io",
- "async-trait",
  "bincode",
  "bitfield",
  "bitvec",
@@ -3119,8 +3074,6 @@ dependencies = [
  "addr2line 0.25.0",
  "ansi-parser",
  "anyhow",
- "async-io",
- "async-trait",
  "axum",
  "axum-extra",
  "base64 0.22.1",
@@ -3507,7 +3460,6 @@ name = "rtthost"
 version = "0.29.0"
 dependencies = [
  "anyhow",
- "async-io",
  "clap",
  "env_logger",
  "probe-rs",
@@ -4033,7 +3985,6 @@ name = "smoke_tester"
 version = "0.29.0"
 dependencies = [
  "anyhow",
- "async-io",
  "clap",
  "colored 3.0.0",
  "env_logger",
@@ -4234,7 +4185,6 @@ name = "target-gen"
 version = "0.29.0"
 dependencies = [
  "anyhow",
- "async-io",
  "clap",
  "cmsis-pack",
  "colored 3.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ probe-rs-mi = { path = "probe-rs-mi", version = "0.1.0" }
 docsplay = "0.1.1"
 thiserror = "2.0.11"
 anyhow = "1.0.82"
-async-trait = "0.1"
 async-io = "2"
 
 [workspace.metadata.release]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ fn main() -> Result<(), probe_rs::Error> {
     // Get a list of all available debug probes.
     let lister = Lister::new();
 
-    let probes = async_io::block_on(lister.list_all());
+    let probes = lister.list_all();
 
     // Use the first probe found.
     let mut probe = probes[0].open()?;
@@ -98,7 +98,7 @@ fn main() -> Result<(), probe_rs::Error> {
       ..Default::default()
     };
 
-    let mut session = async_io::block_on(Session::auto_attach("nRF52840_xxAA", session_config))?;
+    let mut session = Session::auto_attach("nRF52840_xxAA", session_config)?;
 
     // Select a core.
     let mut core = session.core(0)?;

--- a/changelog/changed-probe-lister-async.md
+++ b/changelog/changed-probe-lister-async.md
@@ -1,2 +1,0 @@
-The probe `Lister` trait and consuming interfaces are now async.
-This is an intermediate step and will be complemented with future async ports.

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -27,8 +27,6 @@ remote = [
 
 [dependencies]
 anyhow = { workspace = true }
-async-io.workspace = true
-async-trait.workspace = true
 base64 = "0.22"
 docsplay = { workspace = true }
 jep106 = "0.3"

--- a/probe-rs-tools/src/bin/probe-rs/cmd/benchmark.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/benchmark.rs
@@ -83,7 +83,7 @@ struct TestData {
 }
 
 impl Cmd {
-    pub async fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
+    pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
         let speed = self.common.speed;
         let common_options = self.common.load(registry)?;
         let mut max_speed = self.max_speed;
@@ -96,7 +96,7 @@ impl Cmd {
             speeds.extend_from_slice(&PROBE_SPEEDS);
         };
         // if we can't print basic info, we're probably not going to succeed with testing so bubble up the error
-        Cmd::print_info(&common_options, lister).await?;
+        Cmd::print_info(&common_options, lister)?;
 
         for speed in speeds
             .iter()
@@ -111,8 +111,7 @@ impl Cmd {
                     self.address,
                     self.word_size,
                     self.iterations,
-                )
-                .await;
+                );
                 if let Err(e) = res {
                     println!(
                         "Test failed for speed {} size {} word_size {}bit - {}",
@@ -126,11 +125,8 @@ impl Cmd {
     }
 
     /// Print probe and target info
-    async fn print_info(
-        common_options: &LoadedProbeOptions<'_>,
-        lister: &Lister,
-    ) -> anyhow::Result<()> {
-        let probe = common_options.attach_probe(lister).await?;
+    fn print_info(common_options: &LoadedProbeOptions, lister: &Lister) -> anyhow::Result<()> {
+        let probe = common_options.attach_probe(lister)?;
         let protocol_name = probe
             .protocol()
             .map(|p| p.to_string())
@@ -147,8 +143,8 @@ impl Cmd {
     }
 
     /// Run a specific benchmark
-    async fn benchmark(
-        common_options: &LoadedProbeOptions<'_>,
+    fn benchmark(
+        common_options: &LoadedProbeOptions,
         lister: &Lister,
         speed: u32,
         size: usize,
@@ -156,7 +152,7 @@ impl Cmd {
         word_size: u32,
         iterations: usize,
     ) -> Result<(), anyhow::Error> {
-        let mut probe = common_options.attach_probe(lister).await?;
+        let mut probe = common_options.attach_probe(lister)?;
         let target = common_options.get_target_selector()?;
         if probe.set_speed(speed).is_ok() {
             let mut session = common_options.attach_session(probe, target)?;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -218,10 +218,7 @@ async fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
     };
 
     let lister = Lister::new();
-    let (mut session, probe_options) = match probe_options
-        .simple_attach(&mut registry, &lister)
-        .await
-    {
+    let (mut session, probe_options) = match probe_options.simple_attach(&mut registry, &lister) {
         Ok((session, probe_options)) => (session, probe_options),
 
         Err(OperationError::MultipleProbesFound { list }) => {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -56,9 +56,9 @@ struct CliOptions {
     pub format_options: crate::FormatOptions,
 }
 
-pub async fn main(args: &[OsString]) {
+pub fn main(args: &[OsString]) {
     let mut registry = Registry::from_builtin_families();
-    match main_try(&mut registry, args).await {
+    match main_try(&mut registry, args) {
         Ok(_) => (),
         Err(e) => {
             // Ensure stderr is flushed before calling process::exit,
@@ -73,7 +73,7 @@ pub async fn main(args: &[OsString]) {
     }
 }
 
-async fn main_try(registry: &mut Registry, args: &[OsString]) -> Result<(), OperationError> {
+fn main_try(registry: &mut Registry, args: &[OsString]) -> Result<(), OperationError> {
     // Parse the commandline options.
     let opt = CliOptions::parse_from(args);
 
@@ -128,7 +128,7 @@ async fn main_try(registry: &mut Registry, args: &[OsString]) -> Result<(), Oper
     let lister = Lister::new();
 
     // Attach to specified probe
-    let (mut session, probe_options) = opt.probe_options.simple_attach(registry, &lister).await?;
+    let (mut session, probe_options) = opt.probe_options.simple_attach(registry, &lister)?;
 
     // Flash the binary
     let loader =

--- a/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs
@@ -26,7 +26,7 @@ pub struct Cmd {
 
 impl Cmd {
     /// Run the correct subcommand.
-    pub async fn run(&self, lister: &Lister) -> Result<()> {
+    pub fn run(&self, lister: &Lister) -> Result<()> {
         let shell = Shell::from_env()
             .or(self.shell)
             .ok_or_else(|| anyhow!("The current shell could not be determined. Please specify a shell with the --shell argument."))?;
@@ -36,7 +36,7 @@ impl Cmd {
                 self.install(shell)?;
             }
             CompleteKind::ProbeList { input } => {
-                self.probe_list(lister, input).await?;
+                self.probe_list(lister, input)?;
             }
             CompleteKind::ChipList { input } => {
                 self.chips_list(input)?;
@@ -83,8 +83,8 @@ impl Cmd {
     }
 
     /// List all the found probes in a format the shell autocompletion understands.
-    async fn probe_list(&self, lister: &Lister, input: &str) -> Result<()> {
-        println!("{}", list_probes(lister, input).await?);
+    fn probe_list(&self, lister: &Lister, input: &str) -> Result<()> {
+        println!("{}", list_probes(lister, input)?);
         Ok(())
     }
 
@@ -133,9 +133,9 @@ pub fn list_chips(starts_with: &str) -> Result<String> {
 /// This are all the probes that are currently connected.
 ///
 /// Output will be one line per probe and print the PID:VID:SERIAL and the full name.
-pub async fn list_probes(lister: &Lister, starts_with: &str) -> Result<String> {
+pub fn list_probes(lister: &Lister, starts_with: &str) -> Result<String> {
     let mut output = String::new();
-    let probes = lister.list_all().await;
+    let probes = lister.list_all();
     for probe in probes {
         if probe.identifier.starts_with(starts_with) {
             writeln!(

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -454,7 +454,7 @@ impl Debugger {
         self.config.validate_config_files()?;
 
         let mut session_data =
-            SessionData::new(registry, lister, &mut self.config, self.timestamp_offset).await?;
+            SessionData::new(registry, lister, &mut self.config, self.timestamp_offset)?;
 
         debug_adapter.halt_after_reset = self.config.flashing_config.halt_after_reset;
 
@@ -1302,7 +1302,7 @@ mod test {
 
         let lister = TestLister::new();
         if with_probe {
-            lister.probes.lock().await.push(fake_probe());
+            lister.probes.borrow_mut().push(fake_probe());
         }
         let lister = Lister::with_lister(Box::new(lister));
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -69,7 +69,7 @@ pub(crate) struct SessionData {
 }
 
 impl SessionData {
-    pub(crate) async fn new(
+    pub(crate) fn new(
         registry: &mut Registry,
         lister: &Lister,
         config: &mut configuration::SessionConfig,
@@ -78,7 +78,7 @@ impl SessionData {
         let target_selector = TargetSelector::from(config.chip.as_deref());
 
         let options = config.probe_options().load(registry)?;
-        let target_probe = options.attach_probe(lister).await?;
+        let target_probe = options.attach_probe(lister)?;
         let mut target_session = options
             .attach_session(target_probe, target_selector)
             .map_err(|operation_error| {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/test.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/test.rs
@@ -1,33 +1,33 @@
+use std::cell::RefCell;
+
 use probe_rs::{
     integration::{FakeProbe, ProbeLister},
     probe::{DebugProbeError, DebugProbeInfo, DebugProbeSelector, Probe, ProbeCreationError},
 };
-use tokio::sync::Mutex;
 
 #[derive(Debug)]
 pub struct TestLister {
-    pub probes: Mutex<Vec<(DebugProbeInfo, FakeProbe)>>,
+    pub probes: RefCell<Vec<(DebugProbeInfo, FakeProbe)>>,
 }
 
 impl TestLister {
     pub fn new() -> Self {
         Self {
-            probes: Mutex::new(Vec::new()),
+            probes: RefCell::new(Vec::new()),
         }
     }
 }
 
-#[async_trait::async_trait]
 impl ProbeLister for TestLister {
-    async fn open(&self, selector: &DebugProbeSelector) -> Result<Probe, DebugProbeError> {
-        let probe_index = self.probes.lock().await.iter().position(|(info, _)| {
+    fn open(&self, selector: &DebugProbeSelector) -> Result<Probe, DebugProbeError> {
+        let probe_index = self.probes.borrow().iter().position(|(info, _)| {
             info.product_id == selector.product_id
                 && info.vendor_id == selector.vendor_id
                 && info.serial_number == selector.serial_number
         });
 
         if let Some(index) = probe_index {
-            let (_info, probe) = self.probes.lock().await.swap_remove(index);
+            let (_info, probe) = self.probes.borrow_mut().swap_remove(index);
 
             Ok(Probe::from_specific_probe(Box::new(probe)))
         } else {
@@ -37,10 +37,9 @@ impl ProbeLister for TestLister {
         }
     }
 
-    async fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+    fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
         self.probes
-            .lock()
-            .await
+            .borrow()
             .iter()
             .filter_map(|(info, _)| {
                 if selector

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/mod.rs
@@ -47,8 +47,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub async fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
-        let (mut session, _probe_options) = self.common.simple_attach(registry, lister).await?;
+    pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
+        let (mut session, _probe_options) = self.common.simple_attach(registry, lister)?;
 
         if self.reset_halt {
             session

--- a/probe-rs-tools/src/bin/probe-rs/cmd/itm.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/itm.rs
@@ -69,8 +69,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub async fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
-        let (mut session, _probe_options) = self.common.simple_attach(registry, lister).await?;
+    pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
+        let (mut session, _probe_options) = self.common.simple_attach(registry, lister)?;
 
         match self.source {
             ItmSource::TraceMemory { coreclk } => {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/profile.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/profile.rs
@@ -71,13 +71,12 @@ impl std::fmt::Display for ProfileMethod {
 }
 
 impl ProfileCmd {
-    pub async fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
+    pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, probe_options) = self
             .run
             .shared_options
             .probe_options
-            .simple_attach(registry, lister)
-            .await?;
+            .simple_attach(registry, lister)?;
 
         let loader = build_loader(
             &mut session,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/serve.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/serve.rs
@@ -67,7 +67,7 @@ async fn server_info() -> Html<String> {
     body.push_str("<body>");
     body.push_str("<h1>probe-rs status</h1>");
 
-    let probes = Lister::new().list_all().await;
+    let probes = Lister::new().list_all();
     if probes.is_empty() {
         body.push_str("<p>No probes connected</p>");
     } else {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/trace.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/trace.rs
@@ -25,13 +25,13 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub async fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
+    pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
         let mut xs = vec![];
         let mut ys = vec![];
 
         let start = Instant::now();
 
-        let (mut session, _probe_options) = self.common.simple_attach(registry, lister).await?;
+        let (mut session, _probe_options) = self.common.simple_attach(registry, lister)?;
 
         let mut core = session.core(self.shared.core)?;
 

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -117,7 +117,7 @@ impl Cli {
             Subcommand::Serve(cmd) => cmd.run(_config.server).await,
             Subcommand::List(cmd) => cmd.run(client).await,
             Subcommand::Info(cmd) => cmd.run(client).await,
-            Subcommand::Gdb(cmd) => cmd.run(&mut *client.registry().await, &lister).await,
+            Subcommand::Gdb(cmd) => cmd.run(&mut *client.registry().await, &lister),
             Subcommand::Reset(cmd) => cmd.run(client).await,
             Subcommand::Debug(cmd) => {
                 cmd.run(&mut *client.registry().await, &lister, utc_offset)
@@ -128,14 +128,14 @@ impl Cli {
             Subcommand::Attach(cmd) => cmd.run(client, utc_offset).await,
             Subcommand::Verify(cmd) => cmd.run(client).await,
             Subcommand::Erase(cmd) => cmd.run(client).await,
-            Subcommand::Trace(cmd) => cmd.run(&mut *client.registry().await, &lister).await,
-            Subcommand::Itm(cmd) => cmd.run(&mut *client.registry().await, &lister).await,
+            Subcommand::Trace(cmd) => cmd.run(&mut *client.registry().await, &lister),
+            Subcommand::Itm(cmd) => cmd.run(&mut *client.registry().await, &lister),
             Subcommand::Chip(cmd) => cmd.run(client).await,
-            Subcommand::Benchmark(cmd) => cmd.run(&mut *client.registry().await, &lister).await,
-            Subcommand::Profile(cmd) => cmd.run(&mut *client.registry().await, &lister).await,
+            Subcommand::Benchmark(cmd) => cmd.run(&mut *client.registry().await, &lister),
+            Subcommand::Profile(cmd) => cmd.run(&mut *client.registry().await, &lister),
             Subcommand::Read(cmd) => cmd.run(client).await,
             Subcommand::Write(cmd) => cmd.run(client).await,
-            Subcommand::Complete(cmd) => cmd.run(&lister).await,
+            Subcommand::Complete(cmd) => cmd.run(&lister),
             Subcommand::Mi(cmd) => cmd.run(),
         }
     }
@@ -439,7 +439,7 @@ async fn main() -> Result<()> {
 
     // Special-case `cargo-embed` and `cargo-flash`.
     if let Some(args) = multicall_check(&args, "cargo-flash") {
-        cmd::cargo_flash::main(args).await;
+        cmd::cargo_flash::main(args);
         return Ok(());
     }
     if let Some(args) = multicall_check(&args, "cargo-embed") {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
@@ -285,21 +285,19 @@ impl LimitedLister {
     }
 }
 
-#[async_trait::async_trait]
 impl ProbeLister for LimitedLister {
-    async fn open(&self, selector: &DebugProbeSelector) -> Result<Probe, DebugProbeError> {
+    fn open(&self, selector: &DebugProbeSelector) -> Result<Probe, DebugProbeError> {
         if !self.is_allowed(selector) {
             return Err(DebugProbeError::ProbeCouldNotBeCreated(
                 ProbeCreationError::CouldNotOpen,
             ));
         }
-        self.all_probes.open(selector).await
+        self.all_probes.open(selector)
     }
 
-    async fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+    fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
         self.all_probes
             .list(selector)
-            .await
             .into_iter()
             .filter(|info| self.is_allowed(&DebugProbeSelector::from(info)))
             .collect()
@@ -525,7 +523,7 @@ postcard_rpc::define_dispatch! {
 
         | EndpointTy                | kind      | handler           |
         | ----------                | ----      | -------           |
-        | ListProbesEndpoint        | async     | list_probes       |
+        | ListProbesEndpoint        | blocking  | list_probes       |
         | SelectProbeEndpoint       | async     | select_probe      |
         | AttachEndpoint            | async     | attach            |
 

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -73,7 +73,7 @@ pub async fn target_info(
     let mut registry = ctx.registry().await;
     let probe_options = ProbeOptions::from(&request).load(&mut registry)?;
 
-    let probe = probe_options.attach_probe(&ctx.lister()).await?;
+    let probe = probe_options.attach_probe(&ctx.lister())?;
 
     if let Err(e) = try_show_info(
         ctx,

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/probe.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/probe.rs
@@ -79,13 +79,13 @@ impl ListProbesRequest {
 
 pub type ListProbesResponse = RpcResult<Vec<DebugProbeEntry>>;
 
-pub async fn list_probes(
+pub fn list_probes(
     ctx: &mut RpcContext,
     _header: VarHeader,
     _request: ListProbesRequest,
 ) -> ListProbesResponse {
     let lister = ctx.lister();
-    let probes = lister.list_all().await;
+    let probes = lister.list_all();
 
     Ok(probes
         .into_iter()
@@ -112,9 +112,7 @@ pub async fn select_probe(
     request: SelectProbeRequest,
 ) -> SelectProbeResponse {
     let lister = ctx.lister();
-    let mut list = lister
-        .list(request.probe.map(|sel| sel.into()).as_ref())
-        .await;
+    let mut list = lister.list(request.probe.map(|sel| sel.into()).as_ref());
 
     match list.len() {
         0 => Err(OperationError::NoProbesFound.into()),
@@ -230,7 +228,7 @@ pub async fn attach(
     let common_options = ProbeOptions::from(&request).load(&mut registry)?;
     let target = common_options.get_target_selector()?;
 
-    let probe = match common_options.attach_probe(&ctx.lister()).await {
+    let probe = match common_options.attach_probe(&ctx.lister()) {
         Ok(probe) => probe,
         Err(OperationError::NoProbesFound) => return Ok(AttachResult::ProbeNotFound),
         Err(error) => {

--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -126,7 +126,7 @@ impl ProbeOptions {
 
     /// Convenience method that attaches to the specified probe, target,
     /// and target session.
-    pub async fn simple_attach<'r>(
+    pub fn simple_attach<'r>(
         self,
         registry: &'r mut Registry,
         lister: &Lister,
@@ -134,7 +134,7 @@ impl ProbeOptions {
         let common_options = self.load(registry)?;
 
         let target = common_options.get_target_selector()?;
-        let probe = common_options.attach_probe(lister).await?;
+        let probe = common_options.attach_probe(lister)?;
         let session = common_options.attach_session(probe, target)?;
 
         Ok((session, common_options))
@@ -228,30 +228,27 @@ impl<'r> LoadedProbeOptions<'r> {
     /// If there is only one probe, it will be selected automatically.
     /// If there are multiple probes, the user will be prompted to select one unless
     /// started in non-interactive mode.
-    async fn select_probe(lister: &Lister, non_interactive: bool) -> Result<Probe, OperationError> {
-        let list = lister.list_all().await;
+    fn select_probe(lister: &Lister, non_interactive: bool) -> Result<Probe, OperationError> {
+        let list = lister.list_all();
         let selected = match list.len() {
             0 | 1 => list.first().ok_or(OperationError::NoProbesFound),
             _ if non_interactive => Err(OperationError::MultipleProbesFound { list }),
             _ => Self::interactive_probe_select(&list),
         };
 
-        match selected {
-            Ok(probe_info) => Ok(lister.open(probe_info).await?),
-            Err(error) => Err(error),
-        }
+        selected.and_then(|probe_info| Ok(lister.open(probe_info)?))
     }
 
     /// Attaches to specified probe and configures it.
-    pub async fn attach_probe(&self, lister: &Lister) -> Result<Probe, OperationError> {
+    pub fn attach_probe(&self, lister: &Lister) -> Result<Probe, OperationError> {
         let mut probe = if self.0.dry_run {
             Probe::from_specific_probe(Box::new(FakeProbe::with_mocked_core()))
         } else {
             // If we got a probe selector as an argument, open the probe
             // matching the selector if possible.
             match &self.0.probe {
-                Some(selector) => lister.open(selector).await?,
-                None => Self::select_probe(lister, self.0.non_interactive).await?,
+                Some(selector) => lister.open(selector)?,
+                None => Self::select_probe(lister, self.0.non_interactive)?,
             }
         };
 

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -32,7 +32,6 @@ test = []
 [dependencies]
 anyhow.workspace = true
 async-io.workspace = true
-async-trait.workspace = true
 docsplay.workspace = true
 thiserror.workspace = true
 probe-rs-target.workspace = true

--- a/probe-rs/examples/multidrop_raw.rs
+++ b/probe-rs/examples/multidrop_raw.rs
@@ -10,61 +10,59 @@ use probe_rs::{
 };
 
 fn main() -> Result<()> {
-    async_io::block_on(async move {
-        env_logger::init();
+    env_logger::init();
 
-        // Get a list of all available debug probes.
+    // Get a list of all available debug probes.
 
-        let probe_lister = Lister::new();
+    let probe_lister = Lister::new();
 
-        let probes = probe_lister.list_all().await;
+    let probes = probe_lister.list_all();
 
-        // Use the first probe found.
-        let mut probe: Probe = probes[0].open()?;
+    // Use the first probe found.
+    let mut probe: Probe = probes[0].open()?;
 
-        // Specify the multidrop DP address of the first core,
-        // this is used for the initial connection.
-        let core0 = DpAddress::Multidrop(0x01002927);
+    // Specify the multidrop DP address of the first core,
+    // this is used for the initial connection.
+    let core0 = DpAddress::Multidrop(0x01002927);
 
-        probe.set_speed(100)?;
-        probe.attach_to_unspecified()?;
-        let mut iface = probe
-            .try_into_arm_debug_interface(DefaultArmSequence::create())
-            .map_err(|(_probe, err)| err)?;
+    probe.set_speed(100)?;
+    probe.attach_to_unspecified()?;
+    let mut iface = probe
+        .try_into_arm_debug_interface(DefaultArmSequence::create())
+        .map_err(|(_probe, err)| err)?;
 
-        iface.select_debug_port(core0)?;
+    iface.select_debug_port(core0)?;
 
-        // This is an example on how to do raw DP register access with multidrop.
-        // This reads DPIDR and TARGETID of both cores in a RP2040. This chip is
-        // unconventional because each core has its own DP.
+    // This is an example on how to do raw DP register access with multidrop.
+    // This reads DPIDR and TARGETID of both cores in a RP2040. This chip is
+    // unconventional because each core has its own DP.
 
-        let core1 = DpAddress::Multidrop(0x11002927);
-        const DPIDR: DpRegisterAddress = DpRegisterAddress {
-            address: 0x0,
-            bank: Some(0x0),
-        };
-        const TARGETID: DpRegisterAddress = DpRegisterAddress {
-            address: 0x4,
-            bank: Some(0x2),
-        };
+    let core1 = DpAddress::Multidrop(0x11002927);
+    const DPIDR: DpRegisterAddress = DpRegisterAddress {
+        address: 0x0,
+        bank: Some(0x0),
+    };
+    const TARGETID: DpRegisterAddress = DpRegisterAddress {
+        address: 0x4,
+        bank: Some(0x2),
+    };
 
-        println!(
-            "core0 DPIDR:    {:08x}",
-            iface.read_raw_dp_register(core0, DPIDR)?
-        );
-        println!(
-            "core0 TARGETID: {:08x}",
-            iface.read_raw_dp_register(core0, TARGETID)?
-        );
-        println!(
-            "core1 DPIDR:    {:08x}",
-            iface.read_raw_dp_register(core1, DPIDR)?
-        );
-        println!(
-            "core1 TARGETID: {:08x}",
-            iface.read_raw_dp_register(core1, TARGETID)?
-        );
+    println!(
+        "core0 DPIDR:    {:08x}",
+        iface.read_raw_dp_register(core0, DPIDR)?
+    );
+    println!(
+        "core0 TARGETID: {:08x}",
+        iface.read_raw_dp_register(core0, TARGETID)?
+    );
+    println!(
+        "core1 DPIDR:    {:08x}",
+        iface.read_raw_dp_register(core1, DPIDR)?
+    );
+    println!(
+        "core1 TARGETID: {:08x}",
+        iface.read_raw_dp_register(core1, TARGETID)?
+    );
 
-        Ok(())
-    })
+    Ok(())
 }

--- a/probe-rs/examples/nrf53_recover.rs
+++ b/probe-rs/examples/nrf53_recover.rs
@@ -12,47 +12,45 @@ use probe_rs::{
 };
 
 fn main() -> Result<()> {
-    async_io::block_on(async move {
-        env_logger::init();
+    env_logger::init();
 
-        let lister = Lister::new();
+    let lister = Lister::new();
 
-        // Get a list of all available debug probes.
-        let probes = lister.list_all().await;
+    // Get a list of all available debug probes.
+    let probes = lister.list_all();
 
-        // Use the first probe found.
-        let mut probe = probes[0].open()?;
+    // Use the first probe found.
+    let mut probe = probes[0].open()?;
 
-        probe.attach_to_unspecified()?;
-        let mut iface = probe
-            .try_into_arm_debug_interface(DefaultArmSequence::create())
-            .unwrap();
+    probe.attach_to_unspecified()?;
+    let mut iface = probe
+        .try_into_arm_debug_interface(DefaultArmSequence::create())
+        .unwrap();
 
-        iface.select_debug_port(DpAddress::Default).unwrap();
+    iface.select_debug_port(DpAddress::Default).unwrap();
 
-        const APP_MEM: FullyQualifiedApAddress = FullyQualifiedApAddress::v1_with_default_dp(0);
-        const NET_MEM: FullyQualifiedApAddress = FullyQualifiedApAddress::v1_with_default_dp(1);
-        const APP_CTRL: FullyQualifiedApAddress = FullyQualifiedApAddress::v1_with_default_dp(2);
-        const NET_CTRL: FullyQualifiedApAddress = FullyQualifiedApAddress::v1_with_default_dp(3);
+    const APP_MEM: FullyQualifiedApAddress = FullyQualifiedApAddress::v1_with_default_dp(0);
+    const NET_MEM: FullyQualifiedApAddress = FullyQualifiedApAddress::v1_with_default_dp(1);
+    const APP_CTRL: FullyQualifiedApAddress = FullyQualifiedApAddress::v1_with_default_dp(2);
+    const NET_CTRL: FullyQualifiedApAddress = FullyQualifiedApAddress::v1_with_default_dp(3);
 
-        const ERASEALL: u64 = 0x04;
-        const ERASEALLSTATUS: u64 = 0x08;
+    const ERASEALL: u64 = 0x04;
+    const ERASEALLSTATUS: u64 = 0x08;
 
-        for ap in &[APP_MEM, NET_MEM, APP_CTRL, NET_CTRL] {
-            println!(
-                "IDR {:?} {:x}",
-                ap,
-                iface.read_raw_ap_register(ap, IDR::ADDRESS)?
-            );
-        }
+    for ap in &[APP_MEM, NET_MEM, APP_CTRL, NET_CTRL] {
+        println!(
+            "IDR {:?} {:x}",
+            ap,
+            iface.read_raw_ap_register(ap, IDR::ADDRESS)?
+        );
+    }
 
-        for ap in &[APP_CTRL, NET_CTRL] {
-            // Start erase
-            iface.write_raw_ap_register(ap, ERASEALL, 1)?;
-            // Wait for erase done
-            while iface.read_raw_ap_register(ap, ERASEALLSTATUS)? != 0 {}
-        }
+    for ap in &[APP_CTRL, NET_CTRL] {
+        // Start erase
+        iface.write_raw_ap_register(ap, ERASEALL, 1)?;
+        // Wait for erase done
+        while iface.read_raw_ap_register(ap, ERASEALLSTATUS)? != 0 {}
+    }
 
-        Ok(())
-    })
+    Ok(())
 }

--- a/probe-rs/examples/ram_download.rs
+++ b/probe-rs/examples/ram_download.rs
@@ -150,27 +150,25 @@ fn main() -> Result<()> {
 }
 
 fn open_probe(index: Option<usize>) -> Result<Probe> {
-    async_io::block_on(async move {
-        let lister = Lister::new();
+    let lister = Lister::new();
 
-        let list = lister.list_all().await;
+    let list = lister.list_all();
 
-        let device = match index {
-            Some(index) => list
-                .get(index)
-                .ok_or_else(|| anyhow!("Probe with specified index not found"))?,
-            None => {
-                // open the default probe, if only one probe was found
-                if list.len() == 1 {
-                    &list[0]
-                } else {
-                    return Err(anyhow!("No probe found."));
-                }
+    let device = match index {
+        Some(index) => list
+            .get(index)
+            .ok_or_else(|| anyhow!("Probe with specified index not found"))?,
+        None => {
+            // open the default probe, if only one probe was found
+            if list.len() == 1 {
+                &list[0]
+            } else {
+                return Err(anyhow!("No probe found."));
             }
-        };
+        }
+    };
 
-        let probe = device.open().context("Failed to open probe")?;
+    let probe = device.open().context("Failed to open probe")?;
 
-        Ok(probe)
-    })
+    Ok(probe)
 }

--- a/probe-rs/examples/raw_dap_access.rs
+++ b/probe-rs/examples/raw_dap_access.rs
@@ -7,44 +7,42 @@ use probe_rs::{
 };
 
 fn main() -> Result<()> {
-    async_io::block_on(async move {
-        env_logger::init();
+    env_logger::init();
 
-        let lister = Lister::new();
+    let lister = Lister::new();
 
-        // Get a list of all available debug probes.
-        let probes = lister.list_all().await;
+    // Get a list of all available debug probes.
+    let probes = lister.list_all();
 
-        // Use the first probe found.
-        let mut probe = probes[0].open()?;
+    // Use the first probe found.
+    let mut probe = probes[0].open()?;
 
-        probe.attach_to_unspecified()?;
-        let mut iface = probe
-            .try_into_arm_debug_interface(DefaultArmSequence::create())
-            .unwrap();
+    probe.attach_to_unspecified()?;
+    let mut iface = probe
+        .try_into_arm_debug_interface(DefaultArmSequence::create())
+        .unwrap();
 
-        iface.select_debug_port(DpAddress::Default)?;
+    iface.select_debug_port(DpAddress::Default)?;
 
-        let port = &FullyQualifiedApAddress::v1_with_default_dp(1);
+    let port = &FullyQualifiedApAddress::v1_with_default_dp(1);
 
-        const RESET: u64 = 0;
-        const ERASEALL: u64 = 4;
-        const ERASEALLSTATUS: u64 = 8;
+    const RESET: u64 = 0;
+    const ERASEALL: u64 = 4;
+    const ERASEALLSTATUS: u64 = 8;
 
-        // Reset
-        iface.write_raw_ap_register(port, RESET, 1)?;
-        iface.write_raw_ap_register(port, RESET, 0)?;
+    // Reset
+    iface.write_raw_ap_register(port, RESET, 1)?;
+    iface.write_raw_ap_register(port, RESET, 0)?;
 
-        // Start erase
-        iface.write_raw_ap_register(port, ERASEALL, 1)?;
+    // Start erase
+    iface.write_raw_ap_register(port, ERASEALL, 1)?;
 
-        // Wait for erase done
-        while iface.read_raw_ap_register(port, ERASEALLSTATUS)? != 0 {}
+    // Wait for erase done
+    while iface.read_raw_ap_register(port, ERASEALLSTATUS)? != 0 {}
 
-        // Reset again
-        iface.write_raw_ap_register(port, RESET, 1)?;
-        iface.write_raw_ap_register(port, RESET, 0)?;
+    // Reset again
+    iface.write_raw_ap_register(port, RESET, 1)?;
+    iface.write_raw_ap_register(port, RESET, 0)?;
 
-        Ok(())
-    })
+    Ok(())
 }

--- a/probe-rs/examples/tcp_itm.rs
+++ b/probe-rs/examples/tcp_itm.rs
@@ -6,92 +6,90 @@ use probe_rs::{Error, Permissions, probe::list::Lister};
 use itm::{Decoder, DecoderOptions, TracePacket};
 
 fn main() -> Result<(), Error> {
-    async_io::block_on(async move {
-        env_logger::init();
+    env_logger::init();
 
-        let lister = Lister::new();
+    let lister = Lister::new();
 
-        // Get a list of all available debug probes.
-        let probes = lister.list_all().await;
+    // Get a list of all available debug probes.
+    let probes = lister.list_all();
 
-        // Use the first probe found.
-        let probe = probes[0].open()?;
+    // Use the first probe found.
+    let probe = probes[0].open()?;
 
-        // Attach to a chip.
-        let mut session = probe.attach("stm32f407", Permissions::default())?;
+    // Attach to a chip.
+    let mut session = probe.attach("stm32f407", Permissions::default())?;
 
-        // Create a new SwoConfig with a system clock frequency of 16MHz
-        let cfg = SwoConfig::new(16_000_000)
-            .set_baud(2_000_000)
-            .set_continuous_formatting(false);
+    // Create a new SwoConfig with a system clock frequency of 16MHz
+    let cfg = SwoConfig::new(16_000_000)
+        .set_baud(2_000_000)
+        .set_continuous_formatting(false);
 
-        session.setup_tracing(0, TraceSink::Swo(cfg))?;
+    session.setup_tracing(0, TraceSink::Swo(cfg))?;
 
-        let mut timestamp: f64 = 0.0;
+    let mut timestamp: f64 = 0.0;
 
-        let decoder = Decoder::new(session.swo_reader()?, DecoderOptions { ignore_eof: true });
+    let decoder = Decoder::new(session.swo_reader()?, DecoderOptions { ignore_eof: true });
 
-        let mut stimuli = vec![String::new(); 32];
+    let mut stimuli = vec![String::new(); 32];
 
-        println!("Starting SWO trace ...");
+    println!("Starting SWO trace ...");
 
-        for packet in decoder.singles() {
-            match packet {
-                Ok(TracePacket::LocalTimestamp1 { ts, data_relation }) => {
-                    tracing::debug!(
-                        "Timestamp packet: data_relation={:?} ts={}",
-                        data_relation,
-                        ts
-                    );
-                    let mut time_delta: f64 = ts as f64;
-                    // Divide by core clock frequency to go from ticks to seconds.
-                    time_delta /= 16_000_000.0;
-                    timestamp += time_delta;
-                }
-                // TracePacket::DwtData { id, payload } => {
-                //     tracing::warn!("Dwt: id={} payload={:?}", id, payload);
+    for packet in decoder.singles() {
+        match packet {
+            Ok(TracePacket::LocalTimestamp1 { ts, data_relation }) => {
+                tracing::debug!(
+                    "Timestamp packet: data_relation={:?} ts={}",
+                    data_relation,
+                    ts
+                );
+                let mut time_delta: f64 = ts as f64;
+                // Divide by core clock frequency to go from ticks to seconds.
+                time_delta /= 16_000_000.0;
+                timestamp += time_delta;
+            }
+            // TracePacket::DwtData { id, payload } => {
+            //     tracing::warn!("Dwt: id={} payload={:?}", id, payload);
 
-                //     if id == 17 {
-                //         let value: i32 = payload.pread(0).unwrap();
-                //         tracing::trace!("VAL={}", value);
-                //         // client.send_sample("a", timestamp, value as f64).unwrap();
-                //     }
-                // }
-                Ok(TracePacket::Instrumentation { port, payload }) => {
-                    let id = port as usize;
-                    // First decode the string data from the stimuli.
-                    stimuli[id].push_str(&String::from_utf8_lossy(&payload));
-                    // Then collect all the lines we have gotten so far.
-                    let data = stimuli[id].clone();
-                    let mut lines: Vec<_> = data.lines().collect();
+            //     if id == 17 {
+            //         let value: i32 = payload.pread(0).unwrap();
+            //         tracing::trace!("VAL={}", value);
+            //         // client.send_sample("a", timestamp, value as f64).unwrap();
+            //     }
+            // }
+            Ok(TracePacket::Instrumentation { port, payload }) => {
+                let id = port as usize;
+                // First decode the string data from the stimuli.
+                stimuli[id].push_str(&String::from_utf8_lossy(&payload));
+                // Then collect all the lines we have gotten so far.
+                let data = stimuli[id].clone();
+                let mut lines: Vec<_> = data.lines().collect();
 
-                    // If there is at least one char in the total of all received chars, look at the last one.
-                    let last_char = stimuli[id].chars().last();
-                    if let Some(last_char) = last_char {
-                        // If the last one is not a newline (this is always the last one for Windows (\r\n) as well as Linux (\n)),
-                        // we keep the last line as it was not fully received yet.
-                        if last_char != '\n' {
-                            // Get the last line and keep it if there is even one.
-                            if let Some(last_line) = lines.pop() {
-                                stimuli[id] = last_line.to_string();
-                            }
-                        } else {
-                            stimuli[id] = String::new();
+                // If there is at least one char in the total of all received chars, look at the last one.
+                let last_char = stimuli[id].chars().last();
+                if let Some(last_char) = last_char {
+                    // If the last one is not a newline (this is always the last one for Windows (\r\n) as well as Linux (\n)),
+                    // we keep the last line as it was not fully received yet.
+                    if last_char != '\n' {
+                        // Get the last line and keep it if there is even one.
+                        if let Some(last_line) = lines.pop() {
+                            stimuli[id] = last_line.to_string();
                         }
-                    }
-
-                    // Finally print all due lines!
-                    for line in lines {
-                        println!("{id}> {line}");
+                    } else {
+                        stimuli[id] = String::new();
                     }
                 }
-                _ => {
-                    tracing::warn!("Trace packet: {:?}", packet);
+
+                // Finally print all due lines!
+                for line in lines {
+                    println!("{id}> {line}");
                 }
             }
-            tracing::debug!("{}", timestamp);
+            _ => {
+                tracing::warn!("Trace packet: {:?}", packet);
+            }
         }
+        tracing::debug!("{}", timestamp);
+    }
 
-        Ok(())
-    })
+    Ok(())
 }

--- a/probe-rs/src/flashing/mod.rs
+++ b/probe-rs/src/flashing/mod.rs
@@ -16,15 +16,12 @@
 //! ```no_run
 //! use probe_rs::{Session, SessionConfig, flashing, Permissions};
 //!
-//! # async_io::block_on(async {
-//!
 //! let session_config = SessionConfig::default();
-//! let mut session = Session::auto_attach("nrf51822", session_config).await?;
+//! let mut session = Session::auto_attach("nrf51822", session_config)?;
 //!
 //! flashing::download_file(&mut session, "binary.hex", flashing::Format::Hex)?;
 //!
 //! # Ok::<(), anyhow::Error>(())
-//! # });
 //! ```
 //!
 //! ### Adding data manually
@@ -32,10 +29,8 @@
 //! ```no_run
 //! use probe_rs::{Session, SessionConfig, flashing::{FlashLoader, DownloadOptions}, Permissions};
 //!
-//! # async_io::block_on(async {
-//!
 //! let session_config = SessionConfig::default();
-//! let mut session = Session::auto_attach("nrf51822", session_config).await?;
+//! let mut session = Session::auto_attach("nrf51822", session_config)?;
 //!
 //! let mut loader = session.target().flash_loader();
 //!
@@ -45,7 +40,6 @@
 //! loader.commit(&mut session, DownloadOptions::default())?;
 //!
 //! # Ok::<(), anyhow::Error>(())
-//! # });
 //! ```
 //!
 //!

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -14,12 +14,10 @@
 //! use probe_rs::probe::{list::Lister, Probe};
 //! use probe_rs::Permissions;
 //!
-//! # async_io::block_on(async {
-//!
 //! // Get a list of all available debug probes.
 //! let lister = Lister::new();
 //!
-//! let probes = lister.list_all().await;
+//! let probes = lister.list_all();
 //!
 //! // Use the first probe found.
 //! let mut probe = probes[0].open()?;
@@ -33,7 +31,6 @@
 //! // Halt the attached core.
 //! core.halt(std::time::Duration::from_millis(10))?;
 //! # Ok::<(), Error>(())
-//! # });
 //! ```
 //!
 //! ## Reading from RAM
@@ -42,10 +39,8 @@
 //! # use probe_rs::Error;
 //! use probe_rs::{Session, SessionConfig, MemoryInterface};
 //!
-//! # async_io::block_on(async {
-//!
 //! let session_config = SessionConfig::default();
-//! let mut session = Session::auto_attach("nrf52", session_config).await?;
+//! let mut session = Session::auto_attach("nrf52", session_config)?;
 //! let mut core = session.core(0)?;
 //!
 //! // Read a block of 50 32 bit words.
@@ -64,7 +59,6 @@
 //! core.write_8(0x2000_0000, &buff)?;
 //!
 //! # Ok::<(), Error>(())
-//! # });
 //! ```
 //!
 //! probe-rs is built around 4 main interfaces: the [Probe],

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -279,13 +279,10 @@ impl<T: ProbeError> From<T> for ProbeCreationError {
 /// ```no_run
 /// use probe_rs::probe::{Probe, list::Lister};
 ///
-/// # async_io::block_on(async {
-///
 /// let lister = Lister::new();
 ///
-/// let probe_list = lister.list_all().await;
+/// let probe_list = lister.list_all();
 /// let probe = probe_list[0].open();
-/// # });
 /// ```
 #[derive(Debug)]
 pub struct Probe {

--- a/probe-rs/src/probe/list.rs
+++ b/probe-rs/src/probe/list.rs
@@ -28,21 +28,18 @@ impl Lister {
     }
 
     /// Try to open a probe using the given selector
-    pub async fn open(
-        &self,
-        selector: impl Into<DebugProbeSelector>,
-    ) -> Result<Probe, DebugProbeError> {
-        self.lister.open(&selector.into()).await
+    pub fn open(&self, selector: impl Into<DebugProbeSelector>) -> Result<Probe, DebugProbeError> {
+        self.lister.open(&selector.into())
     }
 
     /// List all available debug probes
-    pub async fn list_all(&self) -> Vec<DebugProbeInfo> {
-        self.lister.list_all().await
+    pub fn list_all(&self) -> Vec<DebugProbeInfo> {
+        self.lister.list_all()
     }
 
     /// List all available debug probes
-    pub async fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
-        self.lister.list(selector).await
+    pub fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+        self.lister.list(selector)
     }
 }
 
@@ -55,27 +52,25 @@ impl Default for Lister {
 /// Trait for a probe lister implementation.
 ///
 /// This trait can be used to implement custom probe listers.
-#[async_trait::async_trait]
-pub trait ProbeLister: std::fmt::Debug + Send + Sync {
+pub trait ProbeLister: std::fmt::Debug {
     /// Try to open a probe using the given selector
-    async fn open(&self, selector: &DebugProbeSelector) -> Result<Probe, DebugProbeError>;
+    fn open(&self, selector: &DebugProbeSelector) -> Result<Probe, DebugProbeError>;
 
     /// List all probes found by the lister.
-    async fn list_all(&self) -> Vec<DebugProbeInfo> {
-        self.list(None).await
+    fn list_all(&self) -> Vec<DebugProbeInfo> {
+        self.list(None)
     }
 
     /// List probes found by the lister, with optional filtering.
-    async fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo>;
+    fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo>;
 }
 
 /// Default lister implementation that includes all built-in probe drivers.
 #[derive(Debug, PartialEq, Eq)]
 pub struct AllProbesLister;
 
-#[async_trait::async_trait]
 impl ProbeLister for AllProbesLister {
-    async fn open(&self, selector: &DebugProbeSelector) -> Result<Probe, DebugProbeError> {
+    fn open(&self, selector: &DebugProbeSelector) -> Result<Probe, DebugProbeError> {
         let selector = selector.into();
 
         let mut open_error = None;
@@ -95,7 +90,7 @@ impl ProbeLister for AllProbesLister {
         Err(open_error.unwrap_or(DebugProbeError::ProbeCouldNotBeCreated(fallback_error)))
     }
 
-    async fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+    fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
         let mut list = vec![];
 
         for driver in Self::DRIVERS {

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -14,12 +14,11 @@
 //! use probe_rs::probe::list::Lister;
 //! use probe_rs::Permissions;
 //! use probe_rs::rtt::Rtt;
-//! # async_io::block_on(async {
 //!
 //! // First obtain a probe-rs session (see probe-rs documentation for details)
 //! let lister = Lister::new();
 //!
-//! let probes = lister.list_all().await;
+//! let probes = lister.list_all();
 //!
 //! let probe = probes[0].open()?;
 //! let mut session = probe.attach("somechip", Permissions::default())?;
@@ -43,7 +42,6 @@
 //! }
 //!
 //! # Ok::<(), Box<dyn std::error::Error>>(())
-//! # });
 //! ```
 
 mod channel;

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -432,11 +432,11 @@ impl Session {
     }
 
     /// Automatically open a probe with the given session config.
-    async fn auto_probe(session_config: &SessionConfig) -> Result<Probe, Error> {
+    fn auto_probe(session_config: &SessionConfig) -> Result<Probe, Error> {
         // Get a list of all available debug probes.
         let lister = Lister::new();
 
-        let probes = lister.list_all().await;
+        let probes = lister.list_all();
 
         // Use the first probe found.
         let mut probe = probes
@@ -459,28 +459,28 @@ impl Session {
 
     /// Automatically creates a session with the first connected probe found.
     #[tracing::instrument(skip(target))]
-    pub async fn auto_attach(
+    pub fn auto_attach(
         target: impl Into<TargetSelector>,
         session_config: SessionConfig,
     ) -> Result<Session, Error> {
         // Attach to a chip.
-        Self::auto_probe(&session_config)
-            .await?
-            .attach(target, session_config.permissions)
+        Self::auto_probe(&session_config)?.attach(target, session_config.permissions)
     }
 
     /// Automatically creates a session with the first connected probe found
     /// using the registry that was provided.
     #[tracing::instrument(skip(target, registry))]
-    pub async fn auto_attach_with_registry(
+    pub fn auto_attach_with_registry(
         target: impl Into<TargetSelector>,
         session_config: SessionConfig,
         registry: &Registry,
     ) -> Result<Session, Error> {
         // Attach to a chip.
-        Self::auto_probe(&session_config)
-            .await?
-            .attach_with_registry(target, session_config.permissions, registry)
+        Self::auto_probe(&session_config)?.attach_with_registry(
+            target,
+            session_config.permissions,
+            registry,
+        )
     }
 
     /// Lists the available cores with their number and their type.

--- a/rtthost/Cargo.toml
+++ b/rtthost/Cargo.toml
@@ -11,7 +11,6 @@ repository.workspace = true
 env_logger = "0.11"
 probe-rs.workspace = true
 anyhow.workspace = true
-async-io.workspace = true
 clap = { version = "4", features = ["cargo", "derive"] }
 
 [lints]

--- a/rtthost/src/main.rs
+++ b/rtthost/src/main.rs
@@ -111,7 +111,7 @@ fn main() -> Result<()> {
 
     let lister = Lister::new();
 
-    let probes = async_io::block_on(lister.list_all());
+    let probes = lister.list_all();
 
     if probes.is_empty() {
         bail!(

--- a/smoke-tester/Cargo.toml
+++ b/smoke-tester/Cargo.toml
@@ -20,7 +20,6 @@ clap = { version = "4.5", features = ["derive"] }
 colored = "3"
 linkme = "0.3.25"
 thiserror.workspace = true
-async-io.workspace = true
 
 [lints]
 workspace = true

--- a/smoke-tester/src/dut_definition.rs
+++ b/smoke-tester/src/dut_definition.rs
@@ -159,16 +159,15 @@ impl DutDefinition {
         DutDefinition::from_raw_definition(raw_definition, file)
     }
 
-    pub async fn open_probe(&self) -> Result<Probe> {
+    pub fn open_probe(&self) -> Result<Probe> {
         let lister = Lister::new();
 
         let mut probe = match &self.probe_selector {
             Some(selector) => lister
                 .open(selector)
-                .await
                 .with_context(|| format!("Failed to open probe with selector {selector}"))?,
             None => {
-                let probes = lister.list_all().await;
+                let probes = lister.list_all();
 
                 anyhow::ensure!(!probes.is_empty(), "No probes detected!");
 

--- a/smoke-tester/src/main.rs
+++ b/smoke-tester/src/main.rs
@@ -131,7 +131,7 @@ fn run_test(definitions: &[DutDefinition], markdown_summary: Option<PathBuf>) ->
     let mut test_tracker = TestTracker::new(definitions);
 
     let result = test_tracker.run(|tracker, definition| {
-        let probe = async_io::block_on(definition.open_probe())?;
+        let probe = definition.open_probe()?;
 
         println_dut_status!(tracker, blue, "Probe: {:?}", probe.get_name());
         println_dut_status!(tracker, blue, "Chip:  {:?}", &definition.chip.name);
@@ -193,7 +193,7 @@ fn run_test(definitions: &[DutDefinition], markdown_summary: Option<PathBuf>) ->
         // Try attaching with hard reset
 
         if definition.reset_connected {
-            let probe = async_io::block_on(definition.open_probe())?;
+            let probe = definition.open_probe()?;
 
             let _session =
                 probe.attach_under_reset(definition.chip.clone(), Permissions::default())?;

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -52,7 +52,6 @@ tracing-subscriber = { version = "0.3.18", features = [
 xshell = { version = "0.2", default-features = false }
 parse_int = "0.9"
 zerocopy = { version = "0.8.0", features = ["derive"] }
-async-io.workspace = true
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -99,7 +99,7 @@ pub fn cmd_test(
     };
 
     let lister = Lister::new();
-    let available_probes = async_io::block_on(lister.list(probe.as_ref()));
+    let available_probes = lister.list(probe.as_ref());
     if available_probes.len() > 1 {
         return Err(anyhow!(
             "Multiple probes were found -- please specify a probe with `--probe`"


### PR DESCRIPTION
We will want to revisit this I think, but only if we can actually finish transforming APIs. A partial asyncification doesn't have the advantages, but has the disadvantages that we're not yet ready for.

This isn't a straight revert, some conflicts needed to be resolved especially with the lockfile, but should be close enough. The original PR should also reapply easily enough.