### PR TITLE
cmsisdap: Check response length when executing a JTAG sequence

### DIFF
--- a/changelog/fixed-cmsisdap-check-jtag-sequence-len.md
+++ b/changelog/fixed-cmsisdap-check-jtag-sequence-len.md
@@ -1,0 +1,1 @@
+* cmsisdap: Check buffer size of response when executing a JTAG sequence.


### PR DESCRIPTION
Got a panic because the rusty probe did not send back enough bytes. 