### PR TITLE
Add support for ESP32C5

### DIFF
--- a/changelog/added-esp32c5.md
+++ b/changelog/added-esp32c5.md
@@ -1,0 +1,1 @@
+Add support for ESP32-C5

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -1917,6 +1917,7 @@ impl<'state> RiscvCommunicationInterface<'state> {
             // Reset is performed by setting the bit high, and then low again
             let mut dmcontrol = readback;
             dmcontrol.set_dmactive(true);
+            dmcontrol.set_haltreq(true);
             dmcontrol.set_hartreset(false);
 
             self.write_dm_register(dmcontrol)?;

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -346,6 +346,14 @@ impl Session {
         }
 
         probe.attach_to_unspecified()?;
+        if let Some(probe) = probe.try_as_jtag_probe()
+            && let Ok(chain) = probe.scan_chain()
+            && !chain.is_empty()
+        {
+            for core in &cores {
+                probe.select_target(core.jtag_tap_index())?;
+            }
+        }
 
         // We try to guess the TAP number. Normally we trust the scan chain, but some probes are
         // only quasi-JTAG (wch-link), so we'll have to work with at least 1, but if we're guessing

--- a/probe-rs/src/vendor/espressif/sequences/esp32c5.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32c5.rs
@@ -1,0 +1,161 @@
+//! Sequences for the ESP32C5.
+
+use std::{sync::Arc, time::Duration};
+
+use super::esp::EspFlashSizeDetector;
+use crate::{
+    MemoryInterface, Session,
+    architecture::riscv::{
+        Dmcontrol, Riscv32,
+        communication_interface::{
+            MemoryAccessMethod, RiscvBusAccess, RiscvCommunicationInterface, Sbaddress0, Sbcs,
+            Sbdata0,
+        },
+        sequences::RiscvDebugSequence,
+    },
+    semihosting::{SemihostingCommand, UnknownCommandDetails},
+    vendor::espressif::sequences::esp::EspBreakpointHandler,
+};
+
+/// The debug sequence implementation for the ESP32C5.
+#[derive(Debug)]
+pub struct ESP32C5 {
+    inner: EspFlashSizeDetector,
+}
+
+impl ESP32C5 {
+    /// Creates a new debug sequence handle for the ESP32C5.
+    pub fn create() -> Arc<dyn RiscvDebugSequence> {
+        Arc::new(Self {
+            inner: EspFlashSizeDetector {
+                stack_pointer: 0x40850000,
+                load_address: 0x40810000,
+                spiflash_peripheral: 0x6000_3000,
+                efuse_get_spiconfig_fn: None,
+                attach_fn: 0x4000_01f0,
+            },
+        })
+    }
+
+    fn disable_wdts(
+        &self,
+        interface: &mut RiscvCommunicationInterface,
+    ) -> Result<(), crate::Error> {
+        tracing::info!("Disabling ESP32-C5 watchdogs...");
+        // disable LP_WDT_SWD
+        interface.write_word_32(0x600B1C20, 0x50D83AA1)?; // write protection off
+        let current = interface.read_word_32(0x600B_1C1C)?;
+        interface.write_word_32(0x600B_1C1C, current | (1 << 18))?; // set RTC_CNTL_SWD_AUTO_FEED_EN
+        interface.write_word_32(0x600B1C20, 0x0)?; // write protection on
+
+        // tg0 wdg
+        interface.write_word_32(0x6000_8064, 0x50D83AA1)?; // write protection off
+        interface.write_word_32(0x6000_8048, 0x0)?;
+        interface.write_word_32(0x6000_8064, 0x0)?; // write protection on
+
+        // tg1 wdg
+        interface.write_word_32(0x6000_9064, 0x50D83AA1)?; // write protection off
+        interface.write_word_32(0x6000_9048, 0x0)?;
+        interface.write_word_32(0x6000_9064, 0x0)?; // write protection on
+
+        // rtc wdg
+        interface.write_word_32(0x600B_1C18, 0x50D83AA1)?; // write protection off
+        interface.write_word_32(0x600B_1C00, 0x0)?;
+        interface.write_word_32(0x600B_1C18, 0x0)?; // write protection on
+
+        Ok(())
+    }
+
+    fn configure_memory_access(
+        &self,
+        interface: &mut RiscvCommunicationInterface<'_>,
+    ) -> Result<(), crate::Error> {
+        let memory_access_config = interface.memory_access_config();
+
+        let accesses = [
+            RiscvBusAccess::A8,
+            RiscvBusAccess::A16,
+            RiscvBusAccess::A32,
+            RiscvBusAccess::A64,
+            RiscvBusAccess::A128,
+        ];
+        for access in accesses {
+            if memory_access_config.default_method(access) != MemoryAccessMethod::SystemBus {
+                // External data/instruction bus
+                // Loading external memory is slower than the CPU. If we can't access something via the
+                // system bus, select the waiting program buffer method.
+                memory_access_config.set_region_override(
+                    access,
+                    0x4200_0000..0x4300_0000,
+                    MemoryAccessMethod::WaitingProgramBuffer,
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl RiscvDebugSequence for ESP32C5 {
+    fn on_connect(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
+        self.configure_memory_access(interface)?;
+        self.disable_wdts(interface)?;
+
+        Ok(())
+    }
+
+    fn on_halt(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
+        self.disable_wdts(interface)
+    }
+
+    fn detect_flash_size(&self, session: &mut Session) -> Result<Option<usize>, crate::Error> {
+        self.inner.detect_flash_size(session)
+    }
+
+    fn reset_system_and_halt(
+        &self,
+        interface: &mut RiscvCommunicationInterface,
+        timeout: Duration,
+    ) -> Result<(), crate::Error> {
+        interface.halt(timeout)?;
+
+        // System reset, ported from OpenOCD.
+        interface.write_dm_register(Sbcs(0x48000))?;
+        interface.write_dm_register(Sbaddress0(0x600b1034))?;
+        interface.write_dm_register(Sbdata0(0x80000000_u32))?;
+
+        // clear dmactive to clear sbbusy otherwise debug module gets stuck
+        interface.write_dm_register(Dmcontrol(0))?;
+
+        interface.write_dm_register(Sbcs(0x48000))?;
+        interface.write_dm_register(Sbaddress0(0x600b1038))?;
+        interface.write_dm_register(Sbdata0(0x10000000_u32))?;
+
+        let mut dmcontrol = Dmcontrol(0);
+        dmcontrol.set_dmactive(true);
+        dmcontrol.set_resumereq(true);
+        interface.write_dm_register(dmcontrol)?;
+
+        std::thread::sleep(Duration::from_millis(10));
+
+        let mut dmcontrol = Dmcontrol(0);
+        dmcontrol.set_dmactive(true);
+        dmcontrol.set_ackhavereset(true);
+        interface.write_dm_register(dmcontrol)?;
+
+        interface.enter_debug_mode()?;
+        self.on_connect(interface)?;
+
+        interface.reset_hart_and_halt(timeout)?;
+
+        Ok(())
+    }
+
+    fn on_unknown_semihosting_command(
+        &self,
+        interface: &mut Riscv32,
+        details: UnknownCommandDetails,
+    ) -> Result<Option<SemihostingCommand>, crate::Error> {
+        EspBreakpointHandler::handle_riscv_idf_semihosting(interface, details)
+    }
+}

--- a/probe-rs/src/vendor/espressif/sequences/mod.rs
+++ b/probe-rs/src/vendor/espressif/sequences/mod.rs
@@ -6,6 +6,7 @@ mod esp;
 // RISC-V ESP32 devices
 pub mod esp32c2;
 pub mod esp32c3;
+pub mod esp32c5;
 pub mod esp32c6;
 pub mod esp32h2;
 

--- a/probe-rs/targets/esp32c5.yaml
+++ b/probe-rs/targets/esp32c5.yaml
@@ -1,0 +1,90 @@
+name: esp32c5
+manufacturer:
+  id: 0x12
+  cc: 0xc
+chip_detection:
+- !Espressif
+  idcode: 0x17c25
+  variants:
+    # 0x1101406f: esp32c5
+    # 0x63e1406f: esp32c5
+    # 0x5fd1406f: esp32c5
+    0: esp32c5 # hacky variant, to be removed once chip detection can use other TAPs
+variants:
+- name: esp32c5
+  cores:
+  - name: main
+    type: riscv
+    core_access_options: !Riscv
+      hart_id: 0
+      jtag_tap: 1
+  memory_map:
+  - !Nvm
+    name: 32 MB Max addressable Flash
+    range:
+      start: 0x0
+      end: 0x2000000
+    cores:
+    - main
+    access:
+      boot: true
+  - !Generic
+    name: ROM
+    range:
+      start: 0x40000000
+      end: 0x40050000
+    cores:
+    - main
+  - !Ram
+    range:
+      start: 0x40800000
+      end: 0x40860000
+    cores:
+    - main
+  - !Nvm
+    name: External flash (Read Only)
+    range:
+      start: 0x42000000
+      end: 0x44000000
+    cores:
+    - main
+    is_alias: true
+  flash_algorithms:
+  - esp32c5-flashloader
+  jtag:
+    scan_chain:
+    - name: dummy
+      ir_len: 5
+    - name: main
+      ir_len: 5
+  default_binary_format: idf
+flash_algorithms:
+- name: esp32c5-flashloader
+  description: A flasher loader for the esp32c5.
+  default: true
+  instructions: UFJPR1JBTSBFUkFTRSBAIApJTklUCkVSUk9SIGJ1ZiBub3Qgd29yZCBhbGlnbmVkCiBieXRlcyBAIFJFQUQgRkxBU0ggAEERBsYixCbCLoSJzYNFBQCTBBUALoWXAH//54CA/30UJoVt9LJAIkSSREEBgoBBEQbGEwcQELcHAQElSKlGioiThxcQPsA+wiMU4QClRyqGPoczVdUCxpezBdUCswW2QJPlBQMjgLcAkwf3/+NhyP4FBzOF+ACtRQUFmY2XAAAA54BA+LJAQQGCgBcDAABnAGMEFwMAAGcAowoXAwAAZwADEBcDAABnAGMRFwMAAGcAAxsXAwAAZwADJhcDAABnACMvCcYXA3//ZwBjBQFFgoBBEQbGNwWBQBMFFQGVRZcAAADngCDywWe3BQABQWaFZv0XEWcBRZcAf//ngEADGcEFRRWogUWXAH//54BACgFFtwWEQDe2hED9ViOiBQAjKgauIyzWriMuBq4jIAawNwbBqjkWkMGyQEEBgoC3BYRAjEE3BsGqORZjlsUEQREGxiLEKoQ3BYFAEwWFAKFFlwAAAOeAIOoihZcAAADngGDsNwWBQBMFBQGFRZcAAADngGDoE1UEAbJAIkRBARcDf/9nAGP4EwVwwYKANwWEQAhBtwXBqrkVYxa1ABcDf/9nAEP0EwVwwYKAlwIAAOeC4kVjksUCKoQT9TQAHcE3BYFAEwVlAe1FlwAAAOeAoOITBTDBGaATBXDBFwMAAGcAI0I3BYFAEwUFAKFFlwAAAOeAYOBKhZcAAADngKDiNwWBQBMFFQOlRZcAAADngKDeIoWXAAAA54Dg4DcFgUATBQUBhUWXAAAA54Dg3LcGgUCThqZYIoWmhUqGskAiRJJEAklBARcDAABnAEMaQREGxiLEJsJKwDKELom3BYRAjEE3BsGqORZjksUCqoQTdTQABcE3BYFAEwVlAe1FlwAAAOeAYNcTBTDBlagTBXDBvaA3BYFAEwUFAKFFlwAAAOeAgNVKhZcAAADngMDXNwWBQBMFFQOlRZcAAADngMDTJoWXAAAA54AA1jcFgUATBQUBhUWXAAAA54AA0rcGgUCThuZaJoWihUqGlwAAAOeAABAzNaAAfRUzdSUBJpUXAwAAZwADMJcCAADngkIwY5LFAiqEE/U0AB3BNwWBQBMFZQHtRZcAAADngADNEwUwwRmgEwVwwRcDAABnAIMsNwWBQBMFpQOtRZcAAADngMDKSoWXAAAA54AAzTcFgUATBRUDpUWXAAAA54AAySKFlwAAAOeAQMs3BYFAEwUFAYVFlwAAAOeAQMcihaaFSoayQCJEkkQCSUEBFwMAAGcA49FBEQbGNwaEQBRCtwXBqhOH5f5jl+YCqoUBRYlGIyAGAGOS1QIFRSrEA0WBAAWJGckoAJVFlwB//+eA4NR11RmgEwVwwbJAQQGCgDlxBt4i3CbaSthO1lLUVtJa0F7OYsxmyjaJroo3u4RAgyWLr2OEpQSRRWN1tgATBUDBCaKDxQoAg8YaAAPHKgCDxzoAkQpxFqIG1Y23BoRA4gdCB12P2Y0jLKuuIy4LriMgu7AjogYAIyoLrgMlC7ARzbKMY2OmAKqMswWVQSMgu7CFRGNnpgCFSSmgEwVQwVWgjUkhbDc1hEA3CoRAkwtFrxEKY4QMCGNSkAhmxgMlS68zBaxAKsgDJ0uvXpdwABwIUoXWhd6GToiXAH//54Bgv7JFY/W8AJMEYMEhqKqEQkUDJkuvs4y8QK6aMpUjKquumcQDJUuvIWbjFcX6GaADJkuvAyWLr4Mly68jKguuLpUzhMUA3oUCmSMui67jUwX4EwUFgBMFBYYpoBOFBIP9hGWN8lBiVNJUQlmyWSJakloCW/JLYkzSTCFhgoAFwkERBsaXAH//54DAvJMFBYCThQWGfYVtjbJAQQGCgAFFgoAtcRQCI64WAIDOxMojqCYBI6Y2AbKJroQqiQFFEwYF8AHKEwYVAKMFoRCqhTKF/bejBbEAY4sJBBMFABBOhGPkqQATBAAQkwWxAEqFIoaXAAAA54DAsKqFfVVjyQUCs4WEALOJiUATBrEAooaZygPHBACDRwYAhQQFBv0W4wj3/jGgIpmuhOOZCfoBRQwCg6DFAYBNxEkDqQUBg6nFABVhgoCyQCJEkkQCSUEBgoBBEQbGIsQmwkrAsoQuibcFhECMQTcGwao5FoKC
+  load_address: 0x40810000
+  data_load_address: 0x40850000
+  pc_init: 0xd0
+  pc_uninit: 0x100
+  pc_program_page: 0xe8
+  pc_erase_sector: 0xd8
+  pc_erase_all: 0xe0
+  pc_verify: 0xf0
+  pc_read: 0xf8
+  data_section_offset: 0x40810678
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x2000000
+    page_size: 0x4000
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 2000
+    sectors:
+    - size: 0x10000
+      address: 0x0
+  cores:
+  - main
+  stack_overflow_check: false
+  transfer_encoding: miniz


### PR DESCRIPTION
Currently requires a custom-built esp-idf bootloader (the one in espflash is too old), but probe-rs can successfully flash and run an esp-idf application.

This chip brings in a new challenge: the CPU sits on JTAG TAP 1, which was unexpected previously. Chip detection still can't handle it, so it's been worked around in a hacky way.

[flash loader](https://github.com/esp-rs/esp-flash-loader/pull/23)