### PR TITLE
Don't assume defmt if a single RTT channel exists (reverts #3379)

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -759,28 +759,27 @@ impl CliRttClient {
 
         // Apply our heuristics based on channel names.
         for channel in up_channels.iter() {
-            let decoder =
-                if channel == "defmt" || (self.defmt_data.is_some() && up_channels.len() == 1) {
-                    if let Some(defmt_data) = self.defmt_data.clone() {
-                        RttDecoder::Defmt {
-                            processor: DefmtProcessor::new(
-                                defmt_data,
-                                self.show_timestamps,
-                                self.show_location,
-                                self.log_format.as_deref(),
-                            ),
-                        }
-                    } else {
-                        // Not much we can do. Don't silently eat the data.
-                        RttDecoder::BinaryLE
+            let decoder = if channel == "defmt" {
+                if let Some(defmt_data) = self.defmt_data.clone() {
+                    RttDecoder::Defmt {
+                        processor: DefmtProcessor::new(
+                            defmt_data,
+                            self.show_timestamps,
+                            self.show_location,
+                            self.log_format.as_deref(),
+                        ),
                     }
                 } else {
-                    RttDecoder::String {
-                        timestamp_offset: self.timestamp_offset,
-                        last_line_done: false,
-                        show_timestamps: self.show_timestamps,
-                    }
-                };
+                    // Not much we can do. Don't silently eat the data.
+                    RttDecoder::BinaryLE
+                }
+            } else {
+                RttDecoder::String {
+                    timestamp_offset: self.timestamp_offset,
+                    last_line_done: false,
+                    show_timestamps: self.show_timestamps,
+                }
+            };
 
             self.channel_processors
                 .push(Channel::new(channel.clone(), decoder));


### PR DESCRIPTION
Reverts #3379, so that channels should be named `defmt`, rather than assuming a single RTT channel in a firmware with defmt present is actually defmt-formatted.

This allows, for example, non-defmt RTT messages in a firmware where defmt is used for another transport. It prevents a situation where RTT messages can appear to the user as being "lost", as probe-rs is still waiting for the defmt framing.

The change is just to remove the extra condition check; rustfmt shifts the blocks over which makes the diff larger.