### PR TITLE
Fixed All Remote Commands Marked as Unsupported

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -486,7 +486,7 @@ async fn main() -> Result<()> {
 
     let result = run_app(connection_params, async |client| {
         anyhow::ensure!(
-            client.is_local_session() || !cli.subcommand.is_remote_cmd(),
+            client.is_local_session() || cli.subcommand.is_remote_cmd(),
             "The subcommand is not supported in remote mode."
         );
 


### PR DESCRIPTION
Fixed incorrect logic in `main.rs` causing all the remote client to fail upon connection due to all commands being marked as unsupported (caused by incorrect check).