### PR TITLE
Refactor CLI debugger

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
@@ -411,7 +411,9 @@ impl Client {
     fn write_to_cli(&mut self, message: impl AsRef<str>) {
         let trimmed = message.as_ref().trim_end();
         if !trimmed.is_empty() {
+            // Shared writer only flushes whole lines
             self.write_raw_to_cli(trimmed);
+            self.write_raw_to_cli("\n");
         }
     }
 
@@ -419,7 +421,7 @@ impl Client {
         if let Some(writer) = self.writer.as_mut() {
             write!(writer, "{}", message.as_ref()).unwrap();
         } else {
-            println!("{}", message.as_ref());
+            print!("{}", message.as_ref());
         }
     }
 


### PR DESCRIPTION
This PR splits a Client object out of CliAdapter. The job of CliAdapter is now only to act as a conduit between the client and server - as it should be. Client is responsible for processing responsed, sending messages, printing output. The PR also removes an unnecessary roundtrip through strings, by deserializing responses directly from Value. Thirdly, the PR delays creating the prompt until the response to the `configurationDone` message arrives. This gives us an option to display progress messages as progress bars, although the debugger has less information (%) than the run command (which receives the total and the current progress as bytes).

This is IMO a neat architectural improvement, CliAdapter has always been quite awkward in its scope.