### PR TITLE
tms570: ensure itr is enabled before each instruction

### DIFF
--- a/changelog/fixed-tms570-reset-by-enabling-itr.md
+++ b/changelog/fixed-tms570-reset-by-enabling-itr.md
@@ -1,0 +1,1 @@
+Fixed reset on TMS570 due to ITR sometimes getting disabled


### PR DESCRIPTION
The reset sequence sometimes disables ITR, which puts the target in a funny state. All transfers need ITR enabled.

Add a step to always ensure ITR is enabled before any memory access. This adds a bit of overhead, but since this is in the reset sequence and is a rare event the additional accesses are acceptable.

This fixes reset on the TMS570.