### PR TITLE
Fix race condition in RISC-V system bus access

### DIFF
--- a/changelog/fixed-riscv-system-bus.md
+++ b/changelog/fixed-riscv-system-bus.md
@@ -1,0 +1,1 @@
+RISC-V: Fixed a bug in the communication interface, potentially causing arbitrary data being read and writes not taking effect.


### PR DESCRIPTION
According to the RISC-V debug specification, trying to issue a read or write request via system bus access while the corresponding control register indicates that the bus is busy results in undefined behavior. However, the RISC-V communication interface implementation currently does not adhere to this, leading to various unwanted side-effects, such as old RTT messages being reprinted or defmt RTT streams being corrupted.

In order to resolve this, this commit introduces an optimistic retry mechanism that checks whether the system bus has been busy at some point during a read or write transaction (using the sbbusyerror flag), repeating the whole operation if that was the case.

Fixes #3861