### PR TITLE
Fix STM32N6 register reset sequence

### DIFF
--- a/changelog/fixed-stm32n6-register-reset.md
+++ b/changelog/fixed-stm32n6-register-reset.md
@@ -1,0 +1,1 @@
+Fixed STM32N6 register reset sequence to use the correct ARMv8-M register set, ensuring security extension registers are properly zeroed after the boot ROM runs.

--- a/probe-rs/src/vendor/st/sequences/stm32n6.rs
+++ b/probe-rs/src/vendor/st/sequences/stm32n6.rs
@@ -12,7 +12,12 @@ use crate::{
         ArmDebugInterface, ArmError, FullyQualifiedApAddress,
         ap::{ApRegister, DRW, TAR},
         armv8m::Aircr,
-        core::{cortex_m::write_core_reg, registers::cortex_m::CORTEX_M_WITH_FP_CORE_REGISTERS},
+        core::{
+            cortex_m::write_core_reg,
+            registers::{
+                armv8m::V8M_MAIN_SEC_FP_REGISTERS, cortex_m::CORTEX_M_WITH_FP_CORE_REGISTERS,
+            },
+        },
         memory::ArmMemoryInterface,
         sequences::{ArmDebugSequence, cortex_m_wait_for_reset},
     },
@@ -122,7 +127,7 @@ impl ArmDebugSequence for Stm32n6 {
         // Try to restore the CPU to a known state after halting. This is necessary on the STM32N6
         // where we can't `reset_and_halt()` into a known state because the boot ROM always runs.
         // See TakeReset() in the arch manual, and DCRSR.REGSEL for register indices.
-        for reg in CORTEX_M_WITH_FP_CORE_REGISTERS.all_registers() {
+        for reg in V8M_MAIN_SEC_FP_REGISTERS.all_registers() {
             write_core_reg(core, reg.into(), 0u32)?;
         }
 


### PR DESCRIPTION
Use `V8M_MAIN_SEC_FP_REGISTERS` instead of `CORTEX_M_WITH_FP_CORE_REGISTERS` when resetting registers in the STM32N6 `reset_catch_clear` sequence

  The STM32N6 is an ARMv8-M main core with security extensions. The previous code used the generic Cortex-M floating-point register set (`CORTEX_M_WITH_FP_CORE_REGISTERS`) which doesn't include the v8-M main and security extension registers. This meant those registers were left in an unknown state after the boot ROM ran, which could cause issues since the STM32N6 can't `reset_and_halt()` into a clean state.
  
 Switching to `V8M_MAIN_SEC_FP_REGISTERS` ensures all relevant registers (including v8-M main and security extension registers) are zeroed out during the reset catch sequence.
 
 I notices that when I was writing a flash-algorithm for the stm32n6-dk and needed to handle register setup myself and could not use the macro approach. With this approach the flash-algorithm could be written with the use of the macro.
 
 The flash algorithm which works but is for from optimal: https://github.com/tarfu/stm32n6-mx66uw1g45g