### PR TITLE
Fix crash on unexpected error type

### DIFF
--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -750,7 +750,7 @@ impl<Probe: AutoImplementJtagAccess> JtagAccess for Probe {
 
             // If an error happens during prep, return no results as chip will be in an inconsistent state
             let op = result.map_err(|e| {
-                BatchExecutionError::new_specific(e.into(), DeferredResultSet::new())
+                BatchExecutionError::new_from_debug_probe(e, DeferredResultSet::new())
             })?;
 
             bits.push((idx, command, op));
@@ -760,7 +760,7 @@ impl<Probe: AutoImplementJtagAccess> JtagAccess for Probe {
         // If an error happens during the final flush, also retry whole operation
         let bitstream = self
             .read_captured_bits()
-            .map_err(|e| BatchExecutionError::new_specific(e.into(), DeferredResultSet::new()))?;
+            .map_err(|e| BatchExecutionError::new_from_debug_probe(e, DeferredResultSet::new()))?;
 
         tracing::debug!("Got responses! Took {:?}! Processing...", t1.elapsed());
         let mut responses = DeferredResultSet::with_capacity(bits.len());

--- a/probe-rs/src/probe/queue.rs
+++ b/probe-rs/src/probe/queue.rs
@@ -39,7 +39,11 @@ impl BatchExecutionError {
         results: DeferredResultSet<CommandResult>,
     ) -> Self {
         BatchExecutionError {
-            error: BatchError::Specific(error),
+            // Just in case the caller passed a boxed DebugProbeError, which they weren't supposed to, convert it back.
+            error: match error.downcast::<DebugProbeError>() {
+                Ok(error) => BatchError::Probe(*error),
+                Err(error) => BatchError::Specific(error),
+            },
             results,
         }
     }


### PR DESCRIPTION
#3828 refactored `BatchExecutionError` to contain a specific and a DebugProbeError variant, but some usages just shoveled DebugProbeError into `new_specific`, which in turn can't be downcast to architecture-specific errors. This PR fixes the usages, and relaxes `new_specific` slightly.