### PR TITLE
Fix DATAVSIZE in DWT_FUNCTIONn configuration

### DIFF
--- a/changelog/fixed-datavsize-selection.md
+++ b/changelog/fixed-datavsize-selection.md
@@ -1,0 +1,1 @@
+When enabling data tracing in a DWT unit, access matches on word size, not byte size.

--- a/probe-rs/src/architecture/arm/component/dwt.rs
+++ b/probe-rs/src/architecture/arm/component/dwt.rs
@@ -62,7 +62,7 @@ impl<'a> Dwt<'a> {
         mask.store_unit(self.component, self.interface, unit)?;
 
         let mut function = Function::load_unit(self.component, self.interface, unit)?;
-        function.set_datavsize(0x10);
+        function.set_datavsize(0b10);
         function.set_emitrange(false);
         function.set_datavmatch(false);
         function.set_cycmatch(false);
@@ -223,3 +223,21 @@ memory_mapped_bitfield_register! {
 }
 
 impl DebugComponentInterface for Pcsr {}
+
+#[cfg(test)]
+mod tests {
+    use super::Function;
+
+    /// Demonstrates a field usage that
+    /// was previously in this module.
+    #[test]
+    fn invalid_datavsize() {
+        let mut func = Function(0);
+
+        func.set_datavsize(0x10);
+        assert_eq!(func.0, 0);
+
+        func.set_datavsize(0b10);
+        assert_eq!(func.0, 0b10 << 10);
+    }
+}


### PR DESCRIPTION
`DATAVSIZE` is two bits wide. The hex literal is out of range, resulting in a `0b00` or "byte" data match.

If the original implementation intended to use word access, we can use a two-bit literal to achieve that, as shown here. Or, we can inline `0b00` to maintain compatibility.