### PR TITLE
Stop unwinding without debuginfo after 500 frames

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
@@ -51,6 +51,7 @@ impl Cmd {
             },
             self.run.shared_options.always_print_stacktrace,
             &mut target_output_files,
+            self.run.shared_options.stack_frame_limit,
         )
         .await?;
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -444,6 +444,7 @@ impl SessionData {
                     initial_registers,
                     exception_interface.as_ref(),
                     instruction_set,
+                    500, // TODO: we should be able to unwind incrementally as the user requests more frames on the UI
                 )?;
             }
         }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -145,6 +145,10 @@ pub struct SharedOptions {
     #[clap(long)]
     pub(crate) always_print_stacktrace: bool,
 
+    /// Limit the number of stack frames to print.
+    #[clap(long, default_value = "500")]
+    pub(crate) stack_frame_limit: u32,
+
     /// Suppress filename and line number information from the rtt log
     #[clap(long)]
     pub(crate) no_location: bool,
@@ -255,6 +259,7 @@ impl Cmd {
                 Some(rtt_client),
                 &mut target_output_files,
                 semihosting_options,
+                self.shared_options.stack_frame_limit,
             )
             .await
         } else {
@@ -271,6 +276,7 @@ impl Cmd {
                 },
                 self.shared_options.always_print_stacktrace,
                 &mut target_output_files,
+                self.shared_options.stack_frame_limit,
             )
             .await
         }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -590,13 +590,18 @@ impl SessionInterface {
             .await
     }
 
-    pub async fn stack_trace(&self, path: PathBuf) -> anyhow::Result<StackTraces> {
+    pub async fn stack_trace(
+        &self,
+        path: PathBuf,
+        stack_frame_limit: u32,
+    ) -> anyhow::Result<StackTraces> {
         let path = self.client.upload_file(&path).await?;
 
         self.client
             .send_resp::<TakeStackTraceEndpoint, _>(&TakeStackTraceRequest {
                 sessid: self.sessid,
                 path: path.display().to_string(),
+                stack_frame_limit,
             })
             .await
     }


### PR DESCRIPTION
Certain firmware that ends up crashing in a recursive way can generate multiple hundereds/thousands of stack frames. probe-rs can read these, but it looks like it's hanging for a very long time. This PR introduces a hard limit of 500 stack frames as a short-term solution.