### PR TITLE
Fixed nRF53 debug unlock failing after mass erase due to checking the wrong AP register.

### DIFF
--- a/changelog/fixed-nrf53-unlock-regression.md
+++ b/changelog/fixed-nrf53-unlock-regression.md
@@ -1,0 +1,1 @@
+Fixed nRF53 debug unlock failing after mass erase due to checking the wrong AP register.


### PR DESCRIPTION
## Fix nRF53 debug unlock regression introduced in v0.30.0

### The Problem

After upgrading from v0.29.1 to v0.30.0, nRF5340 devices fail to unlock after a mass erase:

``
$ probe-rs run --chip nRF5340_xxAA --allow-erase-all ...
 WARN probe_rs::vendor::nordicsemi::sequences::nrf: Core 1 is locked. Erase procedure will be started to unlock it.
 WARN probe_rs::vendor::nordicsemi::sequences::nrf: Core is still locked after erase operation. Retrying
Error: Connecting to the chip was unsuccessful.

Caused by:
    0: An ARM specific error occurred.
    1: An error occurred in the communication with an access port or debug port.
    2: Target device did not respond to request.
``

### Root Cause

Introduced in #3458. The `unlock_core` function added an inline lock status check that reads from the wrong register for nRF53. The existing `is_core_unlocked()` function already handles this correctly for each chip family.

### Fix

Removed the inline check from `unlock_core` and moved the retry logic to `debug_device_unlock`, where it uses the existing `is_core_unlocked()` method. All nRF91x1 functionality (soft reset, retry) is preserved.