### PR TITLE
RP235x RISC-V attach support

### DIFF
--- a/changelog/added-rp235x-riscv-attach.md
+++ b/changelog/added-rp235x-riscv-attach.md
@@ -1,0 +1,1 @@
+Added initial support for attaching to RP235x RISC-V cores

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -231,6 +231,10 @@ pub struct RiscvCoreAccessOptions {
 
     /// The JTAG TAP index of the core's debug module
     pub jtag_tap: Option<usize>,
+
+    /// CoreSight/mem-AP to use as DTM. This is the method used for RP235x
+    #[serde(default)]
+    pub mem_ap: Option<ApAddress>,
 }
 
 /// The data required to access an Xtensa core

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -18,7 +18,6 @@ use probe_rs::{
             },
             sequences::DefaultArmSequence,
         },
-        riscv::communication_interface::RiscvCommunicationInterface,
         xtensa::communication_interface::{
             XtensaCommunicationInterface, XtensaDebugInterfaceState,
         },
@@ -410,11 +409,13 @@ async fn try_read_riscv_info(
 ) -> Result<(), anyhow::Error> {
     if probe.has_riscv_interface() && protocol == WireProtocol::Jtag {
         tracing::debug!("Trying to show RISC-V chip information");
-        let factory = probe.try_get_riscv_interface_builder()?;
-
-        let mut state = factory.create_state();
-        let mut interface = factory.attach(&mut state)?;
-        show_riscv_info(ctx, &mut interface).await?;
+        let idcode = {
+            let factory = probe.try_get_riscv_interface_builder()?;
+            let mut state = factory.create_state();
+            let mut interface = factory.attach(&mut state)?;
+            interface.read_idcode()?
+        };
+        show_riscv_info(ctx, idcode).await?;
     } else if protocol == WireProtocol::Swd {
         ctx.publish::<TargetInfoDataTopic>(
             VarSeq::Seq2(0),
@@ -835,10 +836,8 @@ fn cpu_info_tree(scs: &mut Scs) -> anyhow::Result<ComponentTreeNode> {
 
 async fn show_riscv_info(
     ctx: &mut RpcContext,
-    interface: &mut RiscvCommunicationInterface<'_>,
+    idcode: Option<u32>,
 ) -> anyhow::Result<()> {
-    let idcode = interface.read_idcode()?;
-
     ctx.publish::<TargetInfoDataTopic>(
         VarSeq::Seq2(0),
         &InfoEvent::Idcode {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -834,10 +834,7 @@ fn cpu_info_tree(scs: &mut Scs) -> anyhow::Result<ComponentTreeNode> {
     Ok(tree)
 }
 
-async fn show_riscv_info(
-    ctx: &mut RpcContext,
-    idcode: Option<u32>,
-) -> anyhow::Result<()> {
+async fn show_riscv_info(ctx: &mut RpcContext, idcode: Option<u32>) -> anyhow::Result<()> {
     ctx.publish::<TargetInfoDataTopic>(
         VarSeq::Seq2(0),
         &InfoEvent::Idcode {

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -262,9 +262,8 @@ impl ArmDebugInterface for ArmCommunicationInterface {
         &mut self,
         access_port_address: &FullyQualifiedApAddress,
     ) -> Result<Box<dyn ArmMemoryInterface + '_>, ArmError> {
-        let memory_interface = match access_port_address.ap() {
-            ApAddress::V1(_) => Box::new(ADIMemoryInterface::new(self, access_port_address)?)
-                as Box<dyn ArmMemoryInterface + '_>,
+        let memory_interface: Box<dyn ArmMemoryInterface + '_> = match access_port_address.ap() {
+            ApAddress::V1(_) => Box::new(ADIMemoryInterface::new(self, access_port_address)?),
             ApAddress::V2(_) => ap::v2::new_memory_interface(self, access_port_address)?,
         };
         Ok(memory_interface)

--- a/probe-rs/src/architecture/arm/memory/mod.rs
+++ b/probe-rs/src/architecture/arm/memory/mod.rs
@@ -12,7 +12,7 @@ pub use romtable::{Component, ComponentId, CoresightComponent, PeripheralType, R
 
 /// Trait for accessing memory behind a memory access port,
 /// as defined in the ARM Debug Interface Specification.
-pub trait ArmMemoryInterface: MemoryInterface<ArmError> {
+pub trait ArmMemoryInterface: MemoryInterface<ArmError> + Send {
     /// The underlying MemoryAp address.
     fn fully_qualified_address(&self) -> FullyQualifiedApAddress;
 

--- a/probe-rs/src/architecture/arm/memory/mod.rs
+++ b/probe-rs/src/architecture/arm/memory/mod.rs
@@ -12,7 +12,7 @@ pub use romtable::{Component, ComponentId, CoresightComponent, PeripheralType, R
 
 /// Trait for accessing memory behind a memory access port,
 /// as defined in the ARM Debug Interface Specification.
-pub trait ArmMemoryInterface: MemoryInterface<ArmError> + Send {
+pub trait ArmMemoryInterface: MemoryInterface<ArmError> {
     /// The underlying MemoryAp address.
     fn fully_qualified_address(&self) -> FullyQualifiedApAddress;
 

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -427,12 +427,12 @@ impl Default for RiscvCommunicationInterfaceState {
 
 /// The combined state of a RISC-V debug module and its transport interface.
 pub struct RiscvDebugInterfaceState {
-    pub(super) interface_state: RiscvCommunicationInterfaceState,
+    pub(crate) interface_state: RiscvCommunicationInterfaceState,
     pub(super) dtm_state: Box<dyn Any + Send>,
 }
 
 impl RiscvDebugInterfaceState {
-    pub(super) fn new(dtm_state: Box<dyn Any + Send>) -> Self {
+    pub(crate) fn new(dtm_state: Box<dyn Any + Send>) -> Self {
         Self {
             interface_state: RiscvCommunicationInterfaceState::new(),
             dtm_state,

--- a/probe-rs/src/architecture/riscv/dtm/mem_ap_dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm/mem_ap_dtm.rs
@@ -1,7 +1,7 @@
 //! Memory-mapped DTM (Debug Transport Module) for RISC-V.
 //!
 //! When the RISC-V debug module is behind a CoreSight memory access port (for example RP2350),
-//! the chip exposes the DMI (Debug Module Interface) registers as offsets into the memory AP's 
+//! the chip exposes the DMI (Debug Module Interface) registers as offsets into the memory AP's
 //! address space.
 //! Each DMI register occupies 4 bytes, so address = register * 4
 

--- a/probe-rs/src/architecture/riscv/dtm/mem_ap_dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm/mem_ap_dtm.rs
@@ -1,0 +1,160 @@
+//! Memory-mapped DTM (Debug Transport Module) for RISC-V.
+//!
+//! When the RISC-V debug module is exposed behind a CoreSight mem-AP (e.g. RP2350 over SWD),
+//! there is no JTAG DTM. DMI register accesses are performed as 32-bit memory reads/writes
+//! at byte address `dmi_address * 4` (DM at base 0 in the AP's address space).
+
+use crate::architecture::arm::ArmError;
+use crate::architecture::arm::memory::ArmMemoryInterface;
+use crate::architecture::riscv::communication_interface::RiscvError;
+use crate::architecture::riscv::dtm::DtmAccess;
+use crate::probe::queue::{DeferredResultIndex, DeferredResultSet};
+use crate::probe::{CommandResult, DebugProbeError};
+use std::fmt;
+use std::time::Duration;
+
+/// DMI operation for the pending queue.
+#[derive(Debug)]
+enum DmiOp {
+    Read(u64),
+    Write(u64, u32),
+}
+
+/// DTM that uses a memory interface (mem-AP) to access the RISC-V debug module.
+/// DMI address `a` is accessed at byte address `a * 4` (DM at base 0 in the AP's space).
+pub struct MemApDtm<'state> {
+    memory: Box<dyn ArmMemoryInterface + 'state>,
+    pending: Vec<(DeferredResultIndex, DmiOp)>,
+    results: DeferredResultSet<CommandResult>,
+}
+
+impl fmt::Debug for MemApDtm<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MemApDtm")
+            .field("pending_len", &self.pending.len())
+            .finish()
+    }
+}
+
+fn arm_error_to_riscv(e: ArmError) -> RiscvError {
+    match e {
+        ArmError::Probe(p) => RiscvError::DebugProbe(p),
+        _ => RiscvError::DtmOperationFailed,
+    }
+}
+
+impl<'state> MemApDtm<'state> {
+    /// Create a DTM that performs DMI accesses via the given memory interface.
+    /// DMI address `a` is accessed at byte address `a * 4` (DM at base 0 in the AP's space).
+    pub fn new(memory: Box<dyn ArmMemoryInterface + 'state>) -> Self {
+        Self {
+            memory,
+            pending: Vec::new(),
+            results: DeferredResultSet::new(),
+        }
+    }
+
+    fn dmi_byte_address(&self, dmi_address: u64) -> u64 {
+        dmi_address * 4
+    }
+}
+
+impl DtmAccess for MemApDtm<'_> {
+    fn init(&mut self) -> Result<(), RiscvError> {
+        // No DTMCS to read; memory-mapped path is synchronous.
+        Ok(())
+    }
+
+    fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
+        // Reset is handled by the session / ARM interface when using mem-AP path.
+        Ok(())
+    }
+
+    fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {
+        Ok(())
+    }
+
+    fn clear_error_state(&mut self) -> Result<(), RiscvError> {
+        Ok(())
+    }
+
+    fn read_deferred_result(
+        &mut self,
+        index: DeferredResultIndex,
+    ) -> Result<CommandResult, RiscvError> {
+        // Flush pending DMI operations so the requested result is available (same as JTAG DTM).
+        match self.results.take(index.clone()) {
+            Ok(result) => Ok(result),
+            Err(_) => {
+                self.execute()?;
+                self.results
+                    .take(index)
+                    .map_err(|_| RiscvError::BatchedResultNotAvailable)
+            }
+        }
+    }
+
+    fn execute(&mut self) -> Result<(), RiscvError> {
+        for (index, op) in std::mem::take(&mut self.pending) {
+            match op {
+                DmiOp::Read(addr) => {
+                    let byte_addr = self.dmi_byte_address(addr);
+                    let value = self
+                        .memory
+                        .read_word_32(byte_addr)
+                        .map_err(arm_error_to_riscv)?;
+                    self.results.push(&index, CommandResult::U32(value));
+                }
+                DmiOp::Write(addr, value) => {
+                    let byte_addr = self.dmi_byte_address(addr);
+                    self.memory
+                        .write_word_32(byte_addr, value)
+                        .map_err(arm_error_to_riscv)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn schedule_write(
+        &mut self,
+        address: u64,
+        value: u32,
+    ) -> Result<Option<DeferredResultIndex>, RiscvError> {
+        let index = DeferredResultIndex::new();
+        self.pending
+            .push((index.clone(), DmiOp::Write(address, value)));
+        // Memory-mapped write does not return a value.
+        Ok(None)
+    }
+
+    fn schedule_read(&mut self, address: u64) -> Result<DeferredResultIndex, RiscvError> {
+        let index = DeferredResultIndex::new();
+        self.pending.push((index.clone(), DmiOp::Read(address)));
+        Ok(index)
+    }
+
+    fn read_with_timeout(&mut self, address: u64, _timeout: Duration) -> Result<u32, RiscvError> {
+        let byte_addr = self.dmi_byte_address(address);
+        self.memory
+            .read_word_32(byte_addr)
+            .map_err(arm_error_to_riscv)
+    }
+
+    fn write_with_timeout(
+        &mut self,
+        address: u64,
+        value: u32,
+        _timeout: Duration,
+    ) -> Result<Option<u32>, RiscvError> {
+        let byte_addr = self.dmi_byte_address(address);
+        self.memory
+            .write_word_32(byte_addr, value)
+            .map_err(arm_error_to_riscv)?;
+        Ok(None)
+    }
+
+    fn read_idcode(&mut self) -> Result<Option<u32>, DebugProbeError> {
+        Ok(None)
+    }
+}

--- a/probe-rs/src/architecture/riscv/dtm/mem_ap_dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm/mem_ap_dtm.rs
@@ -1,8 +1,9 @@
 //! Memory-mapped DTM (Debug Transport Module) for RISC-V.
 //!
-//! When the RISC-V debug module is exposed behind a CoreSight mem-AP (e.g. RP2350 over SWD),
-//! there is no JTAG DTM. DMI register accesses are performed as 32-bit memory reads/writes
-//! at byte address `dmi_address * 4` (DM at base 0 in the AP's address space).
+//! When the RISC-V debug module is behind a CoreSight memory access port (for example RP2350),
+//! the chip exposes the DMI (Debug Module Interface) registers as offsets into the memory AP's 
+//! address space.
+//! Each DMI register occupies 4 bytes, so address = register * 4
 
 use crate::architecture::arm::ArmError;
 use crate::architecture::arm::memory::ArmMemoryInterface;
@@ -20,8 +21,7 @@ enum DmiOp {
     Write(u64, u32),
 }
 
-/// DTM that uses a memory interface (mem-AP) to access the RISC-V debug module.
-/// DMI address `a` is accessed at byte address `a * 4` (DM at base 0 in the AP's space).
+/// DTM that performs DMI accesses via a CoreSight memory access port.
 pub struct MemApDtm<'state> {
     memory: Box<dyn ArmMemoryInterface + 'state>,
     pending: Vec<(DeferredResultIndex, DmiOp)>,
@@ -44,8 +44,7 @@ fn arm_error_to_riscv(e: ArmError) -> RiscvError {
 }
 
 impl<'state> MemApDtm<'state> {
-    /// Create a DTM that performs DMI accesses via the given memory interface.
-    /// DMI address `a` is accessed at byte address `a * 4` (DM at base 0 in the AP's space).
+    /// Creates a DTM that performs DMI accesses via the given memory interface.
     pub fn new(memory: Box<dyn ArmMemoryInterface + 'state>) -> Self {
         Self {
             memory,
@@ -54,19 +53,20 @@ impl<'state> MemApDtm<'state> {
         }
     }
 
-    fn dmi_byte_address(&self, dmi_address: u64) -> u64 {
-        dmi_address * 4
+    /// Calculate offset of DMI register.
+    fn dmi_register_to_ap_address(&self, dmi_register: u64) -> u64 {
+        dmi_register * 4
     }
 }
 
 impl DtmAccess for MemApDtm<'_> {
     fn init(&mut self) -> Result<(), RiscvError> {
-        // No DTMCS to read; memory-mapped path is synchronous.
+        // No DTM control register; memory-mapped path is synchronous.
         Ok(())
     }
 
     fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
-        // Reset is handled by the session / ARM interface when using mem-AP path.
+        // Reset is handled by the session (ARM DAP) on the mem-AP path.
         Ok(())
     }
 
@@ -82,7 +82,7 @@ impl DtmAccess for MemApDtm<'_> {
         &mut self,
         index: DeferredResultIndex,
     ) -> Result<CommandResult, RiscvError> {
-        // Flush pending DMI operations so the requested result is available (same as JTAG DTM).
+        // If the result is not ready yet, run pending DMI ops then take it.
         match self.results.take(index.clone()) {
             Ok(result) => Ok(result),
             Err(_) => {
@@ -98,7 +98,7 @@ impl DtmAccess for MemApDtm<'_> {
         for (index, op) in std::mem::take(&mut self.pending) {
             match op {
                 DmiOp::Read(addr) => {
-                    let byte_addr = self.dmi_byte_address(addr);
+                    let byte_addr = self.dmi_register_to_ap_address(addr);
                     let value = self
                         .memory
                         .read_word_32(byte_addr)
@@ -106,7 +106,7 @@ impl DtmAccess for MemApDtm<'_> {
                     self.results.push(&index, CommandResult::U32(value));
                 }
                 DmiOp::Write(addr, value) => {
-                    let byte_addr = self.dmi_byte_address(addr);
+                    let byte_addr = self.dmi_register_to_ap_address(addr);
                     self.memory
                         .write_word_32(byte_addr, value)
                         .map_err(arm_error_to_riscv)?;
@@ -124,7 +124,6 @@ impl DtmAccess for MemApDtm<'_> {
         let index = DeferredResultIndex::new();
         self.pending
             .push((index.clone(), DmiOp::Write(address, value)));
-        // Memory-mapped write does not return a value.
         Ok(None)
     }
 
@@ -135,7 +134,8 @@ impl DtmAccess for MemApDtm<'_> {
     }
 
     fn read_with_timeout(&mut self, address: u64, _timeout: Duration) -> Result<u32, RiscvError> {
-        let byte_addr = self.dmi_byte_address(address);
+        // Memory-mapped path is synchronous; timeout is unused.
+        let byte_addr = self.dmi_register_to_ap_address(address);
         self.memory
             .read_word_32(byte_addr)
             .map_err(arm_error_to_riscv)
@@ -147,7 +147,8 @@ impl DtmAccess for MemApDtm<'_> {
         value: u32,
         _timeout: Duration,
     ) -> Result<Option<u32>, RiscvError> {
-        let byte_addr = self.dmi_byte_address(address);
+        // Memory-mapped path is synchronous; timeout is unused.
+        let byte_addr = self.dmi_register_to_ap_address(address);
         self.memory
             .write_word_32(byte_addr, value)
             .map_err(arm_error_to_riscv)?;
@@ -155,6 +156,7 @@ impl DtmAccess for MemApDtm<'_> {
     }
 
     fn read_idcode(&mut self) -> Result<Option<u32>, DebugProbeError> {
+        // No JTAG = no ID code.
         Ok(None)
     }
 }

--- a/probe-rs/src/architecture/riscv/dtm/mod.rs
+++ b/probe-rs/src/architecture/riscv/dtm/mod.rs
@@ -1,6 +1,7 @@
 //! Debug Transport Module (DTM) access abstraction
 
 pub mod jtag_dtm;
+pub(crate) mod mem_ap_dtm;
 
 use crate::architecture::riscv::communication_interface::RiscvError;
 use crate::probe::queue::DeferredResultIndex;

--- a/probe-rs/src/architecture/riscv/dtm/mod.rs
+++ b/probe-rs/src/architecture/riscv/dtm/mod.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::time::Duration;
 
 /// Debug Transport Module (DTM) access abstraction
-pub trait DtmAccess: Send + fmt::Debug {
+pub trait DtmAccess: fmt::Debug {
     /// Perform interface-specific initialisation upon attaching.
     fn init(&mut self) -> Result<(), RiscvError> {
         Ok(())

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -131,6 +131,7 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
                     core_access_options: CoreAccessOptions::Riscv(RiscvCoreAccessOptions {
                         hart_id: None,
                         jtag_tap: None,
+                        mem_ap: None,
                     }),
                 }],
                 memory_map: vec![],

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -101,6 +101,7 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
                     core_access_options: CoreAccessOptions::Riscv(RiscvCoreAccessOptions {
                         hart_id: None,
                         jtag_tap: None,
+                        mem_ap: None,
                     }),
                 }],
                 memory_map: vec![],

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -291,7 +291,19 @@ impl CoreExt for Core {
                     }
                 })
             }
-            probe_rs_target::CoreAccessOptions::Riscv(_) => None,
+            probe_rs_target::CoreAccessOptions::Riscv(options) => {
+                options.mem_ap.as_ref().map(|ap| {
+                    let dp = DpAddress::Default;
+                    match ap {
+                        probe_rs_target::ApAddress::V1(ap_num) => {
+                            FullyQualifiedApAddress::v1_with_dp(dp, *ap_num)
+                        }
+                        probe_rs_target::ApAddress::V2(ap_num) => {
+                            FullyQualifiedApAddress::v2_with_dp(dp, ApV2Address::new(*ap_num))
+                        }
+                    }
+                })
+            }
             probe_rs_target::CoreAccessOptions::Xtensa(_) => None,
         }
     }

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -1,8 +1,9 @@
 use crate::{
     CoreType, Endian, InstructionSet, MemoryInterface, Target,
     architecture::{
-        arm::sequences::ArmDebugSequence, riscv::sequences::RiscvDebugSequence,
-        xtensa::sequences::XtensaDebugSequence,
+        arm::sequences::{ArmDebugSequence, DefaultArmSequence},
+        riscv::sequences::{DefaultRiscvSequence, RiscvDebugSequence},
+        xtensa::sequences::{DefaultXtensaSequence, XtensaDebugSequence},
     },
     config::DebugSequence,
     error::{BreakpointError, Error},
@@ -702,19 +703,31 @@ pub enum ResolvedCoreOptions {
 
 impl ResolvedCoreOptions {
     fn new(target: &Target, options: CoreAccessOptions) -> Self {
-        match (options, target.debug_sequence.clone()) {
-            (CoreAccessOptions::Arm(options), DebugSequence::Arm(sequence)) => {
+        // When the target's debug_sequence doesn't match this core's architecture (e.g.
+        // RP235x_riscv where the vendor returns Arm(Rp235x) for the family), use the default
+        // sequence for this core's architecture so attach still works.
+        match options {
+            CoreAccessOptions::Arm(options) => {
+                let sequence = match &target.debug_sequence {
+                    DebugSequence::Arm(s) => s.clone(),
+                    _ => DefaultArmSequence::create(),
+                };
                 Self::Arm { sequence, options }
             }
-            (CoreAccessOptions::Riscv(options), DebugSequence::Riscv(sequence)) => {
+            CoreAccessOptions::Riscv(options) => {
+                let sequence = match &target.debug_sequence {
+                    DebugSequence::Riscv(s) => s.clone(),
+                    _ => DefaultRiscvSequence::create(),
+                };
                 Self::Riscv { sequence, options }
             }
-            (CoreAccessOptions::Xtensa(options), DebugSequence::Xtensa(sequence)) => {
+            CoreAccessOptions::Xtensa(options) => {
+                let sequence = match &target.debug_sequence {
+                    DebugSequence::Xtensa(s) => s.clone(),
+                    _ => DefaultXtensaSequence::create(),
+                };
                 Self::Xtensa { sequence, options }
             }
-            _ => unreachable!(
-                "Mismatch between core kind and access options. This is a bug, please report it."
-            ),
         }
     }
 

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -35,6 +35,10 @@ impl CombinedCoreState {
         self.core_state.core_access_options.jtag_tap_index()
     }
 
+    pub(crate) fn is_arm_core(&self) -> bool {
+        self.core_state.is_arm()
+    }
+
     pub(crate) fn attach_arm<'probe>(
         &'probe mut self,
         target: &'probe Target,
@@ -263,6 +267,10 @@ impl CoreState {
         Self {
             core_access_options,
         }
+    }
+
+    pub(crate) fn is_arm(&self) -> bool {
+        matches!(&self.core_access_options, ResolvedCoreOptions::Arm { .. })
     }
 
     pub(crate) fn memory_ap(&self) -> FullyQualifiedApAddress {

--- a/probe-rs/src/probe/queue.rs
+++ b/probe-rs/src/probe/queue.rs
@@ -241,7 +241,7 @@ impl fmt::Debug for DeferredResultIndex {
 
 impl DeferredResultIndex {
     // Intentionally private. User code must not be able to create these.
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self(Arc::new(()))
     }
 
@@ -255,10 +255,12 @@ impl DeferredResultIndex {
         // the read data would be inaccessible.
         Arc::strong_count(&self.0) > 1
     }
+}
 
-    // Intentionally private. User code must not be able to clone these.
+// Intentionally private. User code must not be able to clone these.
+impl Clone for DeferredResultIndex {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self(Arc::clone(&self.0))
     }
 }
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -339,8 +339,12 @@ impl Session {
                 // Wait for the core to be halted. The core should be
                 // halted because we set the `reset_catch` earlier, which
                 // means that the core should stop when coming out of reset.
+                // Non-ARM cores (e.g. RISC-V over mem-AP) did not use reset catch; skip this path.
 
                 for core_id in 0..session.cores.len() {
+                    if !session.cores[core_id].is_arm_core() {
+                        continue;
+                    }
                     let mut core = session
                         .core(core_id)
                         .inspect_err(|e| tracing::error!("Unable to get core {core_id}: {e}"))?;

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -386,19 +386,20 @@ impl Session {
         interface: Box<dyn ArmDebugInterface + 'static>,
     ) -> Result<ArchitectureInterface, Error> {
         use probe_rs_target::Architecture;
-        let mut riscv_mem_ap_cores: Vec<Option<(FullyQualifiedApAddress, RiscvDebugInterfaceState)>> =
-            target
-                .cores
-                .iter()
-                .map(|core| {
-                    if core.core_type.architecture() == Architecture::Riscv {
-                        core.memory_ap()
-                            .map(|ap| (ap, RiscvDebugInterfaceState::new(Box::new(()))))
-                    } else {
-                        None
-                    }
-                })
-                .collect();
+        let mut riscv_mem_ap_cores: Vec<
+            Option<(FullyQualifiedApAddress, RiscvDebugInterfaceState)>,
+        > = target
+            .cores
+            .iter()
+            .map(|core| {
+                if core.core_type.architecture() == Architecture::Riscv {
+                    core.memory_ap()
+                        .map(|ap| (ap, RiscvDebugInterfaceState::new(Box::new(()))))
+                } else {
+                    None
+                }
+            })
+            .collect();
         let has_riscv_mem_ap = riscv_mem_ap_cores.iter().any(Option::is_some);
         if has_riscv_mem_ap {
             let mut arm = interface;
@@ -1010,8 +1011,12 @@ impl Session {
                 match session.core(core) {
                     Ok(mut core) => core.clear_all_hw_breakpoints(),
                     Err(Error::CoreDisabled(_)) => Ok(()),
-                    Err(Error::Riscv(crate::architecture::riscv::communication_interface::RiscvError::Timeout)) => {
-                        tracing::warn!("Core {core} attach or breakpoint clear timed out, skipping");
+                    Err(Error::Riscv(
+                        crate::architecture::riscv::communication_interface::RiscvError::Timeout,
+                    )) => {
+                        tracing::warn!(
+                            "Core {core} attach or breakpoint clear timed out, skipping"
+                        );
                         Ok(())
                     }
                     Err(err) => Err(err),

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -2,15 +2,18 @@ use crate::{
     Core, CoreType, Error,
     architecture::{
         arm::{
-            ArmError, SwoReader,
+            ArmError, FullyQualifiedApAddress, SwoReader,
             communication_interface::ArmDebugInterface,
             component::{TraceSink, get_arm_components},
             dp::DpAddress,
             memory::CoresightComponent,
             sequences::{ArmDebugSequence, DefaultArmSequence},
         },
-        riscv::communication_interface::{
-            RiscvCommunicationInterface, RiscvDebugInterfaceState, RiscvError,
+        riscv::{
+            communication_interface::{
+                RiscvCommunicationInterface, RiscvDebugInterfaceState, RiscvError,
+            },
+            dtm::mem_ap_dtm::MemApDtm,
         },
         xtensa::communication_interface::{
             XtensaCommunicationInterface, XtensaDebugInterfaceState, XtensaError,
@@ -99,6 +102,12 @@ impl fmt::Debug for JtagInterface {
 // TODO: this is somewhat messy because I omitted separating the Probe out of the ARM interface.
 enum ArchitectureInterface {
     Arm(Box<dyn ArmDebugInterface + 'static>),
+    /// ARM DAP with RISC-V cores reachable via mem-AP (e.g. RP2350).
+    ArmWithRiscv {
+        arm: Box<dyn ArmDebugInterface + 'static>,
+        /// Per core_id: Some((ap, state)) for RISC-V cores over mem-AP, None otherwise.
+        riscv_mem_ap_cores: Vec<Option<(FullyQualifiedApAddress, RiscvDebugInterfaceState)>>,
+    },
     Jtag(Probe, Vec<JtagInterface>),
 }
 
@@ -106,6 +115,9 @@ impl fmt::Debug for ArchitectureInterface {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ArchitectureInterface::Arm(_) => f.write_str("ArchitectureInterface::Arm(..)"),
+            ArchitectureInterface::ArmWithRiscv { .. } => {
+                f.write_str("ArchitectureInterface::ArmWithRiscv { .. }")
+            }
             ArchitectureInterface::Jtag(_, ifaces) => f
                 .debug_tuple("ArchitectureInterface::Jtag(..)")
                 .field(ifaces)
@@ -122,6 +134,21 @@ impl ArchitectureInterface {
     ) -> Result<Core<'probe>, Error> {
         match self {
             ArchitectureInterface::Arm(interface) => combined_state.attach_arm(target, interface),
+            ArchitectureInterface::ArmWithRiscv {
+                arm,
+                riscv_mem_ap_cores,
+            } => {
+                let core_id = combined_state.id();
+                if let Some(Some((ap, state))) = riscv_mem_ap_cores.get_mut(core_id) {
+                    let memory = arm.memory_interface(ap).map_err(Error::Arm)?;
+                    let dtm = MemApDtm::new(memory);
+                    let iface =
+                        RiscvCommunicationInterface::new(Box::new(dtm), &mut state.interface_state);
+                    combined_state.attach_riscv(target, iface)
+                } else {
+                    combined_state.attach_arm(target, arm)
+                }
+            }
             ArchitectureInterface::Jtag(probe, ifaces) => {
                 let idx = combined_state.jtag_tap_index();
                 if let Some(probe) = probe.try_as_jtag_probe() {
@@ -173,7 +200,9 @@ impl Session {
             })
             .collect();
 
-        let mut session = if let Architecture::Arm = target.architecture() {
+        // Use ARM DAP path when the target connects via SWD/DAP: either ARM cores or RISC-V cores
+        // over mem-AP (e.g. RP235x_riscv).
+        let mut session = if target.default_core().memory_ap().is_some() {
             Self::attach_arm_debug_interface(probe, target, attach_method, permissions, cores)?
         } else {
             Self::attach_jtag(probe, target, attach_method, permissions, cores)?
@@ -201,9 +230,12 @@ impl Session {
 
         let default_dp = default_memory_ap.dp();
 
+        // Use ARM sequence for DAP operations (unlock, reset). For RISC-V-over-mem-AP targets
+        // (e.g. RP235x_riscv) the target's debug_sequence is Riscv; use default ARM sequence.
         let sequence_handle = match &target.debug_sequence {
             DebugSequence::Arm(sequence) => sequence.clone(),
-            _ => unreachable!("Mismatch between architecture and sequence type!"),
+            DebugSequence::Riscv(_) => DefaultArmSequence::create(),
+            _ => unreachable!("DAP path only used for ARM or RISC-V-over-mem-AP targets"),
         };
 
         if AttachMethod::UnderReset == attach_method {
@@ -264,7 +296,9 @@ impl Session {
         if attach_method == AttachMethod::UnderReset {
             {
                 for core in &cores {
-                    core.arm_reset_catch_set(&mut *interface)?;
+                    if core.is_arm_core() {
+                        core.arm_reset_catch_set(&mut *interface)?;
+                    }
                 }
 
                 let reset_hardware_deassert =
@@ -288,12 +322,15 @@ impl Session {
             // Now that hardware reset is de-asserted, for each core, setup debugging.
             // (Some chips keep cores in power-down under hardware-reset.)
             for core in &cores {
-                core.enable_arm_debug(&mut *interface)?;
+                if core.is_arm_core() {
+                    core.enable_arm_debug(&mut *interface)?;
+                }
             }
 
+            let interfaces = Self::build_arm_interfaces(&target, interface)?;
             let mut session = Session {
                 target,
-                interfaces: ArchitectureInterface::Arm(interface),
+                interfaces,
                 cores,
                 configured_trace_sink: None,
             };
@@ -323,15 +360,57 @@ impl Session {
         } else {
             // For each core, setup debugging
             for core in &cores {
-                core.enable_arm_debug(&mut *interface)?;
+                if core.is_arm_core() {
+                    core.enable_arm_debug(&mut *interface)?;
+                }
             }
 
+            let interfaces = Self::build_arm_interfaces(&target, interface)?;
             Ok(Session {
                 target,
-                interfaces: ArchitectureInterface::Arm(interface),
+                interfaces,
                 cores,
                 configured_trace_sink: None,
             })
+        }
+    }
+
+    /// Returns `Arm(interface)` for a normal Arm system, or `ArmWithRiscv { .. }` if the target has
+    /// RISC-V cores reachable via mem-AP (like on RP235x).
+    fn build_arm_interfaces(
+        target: &Target,
+        interface: Box<dyn ArmDebugInterface + 'static>,
+    ) -> Result<ArchitectureInterface, Error> {
+        use probe_rs_target::Architecture;
+        let mut riscv_mem_ap_cores: Vec<Option<(FullyQualifiedApAddress, RiscvDebugInterfaceState)>> =
+            target
+                .cores
+                .iter()
+                .map(|core| {
+                    if core.core_type.architecture() == Architecture::Riscv {
+                        core.memory_ap()
+                            .map(|ap| (ap, RiscvDebugInterfaceState::new(Box::new(()))))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+        let has_riscv_mem_ap = riscv_mem_ap_cores.iter().any(Option::is_some);
+        if has_riscv_mem_ap {
+            let mut arm = interface;
+            for (ap, state) in riscv_mem_ap_cores.iter_mut().flatten() {
+                let memory = arm.memory_interface(ap).map_err(Error::Arm)?;
+                let dtm = MemApDtm::new(memory);
+                let mut iface =
+                    RiscvCommunicationInterface::new(Box::new(dtm), &mut state.interface_state);
+                iface.enter_debug_mode().map_err(Error::Riscv)?;
+            }
+            Ok(ArchitectureInterface::ArmWithRiscv {
+                arm,
+                riscv_mem_ap_cores,
+            })
+        } else {
+            Ok(ArchitectureInterface::Arm(interface))
         }
     }
 
@@ -634,7 +713,8 @@ impl Session {
     pub fn get_arm_interface(&mut self) -> Result<&mut dyn ArmDebugInterface, ArmError> {
         let interface = match &mut self.interfaces {
             ArchitectureInterface::Arm(state) => state.deref_mut(),
-            _ => return Err(ArmError::NoArmTarget),
+            ArchitectureInterface::ArmWithRiscv { arm, .. } => arm.deref_mut(),
+            ArchitectureInterface::Jtag(..) => return Err(ArmError::NoArmTarget),
         };
 
         Ok(interface)
@@ -645,17 +725,37 @@ impl Session {
         &mut self,
         core_id: usize,
     ) -> Result<RiscvCommunicationInterface<'_>, Error> {
+        // Get tap_idx first so its borrow of self ends before we borrow self.interfaces.
         let tap_idx = self.interface_idx(core_id)?;
-        if let ArchitectureInterface::Jtag(probe, ifaces) = &mut self.interfaces {
-            if let Some(probe) = probe.try_as_jtag_probe() {
-                probe.select_target(tap_idx)?;
+        match &mut self.interfaces {
+            ArchitectureInterface::ArmWithRiscv {
+                arm,
+                riscv_mem_ap_cores,
+            } => {
+                if let Some(Some((ap, state))) = riscv_mem_ap_cores.get_mut(core_id) {
+                    let memory = arm.memory_interface(ap).map_err(Error::Arm)?;
+                    let dtm = MemApDtm::new(memory);
+                    Ok(RiscvCommunicationInterface::new(
+                        Box::new(dtm),
+                        &mut state.interface_state,
+                    ))
+                } else {
+                    Err(RiscvError::NoRiscvTarget.into())
+                }
             }
-            if let JtagInterface::Riscv(state) = &mut ifaces[tap_idx] {
-                let factory = probe.try_get_riscv_interface_builder()?;
-                return Ok(factory.attach_auto(&self.target, state)?);
+            ArchitectureInterface::Jtag(probe, ifaces) => {
+                if let Some(probe) = probe.try_as_jtag_probe() {
+                    probe.select_target(tap_idx)?;
+                }
+                if let JtagInterface::Riscv(state) = &mut ifaces[tap_idx] {
+                    let factory = probe.try_get_riscv_interface_builder()?;
+                    Ok(factory.attach_auto(&self.target, state)?)
+                } else {
+                    Err(RiscvError::NoRiscvTarget.into())
+                }
             }
+            ArchitectureInterface::Arm(_) => Err(RiscvError::NoRiscvTarget.into()),
         }
-        Err(RiscvError::NoRiscvTarget.into())
     }
 
     /// Get the Xtensa probe interface.
@@ -750,10 +850,14 @@ impl Session {
     /// NotImplemented if no custom erase sequence exists
     /// Err(e) if the custom erase sequence failed
     pub fn sequence_erase_all(&mut self) -> Result<(), Error> {
-        let ArchitectureInterface::Arm(ref mut interface) = self.interfaces else {
-            return Err(Error::NotImplemented(
-                "Debug Erase Sequence is not implemented for non-ARM targets.",
-            ));
+        let interface_ref = match &mut self.interfaces {
+            ArchitectureInterface::Arm(i) => i.deref_mut(),
+            ArchitectureInterface::ArmWithRiscv { arm, .. } => arm.deref_mut(),
+            ArchitectureInterface::Jtag(..) => {
+                return Err(Error::NotImplemented(
+                    "Debug Erase Sequence is not implemented for non-ARM targets.",
+                ));
+            }
         };
 
         let DebugSequence::Arm(ref debug_sequence) = self.target.debug_sequence else {
@@ -765,18 +869,26 @@ impl Session {
             .ok_or(Error::Arm(ArmError::NotImplemented("Debug Erase Sequence")))?;
 
         tracing::info!("Trying Debug Erase Sequence");
-        let erase_result = erase_sequence.erase_all(interface.deref_mut());
+        let erase_result = erase_sequence.erase_all(interface_ref);
 
         match erase_result {
             Ok(()) => (),
             // In case this happens after unlock. Try to re-attach the probe once.
-            Err(ArmError::ReAttachRequired) => {
-                Self::reattach_arm_interface(interface, debug_sequence)?;
-                // For re-setup debugging on all cores
-                for core_state in &self.cores {
-                    core_state.enable_arm_debug(interface.deref_mut())?;
+            Err(ArmError::ReAttachRequired) => match &mut self.interfaces {
+                ArchitectureInterface::Arm(interface) => {
+                    Self::reattach_arm_interface(interface, debug_sequence)?;
+                    for core_state in &self.cores {
+                        core_state.enable_arm_debug(interface.deref_mut())?;
+                    }
                 }
-            }
+                ArchitectureInterface::ArmWithRiscv { arm, .. } => {
+                    Self::reattach_arm_interface(arm, debug_sequence)?;
+                    for core_state in &self.cores {
+                        core_state.enable_arm_debug(arm.deref_mut())?;
+                    }
+                }
+                ArchitectureInterface::Jtag(..) => {}
+            },
             Err(e) => return Err(Error::Arm(e)),
         }
         tracing::info!("Device Erased Successfully");
@@ -867,9 +979,14 @@ impl Session {
     }
 
     /// Return the `Architecture` of the currently connected chip.
+    /// For ArmWithRiscv (e.g. RP235x_riscv), returns the first core's architecture
+    /// so that RISC-V-only targets report Riscv rather than Arm.
     pub fn architecture(&self) -> Architecture {
         match &self.interfaces {
             ArchitectureInterface::Arm(_) => Architecture::Arm,
+            ArchitectureInterface::ArmWithRiscv { .. } => {
+                self.target.cores[0].core_type.architecture()
+            }
             ArchitectureInterface::Jtag(_, ifaces) => {
                 if let JtagInterface::Riscv(_) = &ifaces[0] {
                     Architecture::Riscv
@@ -889,6 +1006,10 @@ impl Session {
                 match session.core(core) {
                     Ok(mut core) => core.clear_all_hw_breakpoints(),
                     Err(Error::CoreDisabled(_)) => Ok(()),
+                    Err(Error::Riscv(crate::architecture::riscv::communication_interface::RiscvError::Timeout)) => {
+                        tracing::warn!("Core {core} attach or breakpoint clear timed out, skipping");
+                        Ok(())
+                    }
                     Err(err) => Err(err),
                 }
             })

--- a/probe-rs/targets/RP235x.yaml
+++ b/probe-rs/targets/RP235x.yaml
@@ -33,6 +33,36 @@ variants:
     - core1
   flash_algorithms:
   - algo
+- name: RP235x_riscv
+  part: 0x4c9
+  cores:
+  - name: rv0
+    type: riscv
+    core_access_options: !Riscv
+      hart_id: 0
+      mem_ap: !v2 0xa000
+  - name: rv1
+    type: riscv
+    core_access_options: !Riscv
+      hart_id: 1
+      mem_ap: !v2 0xa000
+  memory_map:
+  - !Nvm
+    range:
+      start: 0x10000000
+      end: 0x14000000
+    cores:
+    - rv0
+    - rv1
+    access:
+      boot: true
+  - !Ram
+    range:
+      start: 0x20000000
+      end: 0x20082000
+    cores:
+    - rv0
+    - rv1
 flash_algorithms:
 - name: algo
   description: algo

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -216,6 +216,7 @@ fn create_core(processor: &Processor) -> Result<ProbeCore> {
             Architecture::Riscv => CoreAccessOptions::Riscv(RiscvCoreAccessOptions {
                 hart_id: None,
                 jtag_tap: None,
+                mem_ap: None,
             }),
             Architecture::Xtensa => {
                 CoreAccessOptions::Xtensa(XtensaCoreAccessOptions { jtag_tap: None })


### PR DESCRIPTION
Initial support for attaching to the RISC-V cores on RP235x.

I had to drop +Send from DtmAccess or I would have had to add +Send to ArmMemoryInterface, and I didn't want to do that. You can drop the last 2 commits to see what that looked like.

There's also a bit of "if not core.arm" added because the Arm debug interface isn't entirely separate from the Arm core debug logic.

Best (short) description for how RISC-V debugging works on RP235x is here:
https://www.reddit.com/r/RISCV/comments/1k6mpof/comment/motpkq4/
This impl is based on what OpenOCD does (though it looked significantly easier to do with their architecture).

Note that this currently does not support:
- Flashing
- Changing CPU type
- Autodetection of CPU type

So you still have to load the firmware on first before debugging.
I've tested it via `probe-rs attach`, and it does work (but takes a while to connect. haven't discovered why yet).