### PR TITLE
ADIv6 support on Black Magic probes

### DIFF
--- a/changelog/added-blackmagic-adiv6.md
+++ b/changelog/added-blackmagic-adiv6.md
@@ -1,0 +1,1 @@
+Added ADIv6 support for Black Magic Debug probes.

--- a/probe-rs/src/architecture/arm/ap/v2/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/v2/mod.rs
@@ -13,7 +13,7 @@ use crate::architecture::arm::{
 };
 
 mod root_memory_interface;
-use root_memory_interface::RootMemoryInterface;
+pub(crate) use root_memory_interface::RootMemoryInterface;
 
 /// Deeply scans the debug port and returns a list of the addresses the memory access points discovered.
 pub fn enumerate_access_ports<ADI: ArmDebugInterface>(

--- a/probe-rs/src/probe/blackmagic/arm.rs
+++ b/probe-rs/src/probe/blackmagic/arm.rs
@@ -1,6 +1,7 @@
 use crate::MemoryInterface;
 use crate::architecture::arm::{
-    ApAddress, ArmDebugInterface, DapAccess, FullyQualifiedApAddress, RawDapAccess, SwoAccess,
+    ApAddress, ApV2Address, ArmDebugInterface, DapAccess, FullyQualifiedApAddress, RawDapAccess,
+    SwoAccess,
     ap::{
         self, AccessPortType, AddressIncrement, CSW, DataSize,
         memory_ap::{MemoryAp, MemoryApType},
@@ -14,7 +15,9 @@ use crate::architecture::arm::{
     memory::ArmMemoryInterface,
     sequences::ArmDebugSequence,
 };
-use crate::probe::blackmagic::{Align, BlackMagicProbe, ProtocolVersion, RemoteCommand};
+use crate::probe::blackmagic::{
+    Accelerators, Align, BlackMagicProbe, ProtocolVersion, RemoteCommand,
+};
 use crate::probe::{ArmError, DebugProbeError, Probe};
 use std::collections::BTreeSet;
 use std::collections::hash_map;
@@ -40,6 +43,9 @@ pub(crate) struct BlackMagicProbeArmDebug {
 
     /// Whether to enable a hardware feature to detect overruns
     use_overrun_detect: bool,
+
+    /// Accelerators supported by this probe.
+    accelerators: Accelerators,
 }
 
 #[derive(Debug)]
@@ -54,6 +60,7 @@ impl BlackMagicProbeArmDebug {
     pub fn new(
         probe: Box<BlackMagicProbe>,
         sequence: Arc<dyn ArmDebugSequence>,
+        accelerators: Accelerators,
     ) -> Result<Self, (Box<BlackMagicProbe>, ArmError)> {
         Ok(Self {
             probe,
@@ -62,6 +69,7 @@ impl BlackMagicProbeArmDebug {
             current_dp: None,
             dps: HashMap::new(),
             use_overrun_detect: true,
+            accelerators,
         })
     }
 
@@ -220,6 +228,11 @@ impl ArmDebugInterface for BlackMagicProbeArmDebug {
         &mut self,
         access_port: &FullyQualifiedApAddress,
     ) -> Result<Box<dyn crate::architecture::arm::memory::ArmMemoryInterface + '_>, ArmError> {
+        // The root port in APv2 is special.
+        if let ApAddress::V2(ApV2Address(None)) = access_port.ap() {
+            return Ok(Box::new(ap::v2::RootMemoryInterface::new(self, access_port.dp())?) as _);
+        }
+
         let mut current_ap = MemoryAp::new(self, access_port)?;
 
         // Construct a CSW to pass to the AP when accessing memory.
@@ -540,10 +553,18 @@ impl DapAccess for BlackMagicProbeArmDebug {
                     }
                 }
             }
-            ApAddress::V2(_) => {
-                return Err(ArmError::NotImplemented(
-                    "BlackMagicProbe does not yet support APv2",
-                ));
+            ApAddress::V2(ApV2Address(apsel)) => {
+                if !self.accelerators.has_adiv6() {
+                    return Err(ArmError::Probe(
+                        DebugProbeError::CommandNotSupportedByProbe {
+                            command_name: "adiv6 raw ap read",
+                        },
+                    ));
+                }
+                let index = 0;
+                let apsel = apsel.unwrap_or(0) | (addr & !0x0FFF);
+                let addr = (addr & 0x0FFF) as u16;
+                RemoteCommand::AdiV6ReadApV4 { index, apsel, addr }
             }
         };
         let result = u32::from_be(
@@ -593,10 +614,23 @@ impl DapAccess for BlackMagicProbeArmDebug {
                     },
                 }
             }
-            ApAddress::V2(_) => {
-                return Err(ArmError::NotImplemented(
-                    "BlackMagicProbe does not yet support APv2",
-                ));
+            ApAddress::V2(ApV2Address(apsel)) => {
+                if !self.accelerators.has_adiv6() {
+                    return Err(ArmError::Probe(
+                        DebugProbeError::CommandNotSupportedByProbe {
+                            command_name: "adiv6 raw ap write",
+                        },
+                    ));
+                }
+                let index = 0;
+                let apsel = apsel.unwrap_or(0) | (addr & !0x0FFF);
+                let addr = (addr & 0x0FFF) as u16;
+                RemoteCommand::AdiV6WriteApV4 {
+                    index,
+                    apsel,
+                    addr,
+                    value,
+                }
             }
         };
 
@@ -711,10 +745,22 @@ impl BlackMagicProbeMemoryInterface<'_> {
                     data,
                 },
             },
-            ApAddress::V2(_) => {
-                return Err(ArmError::NotImplemented(
-                    "BlackMagicProbe does not yet support APv2",
-                ));
+            ApAddress::V2(ApV2Address(apsel)) => {
+                if !self.probe.accelerators.has_adiv6() {
+                    return Err(ArmError::Probe(
+                        DebugProbeError::CommandNotSupportedByProbe {
+                            command_name: "adiv6 memory read",
+                        },
+                    ));
+                }
+                let apsel = apsel.unwrap_or(0);
+                RemoteCommand::AdiV6MemReadV4 {
+                    index: self.index,
+                    apsel,
+                    csw: self.csw,
+                    offset,
+                    data,
+                }
             }
         };
         self.probe
@@ -787,10 +833,23 @@ impl BlackMagicProbeMemoryInterface<'_> {
                     data,
                 },
             },
-            ApAddress::V2(_) => {
-                return Err(ArmError::NotImplemented(
-                    "BlackMagicProbe does not yet support APv2",
-                ));
+            ApAddress::V2(ApV2Address(apsel)) => {
+                if !self.probe.accelerators.has_adiv6() {
+                    return Err(ArmError::Probe(
+                        DebugProbeError::CommandNotSupportedByProbe {
+                            command_name: "adiv6 memory write",
+                        },
+                    ));
+                }
+                let apsel = apsel.unwrap_or(0);
+                RemoteCommand::AdiV6MemWriteV4 {
+                    index: self.index,
+                    apsel,
+                    csw: self.csw,
+                    align,
+                    offset,
+                    data,
+                }
             }
         };
         let result = self

--- a/probe-rs/src/probe/blackmagic/arm.rs
+++ b/probe-rs/src/probe/blackmagic/arm.rs
@@ -1,6 +1,6 @@
 use crate::MemoryInterface;
 use crate::architecture::arm::{
-    ArmDebugInterface, DapAccess, FullyQualifiedApAddress, RawDapAccess, SwoAccess,
+    ApAddress, ArmDebugInterface, DapAccess, FullyQualifiedApAddress, RawDapAccess, SwoAccess,
     ap::{
         self, AccessPortType, AddressIncrement, CSW, DataSize,
         memory_ap::{MemoryAp, MemoryApType},
@@ -47,7 +47,6 @@ pub(crate) struct BlackMagicProbeMemoryInterface<'probe> {
     probe: &'probe mut BlackMagicProbeArmDebug,
     current_ap: MemoryAp,
     index: u8,
-    apsel: u8,
     csw: u32,
 }
 
@@ -188,17 +187,9 @@ impl BlackMagicProbeArmDebug {
         Ok(())
     }
 
-    fn select_ap(&mut self, ap: &FullyQualifiedApAddress) -> Result<u8, ArmError> {
-        let apsel = match ap.ap() {
-            crate::architecture::arm::ApAddress::V1(val) => *val,
-            crate::architecture::arm::ApAddress::V2(_) => {
-                return Err(ArmError::NotImplemented(
-                    "AP address v2 currently unsupported",
-                ));
-            }
-        };
+    fn select_ap(&mut self, ap: &FullyQualifiedApAddress) -> Result<(), ArmError> {
         self.select_dp(ap.dp())?;
-        Ok(apsel)
+        Ok(())
     }
 }
 
@@ -344,7 +335,6 @@ impl ArmDebugInterface for BlackMagicProbeArmDebug {
             probe: self,
             current_ap,
             index: 0,
-            apsel: 0,
             csw: csw.into(),
         }) as _)
     }
@@ -527,30 +517,33 @@ impl DapAccess for BlackMagicProbeArmDebug {
         ap: &FullyQualifiedApAddress,
         addr: u64,
     ) -> Result<u32, ArmError> {
-        // Currently, only APv1 is supported. As such, truncate the address to an 8-bit size.
-        if ap.ap().is_v2() {
-            return Err(ArmError::NotImplemented(
-                "BlackMagicProbe does not yet support APv2",
-            ));
-        }
-        let index = ((addr >> 8) & 0xFF) as u8;
-        let addr = (addr & 0xFF) as u8;
-        let apsel = self.select_ap(ap)?;
-
-        let command = match self.probe.remote_protocol {
-            ProtocolVersion::V0 => {
-                return Err(ArmError::Probe(
-                    DebugProbeError::CommandNotSupportedByProbe {
-                        command_name: "adiv5 raw ap read",
-                    },
+        self.select_ap(ap)?;
+        let command = match ap.ap() {
+            ApAddress::V1(apsel) => {
+                let index = ((addr >> 8) & 0xFF) as u8;
+                let apsel = *apsel;
+                let addr = (addr & 0xFF) as u8;
+                match self.probe.remote_protocol {
+                    ProtocolVersion::V0 => {
+                        return Err(ArmError::Probe(
+                            DebugProbeError::CommandNotSupportedByProbe {
+                                command_name: "adiv5 raw ap read",
+                            },
+                        ));
+                    }
+                    ProtocolVersion::V0P => RemoteCommand::ReadApV0P { apsel, addr },
+                    ProtocolVersion::V1 | ProtocolVersion::V2 => {
+                        RemoteCommand::ReadApV1 { index, apsel, addr }
+                    }
+                    ProtocolVersion::V3 | ProtocolVersion::V4 => {
+                        RemoteCommand::ReadApV3 { index, apsel, addr }
+                    }
+                }
+            }
+            ApAddress::V2(_) => {
+                return Err(ArmError::NotImplemented(
+                    "BlackMagicProbe does not yet support APv2",
                 ));
-            }
-            ProtocolVersion::V0P => RemoteCommand::ReadApV0P { apsel, addr },
-            ProtocolVersion::V1 | ProtocolVersion::V2 => {
-                RemoteCommand::ReadApV1 { index, apsel, addr }
-            }
-            ProtocolVersion::V3 | ProtocolVersion::V4 => {
-                RemoteCommand::ReadApV3 { index, apsel, addr }
             }
         };
         let result = u32::from_be(
@@ -571,37 +564,40 @@ impl DapAccess for BlackMagicProbeArmDebug {
         addr: u64,
         value: u32,
     ) -> Result<(), ArmError> {
-        // Currently, only APv1 is supported. As such, truncate the address to an 8-bit size.
-        if ap.ap().is_v2() {
-            return Err(ArmError::NotImplemented(
-                "BlackMagicProbe does not yet support APv2",
-            ));
-        }
-        let index = ((addr >> 8) & 0xFF) as u8;
-        let addr = (addr & 0xFF) as u8;
-
-        let apsel = self.select_ap(ap)?;
-        let command = match self.probe.remote_protocol {
-            ProtocolVersion::V0 => {
-                return Err(ArmError::Probe(
-                    DebugProbeError::CommandNotSupportedByProbe {
-                        command_name: "adiv5 raw ap write",
+        self.select_ap(ap)?;
+        let command = match ap.ap() {
+            ApAddress::V1(apsel) => {
+                let index = ((addr >> 8) & 0xFF) as u8;
+                let apsel = *apsel;
+                let addr = (addr & 0xFF) as u8;
+                match self.probe.remote_protocol {
+                    ProtocolVersion::V0 => {
+                        return Err(ArmError::Probe(
+                            DebugProbeError::CommandNotSupportedByProbe {
+                                command_name: "adiv5 raw ap write",
+                            },
+                        ));
+                    }
+                    ProtocolVersion::V0P => RemoteCommand::WriteApV0P { apsel, addr, value },
+                    ProtocolVersion::V1 | ProtocolVersion::V2 => RemoteCommand::WriteApV1 {
+                        index,
+                        apsel,
+                        addr,
+                        value,
                     },
+                    ProtocolVersion::V3 | ProtocolVersion::V4 => RemoteCommand::WriteApV3 {
+                        index,
+                        apsel,
+                        addr,
+                        value,
+                    },
+                }
+            }
+            ApAddress::V2(_) => {
+                return Err(ArmError::NotImplemented(
+                    "BlackMagicProbe does not yet support APv2",
                 ));
             }
-            ProtocolVersion::V0P => RemoteCommand::WriteApV0P { apsel, addr, value },
-            ProtocolVersion::V1 | ProtocolVersion::V2 => RemoteCommand::WriteApV1 {
-                index,
-                apsel,
-                addr,
-                value,
-            },
-            ProtocolVersion::V3 | ProtocolVersion::V4 => RemoteCommand::WriteApV3 {
-                index,
-                apsel,
-                addr,
-                value,
-            },
         };
 
         let result = self
@@ -672,47 +668,54 @@ impl BlackMagicProbeMemoryInterface<'_> {
         if data.len() * 2 + 4 >= super::BLACK_MAGIC_REMOTE_SIZE_MAX {
             return Err(ArmError::OutOfBounds);
         }
-        let command = match self.probe.probe.remote_protocol {
-            ProtocolVersion::V0 => {
-                return Err(ArmError::Probe(
-                    DebugProbeError::CommandNotSupportedByProbe {
-                        command_name: "adiv5 memory read",
-                    },
+        let command = match self.current_ap.ap_address().ap() {
+            ApAddress::V1(_) => match self.probe.probe.remote_protocol {
+                ProtocolVersion::V0 => {
+                    return Err(ArmError::Probe(
+                        DebugProbeError::CommandNotSupportedByProbe {
+                            command_name: "adiv5 memory read",
+                        },
+                    ));
+                }
+                ProtocolVersion::V0P => RemoteCommand::MemReadV0P {
+                    apsel: 0,
+                    csw: self.csw,
+                    offset: offset
+                        .try_into()
+                        .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
+                    data,
+                },
+                ProtocolVersion::V1 | ProtocolVersion::V2 => RemoteCommand::MemReadV1 {
+                    index: self.index,
+                    apsel: 0,
+                    csw: self.csw,
+                    offset: offset
+                        .try_into()
+                        .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
+                    data,
+                },
+                ProtocolVersion::V3 => RemoteCommand::MemReadV3 {
+                    index: self.index,
+                    apsel: 0,
+                    csw: self.csw,
+                    offset: offset
+                        .try_into()
+                        .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
+                    data,
+                },
+                ProtocolVersion::V4 => RemoteCommand::MemReadV4 {
+                    index: self.index,
+                    apsel: 0,
+                    csw: self.csw,
+                    offset,
+                    data,
+                },
+            },
+            ApAddress::V2(_) => {
+                return Err(ArmError::NotImplemented(
+                    "BlackMagicProbe does not yet support APv2",
                 ));
             }
-            ProtocolVersion::V0P => RemoteCommand::MemReadV0P {
-                apsel: self.apsel,
-                csw: self.csw,
-                offset: offset
-                    .try_into()
-                    .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
-                data,
-            },
-            ProtocolVersion::V1 | ProtocolVersion::V2 => RemoteCommand::MemReadV1 {
-                index: self.index,
-                apsel: self.apsel,
-                csw: self.csw,
-                offset: offset
-                    .try_into()
-                    .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
-                data,
-            },
-            ProtocolVersion::V3 => RemoteCommand::MemReadV3 {
-                index: self.index,
-                apsel: self.apsel,
-                csw: self.csw,
-                offset: offset
-                    .try_into()
-                    .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
-                data,
-            },
-            ProtocolVersion::V4 => RemoteCommand::MemReadV4 {
-                index: self.index,
-                apsel: self.apsel,
-                csw: self.csw,
-                offset,
-                data,
-            },
         };
         self.probe
             .probe
@@ -737,51 +740,58 @@ impl BlackMagicProbeMemoryInterface<'_> {
         if data.len() * 2 + 42 >= super::BLACK_MAGIC_REMOTE_SIZE_MAX {
             return Err(ArmError::OutOfBounds);
         }
-        let command = match self.probe.probe.remote_protocol {
-            ProtocolVersion::V0 => {
-                return Err(ArmError::Probe(
-                    DebugProbeError::CommandNotSupportedByProbe {
-                        command_name: "adiv5 memory write",
-                    },
+        let command = match self.current_ap.ap_address().ap() {
+            ApAddress::V1(_) => match self.probe.probe.remote_protocol {
+                ProtocolVersion::V0 => {
+                    return Err(ArmError::Probe(
+                        DebugProbeError::CommandNotSupportedByProbe {
+                            command_name: "adiv5 memory write",
+                        },
+                    ));
+                }
+                ProtocolVersion::V0P => RemoteCommand::MemWriteV0P {
+                    apsel: 0,
+                    csw: self.csw,
+                    align,
+                    offset: offset
+                        .try_into()
+                        .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
+                    data,
+                },
+                ProtocolVersion::V1 | ProtocolVersion::V2 => RemoteCommand::MemWriteV1 {
+                    index: self.index,
+                    apsel: 0,
+                    csw: self.csw,
+                    align,
+                    offset: offset
+                        .try_into()
+                        .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
+                    data,
+                },
+                ProtocolVersion::V3 => RemoteCommand::MemWriteV3 {
+                    index: self.index,
+                    apsel: 0,
+                    csw: self.csw,
+                    align,
+                    offset: offset
+                        .try_into()
+                        .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
+                    data,
+                },
+                ProtocolVersion::V4 => RemoteCommand::MemWriteV4 {
+                    index: self.index,
+                    apsel: 0,
+                    csw: self.csw,
+                    align,
+                    offset,
+                    data,
+                },
+            },
+            ApAddress::V2(_) => {
+                return Err(ArmError::NotImplemented(
+                    "BlackMagicProbe does not yet support APv2",
                 ));
             }
-            ProtocolVersion::V0P => RemoteCommand::MemWriteV0P {
-                apsel: self.apsel,
-                csw: self.csw,
-                align,
-                offset: offset
-                    .try_into()
-                    .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
-                data,
-            },
-            ProtocolVersion::V1 | ProtocolVersion::V2 => RemoteCommand::MemWriteV1 {
-                index: self.index,
-                apsel: self.apsel,
-                csw: self.csw,
-                align,
-                offset: offset
-                    .try_into()
-                    .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
-                data,
-            },
-            ProtocolVersion::V3 => RemoteCommand::MemWriteV3 {
-                index: self.index,
-                apsel: self.apsel,
-                csw: self.csw,
-                align,
-                offset: offset
-                    .try_into()
-                    .map_err(|_| ArmError::AddressOutOf32BitAddressSpace)?,
-                data,
-            },
-            ProtocolVersion::V4 => RemoteCommand::MemWriteV4 {
-                index: self.index,
-                apsel: self.apsel,
-                csw: self.csw,
-                align,
-                offset,
-                data,
-            },
         };
         let result = self
             .probe

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -1256,7 +1256,7 @@ impl DebugProbe for BlackMagicProbe {
         };
 
         if accelerators.has_adiv5() {
-            match BlackMagicProbeArmDebug::new(self, sequence) {
+            match BlackMagicProbeArmDebug::new(self, sequence, accelerators) {
                 Ok(interface) => Ok(Box::new(interface)),
                 Err((probe, err)) => Err((probe.into_probe(), err)),
             }

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -27,6 +27,7 @@ use crate::{
         RawJtagIo, RawSwdIo, SwdSettings, WireProtocol, blackmagic::arm::BlackMagicProbeArmDebug,
     },
 };
+use bitfield::bitfield;
 use bitvec::vec::BitVec;
 use serialport::{SerialPortType, available_ports};
 
@@ -76,6 +77,17 @@ impl core::fmt::Display for ProtocolVersion {
             }
         )
     }
+}
+
+bitfield! {
+    #[derive(Copy, Clone)]
+    struct Accelerators(u64);
+    impl Debug;
+
+    bool, has_adiv5, set_has_adiv5: 0;
+    bool, has_cortex_ar, _: 1;
+    bool, has_riscv, _: 2;
+    bool, has_adiv6, _: 3;
 }
 
 #[expect(dead_code)]
@@ -1143,22 +1155,26 @@ impl DebugProbe for BlackMagicProbe {
         mut self: Box<Self>,
         sequence: Arc<dyn ArmDebugSequence>,
     ) -> Result<Box<dyn ArmDebugInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
-        let has_adiv5 = match self.remote_protocol {
-            ProtocolVersion::V0 => false,
+        let accelerators = match self.remote_protocol {
+            ProtocolVersion::V0 => Accelerators(0),
             ProtocolVersion::V0P
             | ProtocolVersion::V1
             | ProtocolVersion::V2
-            | ProtocolVersion::V3 => true,
+            | ProtocolVersion::V3 => {
+                let mut accelerators = Accelerators(0);
+                accelerators.set_has_adiv5(true);
+                accelerators
+            }
             ProtocolVersion::V4 => {
-                if let Ok(accelerators) = self.command(RemoteCommand::GetAccelerators) {
-                    accelerators.0 & 1 != 0
+                if let Ok(response) = self.command(RemoteCommand::GetAccelerators) {
+                    Accelerators(response.0)
                 } else {
-                    false
+                    Accelerators(0)
                 }
             }
         };
 
-        if has_adiv5 {
+        if accelerators.has_adiv5() {
             match BlackMagicProbeArmDebug::new(self, sequence) {
                 Ok(interface) => Ok(Box::new(interface)),
                 Err((probe, err)) => Err((probe.into_probe(), err)),

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -223,6 +223,32 @@ enum RemoteCommand<'a> {
         offset: u64,
         data: &'a [u8],
     },
+    AdiV6ReadApV4 {
+        index: u8,
+        apsel: u64,
+        addr: u16,
+    },
+    AdiV6WriteApV4 {
+        index: u8,
+        apsel: u64,
+        addr: u16,
+        value: u32,
+    },
+    AdiV6MemReadV4 {
+        index: u8,
+        apsel: u64,
+        csw: u32,
+        offset: u64,
+        data: &'a mut [u8],
+    },
+    AdiV6MemWriteV4 {
+        index: u8,
+        apsel: u64,
+        csw: u32,
+        align: Align,
+        offset: u64,
+        data: &'a [u8],
+    },
     JtagNext {
         tms: bool,
         tdi: bool,
@@ -274,6 +300,7 @@ impl RemoteCommand<'_> {
             RemoteCommand::MemReadV1 { data, .. } => Some(data),
             RemoteCommand::MemReadV3 { data, .. } => Some(data),
             RemoteCommand::MemReadV4 { data, .. } => Some(data),
+            RemoteCommand::AdiV6MemReadV4 { data, .. } => Some(data),
             _ => None,
         }
     }
@@ -286,6 +313,7 @@ impl RemoteCommand<'_> {
                 | RemoteCommand::MemReadV1 { .. }
                 | RemoteCommand::MemReadV3 { .. }
                 | RemoteCommand::MemReadV4 { .. }
+                | RemoteCommand::AdiV6MemReadV4 { .. }
         )
     }
 }
@@ -507,6 +535,59 @@ impl std::string::ToString for RemoteCommand<'_> {
             } => {
                 let mut s = format!(
                     "!AM{:02x}{:02x}{:08x}{:02x}{:016x}{:08x}",
+                    index,
+                    apsel,
+                    csw,
+                    *align as u8,
+                    offset,
+                    data.len()
+                );
+                for b in data.iter() {
+                    s.push_str(&format!("{b:02x}"));
+                }
+                s.push('#');
+                s
+            }
+
+            RemoteCommand::AdiV6ReadApV4 { index, apsel, addr } => {
+                format!("!A6a{:02x}{:016x}{:04x}#", index, apsel, 0x1000 | addr)
+            }
+            RemoteCommand::AdiV6WriteApV4 {
+                index,
+                apsel,
+                addr,
+                value,
+            } => format!(
+                "!A6A{:02x}{:016x}{:04x}{:08x}#",
+                index,
+                apsel,
+                0x1000 | addr,
+                value.to_be()
+            ),
+            RemoteCommand::AdiV6MemReadV4 {
+                index,
+                apsel,
+                csw,
+                offset,
+                data,
+            } => format!(
+                "!A6m{:02x}{:016x}{:08x}{:016x}{:08x}#",
+                index,
+                apsel,
+                csw,
+                offset,
+                data.len()
+            ),
+            RemoteCommand::AdiV6MemWriteV4 {
+                index,
+                apsel,
+                csw,
+                align,
+                offset,
+                data,
+            } => {
+                let mut s = format!(
+                    "!A6M{:02x}{:016x}{:08x}{:02x}{:016x}{:08x}",
                     index,
                     apsel,
                     csw,


### PR DESCRIPTION
These commits add ADIv6 support for probes running Black Magic debug firmware. For review purposes, each commit is an independent, meaningful change.

I have tested these changes on an STLink v2 clone running Black Magic firmware, and I have used it to program and debug an RP2350 board (to test the ADIv6 changes) and also an STM32F103 board (to verify ADIv5 still works). Unfortunately I have no other ADIv6 targets handy to test with.

I would appreciate testing with at least one additional ADIv6 target, since this code was scraped together by reading the Black Magic firmware source and comparing it to the ARM documentation. What I know about ADIv6 I learned only in the last two days.

Please let me know of any changes you'd like to help get this merged.

(Related issue: #3063)