### PR TITLE
Parse PAGE_BUFFER address into data_load_address

### DIFF
--- a/target-gen/src/parser.rs
+++ b/target-gen/src/parser.rs
@@ -99,6 +99,10 @@ pub fn extract_flash_algo(
                 algo.rtt_location = Some(sym.st_value);
                 log::debug!("Found RTT control block at address {:#010x}", sym.st_value);
             }
+            "PAGE_BUFFER" => {
+                algo.data_load_address = Some(sym.st_value);
+                log::debug!("Found PAGE_BUFFER at address {:#010x}", sym.st_value);
+            }
 
             _ => {}
         }


### PR DESCRIPTION
If the flash loader defines the `PAGE_BUFFER` symbol, target-gen will use its address as `data_load_address`. This is useful for ESP flash loaders, where the data buffer may not be contiguous with the instructions.