### PR TITLE
arm: make SwdSequence public

### DIFF
--- a/changelog/changed-swdsequence-to-pub.md
+++ b/changelog/changed-swdsequence-to-pub.md
@@ -1,0 +1,1 @@
+Changed `SwdSequence` to `pub` to allow for implementing `ArmDebugSequence` externally.

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -113,6 +113,7 @@ pub fn read_chip_info_from_rom_table(
 }
 
 // TODO: Rename trait!
+/// Support for sending raw sequences via the probe.
 pub trait SwdSequence {
     /// Corresponds to the DAP_SWJ_Sequence function from the ARM Debug sequences
     fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError>;

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     probe::DebugProbeError,
 };
 pub use communication_interface::{
-    ArmChipInfo, ArmCommunicationInterface, ArmDebugInterface, DapError, DapProbe,
+    ArmChipInfo, ArmCommunicationInterface, ArmDebugInterface, DapError, DapProbe, SwdSequence,
 };
 pub use swo::{SwoAccess, SwoConfig, SwoMode, SwoReader};
 pub use traits::*;


### PR DESCRIPTION
Make the `SwdSequence` trait public. This is required to allow an external crate define an object that implements `ArmDebugInterface`.