### PR TITLE
Add riscv FPU registers to GDB server

### DIFF
--- a/changelog/added-riscv-fpu-registers-to-gdb-server.md
+++ b/changelog/added-riscv-fpu-registers-to-gdb-server.md
@@ -1,0 +1,4 @@
+Add RISC-V FPU registers to the GDB server so targets compiled with
+floating-point support correctly advertise the FP capability (`flen`). This
+prevents errors like: "bfd requires flen 4, but target has flen 0".
+

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/desc/data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/desc/data.rs
@@ -257,6 +257,12 @@ fn build_riscv_registers(desc: &mut TargetDescription, regs: &CoreRegisters) {
     desc.add_registers(regs.core_registers());
     desc.add_register(&architecture::riscv::PC);
 
+    if regs.fpu_registers().is_some() {
+        desc.add_gdb_feature("org.gnu.gdb.riscv.fpu");
+        desc.add_registers(regs.fpu_registers().unwrap());
+        desc.add_registers(regs.fpu_status_registers().unwrap());
+    }
+
     desc.update_register_type("pc", "code_ptr");
 }
 

--- a/probe-rs/src/architecture/riscv/registers.rs
+++ b/probe-rs/src/architecture/riscv/registers.rs
@@ -59,11 +59,22 @@ pub const S1: CoreRegister = CoreRegister {
     unwind_rule: UnwindRule::Clear,
 };
 
-/// The RISCV core registers.
+/// The RISCV core registers without FPU.
 pub static RISCV_CORE_REGISTERS: LazyLock<CoreRegisters> =
-    LazyLock::new(|| CoreRegisters::new(RISCV_REGISTERS_SET.iter().collect()));
+    LazyLock::new(|| CoreRegisters::new(RISCV_COMMON_REGS_SET.iter().collect::<Vec<_>>()));
 
-static RISCV_REGISTERS_SET: &[CoreRegister] = &[
+/// The RISCV core registers with FPU.
+pub static RISCV_WITH_FP_CORE_REGISTERS: LazyLock<CoreRegisters> = LazyLock::new(|| {
+    CoreRegisters::new(
+        RISCV_COMMON_REGS_SET
+            .iter()
+            .chain(RISCV_WITH_FP_REGS_SET)
+            .collect(),
+    )
+});
+
+// Non-FPU registers
+static RISCV_COMMON_REGS_SET: &[CoreRegister] = &[
     ZERO,
     RA,
     SP,
@@ -240,5 +251,352 @@ static RISCV_REGISTERS_SET: &[CoreRegister] = &[
         unwind_rule: UnwindRule::Clear,
     },
     PC,
-    // TODO: Add FPU registers
+];
+
+// FPU registers
+static RISCV_WITH_FP_REGS_SET: &[CoreRegister] = &[
+    // Floating point flags and rounding mode CSRs (RV32: 32-bit)
+    CoreRegister {
+        roles: &[RegisterRole::Core("fflags")],
+        id: RegisterId(0x001),
+        data_type: RegisterDataType::UnsignedInteger(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[RegisterRole::Core("frm")],
+        id: RegisterId(0x002),
+        data_type: RegisterDataType::UnsignedInteger(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    // Floating point status/control register
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("fcsr"),
+            RegisterRole::FloatingPointStatus,
+        ],
+        id: RegisterId(0x003),
+        data_type: RegisterDataType::UnsignedInteger(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    // Floating point registers f0 - f31
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f0"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("ft0"),
+        ],
+        id: RegisterId(0x1020),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f1"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("ft1"),
+        ],
+        id: RegisterId(0x1021),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f2"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("ft2"),
+        ],
+        id: RegisterId(0x1022),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f3"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("ft3"),
+        ],
+        id: RegisterId(0x1023),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f4"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("ft4"),
+        ],
+        id: RegisterId(0x1024),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f5"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("ft5"),
+        ],
+        id: RegisterId(0x1025),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f6"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("ft6"),
+        ],
+        id: RegisterId(0x1026),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f7"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("ft7"),
+        ],
+        id: RegisterId(0x1027),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f8"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fs0"),
+        ],
+        id: RegisterId(0x1028),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f9"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fs1"),
+        ],
+        id: RegisterId(0x1029),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f10"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fa0"),
+        ],
+        id: RegisterId(0x102A),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f11"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fa1"),
+        ],
+        id: RegisterId(0x102B),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f12"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fa2"),
+        ],
+        id: RegisterId(0x102C),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f13"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fa3"),
+        ],
+        id: RegisterId(0x102D),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f14"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fa4"),
+        ],
+        id: RegisterId(0x102E),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f15"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fa5"),
+        ],
+        id: RegisterId(0x102F),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f16"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fa6"),
+        ],
+        id: RegisterId(0x1030),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f17"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fa7"),
+        ],
+        id: RegisterId(0x1031),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f18"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fs2"),
+        ],
+        id: RegisterId(0x1032),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f19"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fs3"),
+        ],
+        id: RegisterId(0x1033),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f20"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fs4"),
+        ],
+        id: RegisterId(0x1034),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f21"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fs5"),
+        ],
+        id: RegisterId(0x1035),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f22"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fs6"),
+        ],
+        id: RegisterId(0x1036),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f23"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fs7"),
+        ],
+        id: RegisterId(0x1037),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f24"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fs8"),
+        ],
+        id: RegisterId(0x1038),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f25"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fs9"),
+        ],
+        id: RegisterId(0x1039),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f26"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fs10"),
+        ],
+        id: RegisterId(0x103A),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f27"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("fs11"),
+        ],
+        id: RegisterId(0x103B),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f28"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("ft8"),
+        ],
+        id: RegisterId(0x103C),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f29"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("ft9"),
+        ],
+        id: RegisterId(0x103D),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f30"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("ft10"),
+        ],
+        id: RegisterId(0x103E),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
+    CoreRegister {
+        roles: &[
+            RegisterRole::Core("f31"),
+            RegisterRole::FloatingPoint,
+            RegisterRole::Other("ft11"),
+        ],
+        id: RegisterId(0x103F),
+        data_type: RegisterDataType::FloatingPoint(32),
+        unwind_rule: UnwindRule::Clear,
+    },
 ];

--- a/probe-rs/src/core/dump.rs
+++ b/probe-rs/src/core/dump.rs
@@ -5,7 +5,7 @@ use crate::architecture::arm::core::registers::aarch64::AARCH64_CORE_REGISTERS;
 use crate::architecture::arm::core::registers::cortex_m::{
     CORTEX_M_CORE_REGISTERS, CORTEX_M_WITH_FP_CORE_REGISTERS,
 };
-use crate::architecture::riscv::registers::RISCV_CORE_REGISTERS;
+use crate::architecture::riscv::registers::{RISCV_CORE_REGISTERS, RISCV_WITH_FP_CORE_REGISTERS};
 use crate::architecture::xtensa::arch::{Register as XtensaRegister, SpecialRegister};
 use crate::architecture::xtensa::registers::XTENSA_CORE_REGISTERS;
 use crate::{Core, CoreRegisters, CoreType, Error, InstructionSet, MemoryInterface};
@@ -382,7 +382,13 @@ impl CoreDump {
                     &CORTEX_M_CORE_REGISTERS
                 }
             }
-            CoreType::Riscv => &RISCV_CORE_REGISTERS,
+            CoreType::Riscv => {
+                if self.fpu_support {
+                    &RISCV_WITH_FP_CORE_REGISTERS
+                } else {
+                    &RISCV_CORE_REGISTERS
+                }
+            }
             CoreType::Xtensa => &XTENSA_CORE_REGISTERS,
         }
     }

--- a/probe-rs/src/core/registers.rs
+++ b/probe-rs/src/core/registers.rs
@@ -602,6 +602,20 @@ impl CoreRegisters {
     }
 
     /// Returns an iterator over the descriptions of all the registers of this core.
+    pub fn fpu_status_registers(&self) -> Option<impl Iterator<Item = &CoreRegister>> {
+        let mut fpu_registers = self
+            .0
+            .iter()
+            .filter(|r| r.register_has_role(RegisterRole::FloatingPointStatus))
+            .peekable();
+        if fpu_registers.peek().is_some() {
+            Some(fpu_registers.cloned())
+        } else {
+            None
+        }
+    }
+
+    /// Returns an iterator over the descriptions of all the registers of this core.
     pub fn fpu_registers(&self) -> Option<impl Iterator<Item = &CoreRegister>> {
         let mut fpu_registers = self
             .0


### PR DESCRIPTION
When a binary is compiled for a FPU riscv GDB expects the server to correctly advertise that. Otherwise it fails the following way (see https://sourceware.org/pipermail/gdb-cvs/2019-January/044597.html):

"bfd requires flen 4, but target has flen 0"