### PR TITLE
Update nusb to 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,13 +272,14 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
+checksum = "5136e6c5e7e7978fe23e9876fb924af2c0f84c72127ac6ac17e7c46f457d362c"
 dependencies = [
  "axum",
  "axum-core",
  "bytes",
+ "futures-core",
  "futures-util",
  "headers",
  "http",
@@ -286,11 +287,9 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
- "serde",
- "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -513,30 +512,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-util-schemas"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc1a6f7b5651af85774ae5a34b4e8be397d9cf4bc063b7e6dbd99a841837830"
-dependencies = [
- "semver",
- "serde",
- "serde-untagged",
- "serde-value",
- "thiserror 2.0.16",
- "toml 0.8.23",
- "unicode-xid",
- "url",
-]
-
-[[package]]
 name = "cargo_metadata"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3f56c207c76c07652489840ff98687dcf213de178ac0974660d6fefeaf5ec6"
+checksum = "981a6f317983eec002839b90fae7411a85621410ae591a9cab2ecf5cb5744873"
 dependencies = [
  "camino",
  "cargo-platform",
- "cargo-util-schemas",
  "semver",
  "serde",
  "serde_json",
@@ -699,10 +681,11 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea6d1b751c55bd9c0dda7d4ff752074e98f4765ae969664648bd193bb326d15"
+checksum = "b4ef0193218d365c251b5b9297f9911a908a8ddd2ebd3a36cc5d0ef0f63aee9e"
 dependencies = [
+ "heapless 0.9.2",
  "thiserror 2.0.16",
 ]
 
@@ -1229,16 +1212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "erased-serde"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
-dependencies = [
- "serde",
- "typeid",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +1655,16 @@ name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
  "hash32 0.3.1",
  "stable_deref_trait",
@@ -2418,15 +2401,17 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.1.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6816ab14147f80234c675b80ed6dc4f440d8a1cefc158e766067aedb84c0bcd5"
+checksum = "748f86d9befd480b602c3bebc9ef30dbf2f3dfc8acc4a73d07b90f0117e6de3f"
 dependencies = [
  "cordyceps",
  "loom 0.7.2",
+ "mutex-traits",
  "mycelium-bitfield",
  "pin-project",
  "portable-atomic",
+ "tracing",
 ]
 
 [[package]]
@@ -2529,6 +2514,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "mutex-traits"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3929f2b5633d29cf7b6624992e5f3c1e9334f1193423e12d17be4faf678cde3f"
 
 [[package]]
 name = "mycelium-bitfield"
@@ -2643,9 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "nusb"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701a6a7ed08d280343b136da239b8d62d2f0733866541dff3a0d6bfa9be50139"
+checksum = "d0226f4db3ee78f820747cf713767722877f6449d7a0fcfbf2ec3b840969763f"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2705,15 +2696,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "parking"
@@ -2914,11 +2896,11 @@ dependencies = [
 
 [[package]]
 name = "postcard-rpc"
-version = "0.11.15"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e1944dfb9859e440511700c442edce3eacd5862f90f5a9997d004bd3553f3b"
+checksum = "36b28bfede17d778c72a08681391797c53b043330d2ae016424a54ccc72562eb"
 dependencies = [
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "maitake-sync",
  "portable-atomic",
  "postcard",
@@ -2968,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "probe-rs"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-io",
@@ -2976,7 +2958,7 @@ dependencies = [
  "bitfield",
  "bitvec",
  "clap",
- "cobs 0.4.0",
+ "cobs 0.5.0",
  "docsplay",
  "dunce",
  "env_logger",
@@ -3012,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "probe-rs-debug"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "addr2line 0.25.1",
  "bitfield",
@@ -3042,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "probe-rs-target"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "base64 0.22.1",
  "indexmap",
@@ -3054,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "probe-rs-tools"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "addr2line 0.25.1",
  "ansi-parser",
@@ -3118,7 +3100,7 @@ dependencies = [
  "thiserror 2.0.16",
  "time",
  "tokio",
- "tokio-tungstenite 0.27.0",
+ "tokio-tungstenite 0.28.0",
  "tokio-util",
  "tracing",
  "tracing-appender",
@@ -3442,7 +3424,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rtthost"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3723,27 +3705,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-untagged"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
-dependencies = [
- "erased-serde",
- "serde",
- "typeid",
-]
-
-[[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3979,7 +3940,7 @@ checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "smoke_tester"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4179,7 +4140,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-gen"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4451,9 +4412,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -4461,7 +4422,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.27.0",
+ "tungstenite 0.28.0",
  "webpki-roots 0.26.8",
 ]
 
@@ -4727,9 +4688,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -4758,15 +4719,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-path"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c462d18470a2857aa657d338af5fa67170bb48bcc80a296710ce3b0802a32566"
-
-[[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+checksum = "7922f2cdc51280d47b491af9eafc41eb0cdab85eabcb390c854412fcbf26dbe8"
 
 [[package]]
 name = "typenum"
@@ -4850,12 +4805,6 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
@@ -5490,7 +5439,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,15 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli 0.31.1",
+]
+
+[[package]]
+name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
@@ -199,12 +208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,9 +215,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.8.6"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core",
  "base64 0.22.1",
@@ -232,14 +235,15 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "serde_core",
+ "rustversion",
+ "serde",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "tower",
  "tower-layer",
  "tower-service",
@@ -248,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
  "futures-core",
@@ -259,6 +263,7 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
+ "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -267,14 +272,13 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.12.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5136e6c5e7e7978fe23e9876fb924af2c0f84c72127ac6ac17e7c46f457d362c"
+checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
 dependencies = [
  "axum",
  "axum-core",
  "bytes",
- "futures-core",
  "futures-util",
  "headers",
  "http",
@@ -282,9 +286,26 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
+ "rustversion",
+ "serde",
+ "tower",
  "tower-layer",
  "tower-service",
- "tracing",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line 0.24.2",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.36.7",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -321,18 +342,18 @@ dependencies = [
 
 [[package]]
 name = "bitfield"
-version = "0.19.3"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf79f42d21f18b5926a959280215903e659760da994835d27c3a0c5ff4f898f"
+checksum = "62a3a774b2fcac1b726922b921ebba5e9fe36ad37659c822cf8ff2c1e0819892"
 dependencies = [
  "bitfield-macros",
 ]
 
 [[package]]
 name = "bitfield-macros"
-version = "0.19.3"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6115af052c7914c0cbb97195e5c72cb61c511527250074f5c041d1048b0d8b16"
+checksum = "52511b09931f7d5fe3a14f23adefbc23e5725b184013e96c8419febb61f14734"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -437,9 +458,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytesize"
-version = "2.2.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99fa31e08a43eaa5913ef68d7e01c37a2bdce6ed648168239ad33b7d30a9cd8"
+checksum = "f5c434ae3cf0089ca203e9019ebe529c47ff45cefe8af7c85ecb734ef541822f"
 
 [[package]]
 name = "camino"
@@ -472,13 +493,13 @@ dependencies = [
 
 [[package]]
 name = "cargo-config2"
-version = "0.1.39"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3795d3a48839a46854805f56c8fe9c558f10804bcf57df53925ca843d87c788f"
+checksum = "bdb1d44c72604e6dac5d86fb04a07489b78d2e766a6e06c69c0af09af6e294fc"
 dependencies = [
  "serde",
  "serde_derive",
- "toml 0.9.8",
+ "toml 0.9.7",
  "windows-sys 0.61.0",
 ]
 
@@ -492,17 +513,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo_metadata"
-version = "0.23.0"
+name = "cargo-util-schemas"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "981a6f317983eec002839b90fae7411a85621410ae591a9cab2ecf5cb5744873"
+checksum = "7dc1a6f7b5651af85774ae5a34b4e8be397d9cf4bc063b7e6dbd99a841837830"
+dependencies = [
+ "semver",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror 2.0.16",
+ "toml 0.8.23",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3f56c207c76c07652489840ff98687dcf213de178ac0974660d6fefeaf5ec6"
 dependencies = [
  "camino",
  "cargo-platform",
+ "cargo-util-schemas",
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -577,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -587,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -599,18 +637,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.60"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e602857739c5a4291dfa33b5a298aeac9006185229a700e5810a3ef7272d971"
+checksum = "75bf0b32ad2e152de789bb635ea4d3078f6b838ad7974143e99b99f45a04af4a"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -656,17 +694,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "cobs"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ef0193218d365c251b5b9297f9911a908a8ddd2ebd3a36cc5d0ef0f63aee9e"
+checksum = "fea6d1b751c55bd9c0dda7d4ff752074e98f4765ae969664648bd193bb326d15"
 dependencies = [
- "heapless 0.9.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -754,19 +791,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1005,7 +1032,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1202,6 +1229,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,21 +1275,20 @@ dependencies = [
  "serde",
  "serde_plain",
  "strum 0.27.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "espflash"
-version = "4.2.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62da936dee0276c8cd33b2077fc9faa3be2b1b91a789bc463dafc4e629471d44"
+checksum = "0c63d954132db04edb660af5a554a46f909f7b172d7601b4af3fea994b926821"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.1",
  "bytemuck",
  "esp-idf-part",
  "flate2",
- "gimli 0.32.3",
  "libc",
  "log",
  "md-5",
@@ -1262,7 +1298,7 @@ dependencies = [
  "serde",
  "sha2",
  "strum 0.27.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1306,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "libz-rs-sys",
@@ -1443,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "gdbstub"
-version = "0.7.8"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72742d2b395902caf8a5d520d0dd3334ba6d1138938429200e58d5174e275f3f"
+checksum = "b686b198dfaa4109ebd0443d2841bc521e4b4b2915f1d84b3bb50332a8cdc1ae"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -1528,6 +1564,12 @@ dependencies = [
 
 [[package]]
 name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
@@ -1559,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.10.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51876e3748c4a347fe65b906f2b1ae46a1e55a497b22c94c1f4f2c469ff7673a"
+checksum = "d6a80adfd63bd7ffd94fefc3d22167880c440a724303080e5aa686fa36abaa96"
 dependencies = [
  "log",
  "plain",
@@ -1596,12 +1638,6 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "headers"
@@ -1646,16 +1682,6 @@ name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32 0.3.1",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heapless"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
 dependencies = [
  "hash32 0.3.1",
  "stable_deref_trait",
@@ -2010,21 +2036,21 @@ checksum = "365a784774bb381e8c19edb91190a90d7f2625e057b55de2bc0f6b57bc779ff2"
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade6dfcba0dfb62ad59e59e7241ec8912af34fd29e0e743e3db992bd278e8b65"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console 0.16.0",
  "portable-atomic",
@@ -2089,6 +2115,17 @@ dependencies = [
  "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2264,18 +2301,18 @@ dependencies = [
 
 [[package]]
 name = "linkme"
-version = "0.3.35"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3283ed2d0e50c06dd8602e0ab319bb048b6325d0bba739db64ed8205179898"
+checksum = "a1b1703c00b2a6a70738920544aa51652532cacddfec2e162d2e29eae01e665c"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.35"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5cec0ec4228b4853bb129c84dbf093a27e6c7a20526da046defc334a1b017f7"
+checksum = "04d55ca5d5a14363da83bf3c33874b8feaa34653e760d5216d7ef9829c88001a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2302,10 +2339,11 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -2356,7 +2394,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2380,17 +2418,15 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.2.2"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748f86d9befd480b602c3bebc9ef30dbf2f3dfc8acc4a73d07b90f0117e6de3f"
+checksum = "6816ab14147f80234c675b80ed6dc4f440d8a1cefc158e766067aedb84c0bcd5"
 dependencies = [
  "cordyceps",
  "loom 0.7.2",
- "mutex-traits",
  "mycelium-bitfield",
  "pin-project",
  "portable-atomic",
- "tracing",
 ]
 
 [[package]]
@@ -2480,7 +2516,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -2494,12 +2529,6 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "mutex-traits"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3929f2b5633d29cf7b6624992e5f3c1e9334f1193423e12d17be4faf678cde3f"
 
 [[package]]
 name = "mycelium-bitfield"
@@ -2614,21 +2643,20 @@ dependencies = [
 
 [[package]]
 name = "nusb"
-version = "0.1.14"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f861541f15de120eae5982923d073bfc0c1a65466561988c82d6e197734c19e"
+checksum = "701a6a7ed08d280343b136da239b8d62d2f0733866541dff3a0d6bfa9be50139"
 dependencies = [
- "atomic-waker",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-foundation-sys",
  "futures-core",
  "io-kit-sys",
- "libc",
+ "linux-raw-sys 0.9.2",
  "log",
  "once_cell",
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "slab",
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2636,6 +2664,15 @@ name = "object"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -2670,6 +2707,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2677,9 +2723,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.5"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2687,15 +2733,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.12"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2868,18 +2914,18 @@ dependencies = [
 
 [[package]]
 name = "postcard-rpc"
-version = "0.12.0"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b28bfede17d778c72a08681391797c53b043330d2ae016424a54ccc72562eb"
+checksum = "c7e1944dfb9859e440511700c442edce3eacd5862f90f5a9997d004bd3553f3b"
 dependencies = [
- "heapless 0.9.1",
+ "heapless 0.8.0",
  "maitake-sync",
  "portable-atomic",
  "postcard",
  "postcard-schema",
  "serde",
  "ssmarshal",
- "thiserror 2.0.17",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "trait-variant",
@@ -2922,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "probe-rs"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-io",
@@ -2930,7 +2976,7 @@ dependencies = [
  "bitfield",
  "bitvec",
  "clap",
- "cobs 0.5.0",
+ "cobs 0.4.0",
  "docsplay",
  "dunce",
  "env_logger",
@@ -2958,7 +3004,7 @@ dependencies = [
  "serialport",
  "test-case",
  "test-log",
- "thiserror 2.0.17",
+ "thiserror 2.0.16",
  "tracing",
  "uf2-decode",
  "zerocopy",
@@ -2966,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "probe-rs-debug"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
- "addr2line",
+ "addr2line 0.25.1",
  "bitfield",
  "gimli 0.32.3",
  "insta",
@@ -2981,7 +3027,7 @@ dependencies = [
  "serde",
  "termtree",
  "test-case",
- "thiserror 2.0.17",
+ "thiserror 2.0.16",
  "tracing",
  "typed-path",
 ]
@@ -2996,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "probe-rs-target"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "base64 0.22.1",
  "indexmap",
@@ -3008,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "probe-rs-tools"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
- "addr2line",
+ "addr2line 0.25.1",
  "ansi-parser",
  "anyhow",
  "axum",
@@ -3069,10 +3115,10 @@ dependencies = [
  "termtree",
  "test-case",
  "textwrap",
- "thiserror 2.0.17",
+ "thiserror 2.0.16",
  "time",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.27.0",
  "tokio-util",
  "tracing",
  "tracing-appender",
@@ -3126,7 +3172,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.17",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
 ]
@@ -3145,7 +3191,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.16",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3278,14 +3324,14 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3295,9 +3341,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.12"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722166aa0d7438abbaa4d5cc2c649dac844e8c56d82fb3d33e9c34b5cd268fc6"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3312,9 +3358,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3396,7 +3442,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rtthost"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3453,9 +3499,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "once_cell",
  "ring",
@@ -3506,9 +3552,9 @@ checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rustyline"
-version = "17.0.2"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
+checksum = "a6614df0b6d4cfb20d1d5e295332921793ce499af3ebc011bf1e393380e1e492"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -3640,7 +3686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation 0.10.0",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3668,28 +3714,49 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
  "serde_core",
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_core"
-version = "1.0.228"
+name = "serde-untagged"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3750,9 +3817,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
 dependencies = [
  "serde_core",
 ]
@@ -3771,15 +3838,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.15.1"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa66c845eee442168b2c8134fec70ac50dc20e760769c8ba0ad1319ca1959b04"
+checksum = "c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap",
- "serde_core",
+ "serde",
+ "serde_derive",
  "serde_json",
  "time",
 ]
@@ -3799,21 +3867,20 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.8.1"
+version = "4.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f60a586160667241d7702c420fc223939fb3c0bb8d3fac84f78768e8970dee"
+checksum = "2acaf3f973e8616d7ceac415f53fc60e190b2a686fbcf8d27d0256c741c5007b"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
- "core-foundation 0.10.0",
+ "core-foundation",
  "core-foundation-sys",
  "io-kit-sys",
  "mach2",
  "nix 0.26.4",
- "quote",
  "scopeguard",
  "unescaper",
- "windows-sys 0.52.0",
+ "winapi",
 ]
 
 [[package]]
@@ -3912,18 +3979,18 @@ checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "smoke_tester"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "clap",
  "colored 3.0.0",
- "env_logger",
  "linkme",
  "log",
  "probe-rs",
  "serde",
- "thiserror 2.0.17",
- "toml 0.9.8",
+ "thiserror 2.0.16",
+ "toml 0.9.7",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4112,7 +4179,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-gen"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4139,9 +4206,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom 0.3.1",
@@ -4232,11 +4299,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -4252,9 +4319,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4331,26 +4398,29 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
+ "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.61.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4369,9 +4439,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
@@ -4379,15 +4461,15 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.27.0",
  "webpki-roots 0.26.8",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4410,14 +4492,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.0.3",
- "toml_datetime 0.7.3",
+ "serde_spanned 1.0.2",
+ "toml_datetime 0.7.2",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -4434,9 +4516,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
 dependencies = [
  "serde_core",
 ]
@@ -4457,9 +4539,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
 dependencies = [
  "winnow",
 ]
@@ -4472,9 +4554,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+checksum = "d163a63c116ce562a22cda521fcc4d79152e7aba014456fb5eb442f6d6a10109"
 
 [[package]]
 name = "tower"
@@ -4628,9 +4710,26 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.0",
+ "sha1",
+ "thiserror 2.0.16",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -4641,7 +4740,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.17",
+ "thiserror 2.0.16",
  "utf-8",
 ]
 
@@ -4659,9 +4758,15 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-path"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7922f2cdc51280d47b491af9eafc41eb0cdab85eabcb390c854412fcbf26dbe8"
+checksum = "c462d18470a2857aa657d338af5fa67170bb48bcc80a296710ce3b0802a32566"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -4745,6 +4850,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
@@ -5379,7 +5490,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/changelog/changed-update-to-nusb-0.2.0.md
+++ b/changelog/changed-update-to-nusb-0.2.0.md
@@ -1,0 +1,1 @@
+Updated nusb dependency to version 0.2.0

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -52,7 +52,7 @@ object = { version = "0.37", default-features = false, features = [
     "read_core",
     "std",
 ] }
-nusb = "0.2.0"
+nusb = "0.2.1"
 futures-lite = { version = "2", default-features = false }
 scroll = "0.13"
 serialport = { version = "4.7.0", default-features = false, features = [

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -22,6 +22,7 @@ exclude = ["tests/"]
 [features]
 default = ["builtin-targets", "cmsisdap_v1"]
 
+
 # Enable all built in targets.
 builtin-targets = ["dep:bincode", "dep:serde_yaml", "dep:probe-rs-target"]
 cmsisdap_v1 = ["dep:hidapi"]
@@ -51,7 +52,7 @@ object = { version = "0.37", default-features = false, features = [
     "read_core",
     "std",
 ] }
-nusb = "0.1.12"
+nusb = "0.2.0"
 futures-lite = { version = "2", default-features = false }
 scroll = "0.13"
 serialport = { version = "4.7.0", default-features = false, features = [

--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -1,8 +1,5 @@
 use bitvec::prelude::*;
-use nusb::{
-    DeviceInfo,
-    transfer::{Direction, EndpointType},
-};
+use nusb::{DeviceInfo, MaybeFuture, descriptors::TransferType, transfer::Direction};
 use std::{
     fmt::Debug,
     time::{Duration, Instant},
@@ -86,13 +83,18 @@ impl Debug for ProtocolHandler {
 
 impl ProtocolHandler {
     pub fn new_from_selector(selector: &DebugProbeSelector) -> Result<Self, ProbeCreationError> {
-        let device = nusb::list_devices()
-            .map_err(ProbeCreationError::Usb)?
+        let devices = nusb::list_devices()
+            .wait()
+            .map_err(|e| ProbeCreationError::Usb(e.into()))?;
+        let device = devices
             .filter(is_espjtag_device)
             .find(|device| selector.matches(device))
             .ok_or(ProbeCreationError::NotFound)?;
 
-        let device_handle = device.open().map_err(ProbeCreationError::Usb)?;
+        let device_handle = device
+            .open()
+            .wait()
+            .map_err(|e| ProbeCreationError::Usb(e.into()))?;
 
         tracing::debug!("Aquired handle for probe");
 
@@ -124,7 +126,7 @@ impl ProtocolHandler {
             for endpoint in descriptor.endpoints() {
                 let address = endpoint.address();
                 tracing::trace!("Endpoint {address:#04x}");
-                if endpoint.transfer_type() != EndpointType::Bulk {
+                if endpoint.transfer_type() != TransferType::Bulk {
                     tracing::debug!("Skipping endpoint {address:#04x}");
                     continue;
                 }
@@ -152,7 +154,8 @@ impl ProtocolHandler {
 
         let iface = device_handle
             .claim_interface(interface_number)
-            .map_err(ProbeCreationError::Usb)?;
+            .wait()
+            .map_err(|e| ProbeCreationError::Usb(e.into()))?;
 
         let start = Instant::now();
         let buffer = loop {
@@ -163,7 +166,8 @@ impl ProtocolHandler {
                     0,
                     USB_TIMEOUT,
                 )
-                .map_err(ProbeCreationError::Usb)?;
+                .wait()
+                .map_err(|e| ProbeCreationError::Usb(e.into()))?;
             if !buffer.is_empty() {
                 break buffer;
             }
@@ -533,21 +537,23 @@ pub(super) fn is_espjtag_device(device: &DeviceInfo) -> bool {
 
 #[tracing::instrument(skip_all)]
 pub(super) fn list_espjtag_devices() -> Vec<DebugProbeInfo> {
-    let Ok(devices) = nusb::list_devices() else {
-        return vec![];
-    };
-
-    devices
-        .filter(is_espjtag_device)
-        .map(|device| {
-            DebugProbeInfo::new(
-                "ESP JTAG".to_string(),
-                device.vendor_id(),
-                device.product_id(),
-                device.serial_number().map(Into::into),
-                &EspUsbJtagFactory,
-                None,
-            )
-        })
-        .collect()
+    match nusb::list_devices().wait() {
+        Ok(devices) => devices
+            .filter(is_espjtag_device)
+            .map(|device| {
+                DebugProbeInfo::new(
+                    "ESP JTAG".to_string(),
+                    device.vendor_id(),
+                    device.product_id(),
+                    device.serial_number().map(Into::into),
+                    &EspUsbJtagFactory,
+                    None,
+                )
+            })
+            .collect(),
+        Err(e) => {
+            tracing::warn!("error listing ESP USB JTAG devices: {e}");
+            vec![]
+        }
+    }
 }

--- a/probe-rs/src/probe/ftdi/ftdaye/error.rs
+++ b/probe-rs/src/probe/ftdi/ftdaye/error.rs
@@ -1,4 +1,4 @@
-use nusb::descriptors::ActiveConfigurationError;
+use nusb::ActiveConfigurationError;
 
 use crate::probe::{ProbeError, ftdi::ftdaye::ChipType};
 
@@ -10,7 +10,7 @@ pub enum FtdiError {
     /// operation. It may indicate that the USB device was unplugged, that another application or an
     /// operating system driver is currently using it, or that the current user does not have
     /// permission to access it.
-    Usb(#[from] nusb::Error),
+    Usb(#[from] std::io::Error),
 
     #[error("Unsupported chip type: {0:?}")]
     /// The connected device is not supported by the driver.

--- a/probe-rs/src/probe/glasgow/usb.rs
+++ b/probe-rs/src/probe/glasgow/usb.rs
@@ -1,10 +1,10 @@
-use std::io;
+use std::{io, mem};
 
 use async_io::block_on;
 use futures_lite::future;
 use nusb::{
-    Interface,
-    transfer::{Direction, RequestBuffer},
+    Interface, MaybeFuture,
+    transfer::{Buffer, Bulk, Direction, In, Out},
 };
 
 use crate::probe::{
@@ -46,10 +46,14 @@ impl GlasgowUsbDevice {
             ..selector.clone()
         };
         let device_info = nusb::list_devices()
-            .map_err(ProbeCreationError::Usb)?
+            .wait()
+            .map_err(|e| ProbeCreationError::Usb(e.into()))?
             .find(|device| selector.matches(device))
             .ok_or(ProbeCreationError::NotFound)?;
-        let device = device_info.open().map_err(ProbeCreationError::Usb)?;
+        let device = device_info
+            .open()
+            .wait()
+            .map_err(|e| ProbeCreationError::Usb(e.into()))?;
 
         let mut in_ep_num = None;
         let mut out_ep_num = None;
@@ -80,18 +84,22 @@ impl GlasgowUsbDevice {
         // This makes our endpoints available for use.
         let out_iface = device
             .claim_interface(out_iface_num)
-            .map_err(ProbeCreationError::Usb)?;
+            .wait()
+            .map_err(|e| ProbeCreationError::Usb(e.into()))?;
         let in_iface = device
             .claim_interface(in_iface_num)
-            .map_err(ProbeCreationError::Usb)?;
+            .wait()
+            .map_err(|e| ProbeCreationError::Usb(e.into()))?;
 
         // This takes the applet out of reset.
         out_iface
             .set_alt_setting(1)
-            .map_err(ProbeCreationError::Usb)?;
+            .wait()
+            .map_err(|e| ProbeCreationError::Usb(e.into()))?;
         in_iface
             .set_alt_setting(1)
-            .map_err(ProbeCreationError::Usb)?;
+            .wait()
+            .map_err(|e| ProbeCreationError::Usb(e.into()))?;
 
         Ok(Self {
             out_iface,
@@ -104,38 +112,71 @@ impl GlasgowUsbDevice {
     pub fn transfer(
         &mut self,
         output: Vec<u8>,
-        mut input: impl FnMut(Vec<u8>) -> Result<bool, DebugProbeError>,
+        input: impl FnMut(Vec<u8>) -> Result<bool, DebugProbeError>,
     ) -> Result<(), DebugProbeError> {
-        block_on(async {
-            let out_fut = async {
+        let out_iface = self.out_iface.clone();
+        let in_iface = self.in_iface.clone();
+        let out_ep = self.out_ep_num;
+        let in_ep = self.in_ep_num;
+        let mut input = input;
+        let output = output;
+
+        block_on(async move {
+            let out_fut = async move {
                 if !output.is_empty() {
                     tracing::trace!("OUT URB: {}", hexdump(&output));
-                    let out_buffer_len = output.len();
-                    let out_completion = self.out_iface.bulk_out(self.out_ep_num, output).await;
-                    out_completion
+                    let out_len = output.len();
+                    let mut endpoint = out_iface
+                        .endpoint::<Bulk, Out>(out_ep)
+                        .map_err(|e| DebugProbeError::Usb(e.into()))?;
+
+                    let buffer = Buffer::from(output);
+                    endpoint.submit(buffer);
+
+                    let completion = endpoint.next_complete().await;
+                    completion
                         .status
-                        .map_err(io::Error::other)
+                        .map_err(io::Error::from)
                         .map_err(DebugProbeError::Usb)?;
-                    assert!(out_completion.data.actual_length() == out_buffer_len);
+
+                    if completion.actual_len != out_len {
+                        return Err(DebugProbeError::Other(format!(
+                            "expected to send {out_len} bytes, sent {}",
+                            completion.actual_len
+                        )));
+                    }
                 }
                 Ok(())
             };
-            let in_fut = async {
+
+            let in_fut = async move {
+                let mut endpoint = in_iface
+                    .endpoint::<Bulk, In>(in_ep)
+                    .map_err(|e| DebugProbeError::Usb(e.into()))?;
+
                 let mut buffer = Vec::new();
-                while !input(buffer)? {
-                    let in_completion = self
-                        .in_iface
-                        .bulk_in(self.in_ep_num, RequestBuffer::new(65536))
-                        .await;
-                    in_completion
+                loop {
+                    if input(mem::take(&mut buffer))? {
+                        break;
+                    }
+
+                    let transfer = Buffer::new(65536);
+                    endpoint.submit(transfer);
+
+                    let completion = endpoint.next_complete().await;
+                    completion
                         .status
-                        .map_err(io::Error::other)
+                        .map_err(io::Error::from)
                         .map_err(DebugProbeError::Usb)?;
-                    tracing::trace!("IN URB: {}", hexdump(in_completion.data.as_slice()));
-                    buffer = in_completion.data;
+
+                    let data = completion.buffer.into_vec();
+                    tracing::trace!("IN URB: {}", hexdump(&data));
+                    buffer = data;
                 }
+
                 Ok::<(), DebugProbeError>(())
             };
+
             let (out_result, in_result) = future::zip(out_fut, in_fut).await;
             out_result.and(in_result)
         })

--- a/probe-rs/src/probe/glasgow/usb.rs
+++ b/probe-rs/src/probe/glasgow/usb.rs
@@ -112,14 +112,12 @@ impl GlasgowUsbDevice {
     pub fn transfer(
         &mut self,
         output: Vec<u8>,
-        input: impl FnMut(Vec<u8>) -> Result<bool, DebugProbeError>,
+        mut input: impl FnMut(Vec<u8>) -> Result<bool, DebugProbeError>,
     ) -> Result<(), DebugProbeError> {
         let out_iface = self.out_iface.clone();
         let in_iface = self.in_iface.clone();
         let out_ep = self.out_ep_num;
         let in_ep = self.in_ep_num;
-        let mut input = input;
-        let output = output;
 
         block_on(async move {
             let out_fut = async move {

--- a/probe-rs/src/probe/jlink/error.rs
+++ b/probe-rs/src/probe/jlink/error.rs
@@ -13,7 +13,7 @@ pub enum JlinkError {
     /// operation. It may indicate that the USB device was unplugged, that another application or an
     /// operating system driver is currently using it, or that the current user does not have
     /// permission to access it.
-    Usb(#[from] nusb::Error),
+    Usb(#[from] std::io::Error),
 
     #[error("device is missing capabilities ({0:?}) for operation")]
     /// An operation was attempted that is not supported by the probe.

--- a/probe-rs/src/probe/stlink/tools.rs
+++ b/probe-rs/src/probe/stlink/tools.rs
@@ -1,5 +1,6 @@
 use crate::probe::DebugProbeInfo;
 use crate::probe::stlink::StLinkFactory;
+use nusb::MaybeFuture;
 
 use super::usb_interface::USB_PID_EP_MAP;
 use super::usb_interface::USB_VID;
@@ -12,10 +13,10 @@ pub(super) fn is_stlink_device(device: &nusb::DeviceInfo) -> bool {
 
 #[tracing::instrument(skip_all)]
 pub(super) fn list_stlink_devices() -> Vec<DebugProbeInfo> {
-    let devices = match nusb::list_devices() {
+    let devices = match nusb::list_devices().wait() {
         Ok(d) => d,
         Err(e) => {
-            tracing::warn!("listing stlink devices failed: {:?}", e);
+            tracing::warn!("listing stlink devices failed: {e}");
             return vec![];
         }
     };

--- a/probe-rs/src/probe/usb_util.rs
+++ b/probe-rs/src/probe/usb_util.rs
@@ -24,12 +24,10 @@ impl InterfaceExt for Interface {
             // Request cancellation...
             endpoint.cancel_all();
 
-            // ...and then immediately drain the completion so the endpoint is reusable.
-            while let Some(cancelled) = endpoint.wait_next_complete(Duration::from_millis(10)) {
-                if cancelled.status.is_err() {
-                    break;
-                }
-            }
+            // ...and then immediately drain the completion. Whether the the response is the
+            // result of the original write, the cancellation, or a timeout of the cancellation, we
+            // drop it and return a timeout.
+            let _ = endpoint.wait_next_complete(Duration::from_millis(100));
 
             return Err(io::Error::new(
                 io::ErrorKind::TimedOut,
@@ -57,12 +55,10 @@ impl InterfaceExt for Interface {
             // Request cancellation...
             endpoint.cancel_all();
 
-            // ...and then immediately drain the completion so the endpoint is reusable.
-            while let Some(cancelled) = endpoint.wait_next_complete(Duration::from_millis(10)) {
-                if cancelled.status.is_err() {
-                    break;
-                }
-            }
+            // ...and then immediately drain the completion. Whether the the response is the
+            // result of the original read, the cancellation, or a timeout of the cancellation, we
+            // drop it and return a timeout.
+            let _ = endpoint.wait_next_complete(Duration::from_millis(100));
 
             return Err(io::Error::new(
                 io::ErrorKind::TimedOut,

--- a/probe-rs/src/probe/usb_util.rs
+++ b/probe-rs/src/probe/usb_util.rs
@@ -47,7 +47,7 @@ impl InterfaceExt for Interface {
         }
 
         let max_packet_size = endpoint.max_packet_size().max(1);
-        let requested_len = buf.len().div_ceil(max_packet_size);
+        let requested_len = buf.len().div_ceil(max_packet_size) * max_packet_size;
 
         let transfer_buffer = Buffer::new(requested_len);
         endpoint.submit(transfer_buffer);

--- a/probe-rs/src/probe/usb_util.rs
+++ b/probe-rs/src/probe/usb_util.rs
@@ -1,6 +1,7 @@
-use async_io::{Timer, block_on};
-use futures_lite::FutureExt;
-use nusb::{Interface, transfer::RequestBuffer};
+use nusb::{
+    Interface,
+    transfer::{Buffer, Bulk, In, Out},
+};
 use std::{io, time::Duration};
 
 pub trait InterfaceExt {
@@ -10,33 +11,72 @@ pub trait InterfaceExt {
 
 impl InterfaceExt for Interface {
     fn write_bulk(&self, endpoint: u8, buf: &[u8], timeout: Duration) -> io::Result<usize> {
-        let fut = async {
-            let comp = self.bulk_out(endpoint, buf.to_vec()).await;
-            comp.status.map_err(io::Error::other)?;
+        let mut endpoint = self
+            .endpoint::<Bulk, Out>(endpoint)
+            .map_err(io::Error::from)?;
 
-            let n = comp.data.actual_length();
-            Ok(n)
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let mut transfer_buffer = Buffer::new(buf.len());
+        transfer_buffer.extend_from_slice(buf);
+
+        endpoint.submit(transfer_buffer);
+
+        let Some(completion) = endpoint.wait_next_complete(timeout) else {
+            endpoint.cancel_all();
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "bulk write timed out",
+            ));
         };
 
-        block_on(fut.or(async {
-            Timer::after(timeout).await;
-            Err(std::io::ErrorKind::TimedOut.into())
-        }))
+        completion.status.map_err(io::Error::from)?;
+
+        Ok(completion.actual_len)
     }
 
     fn read_bulk(&self, endpoint: u8, buf: &mut [u8], timeout: Duration) -> io::Result<usize> {
-        let fut = async {
-            let comp = self.bulk_in(endpoint, RequestBuffer::new(buf.len())).await;
-            comp.status.map_err(io::Error::other)?;
+        let mut endpoint = self
+            .endpoint::<Bulk, In>(endpoint)
+            .map_err(io::Error::from)?;
 
-            let n = comp.data.len();
-            buf[..n].copy_from_slice(&comp.data);
-            Ok(n)
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let max_packet_size = endpoint.max_packet_size().max(1);
+        let requested_len = ((buf.len() + max_packet_size - 1) / max_packet_size) * max_packet_size;
+
+        let transfer_buffer = Buffer::new(requested_len);
+        endpoint.submit(transfer_buffer);
+
+        let Some(completion) = endpoint.wait_next_complete(timeout) else {
+            endpoint.cancel_all();
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "bulk read timed out",
+            ));
         };
 
-        block_on(fut.or(async {
-            Timer::after(timeout).await;
-            Err(std::io::ErrorKind::TimedOut.into())
-        }))
+        completion.status.map_err(io::Error::from)?;
+
+        let actual_len = completion.actual_len;
+        let data = completion.buffer;
+
+        if actual_len > buf.len() || data.len() > buf.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "device returned {actual_len} bytes, buffer length is {}",
+                    buf.len()
+                ),
+            ));
+        }
+
+        buf[..actual_len].copy_from_slice(&data[..actual_len]);
+
+        Ok(actual_len)
     }
 }

--- a/probe-rs/src/probe/usb_util.rs
+++ b/probe-rs/src/probe/usb_util.rs
@@ -47,7 +47,7 @@ impl InterfaceExt for Interface {
         }
 
         let max_packet_size = endpoint.max_packet_size().max(1);
-        let requested_len = ((buf.len() + max_packet_size - 1) / max_packet_size) * max_packet_size;
+        let requested_len = buf.len().div_ceil(max_packet_size);
 
         let transfer_buffer = Buffer::new(requested_len);
         endpoint.submit(transfer_buffer);

--- a/smoke-tester/Cargo.toml
+++ b/smoke-tester/Cargo.toml
@@ -14,12 +14,12 @@ anyhow = { version = "1.0" }
 serde = { version = "1", features = ["derive"] }
 probe-rs = { workspace = true }
 toml = "0.9.0"
-env_logger = "0.11.0"
 log = "0.4.21"
 clap = { version = "4.5", features = ["derive"] }
 colored = "3"
 linkme = "0.3.25"
 thiserror.workspace = true
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 
 [lints]
 workspace = true

--- a/smoke-tester/src/main.rs
+++ b/smoke-tester/src/main.rs
@@ -91,7 +91,7 @@ struct Opt {
 }
 
 fn main() -> Result<ExitCode> {
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     let opt = Opt::parse();
 


### PR DESCRIPTION
Full disclosure right up front: I wrote this PR with LLM tooling assistance, but I am responsible for its content.

This PR updates the nusb dependency to version 0.2. The commit message has more flavor, but it's mostly a mechanical change that relies heavily on the blocking API so as to avoid deviation. Reviewers will likely want to pay the most attention to the updates in `InterfaceExt`.

I have tested this change with a Raspberry Pi Pico Probe, flashing real firmware onto a real device on a macOS host. I also have a JLink probe and some STLinkv2-equipped devices (some Nucleos), and would be happy to test those too (smoke-test? something more?). As this is my first time contributing to this codebase, I'm not quite sure what to offer, but understand that PRs which touch nearly every supported probe might be risky.

I've also tried to meet the contribution guidelines, but please let me know if I've erred.

## Example test:

```
     Running `/Users/bmatt/Development/probe-rs/target/debug/smoke_tester test --chip rp235x --probe '2e8a:000c'`
[1/1](RP235x) - Starting Test
[1/1](RP235x) - Probe: "CMSIS-DAP"
[1/1](RP235x) - Chip:  "RP235x"
[1/1](RP235x) - Core 0: Armv8m
[1/1](RP235x) - Halting core..
[1/1](RP235x) - Test [1] - Testing stepping on core 0...
[1/1](RP235x) - Test [1] - R0 value ok!
[1/1](RP235x) - Test [1] - Core halted at 0x20000002, now trying to run...
[1/1](RP235x) - Test [1] - Core halted again!
[1/1](RP235x) - Test [1] - Core halted at 0x20000006, now trying to run...
[1/1](RP235x) - Test [1] - Run core again, with pc = 0x20000008
[1/1](RP235x) - Test [1] - Test passed in 37 ms.
[1/1](RP235x) - Test [2] - Testing HW breakpoints
[1/1](RP235x) - Test [2] - Testing region: <unnamed region> (0x10000000 - 0x14000000)
[1/1](RP235x) - Test [2] - 8 breakpoints supported
[1/1](RP235x) - Test [2] - Test passed in 65 ms.
[1/1](RP235x) - Test [3] - Testing region: <unnamed region> (0x20000000 - 0x20082000)
[1/1](RP235x) - Test [3] - Test - RAM Start 32
[1/1](RP235x) - Test [3] - Test - RAM End 32
[1/1](RP235x) - Test [3] - Test - RAM Start 8
[1/1](RP235x) - Test [3] - Test - RAM 8 Unaligned
[1/1](RP235x) - Test [3] - Test - RAM End 8
[1/1](RP235x) - Test [3] - Testing: write and read at address 0x20000000: 1 byte at RAM start
[1/1](RP235x) - Test [3] - Testing: write and read at address 0x20000000: 4 bytes at RAM start
[1/1](RP235x) - Test [3] - Testing: write and read at address 0x20081FFC: 4 bytes at RAM end
[1/1](RP235x) - Test [3] - Test passed in 3 ms.
[1/1](RP235x) - Test [4] - Testing register write...
[1/1](RP235x) - Test [4] - Test passed in 26 ms.
[1/1](RP235x) - Test [5] - Testing register read...
[1/1](RP235x) - Test [5] - Test passed in 16 ms.
[1/1](RP235x) - Test [6] - Missing resource for test: No flash test binary specified
[1/1](RP235x) - Tests Passed
[DONE] - All DUTs passed.

Test summary:
 [RP235x] passed
All tests passed.
```