### PR TITLE
Allow selecting the preferred flash algorithm for memory regions

### DIFF
--- a/changelog/added-prefer-flash-algo-cli.md
+++ b/changelog/added-prefer-flash-algo-cli.md
@@ -1,0 +1,2 @@
+Added the `--prefer-flash-algorithm` CLI option which allows overriding the flash algorithms to use
+for different memory regions.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -304,6 +304,7 @@ async fn main_try(args: Vec<OsString>, config: Config, offset: UtcOffset) -> Res
             verify: config.flashing.verify,
             chip_erase: config.flashing.do_chip_erase,
             read_flasher_rtt: config.flashing.read_flasher_rtt,
+            prefer_flash_algorithm: Vec::new(),
         };
         let loader = build_loader(&mut session, &path, format_options, image_instr_set)?;
 

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
@@ -38,6 +38,28 @@ pub struct DownloadOptions {
     pub verify: bool,
     /// Disable double buffering when loading flash.
     pub disable_double_buffering: bool,
+    /// If there are multiple valid flash algorithms for a memory region, this list allows
+    /// overriding the default selection.
+    pub preferred_algos: Vec<String>,
+}
+
+impl DownloadOptions {
+    pub fn sanitize(&mut self) {
+        // Remove surrounding quotes and whitespaces from list.
+        if !self.preferred_algos.is_empty() {
+            // Iterate over the vector and modify each string in place
+            for algo in self.preferred_algos.iter_mut() {
+                *algo = algo
+                    .trim()
+                    .trim_matches(|c| c == '\'' || c == '"')
+                    .chars()
+                    .filter(|c| !c.is_whitespace())
+                    .collect();
+            }
+            // Remove any empty strings resulting from inputs like ",," or ", ,"
+            self.preferred_algos.retain(|s| !s.is_empty());
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Schema)]
@@ -99,6 +121,7 @@ impl FlashRequest {
         options.preverify = false;
         options.verify = self.options.verify;
         options.disable_double_buffering = self.options.disable_double_buffering;
+        options.preferred_algos = self.options.preferred_algos.clone();
 
         options
     }

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -335,13 +335,16 @@ pub async fn flash(
     // Start timer.
     let flash_timer = Instant::now();
 
-    let options = DownloadOptions {
+    let mut options = DownloadOptions {
         keep_unwritten_bytes: download_options.restore_unwritten,
         do_chip_erase: chip_erase,
         skip_erase: false,
         verify: download_options.verify,
         disable_double_buffering: download_options.disable_double_buffering,
+        preferred_algos: download_options.prefer_flash_algorithm,
     };
+
+    options.sanitize();
 
     let loader = session
         .build_flash_loader(

--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -46,6 +46,17 @@ pub struct BinaryDownloadOptions {
     /// Whether to read the RTT output from the flash loader, if available.
     #[arg(long, help_heading = "DOWNLOAD CONFIGURATION")]
     pub read_flasher_rtt: bool,
+    /// The preferred flash algorithms for specific memory regions can be overriden.
+    ///
+    /// Multiple algorithms can be specified as a comma-separated list, e.g. --prefer-flash-algorithm=algo1,algo2
+    #[arg(
+        long,
+        env = "PROBE_RS_PREFER_FLASH_ALGO",
+        value_delimiter = ',',
+        num_args = 1..,
+        help_heading = "PROBE CONFIGURATION"
+    )]
+    pub prefer_flash_algorithm: Vec<String>,
 }
 
 /// Supported bit-widths for read/write commands (not every device may support each width).
@@ -115,6 +126,7 @@ pub struct ProbeOptions {
         help_heading = "PROBE CONFIGURATION"
     )]
     pub connect_under_reset: bool,
+
     #[arg(long, env = "PROBE_RS_DRY_RUN", help_heading = "PROBE CONFIGURATION")]
     pub dry_run: bool,
     /// Use this flag to allow all memory, including security keys and 3rd party

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -24,7 +24,7 @@ pub struct Target {
     pub name: String,
     /// The cores of the target.
     pub cores: Vec<Core>,
-    /// The name of the flash algorithm.
+    /// The list of available flash algorithms.
     pub flash_algorithms: Vec<RawFlashAlgorithm>,
     /// The memory map of the target.
     pub memory_map: Vec<MemoryRegion>,

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -229,6 +229,9 @@ pub struct DownloadOptions<'p> {
     pub verify: bool,
     /// Disable double buffering when loading flash.
     pub disable_double_buffering: bool,
+    /// If there are multiple valid flash algorithms for a memory region, this list allows
+    /// overriding the default selection.
+    pub preferred_algos: Vec<String>,
 }
 
 impl DownloadOptions<'_> {

--- a/probe-rs/src/flashing/erase.rs
+++ b/probe-rs/src/flashing/erase.rs
@@ -54,7 +54,7 @@ pub fn erase_all(
 
         let target = session.target();
         let core = target.core_index_by_name(core_name).unwrap();
-        let algo = FlashLoader::get_flash_algorithm_for_region(&region, target, core_name)?;
+        let algo = FlashLoader::get_flash_algorithm_for_region(&region, target, core_name, &[])?;
 
         tracing::debug!("     -- using algorithm: {}", algo.name);
         if let Some(entry) = algos.iter_mut().find(|entry| {
@@ -205,7 +205,7 @@ pub fn erase(
             .ok_or_else(|| FlashError::NoNvmCoreAccess(region.clone()))?;
 
         let algo =
-            FlashLoader::get_flash_algorithm_for_region(region, session.target(), core_name)?;
+            FlashLoader::get_flash_algorithm_for_region(region, session.target(), core_name, &[])?;
 
         let entry = algos
             .entry((algo.name.clone(), core_name.clone()))
@@ -302,7 +302,7 @@ pub fn run_blank_check(
             .ok_or_else(|| FlashError::NoNvmCoreAccess(region.clone()))?;
 
         let algo =
-            FlashLoader::get_flash_algorithm_for_region(region, session.target(), core_name)?;
+            FlashLoader::get_flash_algorithm_for_region(region, session.target(), core_name, &[])?;
 
         let entry = algos
             .entry((algo.name.clone(), core_name.clone()))

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -13,6 +13,12 @@ pub enum FlashError {
         /// The name of the algorithm that was not found.
         algo_name: String,
     },
+    /// Detected multiple preferred algorithms for the same flash region.
+    #[error("detected multiple preferred algorithms for a flash region {region:?}")]
+    MultiplePreferredAlgos {
+        /// The region which matched multiple preferred flash algorithms.
+        region: NvmRegion,
+    },
     /// No flash memory contains the entire requested memory range.
     #[error("No flash memory contains the entire requested memory range {range:#010X?}.")]
     NoSuitableNvm {


### PR DESCRIPTION
- I tested this on the VA108xx target by switching to another algorithm. I only tested it using `probe-rs run` so far.
- However, I could not test the use-case of selecting multiple algorithms where each one overrides a different memory region, the target I use only has one relevant memory region.