### PR TITLE
Call tap_reset before read_idcode in info path

### DIFF
--- a/changelog/fixed-tap-reset-before-idcode.md
+++ b/changelog/fixed-tap-reset-before-idcode.md
@@ -1,0 +1,1 @@
+Reset the JTAG TAP before reading IDCODE in both RISC-V and Xtensa to handle indeterminate state after attach, fixing `probe-rs info` returning no chip.

--- a/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
@@ -337,6 +337,12 @@ impl DtmAccess for JtagDtm<'_> {
     }
 
     fn read_idcode(&mut self) -> Result<Option<u32>, DebugProbeError> {
+        // Reset the JTAG state machine to Test-Logic-Reset before reading the IDCODE.
+        // This is required when read_idcode() is called without a prior dtm.init() (e.g.
+        // from `probe-rs info`), because the TAP state may be indeterminate after attach.
+        // After reset, the IDCODE instruction is automatically loaded into IR, and we then
+        // explicitly load it again via read_register(0x1, …) to be consistent with all paths.
+        self.probe.tap_reset()?;
         let value = self.probe.read_register(0x1, 32)?;
 
         Ok(Some(value.load_le::<u32>()))
@@ -636,6 +642,10 @@ impl DtmAccess for TunneledJtagDtm<'_> {
     }
 
     fn read_idcode(&mut self) -> Result<Option<u32>, DebugProbeError> {
+        // Reset the JTAG state machine to Test-Logic-Reset before reading the IDCODE.
+        // This is required when read_idcode() is called without a prior dtm.init() (e.g.
+        // from `probe-rs info`), because the TAP state may be indeterminate after attach.
+        self.probe.tap_reset()?;
         let value = self.probe.read_register(0x1, 32)?;
         Ok(Some(value.load_le::<u32>()))
     }

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -487,6 +487,7 @@ impl<'probe> Xdm<'probe> {
     }
 
     pub(super) fn read_idcode(&mut self) -> Result<u32, XtensaError> {
+        self.probe.tap_reset()?;
         let instr = TapInstruction::Idcode;
 
         let capture = self


### PR DESCRIPTION
Reset the JTAG TAP to Test-Logic-Reset before reading the IDCODE register in both JtagDtm and TunneledJtagDtm implementations. This is required when read_idcode() is called without a prior dtm.init() (e.g. from probe-rs info), because the TAP state may be indeterminate after attach.