### PR TITLE
jtag: ignore trailing bypass taps on tap scan

### DIFF
--- a/changelog/fixed-jtag-bypass-tap-display.md
+++ b/changelog/fixed-jtag-bypass-tap-display.md
@@ -1,0 +1,1 @@
+Fixed an issue where JTAG scans showed a large number of phantom BYPASS taps at the end of a scan that don't actually exist.


### PR DESCRIPTION
When scanning the JTAG chain the software assumes that IDCODEs that end in a `1` bit are valid. It then assumes that any IDCODE that is all-ones is an IDCODE in BYPASS.

Normally this is an acceptable assumption. However, a TAP of all ones might also be caused by the ones getting shifted in.

Drop the trailing BYPASS taps from the scanned chain. This makes the scan output cleaner and avoids putting a large number of padding bits on any transactions for devices that don't exist.