### PR TITLE
Attach to the probe with the registry which loaded the target from yaml

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -306,9 +306,9 @@ impl<'r> LoadedProbeOptions<'r> {
         }
 
         let session = if self.0.connect_under_reset {
-            probe.attach_under_reset(target, permissions)
+            probe.attach_under_reset_with_registry(target, permissions, self.1)
         } else {
-            probe.attach(target, permissions)
+            probe.attach_with_registry(target, permissions, self.1)
         }
         .map_err(|error| OperationError::AttachingFailed {
             source: error,


### PR DESCRIPTION
Fixes: #3582 

In the current master branch and v0.29.1, specifying the chip-description-path when running `probe-rs dap-server` results in an error.
I think this is because `probe.attach()` and `probe().attach_under_reset()`, called within `attach_session()`, create a new Registry instead of loading the existing Registry from the YAML.
Since `LoadedProbeOptions` loads the YAML in `new()`, this can be resolved by passing `self.1` to `attach_with_registry` or `attach_under_reset_with_registry`.