### PR TITLE
gdb_server: return EFAULT for wrapped read_addrs requests

### DIFF
--- a/changelog/fixed-read_addrs-overflow-efault.md
+++ b/changelog/fixed-read_addrs-overflow-efault.md
@@ -1,0 +1,1 @@
+Detect and handle start_addr + len overflow in read_addrs by returning non-fatal EFAULT (14) when GDB issues wrapped requests (e.g., $mfffffffffffffffc,4), mirroring OpenOCD behavior and preventing the panic in aligned_to_32_split_offset while keeping valid reads unaffected.


### PR DESCRIPTION
## Summary

Handle `start_addr + len` overflow in `read_addrs`. Return non-fatal `EFAULT (14)` instead of panic.

## Environment

* Board: Compute Module 5
* OS: NixOS 25.05
* GDB: 16.2

## Bug

`probe-rs/src/architecture/arm/core/armv8a.rs aligned_to_32_split_offset` panics due to add overflow when GDB sends invalid read request:

```text
[remote] Sending packet: $mfffffffffffffffc,4#2a
```

## Root cause

GDB may request memory at `0xFFFFFFFFFFFFFFFC` with len `4`. `addr + len` wraps, later code overflows and panics.

## Fix

* In `read_addrs`, check `start_addr.checked_add(data.len() as u64)`. (Same as OpenOCD)
* If it returns `None`, return `Err(TargetError::Errno(14))` (non-fatal).

## Result

* No panic. Session continues.
* Valid reads unchanged.