### PR TITLE
Remove url dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2974,7 +2974,6 @@ dependencies = [
  "jep106",
  "serde",
  "serde_with",
- "url",
 ]
 
 [[package]]
@@ -4802,7 +4801,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]

--- a/probe-rs-target/Cargo.toml
+++ b/probe-rs-target/Cargo.toml
@@ -16,7 +16,6 @@ rust-version.workspace = true
 jep106 = "0.3.0"
 serde = { version = "1", features = ["derive"] }
 base64 = "0.22.1"
-url = { version = "2.5", features = ["serde"] }
 indexmap = { version = "2.2", features = ["serde"] }
 serde_with = { version = "3.8", default-features = false, features = [
     "indexmap_2",

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -66,7 +66,7 @@ pub struct Chip {
     pub svd: Option<String>,
     /// Documentation URLs associated with this chip.
     #[serde(default)]
-    pub documentation: HashMap<String, url::Url>,
+    pub documentation: HashMap<String, String>,
     /// The package variants available for this chip.
     ///
     /// If empty, the chip is assumed to have only one package variant.


### PR DESCRIPTION
It seems we don't use any functionality of the URL crate, expect that this would verify the URL when it's parsed.

Removing this reduces the number of dependencies of the `probe-rs` crate from 248 to 204. 

(It also seems that the documentation URL isn't set for any builtin target.)