### PR TITLE
Make smoke-tester viable locally without nextest

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
 probe-rs = "run --package probe-rs-tools --bin probe-rs --features remote --"
-smoke-tester = "run --package smoke_tester --"
+smoke-tester = "test --package smoke_tester --"
 target-gen = "run --package target-gen --release --"

--- a/smoke-tester/Cargo.toml
+++ b/smoke-tester/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1", features = ["derive"] }
 probe-rs = { workspace = true }
 toml = "0.9.0"
 log = "0.4.21"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 colored = "3"
 linkme = "0.3.25"
 thiserror.workspace = true


### PR DESCRIPTION
I would like to be able to run tests against single devices without mucking around with SMOKE_TESTER_CONFIG and separate folder for my DUT definitions.

The log level emitted during test cases can now be configured with SMOKE_TESTER_TEST_LOG, which will be set to info on my raspberry to prevent it from catching fire.