### PR TITLE
Xtensa: Fix step overwriting A3

### DIFF
--- a/changelog/fixed-xtensa-reg.md
+++ b/changelog/fixed-xtensa-reg.md
@@ -1,0 +1,1 @@
+Xtensa: Fixed a bug where instruction stepping trashed a CPU register.

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -280,7 +280,7 @@ impl<'probe> XtensaCommunicationInterface<'probe> {
 
     /// Enter debug mode.
     pub fn enter_debug_mode(&mut self) -> Result<(), XtensaError> {
-        self.state.register_cache = RegisterCache::new();
+        self.clear_register_cache();
         self.xdm.enter_debug_mode()?;
 
         self.state.is_halted = self.xdm.status()?.stopped();
@@ -941,7 +941,6 @@ impl<'probe> XtensaCommunicationInterface<'probe> {
             ps.set_woe(true);
             ps
         })?;
-        self.state.register_cache = RegisterCache::new();
 
         Ok(())
     }

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -105,10 +105,6 @@ impl<'probe> Xtensa<'probe> {
         Ok(this)
     }
 
-    fn clear_cache(&mut self) {
-        self.interface.clear_register_cache();
-    }
-
     fn on_attach(&mut self) -> Result<(), Error> {
         // If the core was reset, force a reconnection.
         let core_reset;
@@ -245,7 +241,9 @@ impl<'probe> Xtensa<'probe> {
 
     fn on_halted(&mut self) -> Result<(), Error> {
         self.state.pc_written = false;
-        self.clear_cache();
+
+        // NB: do not clear the register cache here. We clear it before resuming,
+        // and clearing here would interfere with instruction stepping.
 
         let status = self.status()?;
         tracing::debug!("Core halted: {:#?}", status);


### PR DESCRIPTION
Instruction stepping works by manipulating the ICount and ILevel registers, resuming the core, then waiting for the core to stop, AND resetting ICount to zero. This resetting requires saving and dirtying scratch register. After this, the Xtensa implementation calls `on_halted` which previously cleared the register cache, which meant we lost the saved scratch register.

This PR removes this cache clearing call. As we clear the cache when resuming the core, a halt event (originating outside of the functions in the Xtensa implementation) should not have a dirty register cache.