### PR TITLE
Add rust-version to Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,18 @@ jobs:
         run: cargo doc -p probe-rs --no-deps --all-features --locked
         env:
           RUSTDOCFLAGS: "-D warnings"
+
+  min-version:
+    name: Minimum Rust Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v2.8.2
+
+      - uses: taiki-e/install-action@cargo-hack
+
+      - name: Check minimum Rust version
+        run: cargo hack check --rust-version --workspace --all-targets --ignore-private

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/probe-rs/probe-rs"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 
+# If this is increased, also update the minimum Rust version in .github/workflows/ci.yml
+rust-version = "1.89"
+
 
 [workspace]
 resolver = "2"

--- a/probe-rs-debug/Cargo.toml
+++ b/probe-rs-debug/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 readme.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 description = "Debugging functionlity built on top of the probe-rs crate"
 

--- a/probe-rs-mi/Cargo.toml
+++ b/probe-rs-mi/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 readme.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 description = "The probe-rs machine interface for computers interfacing probe-rs"
 

--- a/probe-rs-target/Cargo.toml
+++ b/probe-rs-target/Cargo.toml
@@ -10,6 +10,7 @@ readme.workspace = true
 categories = ["embedded", "hardware-support", "development-tools::debugging"]
 keywords = ["embedded"]
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 jep106 = "0.3.0"

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://probe.rs"
 repository.workspace = true
 readme.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 description = "A collection of on chip debugging tools to communicate with microchips."
 

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -15,6 +15,7 @@ readme.workspace = true
 categories = ["embedded", "hardware-support", "development-tools::debugging"]
 keywords = ["embedded"]
 license.workspace = true
+rust-version.workspace = true
 
 # Don't include test binaries in published crate
 exclude = ["tests/"]

--- a/rtthost/Cargo.toml
+++ b/rtthost/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license = "MIT"
 authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 env_logger = "0.11"

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 categories = ["embedded", "hardware-support", "development-tools::debugging"]
 keywords = ["embedded"]
 license.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This means better error messages for people using older Rust versions, and also helps when cargo resolves packages.