### PR TITLE
riscv: support harts that are present-but-disabled

### DIFF
--- a/changelog/fixed-riscv-attach-when-cores-unavailable.md
+++ b/changelog/fixed-riscv-attach-when-cores-unavailable.md
@@ -1,0 +1,1 @@
+Fixed attaching to RISC-V cores when one or more hart is not enabled.

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -494,7 +494,7 @@ impl<'state> RiscvCommunicationInterface<'state> {
 
     /// Select current hart
     pub fn select_hart(&mut self, hart: u32) -> Result<(), RiscvError> {
-        if self.state.enabled_harts & (1 << hart) == 0 {
+        if !self.hart_enabled(hart) {
             return Err(RiscvError::HartUnavailable);
         }
 

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -6,10 +6,7 @@ use crate::{
             core::{CortexAState, CortexMState},
             dp::DpAddress,
         },
-        riscv::{
-            RiscvCoreState,
-            communication_interface::{RiscvCommunicationInterface, RiscvError},
-        },
+        riscv::{RiscvCoreState, communication_interface::RiscvCommunicationInterface},
         xtensa::{XtensaCoreState, communication_interface::XtensaCommunicationInterface},
     },
 };
@@ -179,10 +176,6 @@ impl CombinedCoreState {
         };
 
         let hart = options.hart_id.unwrap_or_default();
-        if !interface.hart_enabled(hart) {
-            return Err(RiscvError::HartUnavailable.into());
-        }
-
         interface.select_hart(hart)?;
 
         Ok(Core::new(

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -557,7 +557,11 @@ impl Session {
         self.interfaces
             .attach(&self.target, combined_state)
             .map_err(|e| {
-                if matches!(e, Error::Xtensa(XtensaError::CoreDisabled)) {
+                if matches!(
+                    e,
+                    Error::Xtensa(XtensaError::CoreDisabled)
+                        | Error::Riscv(RiscvError::HartUnavailable),
+                ) {
                     // If the core is disabled, we can't attach to it.
                     // We can't do anything about it, so we just translate
                     // and return the error.


### PR DESCRIPTION
Support riscv targets where the cores are present but are not currently active. This is the case for some targets such as the ESP32P4, where the secondary core is kept halted until the primary core enables it.

This is the core changes from https://github.com/probe-rs/probe-rs/pull/2047 without any ESP32P4-specific additions.