### PR TITLE
Include Xtensa PS register in the register map

### DIFF
--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32s3_coredump_elf.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32s3_coredump_elf.snap
@@ -178,6 +178,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107314147
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107314147
   frame_base: 1070449856
@@ -577,6 +586,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107318906
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107318906
   frame_base: 1070449936
@@ -1018,6 +1036,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107300201
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107300201
   frame_base: 1070449984
@@ -1256,6 +1283,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107299600
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107299600
   frame_base: 1070450064
@@ -1717,6 +1753,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107299600
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U64: 1107299479
   frame_base: 1070450064
@@ -2308,6 +2353,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107315790
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107315790
   frame_base: 1070450240
@@ -2581,6 +2635,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107315790
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U64: 1107315785
   frame_base: 1070450240
@@ -2903,6 +2966,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107315790
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U64: 1107315720
   frame_base: 1070450240
@@ -3168,6 +3240,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107315790
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U64: 1107315720
   frame_base: 1070450240
@@ -3439,6 +3520,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107299257
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107299257
   frame_base: 1070450272
@@ -3721,6 +3811,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107300223
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107300223
   frame_base: 1070450352
@@ -4078,6 +4177,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107300223
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U64: 1107300213
   frame_base: 1070450352
@@ -4264,6 +4372,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107313795
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107313795
   frame_base: 1070450400

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32s3_esp_hal_panic.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32s3_esp_hal_panic.snap
@@ -178,6 +178,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107310682
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107310682
   frame_base: 1070449504
@@ -529,6 +538,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107310574
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107310574
   frame_base: 1070449552
@@ -921,6 +939,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107310611
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107310611
   frame_base: 1070449584
@@ -1263,6 +1290,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107327898
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107327898
   frame_base: 1070449632
@@ -1682,6 +1718,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107301821
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107301821
   frame_base: 1070449680
@@ -1879,6 +1924,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107301788
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107301788
   frame_base: 1070449744
@@ -2076,6 +2130,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107301788
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107301788
   frame_base: 1070449808
@@ -2273,6 +2336,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107301788
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107301788
   frame_base: 1070449872
@@ -2470,6 +2542,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107301788
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107301788
   frame_base: 1070449936
@@ -2667,6 +2748,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107301788
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107301788
   frame_base: 1070450000
@@ -2864,6 +2954,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107300807
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107300807
   frame_base: 1070450064
@@ -3334,6 +3433,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107300807
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U64: 1107300547
   frame_base: 1070450064
@@ -4140,6 +4248,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107323454
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107323454
   frame_base: 1070450240
@@ -4877,6 +4994,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107323454
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U64: 1107323449
   frame_base: 1070450240
@@ -5404,6 +5530,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107323454
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U64: 1107323384
   frame_base: 1070450240
@@ -5669,6 +5804,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107323454
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U64: 1107323384
   frame_base: 1070450240
@@ -5940,6 +6084,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107300249
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107300249
   frame_base: 1070450272
@@ -6222,6 +6375,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107301855
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107301855
   frame_base: 1070450352
@@ -6579,6 +6741,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107301855
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U64: 1107301845
   frame_base: 1070450352
@@ -6765,6 +6936,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1107322891
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1107322891
   frame_base: 1070450400
@@ -6951,6 +7131,15 @@ expression: stack_frames
       dwarf_id: 16
       value:
         U32: 1077381094
+    - core_register:
+        id: 65281
+        roles:
+          - Core: ps
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
   pc:
     U32: 1077381094
   frame_base: 1070450432

--- a/probe-rs/src/architecture/xtensa/registers.rs
+++ b/probe-rs/src/architecture/xtensa/registers.rs
@@ -47,6 +47,14 @@ pub const FP: CoreRegister = CoreRegister {
     unwind_rule: UnwindRule::Clear,
 };
 
+/// Processor status register.
+pub const PS: CoreRegister = CoreRegister {
+    roles: &[RegisterRole::Core("ps"), RegisterRole::ProcessorStatus],
+    id: crate::RegisterId(0xFF01),
+    data_type: RegisterDataType::UnsignedInteger(32),
+    unwind_rule: UnwindRule::Clear,
+};
+
 /// XTENSA core registers
 pub static XTENSA_CORE_REGISTERS: LazyLock<CoreRegisters> =
     LazyLock::new(|| CoreRegisters::new(XTENSA_REGISTERS_SET.iter().collect()));
@@ -150,4 +158,5 @@ static XTENSA_REGISTERS_SET: &[CoreRegister] = &[
         unwind_rule: UnwindRule::Clear,
     },
     PC,
+    PS,
 ];


### PR DESCRIPTION
This causes `info reg` to print PS as well.