### PR TITLE
rp235x: more reliable reset

### DIFF
--- a/changelog/fixed-rp235x-reset.md
+++ b/changelog/fixed-rp235x-reset.md
@@ -1,0 +1,1 @@
+Fixed the RP235x reset sequence by giving it a timeout rather than a loop limit


### PR DESCRIPTION
The RP235x sometimes doesn't reset after a RescueDP reset. It's unclear exactly why this is. A wild theory is that maybe XIP SPI isn't working properly and needs time to recover. Whatever the reason, a reset usually fixes it.

The longest-observed reset time was 465 ms after 5000 loops. That is, the time between when we start issuing RescueDP commands and the time the target actually starts responding is around 465 ms. This seems like some sort of timeout, possibly within the SPI flash itself. It is observed more often when resetting from user code, but delays of up to 10 ms have been observed when restarting from programming code.

Set an overall process timeout of 1000 ms, which is roughly twice the observed maximum latency, and continue trying to reset the target until successful or until this process times out.

This closes #3563