### PR TITLE
Add CH32V208 Support

### DIFF
--- a/changelog/added-support-for-CH32V208.md
+++ b/changelog/added-support-for-CH32V208.md
@@ -1,0 +1,1 @@
+Add support for CH32V003 RV32EC RISC-V MCU

--- a/probe-rs/targets/CH32V2_Series.yaml
+++ b/probe-rs/targets/CH32V2_Series.yaml
@@ -1,0 +1,49 @@
+name: CH32V2 Series
+variants:
+- name: CH32V208
+  cores:
+  - name: main
+    type: riscv
+    core_access_options: !Riscv
+  memory_map:
+  - !Nvm
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    cores:
+    - main
+    access:
+      boot: true
+  - !Ram
+    range:
+      start: 0x20000000
+      end: 0x20010000
+    cores:
+    - main
+  flash_algorithms:
+  - ch32v208-flash-algorithm
+flash_algorithms:
+- name: ch32v208-flash-algorithm
+  description: Flash algoritm for the ch32v3xx series
+  default: true
+  instructions: NwUAIINFRSI3JQJAicUMSZPlBQgMyX0WjUVjdbYCtwVnRTeW782ThTUSEwa2mkzBUMFM0bcFACBQ0QVFI4KlIgFFgoCXAAAA54DgGrcFACADxUUiGckBRTcmAkAUSpPmBggUyiOCBSKCgAVFgoC3BQAgg8VFIpHJQREGxiLEJsIqhEYFCcURRZGgBUWCgJcAAADngAATHem3JAJAiEi3BQAIopU3BgQAUY2IyMzIiEgTZQUEiMiXAAAA54CAEBnljEg3Bvz/fRbxjYzIskAiRJJEQQGCgAERBs4izCbKSshOxq6EtwUAIIPFRSKJzSqEtykCQAOlCQGhZZOFBQhtjRnJGUURoAVF8kBiRNJEQkmySQVhgoATdfQPGcERRe23MokDpQkBwWVNjSOoqQCXAAAA54AACWn5AUY3BQAI8ZgqlDcF8AATCBUAscSTBUkA8RSDRgkAA0cZACKWg0cpAANFOQAiB9mOEwQWAMIHYgVdjVWNCMJChn0WAc6DpskAE/UmAHX5wYoNRi6J3d4dRaW/CUWVvwOlCQG3BSAATY0jqKkAlwAAAOeAoAEx/YOlCQFBdn0W8Y0jqLkAsbc3BfAABQW3JQJAfRUFwdBFk3YWAIHGk3YGAuXaQYoJ6gFF0EUTdvb90MWCgBVFgoAdRYKAQREGxiLEAAiXAAAA54CAAAGgAAAAAA==
+  load_address: 0x20000020
+  pc_init: 0x0
+  pc_uninit: 0x4c
+  pc_program_page: 0xd6
+  pc_erase_sector: 0x6e
+  pc_erase_all: 0x0
+  data_section_offset: 0x208
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x10000
+    page_size: 0x100
+    erased_byte_value: 0x39
+    program_page_timeout: 1000
+    erase_sector_timeout: 2000
+    sectors:
+    - size: 0x8000
+      address: 0x0
+  cores:
+  - main


### PR DESCRIPTION
I've developed a flash algorithm for the CH32V208, which, with minor configuration adjustments (add content in the variants), should theoretically also support the CH32V2 and V3 series.  :)

Its source code is available at: [here](https://github.com/Oveln/flash-algorithms/tree/main/ch32v208)