### PR TITLE
Clear ExecBusy before re-polling Xtensa instructions

### DIFF
--- a/changelog/fixed-xtensa-instruction-poll.md
+++ b/changelog/fixed-xtensa-instruction-poll.md
@@ -1,0 +1,1 @@
+Fixed polling long-running Xtensa instructions.

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -319,7 +319,8 @@ impl<'probe> Xdm<'probe> {
                             // retry, but we should probably add some no-ops later.
                         }
                         ProbeRsError::Xtensa(XtensaError::XdmError(Error::ExecBusy)) => {
-                            // The instruction is still executing. Retry the Debug Status read.
+                            // The instruction is still executing. Clear ExecBusy and retry the Debug Status read.
+                            self.clear_exception_state()?;
                             to_consume -= 1;
                         }
                         ProbeRsError::Xtensa(XtensaError::XdmError(Error::ExecExeception)) => {


### PR DESCRIPTION
This PR fixes the regression caused by https://github.com/probe-rs/probe-rs/pull/3569