### PR TITLE
Add hints on Linux if the probe list is empty or probe can not be opened

### DIFF
--- a/changelog/added-linux-setup-hints.md
+++ b/changelog/added-linux-setup-hints.md
@@ -6,3 +6,5 @@ The hints cover the following cases:
 - The user uses systemd >= 258 and the `plugdev` group is missing or has an id <= 1000.
   See https://github.com/probe-rs/probe-rs/issues/3566 for more info.
 - The user does not belong to the `plugdev` group.
+
+You can disable the hints if by setting the `PROBE_RS_DISABLE_SETUP_HINTS` variable.

--- a/changelog/added-linux-setup-hints.md
+++ b/changelog/added-linux-setup-hints.md
@@ -3,7 +3,9 @@ Added hints on Linux that warn the user if their setup might be incorrect.
 The hints cover the following cases:
 
 - The user has no udev rule file containing the string `probe-rs`.
-- The user uses systemd >= 258 and the `plugdev` group is missing or has an id <= 1000.
+- The `plugdev` group is missing 
+- The `plugdev` group is not a system group (ie. the group has id >= 1000) and
+  uses a recent systemd version (ie >= 258).
   See https://github.com/probe-rs/probe-rs/issues/3566 for more info.
 - The user does not belong to the `plugdev` group.
 

--- a/changelog/added-linux-setup-hints.md
+++ b/changelog/added-linux-setup-hints.md
@@ -1,0 +1,8 @@
+Added hints on Linux that warn the user if their setup might be incorrect.
+
+The hints cover the following cases:
+
+- The user has no udev rule file containing the string `probe-rs`.
+- The user uses systemd >= 258 and the `plugdev` group is missing or has an id <= 1000.
+  See https://github.com/probe-rs/probe-rs/issues/3566 for more info.
+- The user does not belong to the `plugdev` group.

--- a/probe-rs/src/probe/list.rs
+++ b/probe-rs/src/probe/list.rs
@@ -37,7 +37,7 @@ impl Lister {
         self.lister.list_all()
     }
 
-    /// List all available debug probes
+    /// List probes found by the lister, with optional filtering.
     pub fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
         self.lister.list(selector)
     }

--- a/probe-rs/src/probe/list.rs
+++ b/probe-rs/src/probe/list.rs
@@ -97,7 +97,7 @@ impl ProbeLister for AllProbesLister {
             list.extend(driver.list_probes_filtered(selector));
         }
 
-        if list.is_empty() {
+        if list.is_empty() && std::env::var("PROBE_RS_DISABLE_SETUP_HINTS").is_err() {
             #[cfg(target_os = "linux")]
             linux::help_linux();
         }


### PR DESCRIPTION
This should fix confusion for new users not following the guide and for existing users upgrading their OS (ie systemd)

See also https://github.com/probe-rs/probe-rs/issues/3566

Replaces (builts on) https://github.com/probe-rs/probe-rs/pull/3576