### PR TITLE
fix: Don't panic when serial number is not part of probe descriptor

### DIFF
--- a/changelog/fixed-panic-no-serial-number.md
+++ b/changelog/fixed-panic-no-serial-number.md
@@ -1,0 +1,1 @@
+Fix a panic which could happen when trying to select a probe without specifying a serial number.

--- a/probe-rs/src/probe/glasgow/mux.rs
+++ b/probe-rs/src/probe/glasgow/mux.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, collections::BTreeMap, io};
 
-use crate::probe::{DebugProbeError, DebugProbeSelector, ProbeError};
+use crate::probe::{DebugProbeError, DebugProbeSelector, ProbeCreationError, ProbeError};
 
 use super::{net::GlasgowNetDevice, proto::Target, usb::GlasgowUsbDevice};
 
@@ -94,8 +94,9 @@ impl GlasgowDevice {
 
     pub fn new_from_selector(selector: &DebugProbeSelector) -> Result<Self, DebugProbeError> {
         let Some(ref serial) = selector.serial_number else {
-            unreachable!()
+            return Err(ProbeCreationError::NotFound.into());
         };
+
         if serial.starts_with("tcp:") || serial.starts_with("unix:") {
             Ok(Self::new(GlasgowDeviceInner::Net(
                 GlasgowNetDevice::new_from_selector(selector)?,


### PR DESCRIPTION
The probe can't assume that a serial number is present.