### PR TITLE
Do not clean instruction done status

### DIFF
--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -688,7 +688,6 @@ impl<'probe> Xdm<'probe> {
             let mut status = DebugStatus(0);
 
             status.set_exec_exception(true);
-            status.set_exec_done(true);
             status.set_exec_overrun(true);
 
             status


### PR DESCRIPTION
This PR fixes the following error:

```
The instruction was ignored. Most often this indicates that the core was not halted before requesting instruction execution.
```

The "done" flag should not be cleared while waiting for an instruction to complete. The instruction may successfully complete before probe-rs clears the done flag, which results in the above error when everything should be going just fine. This regression was introduced in https://github.com/probe-rs/probe-rs/pull/3641