### PR TITLE
fix(target-gen): Correct path handling for local unzipped packs

### DIFF
--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -242,15 +242,15 @@ fn core_to_probe_core(value: &Core) -> Result<CoreType, Error> {
 
 // Process all `.pdsc` files in the given directory.
 pub fn visit_dirs(path: &Path, families: &mut Vec<ChipFamily>) -> Result<()> {
-    walk_files(path, &mut |path| {
-        if has_extension(path, "pack") {
-            log::info!("Found .pdsc file: {}", path.display());
+    walk_files(path, &mut |file_path| {
+        if has_extension(file_path, "pdsc") {
+            log::info!("Found .pdsc file: {}", file_path.display());
 
-            let package = Package::from_path(path)
-                .context(format!("Failed to open .pdsc file {}.", path.display()))?;
+            let package = Package::from_path(file_path)
+                .context(format!("Failed to open .pdsc file {}.", file_path.display()))?;
 
             extract_families::<fs::File>(package, Kind::Directory(path), families, false)
-                .context(format!("Failed to process .pdsc file {}.", path.display()))?;
+                .context(format!("Failed to process .pdsc file {}.", file_path.display()))?;
         }
 
         Ok(())


### PR DESCRIPTION
I found that `target-gen` couldn't process a directory of unzipped CMSIS-Packs. This PR fixes it.

1. Fixed a typo in `visit_dirs` that was searching for the `.pack` extension instead of `.pdsc`.

2. Resolved a variable shadowing issue with `path` in the `walk_files` closure in `visit_dirs`. This was causing the full `.pdsc` file path to be used as a base directory instead of its parent, which broke relative path lookups for flash algorithms.