### PR TITLE
Print read memory as a table of values by default

### DIFF
--- a/changelog/changed-read.md
+++ b/changelog/changed-read.md
@@ -1,0 +1,1 @@
+`probe-rs read` now supports multiple output formats when printing to console. The default output format has been changed to `hex-table`.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/read.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/read.rs
@@ -10,10 +10,112 @@ use crate::util::common_options::{ProbeOptions, ReadWriteBitWidth, ReadWriteOpti
 use std::io::Write;
 use std::path::PathBuf;
 
-#[derive(clap::ValueEnum, Clone)]
-enum FileFormat {
-    Hex,
+#[derive(clap::ValueEnum, Clone, Copy)]
+enum OutputFormat {
+    /// Intel Hex Format
+    Ihex,
+    /// Simple list of hexadecimal numbers
+    SimpleHex,
+    /// Hexadecimal numbers formatted into a table
+    HexTable,
+    /// The raw binary
     Binary,
+}
+
+impl OutputFormat {
+    fn write(
+        self,
+        dst: impl Write,
+        address: u64,
+        width: ReadWriteBitWidth,
+        data: &[u8],
+    ) -> anyhow::Result<()> {
+        match self {
+            OutputFormat::Binary => Self::write_binary(dst, data),
+            OutputFormat::Ihex => Self::write_ihex(dst, address, data),
+            OutputFormat::SimpleHex => Self::write_simple_hex(dst, width, data),
+            OutputFormat::HexTable => Self::write_hex_table(dst, address, width, data),
+        }
+    }
+
+    fn write_simple_hex(
+        mut dst: impl Write,
+        width: ReadWriteBitWidth,
+        data: &[u8],
+    ) -> anyhow::Result<()> {
+        let bytes = match width {
+            ReadWriteBitWidth::B8 => 1,
+            ReadWriteBitWidth::B16 => 2,
+            ReadWriteBitWidth::B32 => 4,
+            ReadWriteBitWidth::B64 => 8,
+        };
+
+        let mut first = true;
+        for window in data.chunks(bytes) {
+            if first {
+                first = false;
+            } else {
+                write!(dst, " ")?;
+            }
+
+            for byte in window.iter().rev() {
+                write!(dst, "{byte:02x}")?;
+            }
+        }
+
+        writeln!(dst)?;
+        Ok(())
+    }
+
+    fn write_hex_table(
+        mut dst: impl Write,
+        mut address: u64,
+        width: ReadWriteBitWidth,
+        data: &[u8],
+    ) -> anyhow::Result<()> {
+        let bytes_in_line = match width {
+            ReadWriteBitWidth::B8 => 8,
+            ReadWriteBitWidth::B16 => 16,
+            ReadWriteBitWidth::B32 | ReadWriteBitWidth::B64 => 32,
+        };
+        for window in data.chunks(bytes_in_line) {
+            write!(dst, "{address:08x}: ")?;
+            Self::write_simple_hex(&mut dst, width, window)?;
+            address += bytes_in_line as u64;
+        }
+
+        Ok(())
+    }
+
+    fn write_binary(mut dst: impl Write, data: &[u8]) -> anyhow::Result<()> {
+        dst.write_all(data)?;
+
+        Ok(())
+    }
+
+    fn write_ihex(mut dst: impl Write, address: u64, data: &[u8]) -> anyhow::Result<()> {
+        let mut running_address = address;
+        let mut records = vec![];
+
+        for chunk in &data.iter().copied().chunks(255) {
+            let address_msbs: u16 = (running_address >> 16)
+                .try_into()
+                .context("Hex format only supports addressing up to 32 bits")?;
+
+            records.push(Record::ExtendedLinearAddress(address_msbs));
+
+            records.push(Record::Data {
+                offset: (running_address & 0xFFFF) as u16,
+                value: chunk.collect(),
+            });
+            running_address += 255;
+        }
+        records.push(Record::EndOfFile);
+        let hexdata = ihex::create_object_file_representation(&records)?;
+        dst.write_all(hexdata.as_bytes())?;
+
+        Ok(())
+    }
 }
 
 /// Read from target memory address
@@ -29,8 +131,6 @@ enum FileFormat {
 ///
 /// If the --output argument is provided, readback data is instead saved to a file as hex/bin.
 /// In this case, the read word width has no effect except determining the total number of bytes
-///
-/// NOTE: Only supports RAM addresses
 #[derive(clap::Parser)]
 #[clap(verbatim_doc_comment)]
 pub struct Cmd {
@@ -45,128 +145,110 @@ pub struct Cmd {
 
     /// Number of words to read from the target
     words: usize,
+
     /// File to output binary data to
     #[arg(long, short)]
     output: Option<PathBuf>,
+
     /// Format of the outputted binary data
-    #[clap(value_enum, default_value_t=FileFormat::Hex)]
-    #[arg(long, short, requires("output"))]
-    format: FileFormat,
+    #[clap(value_enum, default_value_t=OutputFormat::HexTable)]
+    #[arg(long, short)]
+    format: OutputFormat,
 }
 
 impl Cmd {
-    async fn read_to_console(
-        core: CoreInterface,
-        address: u64,
-        width: ReadWriteBitWidth,
-        nwords: usize,
-    ) -> anyhow::Result<()> {
-        match width {
-            ReadWriteBitWidth::B8 => {
-                let values = core.read_memory_8(address, nwords).await?;
-                for val in values {
-                    print!("{val:02x} ");
-                }
-            }
-            ReadWriteBitWidth::B16 => {
-                let values = core.read_memory_16(address, nwords).await?;
-                for val in values {
-                    print!("{val:04x} ");
-                }
-            }
-            ReadWriteBitWidth::B32 => {
-                let values = core.read_memory_32(address, nwords).await?;
-                for val in values {
-                    print!("{val:08x} ");
-                }
-            }
-            ReadWriteBitWidth::B64 => {
-                let values = core.read_memory_64(address, nwords).await?;
-                for val in values {
-                    print!("{val:016x} ");
-                }
-            }
-        }
-        println!();
-        Ok(())
-    }
-
-    async fn read_to_file(
-        core: CoreInterface,
-        address: u64,
-        width: ReadWriteBitWidth,
-        nwords: usize,
-        path: PathBuf,
-        format: FileFormat,
-    ) -> anyhow::Result<()> {
-        let nbytes = nwords
-            * match width {
-                ReadWriteBitWidth::B8 => 1,
-                ReadWriteBitWidth::B16 => 2,
-                ReadWriteBitWidth::B32 => 4,
-                ReadWriteBitWidth::B64 => 8,
-            };
-
-        let data = core.read_memory_8(address, nbytes).await?;
-
-        let mut running_address = address;
-        match format {
-            FileFormat::Binary => {
-                std::fs::File::create(path)?.write_all(&data)?;
-            }
-            FileFormat::Hex => {
-                let mut records = vec![];
-
-                for chunk in &data.into_iter().chunks(255) {
-                    let address_msbs: u16 = (running_address >> 16)
-                        .try_into()
-                        .context("Hex format only supports addressing up to 32 bits")?;
-
-                    records.push(Record::ExtendedLinearAddress(address_msbs));
-
-                    records.push(Record::Data {
-                        offset: (running_address & 0xFFFF) as u16,
-                        value: chunk.collect(),
-                    });
-                    running_address += 255;
-                }
-                records.push(Record::EndOfFile);
-                let hexdata = ihex::create_object_file_representation(&records)?;
-                std::fs::File::create(path)?.write_all(hexdata.as_bytes())?;
-            }
-        }
-        Ok(())
-    }
-
     pub async fn run(self, client: RpcClient) -> anyhow::Result<()> {
         let session = cli::attach_probe(&client, self.probe_options, false).await?;
         let core = session.core(self.shared.core);
 
+        let data = Self::read_memory(
+            core,
+            self.read_write_options.address,
+            self.read_write_options.width,
+            self.words,
+        )
+        .await?;
+
         match self.output {
-            Some(path) => {
-                Cmd::read_to_file(
-                    core,
-                    self.read_write_options.address,
-                    self.read_write_options.width,
-                    self.words,
-                    path,
-                    self.format,
-                )
-                .await?
-            }
-            None => {
-                Cmd::read_to_console(
-                    core,
-                    self.read_write_options.address,
-                    self.read_write_options.width,
-                    self.words,
-                )
-                .await?
-            }
+            Some(path) => Self::save_to_file(
+                self.read_write_options.address,
+                &data,
+                path,
+                self.read_write_options.width,
+                self.format,
+            )?,
+            None => Self::print_to_console(
+                self.read_write_options.address,
+                &data,
+                self.read_write_options.width,
+                self.format,
+            )?,
         };
 
         session.resume_all_cores().await?;
 
+        Ok(())
+    }
+
+    async fn read_memory(
+        core: CoreInterface,
+        address: u64,
+        width: ReadWriteBitWidth,
+        nwords: usize,
+    ) -> anyhow::Result<Vec<u8>> {
+        let bytes = match width {
+            ReadWriteBitWidth::B8 => {
+                let values = core.read_memory_8(address, nwords).await?;
+                values
+                    .into_iter()
+                    .flat_map(|v| v.to_le_bytes())
+                    .collect::<Vec<_>>()
+            }
+            ReadWriteBitWidth::B16 => {
+                let values = core.read_memory_16(address, nwords).await?;
+                values
+                    .into_iter()
+                    .flat_map(|v| v.to_le_bytes())
+                    .collect::<Vec<_>>()
+            }
+            ReadWriteBitWidth::B32 => {
+                let values = core.read_memory_32(address, nwords).await?;
+                values
+                    .into_iter()
+                    .flat_map(|v| v.to_le_bytes())
+                    .collect::<Vec<_>>()
+            }
+            ReadWriteBitWidth::B64 => {
+                let values = core.read_memory_64(address, nwords).await?;
+                values
+                    .into_iter()
+                    .flat_map(|v| v.to_le_bytes())
+                    .collect::<Vec<_>>()
+            }
+        };
+        Ok(bytes)
+    }
+
+    fn save_to_file(
+        address: u64,
+        data: &[u8],
+        path: PathBuf,
+        width: ReadWriteBitWidth,
+        format: OutputFormat,
+    ) -> anyhow::Result<()> {
+        let mut file = std::fs::File::create(path)?;
+        format.write(&mut file, address, width, data)?;
+        Ok(())
+    }
+
+    fn print_to_console(
+        address: u64,
+        data: &[u8],
+        width: ReadWriteBitWidth,
+        format: OutputFormat,
+    ) -> anyhow::Result<()> {
+        let mut stdout = std::io::stdout();
+        format.write(&mut stdout, address, width, data)?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR changes the output format of `probe-rs read` making it a bit more useful for directly observing memory. Examples:

```
cargo probe-rs read b8 0x40001000 64
40001000: 6f 40 d1 5f 6f 40 b1 60
40001008: 6f 40 d1 63 6f 50 51 7e
40001010: 00 00 00 00 00 00 00 00
40001018: 6f 70 61 3c 6f 70 61 47
40001020: 6f 70 c1 55 6f 70 41 5b
40001028: 6f 70 a1 61 6f 70 e1 64
40001030: 6f 70 91 0e 6f 70 51 1f
40001038: 6f 70 31 29 6f 70 31 3c

cargo probe-rs read b32 0x40001000 64
40001000: 5fd1406f 60b1406f 63d1406f 7e51506f 00000000 00000000 3c61706f 4761706f
40001020: 55c1706f 5b41706f 61a1706f 64e1706f 0e91706f 1f51706f 2931706f 3c31706f
40001040: 4791706f 4971706f 4ab1706f 0561706f 1381706f 1941706f 1dc1706f 2181706f
40001060: 2341706f 2561706f 2b21706f 50c1606f 5461606f 5901606f 5e21606f 5b21606f
40001080: 63a1706f 7441706f 4871606f 53f1606f 1fa1606f 22a1606f 2cc1606f 3ca1606f
400010a0: 6041606f 71c1606f 7ba1606f 2d51606f 1011506f 1271506f 0240d06f 6530c06f
400010c0: 7470c06f 6830c06f 52a1506f 5621006f 3960806f 38e0d06f 4761506f 0d60206f
400010e0: 0dc0206f 0fc0206f 7210206f 7630206f 7db0206f 0120306f 57f0206f 6110206f

cargo probe-rs read b32 0x40001000 64 --format ihex
:020000044000BA
:FF1000006F40D15F6F40B1606F40D1636F50517E00000000000000006F70613C6F7061476F70C1556F70415B6F70A1616F70E1646F70910E6F70511F6F7031296F70313C6F7091476F7071496F70B14A6F7061056F7081136F7041196F70C11D6F7081216F7041236F7061256F70212B6F60C1506F6061546F6001596F60215E6F60215B6F70A1636F7041746F6071486F60F1536F60A11F6F60A1226F60C12C6F60A13C6F6041606F60C1716F60A17B6F60512D6F5011106F5071126FD040026FC030656FC070746FC030686F50A1526F0021566F8060396FD0E0386F5061476F20600D6F20C00D6F20C00F6F2010726F2030766F20B07D6F3020016F20F0576F201075
:020000044000BA
:0110FF00618F
:00000001FF
```