### PR TITLE
fix: DAP static watch evaluation

### DIFF
--- a/changelog/fixed-dap-global-watch-evaluation.md
+++ b/changelog/fixed-dap-global-watch-evaluation.md
@@ -1,0 +1,1 @@
+Fix DAP watch evaluations for static variables by loading only requested globals lazily while preserving fast value updates between steps.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -398,8 +398,10 @@ impl SessionData {
                 let exception_interface = exception_handler_for_core(target_core.core.core_type());
                 let instruction_set = target_core.core.instruction_set().ok();
 
-                target_core.core_data.static_variables =
-                    Some(target_core.core_data.debug_info.create_static_scope_cache());
+                if target_core.core_data.static_variables.is_none() {
+                    target_core.core_data.static_variables =
+                        Some(target_core.core_data.debug_info.create_static_scope_cache());
+                }
 
                 target_core.core_data.stack_frames = target_core.core_data.debug_info.unwind(
                     &mut target_core.core,


### PR DESCRIPTION
Fixes: #3627 and https://github.com/probe-rs/vscode/issues/123

Previously the DAP `evaluate` handler never surfaced statics because it only searched stack-frame locals (and, on miss, the peripheral cache).

The fix teaches the handler to resolve globals through the static variable cache, expanding only the requested symbol and persisting the updated value.