### PR TITLE
Reset core before system reset

### DIFF
--- a/changelog/changed-xtensa-system-reset.md
+++ b/changelog/changed-xtensa-system-reset.md
@@ -1,0 +1,1 @@
+Change reset sequence for ESP32 Xtensa devices to improve reliability.

--- a/probe-rs/src/vendor/espressif/sequences/esp32.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32.rs
@@ -127,10 +127,8 @@ impl XtensaDebugSequence for ESP32 {
         const RTC_CNTL_RESET_STATE_DEF: u32 = 0x3000;
 
         {
-            let _span = tracing::debug_span!("Halting core").entered();
-            if !core.core_halted()? {
-                core.halt(timeout)?;
-            }
+            let _span = tracing::debug_span!("Resetting core").entered();
+            core.reset_and_halt(timeout)?;
         }
 
         // A program that does the system reset and then loops,

--- a/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s2.rs
@@ -194,7 +194,10 @@ impl XtensaDebugSequence for ESP32S2 {
 
         const SYS_RESET: u32 = 1 << 31;
 
-        core.reset_and_halt(timeout)?;
+        {
+            let _span = tracing::debug_span!("Resetting core").entered();
+            core.reset_and_halt(timeout)?;
+        }
 
         // Set some clock-related RTC registers to the default values
         core.write_word_32(Self::STORE4, 0)?;

--- a/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
+++ b/probe-rs/src/vendor/espressif/sequences/esp32s3.rs
@@ -151,10 +151,8 @@ impl XtensaDebugSequence for ESP32S3 {
         const RTC_CNTL_RESET_STATE_DEF: u32 = 0x3000;
 
         {
-            let _span = tracing::debug_span!("Halting core").entered();
-            if !core.core_halted()? {
-                core.halt(timeout)?;
-            }
+            let _span = tracing::debug_span!("Resetting core").entered();
+            core.reset_and_halt(timeout)?;
         }
 
         // A program that does the system reset and then loops,


### PR DESCRIPTION
For some reason, just halting the core isn't sufficient in some cases - the reset program times out. This PR resets the core first, before downloading the reset routine.

This issue can be observed when the `https://github.com/esp-rs/esp-hal/tree/main/examples/ble/scanner` is running on an ESP32-S3. Before this PR, probe-rs fails during flash size detection.