### PR TITLE
arm: get_arm_component returns an error early without enumerating through all the interfaces.

### DIFF
--- a/changelog/fixed-arm-get-components.md
+++ b/changelog/fixed-arm-get-components.md
@@ -1,0 +1,1 @@
+Fixed an issue when enumerating through access ports in `get_arm_components`. If an access port base address is not present is should be skipped.


### PR DESCRIPTION
The base_address function in [probe-rs/src/architecture/arm/ap/memory_ap/mod.rs](https://github.com/probe-rs/probe-rs/blob/c6ca9fd3fba3425f4fd2fc722c904fcdb2f8480b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs#L96) returns an error when the P bit is unset as referenced in https://github.com/probe-rs/probe-rs/pull/3404. However this breaks the get_arm_component function in https://github.com/probe-rs/probe-rs/blob/c6ca9fd3fba3425f4fd2fc722c904fcdb2f8480b/probe-rs/src/architecture/arm/component/mod.rs#L117 as it returns an error early.
This breaks the function in my STM32H7B0 as it returns early without enumerating through all memory interfaces.
Not sure if this issue is applicable or my fix is up to the standards but thought it could be helpful to others which use the probe-rs as a library like me (Using it to configure the ETM).