### PR TITLE
Stop freaking people out during unwinding

### DIFF
--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -9,6 +9,7 @@ use super::{
 use crate::{SourceLocation, VerifiedBreakpoint, stack_frame::StackFrameInfo, unit_info::RangeExt};
 use gimli::{
     BaseAddresses, DebugFrame, RunTimeEndian, UnwindContext, UnwindSection, UnwindTableRow,
+    read::RegisterRule,
 };
 use object::read::{Object, ObjectSection};
 use probe_rs::{
@@ -1135,8 +1136,6 @@ pub fn unwind_register(
     unwind_cfa: Option<u64>,
     memory: &mut dyn MemoryInterface,
 ) -> Result<Option<RegisterValue>, Error> {
-    use gimli::read::RegisterRule;
-
     // If we do not have unwind info, or there is no register rule, then use UnwindRule::Undefined.
     let register_rule = debug_register
         .dwarf_id
@@ -1336,7 +1335,7 @@ fn unwind_program_counter_register(
     register_rule_string: &mut String,
 ) -> Option<RegisterValue> {
     if return_address.is_max_value() || return_address.is_zero() {
-        tracing::warn!(
+        tracing::debug!(
             "No reliable return address is available, so we cannot determine the program counter to unwind the previous frame."
         );
         return None;

--- a/probe-rs-debug/src/exception_handling/riscv.rs
+++ b/probe-rs-debug/src/exception_handling/riscv.rs
@@ -15,6 +15,11 @@ impl RiscvExceptionHandler {
         memory: &mut dyn MemoryInterface,
         unwind_registers: &mut DebugRegisters,
     ) -> Result<(), DebugError> {
+        let ra = unwind_registers.get_register_value_by_role(&RegisterRole::ReturnAddress)?;
+        if ra == 0 {
+            return Ok(());
+        }
+
         // Current register values.
         let sp = unwind_registers.get_register_value_by_role(&RegisterRole::StackPointer)?;
 

--- a/probe-rs-debug/src/exception_handling/xtensa.rs
+++ b/probe-rs-debug/src/exception_handling/xtensa.rs
@@ -35,6 +35,11 @@ impl XtensaExceptionHandler {
 
         // We can try and use FP to unwind SP and RA that allows us to continue unwinding.
 
+        let ra = unwind_registers.get_register_value_by_role(&RegisterRole::ReturnAddress)?;
+        if ra == 0 {
+            return Ok(());
+        }
+
         // Current register values.
         let sp = unwind_registers.get_register_value_by_role(&RegisterRole::StackPointer)?;
 
@@ -45,7 +50,6 @@ impl XtensaExceptionHandler {
             ));
         }
 
-        let ra = unwind_registers.get_register_value_by_role(&RegisterRole::ReturnAddress)?;
         let windowsize = (ra & 0xc000_0000) >> 30;
 
         // Read A0-A3 from current stack frame's Register-Spill Area.


### PR DESCRIPTION
Treat LR=0 as a normal termination condition, and stop emitting unnecessarily scary warnings/errors caused by it.