### PR TITLE
jtag: mark JtagSequence members as pub

### DIFF
--- a/changelog/changed-make-jtagsequence-members-pub.md
+++ b/changelog/changed-make-jtagsequence-members-pub.md
@@ -1,0 +1,1 @@
+Updated `JtagSequence` members so they are now `pub` rather than `pub(crate)`, allowing this struct to be used by library users.

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -1387,13 +1387,13 @@ pub trait JtagAccess: DebugProbe {
 /// A raw JTAG bit sequence.
 pub struct JtagSequence {
     /// TDO capture
-    pub(crate) tdo_capture: bool,
+    pub tdo_capture: bool,
 
     /// TMS value
-    pub(crate) tms: bool,
+    pub tms: bool,
 
     /// Data to generate on TDI
-    pub(crate) data: BitVec,
+    pub data: BitVec,
 }
 
 /// A low-level JTAG register write command.


### PR DESCRIPTION
Mark the members of the `JtagSequence` struct as `pub`. This struct is only used in `pub fn JtagAccess::shift_raw_sequence(&mut self, sequence: JtagSequence);` which is a public function, however this function can't be called as `JtagSequence` is currently a sealed trait.

Mark the members as `pub` rather than `pub(crate)`, allowing raw JTAG sequences to be created by users of the `probe-rs` library.