### PR TITLE
Print some error context, conserve algo default flag, fix `data_section_offset` for new algos

### DIFF
--- a/target-gen/src/parser.rs
+++ b/target-gen/src/parser.rs
@@ -115,6 +115,10 @@ pub fn extract_flash_algo(
         );
 
         algo.load_address = Some(algorithm_binary.code_section.load_address as u64);
+        algo.data_section_offset = (algorithm_binary.data_section.start
+            - algorithm_binary.code_section.load_address) as u64;
+    } else {
+        algo.data_section_offset = algorithm_binary.data_section.start as u64;
     }
 
     algo.description.clone_from(&flash_device.name);
@@ -124,7 +128,6 @@ pub fn extract_flash_algo(
         .unwrap()
         .to_lowercase();
     algo.default = default;
-    algo.data_section_offset = algorithm_binary.data_section.start as u64;
     algo.flash_properties = FlashProperties::from(flash_device);
     algo.big_endian = !elf.little_endian;
 


### PR DESCRIPTION
This PR adds some error context strings to target-gen to pin down errors more easily. Additionally, `data_section_offset` is now calculated in `extract_flash_algo` so that `--fixed-load-address` correctly produces an offset instead of an absolute value for new algorithms.