### PR TITLE
rtt: use 32-bit field sizes and offsets for 64-bit targets

### DIFF
--- a/changelog/fixed-rtt-on-64-bit-targets.md
+++ b/changelog/fixed-rtt-on-64-bit-targets.md
@@ -1,0 +1,1 @@
+Fixed RTT on 64-bit targets so all flag and offset fields are 32-bits

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -294,7 +294,7 @@ impl RttConnection {
 
     /// Overwrites the control block with zeros. This is useful after resets.
     pub fn clear_control_block(&mut self, core: &mut Core) -> Result<(), Error> {
-        let zeros = vec![0; Rtt::control_block_size(core)];
+        let zeros = vec![0; Rtt::control_block_size()];
         core.write(self.control_block_addr, &zeros)?;
         self.active_down_channels.clear();
         self.active_up_channels.clear();


### PR DESCRIPTION
The [Segger headers](https://github.com/zephyrproject-rtos/segger/blob/9f08435a79d41133d7046b7c59d1b25929eda450/SEGGER/SEGGER_RTT.h#L316-L352) use `unsigned` as their datatype, which is 32-bits on aarch64 and x86_64.

Adjust the RTT code in probe-rs to use 32-bit values for all offset and flag fields, while still keeping 64-bit field sizes for 64-bit targets.