### PR TITLE
Add support for onboard Digilent HS1 probes

### DIFF
--- a/changelog/added-digilent-hs1-onboard.md
+++ b/changelog/added-digilent-hs1-onboard.md
@@ -1,1 +1,0 @@
-Added support for onboard Digilent HS1 probes

--- a/changelog/fixed-digilent-hs1-onboard.md
+++ b/changelog/fixed-digilent-hs1-onboard.md
@@ -1,0 +1,1 @@
+Fixed support for onboard Digilent HS1 probes


### PR DESCRIPTION
**Problem**
Testing a new FPGA board with a RISC-V soft-core, I found out that the onboard Digilent USB-JTAG adapter wasn't supported by the Digilent cases in probe-rs. The default FTDI pin layout was not working, and the cases for Digilent probes did not cover this adapter.

This probe (`probe-rs list`):
`[0]: Digilent USB Device -- 0403:6010:210292BB2F4C (FTDI)`

Previously supported Digilent probes:
```rust
// Digilent HS3
(0x0403, 0x6014, "Digilent USB Device") => (0x2088, 0x308b),
// Digilent HS2
(0x0403, 0x6014, "Digilent Adept USB Device") => (0x00e8, 0x60eb),
// Digilent HS1
(0x0403, 0x6010, "Digilent Adept USB Device") => (0x0088, 0x008b),
// Other devices:
// TMS starts high
// TMS, TDO and TCK are outputs
_ => (0x0008, 0x000b)
```

**Solution**
This change modifies the Digilent HS1 case to ignore the description string. For HS2 and HS3 probes, differentiating requires the string because the USB IDs are the same. For the HS1, it has a distinct ID so we can ignore the description string.

```rust
// Digilent HS1
(0x0403, 0x6010, _) => (0x0088, 0x008b),
```