### PR TITLE
CLI debugger: create seperate prompts for RTT channels

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1661,9 +1661,9 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
     }
 
     /// Send a custom `probe-rs-rtt-channel-config` event to the MS DAP Client, to create a window for a specific RTT channel.
-    pub fn open_prompt(&mut self, kind: &str, name: &str, handle: u32) -> bool {
+    pub fn open_prompt(&mut self, kind: PromptKind, name: &str, handle: u32) -> bool {
         let Ok(event_body) = serde_json::to_value(CreatePromptEventBody {
-            prompt_kind: kind.to_string(),
+            prompt_kind: kind,
             prompt_name: name.to_string(),
             prompt_handle: handle,
         }) else {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/dap_types.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/dap_types.rs
@@ -43,10 +43,16 @@ pub struct RttChannelEventBody {
     pub data_format: rtt::DataFormat,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PromptKind {
+    Rtt,
+}
+
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreatePromptEventBody {
-    pub prompt_kind: String,
+    pub prompt_kind: PromptKind,
     pub prompt_name: String,
     pub prompt_handle: u32,
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroU32;
 use std::{ops::Range, path::Path};
 
 use super::session_data::{self, ActiveBreakpoint, BreakpointType, SourceLocationScope};
-use crate::cmd::dap_server::debug_adapter::dap::dap_types::MessageSeverity;
+use crate::cmd::dap_server::debug_adapter::dap::dap_types::{MessageSeverity, PromptKind};
 use crate::cmd::dap_server::debug_adapter::dap::repl_commands::ReplCommand;
 use crate::util::rtt::client::RttClient;
 use crate::util::rtt::{self, DataFormat, DefmtProcessor, DefmtState};
@@ -304,7 +304,11 @@ impl CoreHandle<'_> {
         }
 
         for down_channel in client.down_channels() {
-            debug_adapter.open_prompt("rtt", &down_channel.channel_name(), down_channel.number());
+            debug_adapter.open_prompt(
+                PromptKind::Rtt,
+                &down_channel.channel_name(),
+                down_channel.number(),
+            );
         }
 
         self.core_data.rtt_connection = Some(debug_rtt::RttConnection {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
@@ -11,6 +11,7 @@ use tokio::runtime::Runtime;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
 use crate::cmd::dap_server::debug_adapter::dap::adapter::DebugAdapter;
+use crate::cmd::dap_server::debug_adapter::dap::dap_types;
 use crate::cmd::dap_server::debug_adapter::dap::dap_types::InitializeRequestArguments;
 use crate::cmd::dap_server::debug_adapter::dap::dap_types::OutputEventBody;
 use crate::cmd::dap_server::debug_adapter::dap::dap_types::ProgressStartEventBody;
@@ -577,7 +578,7 @@ impl Client {
                 };
 
                 let prompt = serde_json::from_value::<CreatePromptEventBody>(body)?;
-                if prompt.prompt_kind.as_str() == "rtt" {
+                if prompt.prompt_kind == dap_types::PromptKind::Rtt {
                     self.prompts.push(PromptKind::Rtt {
                         channel: prompt.prompt_handle,
                         channel_name: prompt.prompt_name.clone(),


### PR DESCRIPTION
This PR implements cycling through RTT channels via ctrl-d in the CLI debugger.