### PR TITLE
Fix 'probe-rs run' with .hex files 

### DIFF
--- a/changelog/fixed-run-with-hex-file.md
+++ b/changelog/fixed-run-with-hex-file.md
@@ -1,0 +1,1 @@
+Fixed error when using `probe-rs run` with a non-ELF binary

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -458,7 +458,13 @@ impl EmbeddedTestElfInfo {
         file.read_to_end(&mut buffer)?;
         let buffer = buffer.as_slice();
 
-        let elf = object::File::parse(buffer).context("Failed to parse ELF file")?;
+        let elf = match object::File::parse(buffer) {
+            Ok(elf) => elf,
+            Err(e) => {
+                tracing::debug!("Failed to parse ELF file: {e}");
+                return Ok(None);
+            }
+        };
 
         ElfReader { buffer, elf }
             .decode()


### PR DESCRIPTION
`probe-rs run` failed when trying to discover embedded tests when passed a non-ELF file, even when `--binary-format hex` was specified. This was a regression introduced in https://github.com/probe-rs/probe-rs/pull/3003.

This PR handles an ELF parse failure by assuming the file does not contain embedded tests, as was done prior to https://github.com/probe-rs/probe-rs/pull/3003.

Fixes https://github.com/probe-rs/probe-rs/issues/3602.

(I could also check the expected binary format, but that would be incompatible with the TODO in `run.rs`:
```rs
    pub async fn run(self, client: RpcClient, utc_offset: UtcOffset) -> anyhow::Result<()> {
        // Detect run mode based on ELF file
        let run_mode = detect_run_mode(&self)?;

        // TODO: Skip attach_probe & flashing, if user only wants to list tests (only possible when using embedded_test with protocol version >= 1)

        let session = cli::attach_probe(&client, self.probe_options, false).await?;

```
...since the expected format may depend on the target, which may be autodetected.)