### PR TITLE
Add disassemble command to the debug REPL

### DIFF
--- a/changelog/added-disassembly.md
+++ b/changelog/added-disassembly.md
@@ -1,0 +1,1 @@
+Added a `disassemble` command to the debug CLI

--- a/changelog/changed-disassembly-debug-info.md
+++ b/changelog/changed-disassembly-debug-info.md
@@ -1,0 +1,1 @@
+Loosened the requirement for debug info when disassembling.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1178,36 +1178,6 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         self.send_response(request, Ok(Some(ScopesResponseBody { scopes: dap_scopes })))
     }
 
-    /// Attempt to extract disassembled source code to supply the instruction_count required.
-    pub(crate) fn get_disassembled_source(
-        &mut self,
-        target_core: &mut CoreHandle<'_>,
-        // The program_counter where our desired instruction range is based.
-        memory_reference: i64,
-        // The number of bytes offset from the memory reference. Can be zero.
-        byte_offset: i64,
-        // The number of instruction offset from the memory reference. Can be zero.
-        instruction_offset: i64,
-        // The EXACT number of instructions to return in the result.
-        instruction_count: i64,
-    ) -> Result<Vec<dap_types::DisassembledInstruction>, DebuggerError> {
-        let assembly_lines = disassemble_target_memory(
-            target_core,
-            instruction_offset,
-            byte_offset,
-            memory_reference as u64,
-            instruction_count,
-        )?;
-
-        if assembly_lines.is_empty() {
-            Err(DebuggerError::Other(anyhow::anyhow!(
-                "No valid instructions found at memory reference {memory_reference:#010x?}"
-            )))
-        } else {
-            Ok(assembly_lines)
-        }
-    }
-
     /// Implementing the MS DAP for `request Disassemble` has a number of problems:
     /// - The api requires that we return EXACTLY the instruction_count specified.
     ///   - From testing, if we provide slightly fewer or more instructions, the current versions of VSCode will behave in unpredictable ways (frequently causes runaway renderer processes).
@@ -1875,6 +1845,36 @@ impl<P: ProtocolAdapter + ?Sized> DebugAdapter<P> {
             self.dyn_send_event("stopped", serde_json::to_value(event_body).ok())?;
         }
         Ok(program_counter)
+    }
+
+    /// Attempt to extract disassembled source code to supply the instruction_count required.
+    pub(crate) fn get_disassembled_source(
+        &mut self,
+        target_core: &mut CoreHandle<'_>,
+        // The program_counter where our desired instruction range is based.
+        memory_reference: i64,
+        // The number of bytes offset from the memory reference. Can be zero.
+        byte_offset: i64,
+        // The number of instruction offset from the memory reference. Can be zero.
+        instruction_offset: i64,
+        // The EXACT number of instructions to return in the result.
+        instruction_count: i64,
+    ) -> Result<Vec<dap_types::DisassembledInstruction>, DebuggerError> {
+        let assembly_lines = disassemble_target_memory(
+            target_core,
+            instruction_offset,
+            byte_offset,
+            memory_reference as u64,
+            instruction_count,
+        )?;
+
+        if assembly_lines.is_empty() {
+            Err(DebuggerError::Other(anyhow::anyhow!(
+                "No valid instructions found at memory reference {memory_reference:#010x?}"
+            )))
+        } else {
+            Ok(assembly_lines)
+        }
     }
 
     #[tracing::instrument(level = "trace", skip_all)]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands.rs
@@ -16,6 +16,7 @@ use std::{fmt::Display, time::Duration};
 pub(crate) mod backtrace;
 pub(crate) mod breakpoint;
 pub(crate) mod cpu;
+pub(crate) mod disassemble;
 pub(crate) mod embedded_test;
 pub(crate) mod info;
 pub(crate) mod inspect;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/disassemble.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/disassemble.rs
@@ -1,0 +1,93 @@
+use crate::cmd::dap_server::{
+    DebuggerError,
+    debug_adapter::{
+        dap::{
+            dap_types::{/*DisassembleResponseBody,*/ EvaluateArguments, MemoryAddress},
+            repl_commands::{DebugAdapter, EvalResponse, EvalResult, REPL_COMMANDS, ReplCommand},
+            repl_types::ReplCommandArgs,
+        },
+        protocol::ProtocolAdapter,
+    },
+    server::core_data::CoreHandle,
+};
+use linkme::distributed_slice;
+
+#[distributed_slice(REPL_COMMANDS)]
+static DISASSEMBLE: ReplCommand = ReplCommand {
+    command: "disassemble",
+    help_text: "Disassembles the specified instruction count, beginning at the specified address.",
+    requires_target_halted: true,
+    sub_commands: &[],
+    args: &[
+        ReplCommandArgs::Required("start"),
+        ReplCommandArgs::Required("instructions"),
+    ],
+    handler: disassemble,
+};
+
+fn disassemble(
+    target_core: &mut CoreHandle<'_>,
+    command_arguments: &str,
+    _: &EvaluateArguments,
+    adapter: &mut DebugAdapter<dyn ProtocolAdapter + '_>,
+) -> EvalResult {
+    // Current limitations:
+    //
+    // - No support for disassembling a function by its global name, or by a
+    // local variable that points to it
+    //   - Global lookups require either a .symtab or debug_info
+    //   - Local lookups require a debug_info and some idea of the current
+    //   stack frame index; the latter also requires "up" and "down" commands
+    // - No support for doing math on the address or instruction-count
+    //   - Would require parsing an expression, and potentially dereferencing
+    //   many symbol or register values, then doing the offset
+    // - An instruction count is always required
+    //   - When function lookup support is added we could fetch the size as well
+    //   as the address, and go to the end
+
+    let mut input_arguments = command_arguments.split_whitespace();
+    let Some(address_str) = input_arguments.next() else {
+        return Err(DebuggerError::UserMessage(format!(
+            "Invalid parameters {command_arguments:?} (bad address). See the `help` command for more information."
+        )));
+    };
+    let Some(instructions_str) = input_arguments.next() else {
+        return Err(DebuggerError::UserMessage(format!(
+            "Invalid parameters {command_arguments:?} (bad instruction count). See the `help` command for more information."
+        )));
+    };
+
+    let address = if let Some(reg) = address_str.strip_prefix('$') {
+        let Some(register) = target_core.core.registers().all_registers().find(|r| {
+            std::iter::once(r.name().to_string())
+                .chain(r.roles.iter().map(|role| role.to_string()))
+                .any(|name| name.eq_ignore_ascii_case(reg))
+        }) else {
+            return Err(DebuggerError::UserMessage(format!(
+                "Invalid parameter {command_arguments:?}: invalid register."
+            )));
+        };
+        target_core.core.read_core_reg(register)?
+    } else if let Ok(mem_addr) = MemoryAddress::try_from(address_str.trim_start_matches('*')) {
+        mem_addr.0
+    } else {
+        // Try to resolve a global symbol
+        return Err(DebuggerError::Unimplemented);
+    } as i64;
+
+    let instructions: i64 = parse_int::parse(instructions_str).map_err(|error| {
+        DebuggerError::UserMessage(format!(
+            "Invalid instruction count: {instructions_str:?}: {error:?}"
+        ))
+    })?;
+
+    let instructions = adapter.get_disassembled_source(target_core, address, 0, 0, instructions)?;
+
+    Ok(EvalResponse::Message(
+        instructions
+            .iter()
+            .map(|insn| insn.to_string())
+            .collect::<Vec<_>>()
+            .join(""),
+    ))
+}

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/disassemble.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/disassemble.rs
@@ -2,7 +2,7 @@ use crate::cmd::dap_server::{
     DebuggerError,
     debug_adapter::{
         dap::{
-            dap_types::{/*DisassembleResponseBody,*/ EvaluateArguments, MemoryAddress},
+            dap_types::{EvaluateArguments, MemoryAddress},
             repl_commands::{DebugAdapter, EvalResponse, EvalResult, REPL_COMMANDS, ReplCommand},
             repl_types::ReplCommandArgs,
         },
@@ -15,7 +15,7 @@ use linkme::distributed_slice;
 #[distributed_slice(REPL_COMMANDS)]
 static DISASSEMBLE: ReplCommand = ReplCommand {
     command: "disassemble",
-    help_text: "Disassembles the specified instruction count, beginning at the specified address.",
+    help_text: "Disassembles the specified instruction count, beginning at the specified address.  Address forms can be a literal number, with or without a * prefix, or $<register> where <register> is any of the target core's register names.  For example *0x1000 or $r15 or $pc.",
     requires_target_halted: true,
     sub_commands: &[],
     args: &[

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
@@ -95,11 +95,9 @@ pub(crate) fn disassemble_target_memory(
     memory_reference: u64,
     instruction_count: i64,
 ) -> Result<Vec<DisassembledInstruction>, DebuggerError> {
-    let Some(ref debug_info) = target_core.core_data.debug_info else {
-        return Err(DebuggerError::Other(anyhow!(
-            "Cannot disassemble target memory without debug information."
-        )));
-    };
+    use probe_rs::CoreInterface;
+
+    let debug_info = target_core.core_data.debug_info.as_ref();
 
     let instruction_set = target_core.core.instruction_set()?;
     match instruction_set {
@@ -151,7 +149,8 @@ pub(crate) fn disassemble_target_memory(
         // length instructions are not necessarily word-aligned, i.e.
         // in the case of ARM Thumbv2, instructions are embedded into
         // a 16-bit halfword stream.
-        if let Some(source_location) = debug_info.get_source_location(start_from_address)
+        if let Some(info) = debug_info
+            && let Some(source_location) = info.get_source_location(start_from_address)
             && let Some(source_address) = source_location.address
         {
             start_from_address = source_address;
@@ -169,7 +168,10 @@ pub(crate) fn disassemble_target_memory(
     let mut disassembled_instructions: Vec<DisassembledInstruction> = vec![];
     let mut maybe_previous_source_location = None;
     let mut maybe_reference_instruction_index = None;
-    let convert_endianness = debug_info.endianness() == RunTimeEndian::Big;
+    let convert_endianness = match debug_info {
+        Some(di) => di.endianness() == RunTimeEndian::Big,
+        None => target_core.core.endianness()? == probe_rs::Endian::Big,
+    };
 
     let mut instruction_pointer = start_from_address;
     'instruction_loop: while instruction_pointer < read_until_address {
@@ -297,8 +299,9 @@ pub(crate) fn disassemble_target_memory(
                 let mut location = None;
                 let mut line = None;
                 let mut column = None;
-                if let Some(current_source_location) =
-                    debug_info.get_source_location(instruction.address())
+                if let Some(di) = debug_info
+                    && let Some(current_source_location) =
+                        di.get_source_location(instruction.address())
                 {
                     if maybe_previous_source_location.is_none()
                         || maybe_previous_source_location.is_some_and(|previous_source_location| {


### PR DESCRIPTION
Hook up the REPL to the DAP server disassembly support.  Parse an address (either a number or a register reference, but no math and no function lookups yet) and an instruction count, and return a formatted string.

Also remove the requirement for a debug_info in the disassembly helper.  When debugging a raw microcontroller with no binary, we still want to be able to disassemble the raw bytes, even if we don't get source locations.  We do still need the ability to determine endianness, but we can just get it from the running core.

Make the disassembly helper callable from a dyn reference as well.