### PR TITLE
Don't stop the debugger when the core is in lockup state

### DIFF
--- a/changelog/fixed-dont-stop-debugger-on-lockup.md
+++ b/changelog/fixed-dont-stop-debugger-on-lockup.md
@@ -1,0 +1,1 @@
+arm: When a lockup is detected, don't stop the debugger.


### PR DESCRIPTION
When a chip is locked up it's very nice if your debugger keeps working :sweat_smile:.

Ideally, the state should be communicated to the user in some way.