### PR TITLE
Add Linux spidev SWD probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,7 +648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -657,7 +657,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -923,7 +923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1077,7 +1077,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1207,7 +1207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2433,6 +2433,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -2468,7 +2480,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2872,6 +2884,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serialport",
+ "spidev",
  "test-case",
  "test-log",
  "thiserror 2.0.18",
@@ -3112,7 +3125,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3421,7 +3434,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3914,6 +3927,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "spidev"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f611021817865236902d15bdf8d729b0bd232141b568d56bb88409a8dc27397"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "nix 0.29.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4097,7 +4121,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4972,7 +4996,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/changelog/added-linux-spidev-swd-probe.md
+++ b/changelog/added-linux-spidev-swd-probe.md
@@ -1,0 +1,1 @@
+Added a probe that uses Linux spidev to emulate SWD with full-duplex SPI

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -61,6 +61,7 @@ scroll = "0.13"
 serialport = { version = "4.7.0", default-features = false, features = [
     "usbportinfo-interface",
 ] }
+spidev = "0.7"
 tracing = "0.1"
 parking_lot = "0.12.2"
 zerocopy = { version = "0.8.0", features = ["derive"] }

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -10,6 +10,7 @@ pub mod fake_probe;
 pub mod ftdi;
 pub mod glasgow;
 pub mod jlink;
+pub mod linuxspidevswd;
 pub mod list;
 mod selector;
 pub mod sifliuart;

--- a/probe-rs/src/probe/linuxspidevswd/mod.rs
+++ b/probe-rs/src/probe/linuxspidevswd/mod.rs
@@ -1,0 +1,441 @@
+//! A probe that uses Linux spidev to emulate SWD using full-duplex SPI transfers.
+//!
+//! This implementation is designed to be broadly compatible with different SPI peripherals,
+//! so doesn't use uncommon features such as 3-wire SPI or LSB-first transfers.
+//!
+//! The SPI output (PICO) and input (POCI) lines of the host must be tied together with a resistor.
+//! This enables the host to drive the SWDIO line for host send phases and read the SWDIO line
+//! during target send phases, while still allowing the target's SWD port to drive the line.
+//!
+//! For example:
+//!
+//! ```text
+//!    Host                     Target
+//! +--------+     1K         +--------+
+//! |    PICO|---/\/\/\---+   |        |
+//! |        |            |   |        |
+//! |    POCI|------------+---|SWDIO   |
+//! |        |                |        |
+//! |     SCK|----------------|SWDCLK  |
+//! +--------+                +--------+
+//! ```
+//!
+//! The exact choice of resistor value depends on SWD clock speed and target/host
+//! drive strength. However, 1 kilo-ohm is a good starting value, and has been found
+//! to work well at speeds of 25 MHz.
+
+use crate::{
+    CoreStatus,
+    architecture::arm::{
+        ArmCommunicationInterface, ArmDebugInterface, ArmError, DapError, DapProbe, RawDapAccess,
+        RegisterAddress,
+        dp::{DpRegister, RdBuff},
+        sequences::ArmDebugSequence,
+    },
+    probe::{DebugProbe, DebugProbeError, ProbeError, WireProtocol},
+};
+use spidev::{SpiModeFlags, SpidevOptions, SpidevTransfer};
+use std::fmt::Debug;
+
+const WRITE_PACKET_SIZE: usize = 7;
+const READ_PACKET_SIZE: usize = 8;
+/// Maximum number of bytes allowed in a single SPI transaction.
+const MAX_QUEUE_BYTES: usize = 4096;
+
+/// Probe using Linux spidev to emulate SWD with full-duplex SPI.
+pub struct LinuxSpidevSwdProbe {
+    spidev: spidev::Spidev,
+    speed_khz: u32,
+
+    tx_buffer: Vec<u8>,
+    rx_buffer: Vec<u8>,
+}
+
+impl Debug for LinuxSpidevSwdProbe {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LinuxSpidevSwdProbe")
+            .field("spidev", &self.spidev)
+            .field("speed_khz", &self.speed_khz)
+            .finish_non_exhaustive()
+    }
+}
+
+impl LinuxSpidevSwdProbe {
+    /// Construct a new spidev SWD probe for the given SPI port.
+    pub fn new(spidev: spidev::Spidev) -> Self {
+        LinuxSpidevSwdProbe {
+            spidev,
+            speed_khz: 1000,
+            tx_buffer: Vec::new(),
+            rx_buffer: vec![0; MAX_QUEUE_BYTES],
+        }
+    }
+
+    /// Configure the spidev device.
+    fn configure_spidev(&mut self) -> Result<(), DebugProbeError> {
+        let options = SpidevOptions::new()
+            .bits_per_word(8)
+            .max_speed_hz(self.speed_khz * 1000)
+            .mode(SpiModeFlags::SPI_MODE_3)
+            .build();
+        self.spidev
+            .configure(&options)
+            .map_err(|e| DebugProbeError::ProbeSpecific(LinuxSpidevSwdError::Io(e).into()))
+    }
+
+    /// Transfer the TX buffer, packetize, and fix bit order.
+    fn transfer(&mut self, packet_size: usize) -> Result<impl Iterator<Item = u64>, ArmError> {
+        assert!(packet_size <= 8);
+
+        let rx_buffer = &mut self.rx_buffer[0..self.tx_buffer.len()];
+        let mut transfer = SpidevTransfer::read_write(&self.tx_buffer, rx_buffer);
+
+        let result = self.spidev.transfer(&mut transfer);
+        self.tx_buffer.clear();
+        result.map_err(|e| DebugProbeError::ProbeSpecific(LinuxSpidevSwdError::Io(e).into()))?;
+
+        Ok(rx_buffer.chunks_exact(packet_size).map(move |packet| {
+            let mut data = [0u8; 8];
+            data[0..packet_size].copy_from_slice(packet);
+            u64::from_be_bytes(data).reverse_bits()
+        }))
+    }
+
+    /// Flush pending writes in the TX buffer.
+    fn flush_writes(&mut self) -> Result<(), ArmError> {
+        if self.tx_buffer.is_empty() {
+            return Ok(());
+        }
+
+        // Add 8 extra idle cycles, because we aren't going to be immediately
+        // sending an additional transaction after the last one.
+        self.tx_buffer.extend_from_slice(&[0]);
+
+        // Do the transfer and verify.
+        for packet in self.transfer(WRITE_PACKET_SIZE)? {
+            let response = SwdWritePacket(packet);
+            parse_swd_ack(response.ack())?;
+        }
+
+        Ok(())
+    }
+}
+
+impl DebugProbe for LinuxSpidevSwdProbe {
+    fn get_name(&self) -> &str {
+        "spidev SWD"
+    }
+
+    fn speed_khz(&self) -> u32 {
+        self.speed_khz
+    }
+
+    fn set_speed(&mut self, speed_khz: u32) -> Result<u32, DebugProbeError> {
+        let prev_speed_khz = self.speed_khz;
+        self.speed_khz = speed_khz;
+        if let Err(e) = self.configure_spidev() {
+            self.speed_khz = prev_speed_khz;
+            return Err(e);
+        }
+        Ok(self.speed_khz)
+    }
+
+    fn attach(&mut self) -> Result<(), DebugProbeError> {
+        self.configure_spidev()
+    }
+
+    fn detach(&mut self) -> Result<(), crate::Error> {
+        Ok(())
+    }
+
+    fn target_reset(&mut self) -> Result<(), DebugProbeError> {
+        Err(DebugProbeError::NotImplemented {
+            function_name: "target_reset",
+        })
+    }
+
+    fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
+        Err(DebugProbeError::NotImplemented {
+            function_name: "target_reset_assert",
+        })
+    }
+
+    fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {
+        Err(DebugProbeError::NotImplemented {
+            function_name: "target_reset_deassert",
+        })
+    }
+
+    fn select_protocol(&mut self, protocol: WireProtocol) -> Result<(), DebugProbeError> {
+        if protocol != WireProtocol::Swd {
+            Err(DebugProbeError::UnsupportedProtocol(protocol))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn active_protocol(&self) -> Option<WireProtocol> {
+        Some(WireProtocol::Swd)
+    }
+
+    fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
+    }
+
+    fn has_arm_interface(&self) -> bool {
+        true
+    }
+
+    fn try_get_arm_debug_interface<'probe>(
+        self: Box<Self>,
+        sequence: std::sync::Arc<dyn ArmDebugSequence>,
+    ) -> Result<Box<dyn ArmDebugInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
+        Ok(ArmCommunicationInterface::create(
+            self, sequence, /* use_overrun_detect*/ false,
+        ))
+    }
+}
+
+impl DapProbe for LinuxSpidevSwdProbe {}
+
+fn parse_swd_ack(ack: u64) -> Result<(), DapError> {
+    // These are the little-endian interpretations of bits,
+    // so appear backwards relative to the wire order.
+    match ack {
+        0b001 => Ok(()),
+        0b010 => Err(DapError::WaitResponse),
+        0b100 => Err(DapError::FaultResponse),
+        0b111 => Err(DapError::NoAcknowledge),
+        _ => Err(DapError::Protocol(WireProtocol::Swd)),
+    }
+}
+
+impl RawDapAccess for LinuxSpidevSwdProbe {
+    fn raw_read_register(&mut self, address: RegisterAddress) -> Result<u32, ArmError> {
+        let mut data = 0;
+        self.raw_read_block(address, std::slice::from_mut(&mut data))?;
+        Ok(data)
+    }
+
+    fn raw_write_register(&mut self, address: RegisterAddress, value: u32) -> Result<(), ArmError> {
+        self.raw_write_block(address, &[value])
+    }
+
+    fn raw_read_block(
+        &mut self,
+        address: RegisterAddress,
+        values: &mut [u32],
+    ) -> Result<(), ArmError> {
+        // Flush any queued writes.
+        self.flush_writes()?;
+
+        // Build the tx buffer.
+        self.tx_buffer
+            .reserve((values.len() + 1) * READ_PACKET_SIZE);
+        let packet = SwdReadPacket::new(address);
+        for _ in 0..values.len() {
+            let packet = packet.0.reverse_bits().to_be_bytes();
+            self.tx_buffer.extend_from_slice(&packet);
+        }
+
+        if address.is_ap() {
+            // AP reads are pipelined. We need to insert a read to Dap:RDBUFF to get
+            // the actual return value for the final read.
+            let packet = SwdReadPacket::new(RegisterAddress::DpRegister(RdBuff::ADDRESS));
+            let packet = packet.0.reverse_bits().to_be_bytes();
+            self.tx_buffer.extend_from_slice(&packet);
+        }
+
+        // Do the transfer and read results.
+        let mut i = 0;
+        let mut skip_packet = address.is_ap();
+        for packet in self.transfer(READ_PACKET_SIZE)? {
+            let response = SwdReadPacket(packet);
+            parse_swd_ack(response.ack())?;
+
+            // Check RDATA parity bit.
+            let parity = (response.data().count_ones() & 1) == 1;
+            if parity != response.parity2() {
+                return Err(ArmError::Dap(DapError::IncorrectParity));
+            }
+
+            // Possibly skip the first packet.
+            if skip_packet {
+                skip_packet = false;
+                continue;
+            }
+
+            values[i] = response.data();
+            i += 1;
+        }
+
+        Ok(())
+    }
+
+    fn raw_write_block(
+        &mut self,
+        address: RegisterAddress,
+        values: &[u32],
+    ) -> Result<(), ArmError> {
+        // Build the tx buffer.
+        self.tx_buffer.reserve(values.len() * WRITE_PACKET_SIZE);
+        let mut packet = SwdWritePacket::new(address, 0);
+        for &value in values {
+            SwdWritePacket::update_data(&mut packet, value);
+
+            let packet = packet.0.reverse_bits().to_be_bytes();
+            self.tx_buffer
+                .extend_from_slice(&packet[0..WRITE_PACKET_SIZE]);
+
+            // If there isn't space for another write packet plus idle cycles, flush the queue.
+            let available = MAX_QUEUE_BYTES - self.tx_buffer.len() - 1;
+            if available < WRITE_PACKET_SIZE {
+                self.flush_writes()?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn raw_flush(&mut self) -> Result<(), ArmError> {
+        self.flush_writes()
+    }
+
+    fn jtag_sequence(&mut self, _cycles: u8, _tms: bool, _tdi: u64) -> Result<(), DebugProbeError> {
+        Err(DebugProbeError::NotImplemented {
+            function_name: "jtag_sequence",
+        })
+    }
+
+    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError> {
+        // Output bit_len bits, least-significant bit first.
+        // We can only output bytes, so mask out unused bits and round up.
+        let bits = bits & ((1u64 << bit_len) - 1);
+        let tx = bits.reverse_bits().to_be_bytes();
+        let mut rx = [0u8; 8];
+        let num_bytes = bit_len.div_ceil(8) as usize;
+        let mut transfer = SpidevTransfer::read_write(&tx[0..num_bytes], &mut rx[0..num_bytes]);
+        self.spidev
+            .transfer(&mut transfer)
+            .map_err(|e| DebugProbeError::ProbeSpecific(LinuxSpidevSwdError::Io(e).into()))
+    }
+
+    fn swj_pins(
+        &mut self,
+        _pin_out: u32,
+        _pin_select: u32,
+        _pin_wait: u32,
+    ) -> Result<u32, DebugProbeError> {
+        Err(DebugProbeError::NotImplemented {
+            function_name: "swj_pins",
+        })
+    }
+
+    fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
+    }
+
+    fn core_status_notification(&mut self, _state: CoreStatus) -> Result<(), DebugProbeError> {
+        Ok(())
+    }
+}
+
+bitfield::bitfield! {
+    /// A SWD write packet
+    #[derive(Copy, Clone)]
+    struct SwdWritePacket(u64);
+    impl Debug;
+
+    // Common header
+    start, set_start: 0;
+    ap_n_dp, set_ap_n_dp: 1;
+    r_n_w, set_r_n_w: 2;
+    a2, set_a2: 3;
+    a3, set_a3: 4;
+    parity1, set_parity1: 5;
+    stop, set_stop: 6;
+    park, set_park: 7;
+    _, set_turnaround1: 8;
+    ack, set_ack: 11, 9;
+
+    // Write specific
+    _, set_turnaround2: 12;
+    u32, data, set_data: 44, 13;
+    parity2, set_parity2: 45;
+}
+
+bitfield::bitfield! {
+    /// A SWD read packet
+    #[derive(Copy, Clone)]
+    struct SwdReadPacket(u64);
+    impl Debug;
+
+    // Common header
+    start, set_start: 0;
+    ap_n_dp, set_ap_n_dp: 1;
+    r_n_w, set_r_n_w: 2;
+    a2, set_a2: 3;
+    a3, set_a3: 4;
+    parity1, set_parity1: 5;
+    stop, set_stop: 6;
+    park, set_park: 7;
+    _, set_turnaround1: 8;
+    ack, set_ack: 11, 9;
+
+    // Read specific
+    u32, data, set_data: 43, 12;
+    parity2, set_parity2: 44;
+    _, set_turnaround2: 45;
+}
+
+impl SwdWritePacket {
+    fn new(address: RegisterAddress, data: u32) -> Self {
+        let mut packet = SwdWritePacket(0);
+        packet.set_start(true);
+        packet.set_ap_n_dp(address.is_ap());
+        packet.set_r_n_w(false);
+        packet.set_a2(address.a2());
+        packet.set_a3(address.a3());
+        packet.set_parity1(address.is_ap() ^ false ^ address.a2() ^ address.a3());
+        packet.set_stop(false);
+        packet.set_park(true);
+        packet.set_data(data);
+        packet.set_parity2((data.count_ones() & 1) == 1);
+        packet
+    }
+
+    fn update_data(this: &mut Self, data: u32) {
+        this.set_data(data);
+        this.set_parity2((data.count_ones() & 1) == 1);
+    }
+}
+
+impl SwdReadPacket {
+    fn new(address: RegisterAddress) -> Self {
+        let mut packet = SwdReadPacket(0);
+        packet.set_start(true);
+        packet.set_ap_n_dp(address.is_ap());
+        packet.set_r_n_w(true);
+        packet.set_a2(address.a2());
+        packet.set_a3(address.a3());
+        packet.set_parity1(address.is_ap() ^ true ^ address.a2() ^ address.a3());
+        packet.set_stop(false);
+        packet.set_park(true);
+        packet
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum LinuxSpidevSwdError {
+    Io(std::io::Error),
+}
+
+impl core::fmt::Display for LinuxSpidevSwdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "IO error {e}"),
+        }
+    }
+}
+
+impl ProbeError for LinuxSpidevSwdError {}


### PR DESCRIPTION
This commit adds a DebugProbe implementation that uses Linux spidev to emulate SWD with full-duplex SPI transactions. This is much faster than bit-banging SWD, and works well for embedded Linux boards, like Raspberry Pis.

@bugadani: Following our discussion in #3812, this is an example of a probe that would be useful to include in probe-rs, but has a problematic dependency for some users (`spidev`, which is Linux only). So it would be desirable to gate this behind a specific feature. If built-in probes were split into a separate crate, you'd probably also want to be able to turn off specific probes to avoid the downstream dependencies.