### PR TITLE
Add Windows ARM64 builds

### DIFF
--- a/.github/workflows/v-release.yml
+++ b/.github/workflows/v-release.yml
@@ -60,12 +60,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
       - name: Install dist
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.28.2/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:
@@ -119,6 +120,7 @@ jobs:
           git config --global core.longpaths true
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
       - name: Install Rust non-interactively if not already installed
         if: ${{ matrix.container }}
@@ -181,6 +183,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
       - name: Install cached dist
         uses: actions/download-artifact@v4
@@ -230,6 +233,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
       - name: Install cached dist
         uses: actions/download-artifact@v4
@@ -294,6 +298,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: true
           repository: "probe-rs/homebrew-probe-rs"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       # So we have access to the formula
@@ -340,4 +345,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive

--- a/changelog/added-windows-arm64-release-binaries.md
+++ b/changelog/added-windows-arm64-release-binaries.md
@@ -1,0 +1,1 @@
+Enable generation of Windows ARM64 binaries when creating releases

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,7 +8,7 @@ cargo-dist-version = "0.30.0"
 # CI backends to support
 ci = "github"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Build only the required packages, and individually
 precise-builds = true
 # The archive format to use for non-windows builds (defaults .tar.xz)

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.28.2"
+cargo-dist-version = "0.30.0"
 # CI backends to support
 ci = "github"
 # Target platforms to build apps for (Rust target-triple syntax)


### PR DESCRIPTION
Windows ARM64 builds via dist were blocked on issues with the 'ring' crate, but these have now been resolved.
I updated cargo-dist 28.2 to dist(new name) 30 via `dist-init` and added Windows AARCH64/ARM64 builds to the dist list.
I have tested building with this setup locally on Linux x64, Windows x64 and Windows ARM64.

I'll be using these builds myself, feel free to tag me on any Win ARM64 issues. Also, if these builds ever block CI feel free to disable them and leave it to me to fix. The number of users affected is going to be pretty small (steam hardware survey says WinARM64 is 0.5% of all users)

[edit]
my test builds were for the wrong arch. this is still broken, marking this draft until a dist fix is done