### PR TITLE
Add force_scan_chain to bypass JTAG auto-detection

### DIFF
--- a/changelog/added-force-scan-chain.md
+++ b/changelog/added-force-scan-chain.md
@@ -1,0 +1,1 @@
+Added `force_scan_chain` field to JTAG configuration in target YAML files. When set to true, bypasses JTAG auto-detection and uses the specified scan chain directly.

--- a/changelog/added-scan-chain-cli-flag.md
+++ b/changelog/added-scan-chain-cli-flag.md
@@ -1,0 +1,1 @@
+Added `--scan-chain` flag to `probe-rs info` command for manual JTAG scan chain override.

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -46,6 +46,15 @@ pub struct Jtag {
     #[serde(default)]
     pub scan_chain: Option<Vec<ScanChainElement>>,
 
+    /// When set to `true`, the scan chain described in `scan_chain` is used as-is, bypassing
+    /// the JTAG auto-detection (DR/IR scan). This is required for targets whose JTAG TAP does
+    /// not respond to the standard IDCODE scan (e.g., some RISC-V cores during early power-up).
+    ///
+    /// When `false` (the default), `scan_chain` is treated as a hint for IR-length disambiguation
+    /// during the normal auto-detection scan.
+    #[serde(default)]
+    pub force_scan_chain: bool,
+
     /// Describes JTAG tunnel for Risc-V
     #[serde(default)]
     pub riscv_tunnel: Option<RiscvJtagTunnel>,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -34,6 +34,13 @@ pub struct Cmd {
     /// when connecting. This is required for targets using SWD multidrop
     #[arg(long, value_parser = parse_hex)]
     target_sel: Option<u32>,
+    /// Override JTAG scan chain IR lengths (bypasses auto-detection)
+    ///
+    /// Specify one or more IR lengths (in bits) for each TAP in the chain, in scan-chain order.
+    /// For example, `--scan-chain 5` for a single-TAP chain with IR length 5.
+    /// When set, the normal JTAG auto-detection DR/IR scan is skipped entirely.
+    #[arg(long, value_delimiter = ',', value_name = "IR_LEN")]
+    scan_chain: Vec<u8>,
 }
 
 fn parse_hex(src: &str) -> Result<u32, ParseIntError> {
@@ -67,6 +74,7 @@ impl Cmd {
                 speed: self.common.speed,
                 connect_under_reset: self.common.connect_under_reset,
                 dry_run: self.common.dry_run,
+                scan_chain: self.scan_chain.clone(),
             };
 
             let result = client

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -25,6 +25,7 @@ use probe_rs::{
     },
     probe::{Probe, WireProtocol as ProbeRsWireProtocol},
 };
+use probe_rs_target::ScanChainElement;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -44,6 +45,12 @@ pub struct TargetInfoRequest {
     pub dry_run: bool,
     pub target_sel: Option<u32>,
     pub protocol: WireProtocol,
+    /// IR lengths for each TAP in the scan chain, in scan-chain order.
+    ///
+    /// When non-empty, the JTAG auto-detection scan is bypassed and these values are used
+    /// directly. For example, `[5]` specifies a single-TAP chain with IR length 5.
+    #[serde(default)]
+    pub scan_chain: Vec<u8>,
 }
 
 impl From<&TargetInfoRequest> for ProbeOptions {
@@ -78,6 +85,7 @@ pub async fn target_info(
     if let Err(e) = try_show_info(
         ctx,
         probe,
+        request.scan_chain.clone(),
         request.protocol,
         probe_options.connect_under_reset(),
         request.target_sel,
@@ -289,11 +297,25 @@ impl ComponentTreeNode {
 async fn try_show_info(
     ctx: &mut RpcContext,
     mut probe: Probe,
+    scan_chain: Vec<u8>,
     protocol: WireProtocol,
     connect_under_reset: bool,
     target_sel: Option<u32>,
 ) -> anyhow::Result<()> {
     probe.select_protocol(ProbeRsWireProtocol::from(protocol))?;
+
+    if !scan_chain.is_empty()
+        && let Some(jtag) = probe.try_as_jtag_probe()
+    {
+        let chain = scan_chain
+            .iter()
+            .map(|&ir_len| ScanChainElement {
+                name: None,
+                ir_len: Some(ir_len),
+            })
+            .collect::<Vec<_>>();
+        jtag.set_scan_chain(&chain)?;
+    }
 
     if connect_under_reset {
         probe.attach_to_unspecified_under_reset()?;

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -349,7 +349,14 @@ impl Session {
             && let Some(scan_chain) = jtag.scan_chain.clone()
             && let Some(probe) = probe.try_as_jtag_probe()
         {
-            probe.set_expected_scan_chain(&scan_chain)?;
+            if jtag.force_scan_chain {
+                // Bypass JTAG auto-detection entirely; use the scan chain from the target YAML.
+                // This is required for targets whose TAP does not respond to the standard IDCODE
+                // DR scan (e.g., some RISC-V cores during early power-up).
+                probe.set_scan_chain(&scan_chain)?;
+            } else {
+                probe.set_expected_scan_chain(&scan_chain)?;
+            }
         }
 
         probe.attach_to_unspecified()?;


### PR DESCRIPTION
Add a force_scan_chain boolean field to the Jtag struct in probe-rs-target. When set to true in a target YAML, attach_jtag in session.rs calls set_scan_chain() (which sets the chain unconditionally) instead of set_expected_scan_chain() (which merely provides a hint and falls back to auto-detection). This is necessary for targets like the Nuclei UX600 where JTAG auto-scan does not reliably recover the scan chain.