### PR TITLE
downgrade cidr preamble mismatch warning to info

### DIFF
--- a/changelog/changed-romtable-cidr-mismatch-message-to-info.md
+++ b/changelog/changed-romtable-cidr-mismatch-message-to-info.md
@@ -1,0 +1,1 @@
+Changed the warning macro that is emitted when a CIDR value doesn't match to an info block since there's nothing probe-rs or the user can do about it.

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -308,7 +308,7 @@ impl<'probe: 'memory, 'memory> ComponentInformationReader<'probe, 'memory> {
 
         for i in 0..4 {
             if preambles[i] != expected[i] {
-                tracing::warn!(
+                tracing::info!(
                     "Component at 0x{:x}: CIDR{} has invalid preamble (expected 0x{:x}, got 0x{:x})",
                     self.base_address,
                     i,


### PR DESCRIPTION
When a CIDR value doesn't match the expected value, print out an `info!()` message rather than a `warn!()` message.

This is because devices ship with broken romtables, and there's nothing that either probe-rs or the user can do about it. This change prevents this message from showing during the course of normal operations where `WARN` messages are shown by default.