### PR TITLE
target-gen: when updating a chip yaml, always update load address to the right address

### DIFF
--- a/changelog/fixed-target-gen-load-address-update.md
+++ b/changelog/fixed-target-gen-load-address-update.md
@@ -1,0 +1,1 @@
+Fixed target-gen to always update the load address

--- a/target-gen/src/commands/elf.rs
+++ b/target-gen/src/commands/elf.rs
@@ -70,11 +70,6 @@ pub fn cmd_elf(
             algorithm.name = name;
         }
 
-        // if a load address was specified, use it in the replacement
-        if let Some(load_addr) = current.load_address {
-            algorithm.load_address = Some(load_addr);
-            algorithm.data_section_offset = algorithm.data_section_offset.saturating_sub(load_addr);
-        }
         // core access cannot be determined, use the current value
         algorithm.cores.clone_from(&current.cores);
         algorithm.description.clone_from(&current.description);

--- a/target-gen/src/parser.rs
+++ b/target-gen/src/parser.rs
@@ -124,7 +124,8 @@ pub fn extract_flash_algo(
         .unwrap()
         .to_lowercase();
     algo.default = default;
-    algo.data_section_offset = algorithm_binary.data_section.start as u64;
+    algo.data_section_offset = algorithm_binary.data_section.start as u64
+        - algorithm_binary.code_section.load_address as u64;
     algo.flash_properties = FlashProperties::from(flash_device);
     algo.big_endian = !elf.little_endian;
 


### PR DESCRIPTION
Apparently intentionally, `target-gen elf --fixed-load-address -u`, i.e. when updating an existing chip yaml with a new flash algorithm that has a fixed load address, would retain the old load address.

This doesn't work since with `--fixed-load-address`, the assumption is that the code is _not_ position independent, so it must be loaded at the correct address.

Further, fix `data_section_offset` to be relative to the load address; previously this was the case only when the load address was retained; otherwise, the absolute address of the data section would be used.

To be fair, the behavior puzzles me a bit - am I missing a common case of how this is supposed to be used?
