### PR TITLE
Normalize NXP chip names

### DIFF
--- a/changelog/changed-nxp-target-names.md
+++ b/changelog/changed-nxp-target-names.md
@@ -1,0 +1,1 @@
+Normalized NXP chip names to omit redundant "NXP" prefix

--- a/probe-rs/targets/MIMXRT1010.yaml
+++ b/probe-rs/targets/MIMXRT1010.yaml
@@ -1,4 +1,4 @@
-name: NXP MIMXRT1010 Series
+name: MIMXRT1010 Series
 manufacturer:
   id: 0x15
   cc: 0x0

--- a/probe-rs/targets/MIMXRT1015.yaml
+++ b/probe-rs/targets/MIMXRT1015.yaml
@@ -1,4 +1,4 @@
-name: NXP MIMXRT1015 Series
+name: MIMXRT1015 Series
 manufacturer:
   id: 0x15
   cc: 0x0

--- a/probe-rs/targets/MIMXRT1020.yaml
+++ b/probe-rs/targets/MIMXRT1020.yaml
@@ -1,4 +1,4 @@
-name: NXP MIMXRT1020 Series
+name: MIMXRT1020 Series
 manufacturer:
   id: 0x15
   cc: 0x0

--- a/probe-rs/targets/MIMXRT1050.yaml
+++ b/probe-rs/targets/MIMXRT1050.yaml
@@ -1,4 +1,4 @@
-name: NXP MIMXRT1050 Series (Rev B)
+name: MIMXRT1050 Series (Rev B)
 manufacturer:
   id: 0x15
   cc: 0x0

--- a/probe-rs/targets/MIMXRT1060.yaml
+++ b/probe-rs/targets/MIMXRT1060.yaml
@@ -1,4 +1,4 @@
-name: NXP MIMXRT1060 Series (Rev A)
+name: MIMXRT1060 Series (Rev A)
 manufacturer:
   id: 0x15
   cc: 0x0

--- a/probe-rs/targets/MIMXRT1064.yaml
+++ b/probe-rs/targets/MIMXRT1064.yaml
@@ -1,4 +1,4 @@
-name: NXP MIMXRT1064 Series (Rev A)
+name: MIMXRT1064 Series (Rev A)
 manufacturer:
   id: 0x15
   cc: 0x0

--- a/probe-rs/targets/MIMXRT500.yaml
+++ b/probe-rs/targets/MIMXRT500.yaml
@@ -1,4 +1,4 @@
-name: NXP MIMXRT500 Series
+name: MIMXRT500 Series
 manufacturer:
   id: 0x15
   cc: 0x0


### PR DESCRIPTION
Some of these started with "NXP", while others were just the bare part number. Standardize on the latter, since that's what the majority of other targets do. This makes the listing at https://probe.rs/targets/ more readable.