### PR TITLE
Add function to spill registers, simplify Xtensa memory reads

### DIFF
--- a/changelog/added-spill.md
+++ b/changelog/added-spill.md
@@ -1,0 +1,1 @@
+Added `CoreInterface::spill_registers` method.

--- a/probe-rs-debug/src/registers.rs
+++ b/probe-rs-debug/src/registers.rs
@@ -84,6 +84,9 @@ pub struct DebugRegisters(pub Vec<DebugRegister>);
 impl DebugRegisters {
     /// Read all registers defined in [`probe_rs::core::CoreRegisters`] from the given core.
     pub fn from_core(core: &mut impl CoreInterface) -> Self {
+        if let Err(error) = core.spill_registers() {
+            tracing::warn!("Failed to spill registers: {error}");
+        };
         Self::from_core_registers(core.registers(), |register_id| {
             core.read_core_reg(*register_id)
                 .inspect_err(|error| {

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -165,6 +165,13 @@ pub trait CoreInterface: MemoryInterface {
     fn is_64_bit(&self) -> bool {
         false
     }
+
+    /// Spill registers into memory.
+    fn spill_registers(&mut self) -> Result<(), Error> {
+        // For most architectures, this is not necessary. Use cases include processors
+        // that have a windowed register file, where the whole register file is not visible at once.
+        Ok(())
+    }
 }
 
 /// Generic core handle representing a physical core on an MCU.
@@ -537,6 +544,11 @@ impl<'probe> Core<'probe> {
     pub fn is_64_bit(&self) -> bool {
         self.inner.is_64_bit()
     }
+
+    /// Spill registers into memory.
+    pub fn spill_registers(&mut self) -> Result<(), Error> {
+        self.inner.spill_registers()
+    }
 }
 
 impl CoreInterface for Core<'_> {
@@ -665,6 +677,10 @@ impl CoreInterface for Core<'_> {
 
     fn is_64_bit(&self) -> bool {
         self.is_64_bit()
+    }
+
+    fn spill_registers(&mut self) -> Result<(), Error> {
+        self.spill_registers()
     }
 }
 

--- a/probe-rs/src/core/dump.rs
+++ b/probe-rs/src/core/dump.rs
@@ -163,7 +163,9 @@ impl CoreDump {
     /// # Arguments
     /// * `core`: The core to dump.
     /// * `ranges`: Memory ranges that should be dumped.
-    pub fn dump_core(core: &mut Core, ranges: Vec<Range<u64>>) -> Result<Self, Error> {
+    pub fn dump_core(core: &mut Core<'_>, ranges: Vec<Range<u64>>) -> Result<Self, Error> {
+        core.spill_registers()?;
+
         let mut registers = HashMap::new();
         for register in core.registers().all_registers() {
             let value = core.read_core_reg(register.id())?;


### PR DESCRIPTION
This PR introduces a new function to `Core/CoreInterface`, `spill_registers`. It is meant to move out-of-window register data (that would not be part of DebugRegisters, and may control stack pointer/return address information necessary to unwind the stack) into memory, according to the underlying CPU architecture's rules. This allows removing hacky workarounds like spilling registers on memory read operations (in case the read would be part of the unwinding process).