### PR TITLE
Increase page size for all remaining MCXA2 MCUs

### DIFF
--- a/changelog/changed-mcxa25x-mcxa26x-page-size.md
+++ b/changelog/changed-mcxa25x-mcxa26x-page-size.md
@@ -1,0 +1,1 @@
+Changed MCXA26x and MCXA25x Flash algorithm page size to 4096 bytes

--- a/probe-rs/targets/MCXA.yaml
+++ b/probe-rs/targets/MCXA.yaml
@@ -1347,7 +1347,7 @@ flash_algorithms:
       address_range:
         start: 0x0
         end: 0x7e000
-      page_size: 0x80
+      page_size: 0x1000
       erased_byte_value: 0xff
       program_page_timeout: 300
       erase_sector_timeout: 3000
@@ -1371,7 +1371,7 @@ flash_algorithms:
       address_range:
         start: 0x0
         end: 0xfe000
-      page_size: 0x80
+      page_size: 0x1000
       erased_byte_value: 0xff
       program_page_timeout: 300
       erase_sector_timeout: 3000
@@ -1395,7 +1395,7 @@ flash_algorithms:
       address_range:
         start: 0x0
         end: 0x7e000
-      page_size: 0x80
+      page_size: 0x1000
       erased_byte_value: 0xff
       program_page_timeout: 300
       erase_sector_timeout: 3000
@@ -1419,7 +1419,7 @@ flash_algorithms:
       address_range:
         start: 0x0
         end: 0xfe000
-      page_size: 0x80
+      page_size: 0x1000
       erased_byte_value: 0xff
       program_page_timeout: 300
       erase_sector_timeout: 3000
@@ -1442,7 +1442,7 @@ flash_algorithms:
       address_range:
         start: 0x0
         end: 0x80000
-      page_size: 0x80
+      page_size: 0x1000
       erased_byte_value: 0xff
       program_page_timeout: 300
       erase_sector_timeout: 3000


### PR DESCRIPTION
All their current flashing algos can deal with 4096B page size. Let's help everyone enjoy faster flashing speeds.