### PR TITLE
Return non-zero exit code when firmware exits with an error

### DIFF
--- a/changelog/changed-exit-code.md
+++ b/changelog/changed-exit-code.md
@@ -1,0 +1,1 @@
+Allow errors reported by the firmware to affect the CLI exit code


### PR DESCRIPTION
When a firmware uses semihosting to [exit](https://docs.rs/cortex-m-semihosting/latest/cortex_m_semihosting/debug/fn.exit.html) with an error, the probe-rs CLI reports

```
Firmware exited with: Unknown runtime error
Core 0
    Frame 0: syscall1 @ 0x002012dc inline
    ...
    Frame 8: Reset @ 0x00200348> @ 0x0000000000200348
```

but exits with exit code 0. I expected it to exit with a non-zero exit code.

Allow the error to affect the exit status. As a side effect of this change, the error message is printed again at the end.

```
Firmware exited with: Unknown runtime error
Core 0
    Frame 0: syscall1 @ 0x002012dc inline
    ...
    Frame 8: Reset @ 0x00200348> @ 0x0000000000200348

Error: Unknown runtime error
```