### PR TITLE
Add ESP32-C6 ROM to the memory map

### DIFF
--- a/changelog/added-esp32-rom-to-mmap.md
+++ b/changelog/added-esp32-rom-to-mmap.md
@@ -1,0 +1,1 @@
+Add ROM regions to the ESP32 memory maps.

--- a/changelog/added-esp32c6-rom-to-mmap.md
+++ b/changelog/added-esp32c6-rom-to-mmap.md
@@ -1,1 +1,0 @@
-Add ESP32-C6 ROM (320KB) to the target file's memory map.

--- a/probe-rs/targets/esp32.yaml
+++ b/probe-rs/targets/esp32.yaml
@@ -37,6 +37,14 @@ variants:
     - main
     - app
     is_alias: true
+  - !Generic
+    name: ROM1, Data bus
+    range:
+      start: 0x3FF90000
+      end: 0x3FFA0000
+    cores:
+    - main
+    - app
   - !Ram
     name: SRAM2, Data bus
     range:
@@ -50,6 +58,14 @@ variants:
     range:
       start: 0x3ffe0000
       end: 0x40000000
+    cores:
+    - main
+    - app
+  - !Generic
+    name: ROM0
+    range:
+      start: 0x40000000
+      end: 0x40060000
     cores:
     - main
     - app

--- a/probe-rs/targets/esp32c2.yaml
+++ b/probe-rs/targets/esp32c2.yaml
@@ -32,11 +32,32 @@ variants:
     cores:
     - main
     is_alias: true
+  - !Generic
+    name: ROM1, Data bus
+    range:
+      start: 0x3FF00000
+      end: 0x3FF50000
+    cores:
+    - main
   - !Ram
     name: SRAM1 Data bus
     range:
       start: 0x3fca0000
       end: 0x3fce0000
+    cores:
+    - main
+  - !Generic
+    name: ROM0
+    range:
+      start: 0x40000000
+      end: 0x40040000
+    cores:
+    - main
+  - !Generic
+    name: ROM1
+    range:
+      start: 0x40040000
+      end: 0x40090000
     cores:
     - main
   - !Ram

--- a/probe-rs/targets/esp32c3.yaml
+++ b/probe-rs/targets/esp32c3.yaml
@@ -41,6 +41,27 @@ variants:
       end: 0x3fce0000
     cores:
     - main
+  - !Generic
+    name: ROM1, Data bus
+    range:
+      start: 0x3FF00000
+      end: 0x3FF20000
+    cores:
+    - main
+  - !Generic
+    name: ROM0
+    range:
+      start: 0x40000000
+      end: 0x40040000
+    cores:
+    - main
+  - !Generic
+    name: ROM1
+    range:
+      start: 0x40040000
+      end: 0x40060000
+    cores:
+    - main
   - !Ram
     name: SRAM Instruction bus
     range:

--- a/probe-rs/targets/esp32h2.yaml
+++ b/probe-rs/targets/esp32h2.yaml
@@ -23,6 +23,13 @@ variants:
     - main
     access:
       boot: true
+  - !Generic
+    name: ROM
+    range:
+      start: 0x40000000
+      end: 0x40020000
+    cores:
+    - main
   - !Ram
     range:
       start: 0x40800000

--- a/probe-rs/targets/esp32s2.yaml
+++ b/probe-rs/targets/esp32s2.yaml
@@ -36,6 +36,13 @@ variants:
     cores:
     - main
     is_alias: true
+  - !Generic
+    name: ROM1, Data bus
+    range:
+      start: 0x3FFA0000
+      end: 0x3FFB0000
+    cores:
+    - main
   - !Ram
     name: SRAM0, Data bus
     range:
@@ -48,6 +55,20 @@ variants:
     range:
       start: 0x3ffb8000
       end: 0x40000000
+    cores:
+    - main
+  - !Generic
+    name: ROM0
+    range:
+      start: 0x40000000
+      end: 0x40010000
+    cores:
+    - main
+  - !Generic
+    name: ROM1
+    range:
+      start: 0x40010000
+      end: 0x40020000
     cores:
     - main
   - !Ram

--- a/probe-rs/targets/esp32s3.yaml
+++ b/probe-rs/targets/esp32s3.yaml
@@ -53,6 +53,30 @@ variants:
     cores:
     - cpu0
     - cpu1
+  - !Generic
+    name: ROM1, Data bus
+    range:
+      start: 0x3FF00000
+      end: 0x3FF20000
+    cores:
+    - cpu0
+    - cpu1
+  - !Generic
+    name: ROM0
+    range:
+      start: 0x40000000
+      end: 0x40040000
+    cores:
+    - cpu0
+    - cpu1
+  - !Generic
+    name: ROM1
+    range:
+      start: 0x40040000
+      end: 0x40060000
+    cores:
+    - cpu0
+    - cpu1
   - !Ram
     name: SRAM1 Instruction bus
     range:


### PR DESCRIPTION
Declare ESP32-C6's ROM (320KB) in the target file's memory map.