### PR TITLE
fix probe selector match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,6 +2563,7 @@ dependencies = [
  "once_cell",
  "rustix",
  "slab",
+ "tokio",
  "windows-sys 0.61.2",
 ]
 

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -116,6 +116,7 @@ postcard = { version = "1.0", features = ["use-std"] }
 postcard-rpc = { version = "0.12.0", features = ["use-std"] }
 postcard-schema = { version = "0.2.0", features = ["use-std", "derive"] }
 sha2 = "0.11"
+nusb = { workspace = true, features = ["tokio"] }
 
 # gdb server
 gdbstub = "0.7.6"
@@ -143,5 +144,4 @@ formula = "probe-rs"
 workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nusb.workspace = true
 rustix = { version = "1.1.4", features = ["fs"] }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/serve.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/serve.rs
@@ -29,7 +29,7 @@ use crate::{
         functions::{ProbeAccess, RpcApp},
         transport::websocket::{AxumWebsocketTx, WebsocketRx},
     },
-    util::usb,
+    util::pwr,
 };
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -121,7 +121,7 @@ impl Cmd {
         }
 
         if config.cycle_power {
-            usb::power_enable().await?;
+            pwr::power_enable().await?;
         }
 
         #[cfg(unix)]

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -3,6 +3,7 @@
 use std::fmt::Display;
 use std::future::pending;
 use std::io::Write;
+use std::time::Duration;
 use std::{future::Future, ops::DerefMut, path::Path, time::Instant};
 
 use anyhow::Context;
@@ -26,7 +27,7 @@ use crate::rpc::Key;
 use crate::rpc::functions::monitor::{ChannelInfo, MonitorExitReason};
 use crate::rpc::utils::run_loop::VectorCatchConfig;
 use crate::rpc::utils::semihosting::SemihostingOptions;
-use crate::util::usb::power_reset;
+use crate::util::pwr::power_reset;
 use crate::{
     FormatOptions,
     rpc::{
@@ -76,16 +77,11 @@ pub async fn attach_probe(
         client.load_chip_family(file).await?;
     }
 
-    let probe = match probe_options.cycle_power {
-        false => select_probe(client, probe_options.probe.map(Into::into)).await?,
-        true => {
-            let probe = select_probe(client, probe_options.clone().probe.map(Into::into)).await?;
+    let probe = select_probe(client, probe_options.probe.map(Into::into)).await?;
 
-            power_reset(probe.serial_number.as_str(), 1.0).await?;
-
-            select_probe(client, probe_options.probe.map(Into::into)).await?
-        }
-    };
+    if probe_options.cycle_power {
+        power_reset(probe.selector().into(), Duration::from_secs(1)).await?;
+    }
 
     let result = client
         .attach_probe(AttachRequest {

--- a/probe-rs-tools/src/bin/probe-rs/util/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/mod.rs
@@ -4,8 +4,8 @@ pub mod common_options;
 pub mod flash;
 pub mod logging;
 pub mod meta;
+pub mod pwr;
 pub mod rtt;
-pub mod usb;
 pub mod visualizer;
 
 use std::num::ParseIntError;

--- a/probe-rs-tools/src/bin/probe-rs/util/pwr.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/pwr.rs
@@ -1,38 +1,30 @@
 //! Helpers for usb power control
 
+use std::time::Duration;
+
 use anyhow::Result;
+use anyhow::anyhow;
+use nusb::DeviceInfo;
+use probe_rs::probe::DebugProbeSelector;
 
-#[cfg(not(target_os = "linux"))]
 /// Reset power on a probe
-pub async fn power_reset(_probe_serial: &str, _cycle_delay_seconds: f64) -> Result<()> {
-    anyhow::bail!("USB power reset is only supported on linux")
-}
+pub async fn power_reset(selector: DebugProbeSelector, delay: Duration) -> Result<()> {
+    let dev = nusb::list_devices()
+        .await?
+        .find(|d| selector.matches(d))
+        .ok_or_else(|| anyhow!("device with selector {} not found", selector))?;
 
-#[cfg(all(feature = "remote", not(target_os = "linux")))]
-/// Enable power control on all attached hubs
-pub async fn power_enable() -> Result<()> {
-    anyhow::bail!("USB power reset is only supported on linux")
+    power_reset_impl(&dev, delay).await
 }
 
 #[cfg(target_os = "linux")]
 /// Reset power on a probe
-pub async fn power_reset(probe_serial: &str, cycle_delay_seconds: f64) -> Result<()> {
+async fn power_reset_impl(dev: &DeviceInfo, delay: Duration) -> Result<()> {
     use rustix::fd::OwnedFd;
     use rustix::fs::{Mode, OFlags};
     use std::fs::File;
     use std::io::Write;
-    use std::time::Duration;
-
-    use anyhow::anyhow;
     use tokio::time::sleep;
-
-    fn to_hex(s: &str) -> String {
-        use std::fmt::Write;
-        s.as_bytes().iter().fold(String::new(), |mut s, b| {
-            let _ = write!(s, "{b:02X}"); // Writing a String never fails
-            s
-        })
-    }
 
     fn disable_f(port_fd: &OwnedFd) -> rustix::io::Result<File> {
         Ok(rustix::fs::openat(
@@ -44,22 +36,11 @@ pub async fn power_reset(probe_serial: &str, cycle_delay_seconds: f64) -> Result
         .into())
     }
 
-    let dev = nusb::list_devices()
-        .await?
-        .find(|d| {
-            let serial = d.serial_number().unwrap_or_default();
-
-            serial == probe_serial || to_hex(serial) == probe_serial
-        })
-        .ok_or_else(|| anyhow!("device with serial {} not found", probe_serial))?;
-
-    let port_path = dev.sysfs_path().join("port");
-
     // The USB device goes away when we disable power to it.
     // If we open the port dir we can keep a "handle" to it even if the device goes away, so
     // we can write `disable=0` with openat() to reenable it.
     let port_fd = rustix::fs::open(
-        port_path,
+        dev.sysfs_path().join("port"),
         OFlags::DIRECTORY | OFlags::CLOEXEC,
         Mode::empty(),
     )?;
@@ -68,7 +49,7 @@ pub async fn power_reset(probe_serial: &str, cycle_delay_seconds: f64) -> Result
     disable_f(&port_fd)?.write_all(b"1")?;
 
     // sleep
-    sleep(Duration::from_secs_f64(cycle_delay_seconds)).await;
+    sleep(delay).await;
 
     // enable port power
     disable_f(&port_fd)?.write_all(b"0")?;
@@ -76,11 +57,21 @@ pub async fn power_reset(probe_serial: &str, cycle_delay_seconds: f64) -> Result
     Ok(())
 }
 
+#[cfg(not(target_os = "linux"))]
+async fn power_reset_impl(_dev: &DeviceInfo, _delay: Duration) -> Result<()> {
+    anyhow::bail!("USB power reset is only supported on linux")
+}
+
+#[cfg(all(feature = "remote", not(target_os = "linux")))]
+/// Enable power control on all attached hubs
+pub async fn power_enable() -> Result<()> {
+    anyhow::bail!("USB power reset is only supported on linux")
+}
+
 #[cfg(all(feature = "remote", target_os = "linux"))]
 /// Enable power control on all attached hubs
 pub async fn power_enable() -> Result<()> {
     use std::fs;
-    use std::time::Duration;
 
     use tokio::time::sleep;
     use tracing::{info, warn};

--- a/probe-rs/src/probe/selector.rs
+++ b/probe-rs/src/probe/selector.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::probe::DebugProbeInfo;
+use crate::probe::{DebugProbeInfo, usb_util::to_hex};
 
 use nusb::DeviceInfo;
 
@@ -108,7 +108,7 @@ impl DebugProbeSelector {
                 .as_ref()
                 .map(|s| {
                     if let Some(serial_number) = serial_number {
-                        serial_number == s
+                        serial_number == s || to_hex(serial_number).as_str() == s
                     } else {
                         // Match probes without serial number when the
                         // selector has a third, empty part ("VID:PID:")

--- a/probe-rs/src/probe/stlink/tools.rs
+++ b/probe-rs/src/probe/stlink/tools.rs
@@ -1,10 +1,10 @@
 use crate::probe::DebugProbeInfo;
 use crate::probe::stlink::StLinkFactory;
+use crate::probe::usb_util::to_hex;
 use nusb::MaybeFuture;
 
 use super::usb_interface::USB_PID_EP_MAP;
 use super::usb_interface::USB_VID;
-use std::fmt::Write;
 
 pub(super) fn is_stlink_device(device: &nusb::DeviceInfo) -> bool {
     // Check the VID/PID.
@@ -46,10 +46,7 @@ pub(super) fn read_serial_number(device: &nusb::DeviceInfo) -> Option<String> {
         if s.len() < 24 {
             // Some STLink (especially V2) have their serial number stored as a 12 bytes binary string
             // containing non printable characters, so convert to a hex string to make them printable.
-            s.as_bytes().iter().fold(String::new(), |mut s, b| {
-                let _ = write!(s, "{b:02X}"); // Writing a String never fails
-                s
-            })
+            to_hex(s)
         } else {
             // Other STlink (especially V2-1) have their serial number already stored as a 24 characters
             // hex string so they don't need to be converted

--- a/probe-rs/src/probe/usb_util.rs
+++ b/probe-rs/src/probe/usb_util.rs
@@ -4,7 +4,16 @@ use nusb::{
     Interface,
     transfer::{Buffer, Bulk, In, Out},
 };
+use std::fmt::Write;
 use std::{io, time::Duration};
+
+/// Encode a usb serial number as a hex
+pub(crate) fn to_hex(s: &str) -> String {
+    s.as_bytes().iter().fold(String::new(), |mut s, b| {
+        let _ = write!(s, "{b:02X}"); // Writing a String never fails
+        s
+    })
+}
 
 /// USB bulk transfer utility functions.
 pub trait InterfaceExt {


### PR DESCRIPTION
- rename the `usb.rs` file to `pwr.rs` to better match what it's doing.
- in power_reset, move the nusb acquisition code out of the platform specific impl, so that it can be tested on all platforms
- refactor the nusb acquisition code to use the probe-selector abstraction.
-  fix the probe selector abstraction to handle STLink devices with unprintable serial numbers.