### PR TITLE
make flashing to SF32LB586 work

### DIFF
--- a/probe-rs/targets/SF32LB58_Series.yaml
+++ b/probe-rs/targets/SF32LB58_Series.yaml
@@ -1,6 +1,6 @@
 name: SF32LB58 Series
 variants:
-- name: SF32LB58
+- name: SF32LB586
   cores:
   - name: hcpu
     type: armv8m


### PR DESCRIPTION
APSEL in AP SELECT register cannot be set to values other than 0

<img width="1100" height="292" alt="image" src="https://github.com/user-attachments/assets/364cc563-8bab-4c87-bd5a-68a3455a5773" />
<img width="1387" height="171" alt="微信图片_20251127183504_64" src="https://github.com/user-attachments/assets/28137fe2-6fd8-4ced-9111-4a6ead6bccc3" />

fixed Flash4 Region Address Range

added bootloader flash region
