### PR TITLE
armv7a/armv8a: reset fast mode and catch debug aborts

### DIFF
--- a/changelog/fixed-cortexa-clear-fast-copy-on-connect.md
+++ b/changelog/fixed-cortexa-clear-fast-copy-on-connect.md
@@ -1,0 +1,1 @@
+Reset the EXTDCC mode (ARMv7A) or Memory Access mode (ARMv8A) when starting the debug core.

--- a/changelog/fixed-cortexa-data-abort-handling.md
+++ b/changelog/fixed-cortexa-data-abort-handling.md
@@ -1,0 +1,1 @@
+Check for data aborts when executing instructions on ARMv7A and ARMv8A.

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -169,12 +169,13 @@ fn armv7a_core_start(
     let address = Dbgdscr::get_mmio_address_from_base(debug_base)?;
     let mut dbgdscr = Dbgdscr(core.read_word_32(address)?);
 
-    if dbgdscr.hdbgen() {
+    if dbgdscr.hdbgen() && dbgdscr.extdccmode() == 0 {
         tracing::debug!("Core is already in debug mode, no need to enable it again");
         return Ok(());
     }
 
     dbgdscr.set_hdbgen(true);
+    dbgdscr.set_extdccmode(0);
     core.write_word_32(address, dbgdscr.into())?;
 
     Ok(())
@@ -308,12 +309,13 @@ fn armv8a_core_start(
     let address = Edscr::get_mmio_address_from_base(debug_base)?;
     let mut edscr = Edscr(core.read_word_32(address)?);
 
-    if edscr.hde() {
+    if edscr.hde() && !edscr.ma() {
         tracing::debug!("Core is already in debug mode, no need to enable it again");
         return Ok(());
     }
 
     edscr.set_hde(true);
+    edscr.set_ma(false);
     core.write_word_32(address, edscr.into())?;
 
     Ok(())


### PR DESCRIPTION
If an instruction fails, the current implementation will continue to poll to retrieve the data. However, since the instruction has failed, this will never occur and the program will wait indefinitely.

Check for data aborts as part of every loop. Additionally, add a timeout to prevent indefinite polling.

Additionally, clear the Memory Access mode for ARMv8A, and set EXTDCC mode to 0 for ARMv7A. This will fix connecting to a core that has been interrupted while transferring files, for example when hitting Control-C during a flash upload.