### PR TITLE
Add SiFive FU740 support

### DIFF
--- a/changelog/added-sifive-fu740-support.md
+++ b/changelog/added-sifive-fu740-support.md
@@ -1,0 +1,1 @@
+Added SiFive FU740-C000 (HiFive Unmatched) support with debug sequences for the e51 monitor core, including ebreakm bootstrap, program buffer memory access, and QSPI0 XIP flash controller handling.

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -1345,8 +1345,6 @@ impl<'state> RiscvCommunicationInterface<'state> {
     /// When set, `halted_access` writes `dcsr.prv = M` after every internal
     /// halt so that program-buffer instructions use physical addresses
     /// regardless of the privilege level at which the hart was interrupted.
-    // Used by vendor sequences (e.g. Nuclei, SiFive) not yet in this branch.
-    #[expect(dead_code)]
     pub(crate) fn set_force_machine_mode_progbuf(&mut self, force: bool) {
         self.state.force_machine_mode_progbuf = force;
     }
@@ -2251,6 +2249,25 @@ impl<'state> RiscvCommunicationInterface<'state> {
         })
     }
 
+    /// Read a CSR via the program buffer, forcing 64-bit abstract-command width.
+    ///
+    /// Unlike [`Self::read_csr_progbuf`], which uses the XLEN mode that has already been
+    /// detected, this method temporarily sets `xlen_64 = true` so that S0 is saved and
+    /// read back with 64-bit abstract commands.  This is necessary when reading CSRs
+    /// (such as MISA) before XLEN has been determined, e.g. in a vendor `on_connect`
+    /// sequence.
+    ///
+    /// On RV32 targets the underlying 64-bit abstract command will fail with
+    /// [`AbstractCommandErrorKind::NotSupported`], which is propagated as an error so that
+    /// callers can handle RV32/RV64 detection gracefully.
+    pub(crate) fn read_csr_progbuf_64(&mut self, address: u16) -> Result<u64, RiscvError> {
+        let saved_xlen = self.state.xlen_64;
+        self.state.xlen_64 = true;
+        let result = self.read_csr_progbuf(address);
+        self.state.xlen_64 = saved_xlen;
+        result
+    }
+
     /// Write a CSR value via the program buffer (fallback when abstract commands are unsupported).
     ///
     /// Writes `value` into S0 then executes `csrw addr, s0` in the program buffer. Width is
@@ -2589,6 +2606,25 @@ impl<'state> RiscvCommunicationInterface<'state> {
     /// Returns a mutable reference to the memory access configuration.
     pub fn memory_access_config(&mut self) -> &mut MemoryAccessConfig {
         &mut self.state.memory_access_config
+    }
+
+    /// Clear the abstractauto register to disable any auto-execution,
+    /// clear cmderr, and invalidate the progbuf cache.
+    ///
+    /// This should be called during session setup to prevent stale autoexec
+    /// state from a previous crashed session from interfering.
+    pub fn clear_abstractauto(&mut self) {
+        if let Err(e) = self.write_dm_register(Abstractauto(0)) {
+            tracing::debug!("Failed to clear abstractauto: {:?}", e);
+        }
+        // Clear any cmderr that may have been caused by stale autoexec.
+        let mut abstractcs_clear = Abstractcs(0);
+        abstractcs_clear.set_cmderr(0x7);
+        if let Err(e) = self.write_dm_register(abstractcs_clear) {
+            tracing::debug!("Failed to clear abstractcs cmderr: {:?}", e);
+        }
+        // Invalidate the progbuf cache so the next operation fully rewrites it.
+        self.state.progbuf_cache = [0u32; 16];
     }
 }
 

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -2656,6 +2656,25 @@ impl<'state> RiscvCommunicationInterface<'state> {
     pub fn memory_access_config(&mut self) -> &mut MemoryAccessConfig {
         &mut self.state.memory_access_config
     }
+
+    /// Clear the abstractauto register to disable any auto-execution,
+    /// clear cmderr, and invalidate the progbuf cache.
+    ///
+    /// This should be called during session setup to prevent stale autoexec
+    /// state from a previous crashed session from interfering.
+    pub fn clear_abstractauto(&mut self) {
+        if let Err(e) = self.write_dm_register(Abstractauto(0)) {
+            tracing::debug!("Failed to clear abstractauto: {:?}", e);
+        }
+        // Clear any cmderr that may have been caused by stale autoexec.
+        let mut abstractcs_clear = Abstractcs(0);
+        abstractcs_clear.set_cmderr(0x7);
+        if let Err(e) = self.write_dm_register(abstractcs_clear) {
+            tracing::debug!("Failed to clear abstractcs cmderr: {:?}", e);
+        }
+        // Invalidate the progbuf cache so the next operation fully rewrites it.
+        self.state.progbuf_cache = [0u32; 16];
+    }
 }
 
 pub(crate) trait LargeRegister {

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -848,6 +848,10 @@ impl<X: XlenMode> CoreInterface for RiscvCore<'_, X> {
         X::core_type()
     }
 
+    fn is_64_bit(&self) -> bool {
+        matches!(X::core_type(), CoreType::Riscv64)
+    }
+
     fn instruction_set(&mut self) -> Result<InstructionSet, Error> {
         // Check if the Bit at position 2 (signifies letter C, for compressed) is set.
         let misa_val = self.interface.read_csr(0x301)?;

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -854,6 +854,10 @@ impl<X: XlenMode> CoreInterface for RiscvCore<'_, X> {
         X::core_type()
     }
 
+    fn is_64_bit(&self) -> bool {
+        matches!(X::core_type(), CoreType::Riscv64)
+    }
+
     fn instruction_set(&mut self) -> Result<InstructionSet, Error> {
         // Check if the Bit at position 2 (signifies letter C, for compressed) is set.
         let misa_val = self.interface.read_csr(0x301)?;

--- a/probe-rs/src/vendor/mod.rs
+++ b/probe-rs/src/vendor/mod.rs
@@ -29,6 +29,7 @@ pub mod nordicsemi;
 pub mod nxp;
 pub mod raspberrypi;
 pub mod renesas;
+pub mod sifive;
 pub mod sifli;
 pub mod silabs;
 pub mod st;
@@ -84,6 +85,7 @@ static VENDORS: LazyLock<RwLock<Vec<&'static dyn Vendor>>> = LazyLock::new(|| {
         &raspberrypi::RaspberryPi,
         &st::St,
         &vorago::Vorago,
+        &sifive::Sifive,
         &sifli::Sifli,
         &renesas::Renesas,
     ];

--- a/probe-rs/src/vendor/mod.rs
+++ b/probe-rs/src/vendor/mod.rs
@@ -30,6 +30,7 @@ pub mod nuclei;
 pub mod nxp;
 pub mod raspberrypi;
 pub mod renesas;
+pub mod sifive;
 pub mod sifli;
 pub mod silabs;
 pub mod st;
@@ -96,6 +97,7 @@ static VENDORS: LazyLock<RwLock<Vec<&'static dyn Vendor>>> = LazyLock::new(|| {
         &raspberrypi::RaspberryPi,
         &st::St,
         &vorago::Vorago,
+        &sifive::Sifive,
         &sifli::Sifli,
         &renesas::Renesas,
         &wch::Wch,

--- a/probe-rs/src/vendor/sifive/mod.rs
+++ b/probe-rs/src/vendor/sifive/mod.rs
@@ -1,0 +1,42 @@
+//! SiFive vendor support.
+
+use probe_rs_target::Chip;
+
+use crate::{
+    config::{DebugSequence, Registry},
+    error::Error,
+    vendor::Vendor,
+};
+
+pub mod sequences;
+
+/// SiFive vendor.
+#[derive(docsplay::Display)]
+pub struct Sifive;
+
+impl Vendor for Sifive {
+    fn try_create_debug_sequence(&self, _chip: &Chip) -> Option<DebugSequence> {
+        // SiFive chips share the default RISC-V debug sequence for now.
+        // Chip-specific sequences will be added in a follow-up commit.
+        None
+    }
+
+    fn try_detect_riscv_chip(
+        &self,
+        _registry: &Registry,
+        _probe: &mut crate::architecture::riscv::communication_interface::RiscvCommunicationInterface,
+        idcode: u32,
+    ) -> Result<Option<String>, Error> {
+        // FU740-C000 JTAG IDCODE: 0x20000913
+        // Version=2, Part=0, Manufacturer=0x489 (SiFive, JEP106 bank 10 id 0x09)
+        if idcode == 0x2000_0913 {
+            tracing::info!(
+                "SifiveVendor: detected FU740-C000 via IDCODE {:#010x}",
+                idcode
+            );
+            return Ok(Some("FU740-C000".to_string()));
+        }
+
+        Ok(None)
+    }
+}

--- a/probe-rs/src/vendor/sifive/mod.rs
+++ b/probe-rs/src/vendor/sifive/mod.rs
@@ -15,10 +15,12 @@ pub mod sequences;
 pub struct Sifive;
 
 impl Vendor for Sifive {
-    fn try_create_debug_sequence(&self, _chip: &Chip) -> Option<DebugSequence> {
-        // SiFive chips share the default RISC-V debug sequence for now.
-        // Chip-specific sequences will be added in a follow-up commit.
-        None
+    fn try_create_debug_sequence(&self, chip: &Chip) -> Option<DebugSequence> {
+        if chip.name.starts_with("FU740") {
+            Some(DebugSequence::Riscv(sequences::SifiveSequence::create()))
+        } else {
+            None
+        }
     }
 
     fn try_detect_riscv_chip(

--- a/probe-rs/src/vendor/sifive/sequences.rs
+++ b/probe-rs/src/vendor/sifive/sequences.rs
@@ -1,13 +1,215 @@
 //! Debug sequences for SiFive RISC-V targets.
-//!
-//! The SiFive FU740 uses RISC-V Debug Spec 0.13.2.  This file is reserved
-//! for chip-specific extensions that will be added in follow-up commits.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-use crate::architecture::riscv::sequences::{DefaultRiscvSequence, RiscvDebugSequence};
+use std::time::Duration;
 
-/// Returns the default debug sequence for SiFive chips.
-pub fn sifive_sequence() -> Arc<dyn RiscvDebugSequence> {
-    DefaultRiscvSequence::create()
+use crate::architecture::riscv::communication_interface::{
+    AccessRegisterCommand, MemoryAccessMethod, RiscvBusAccess, RiscvCommunicationInterface,
+};
+use crate::architecture::riscv::sequences::RiscvDebugSequence;
+use crate::core::RegisterId;
+use crate::memory::MemoryInterface;
+
+/// QSPI0 controller base address on the FU740-C000.
+///
+/// The onboard IS25WP256D SPI NOR flash is connected to QSPI0.
+/// Its memory-mapped (XIP) window starts at 0x20000000.
+const QSPI0_BASE: u64 = 0x1004_0000;
+
+/// Offset of the Flash-Controller register (`fctrl`) within the QSPI block.
+///
+/// Bit 0: 1 = enable memory-mapped (XIP) flash access.
+const QSPI_FCTRL: u64 = 0x60;
+
+/// Bit 0 of `fctrl`: set to enable XIP, clear to disable.
+const FCTRL_EN: u32 = 1;
+
+/// Debug sequence for SiFive FU740-C000 (HiFive Unmatched).
+///
+/// # Program-buffer bootstrap (`dcsr.ebreakm`)
+///
+/// The FU740 Debug Module (Debug Spec 0.13.2) returns `cmderr=2` (not
+/// supported) for abstract CSR access, but implements abstract GPR access
+/// natively.  Program buffer execution requires `dcsr.ebreakm=1` so that
+/// the `ebreak` at the end of the buffer enters debug mode; without it the
+/// ebreak causes an M-mode exception.
+///
+/// `on_connect` sets `ebreakm=1` (and `prv=M`) using a minimal bootstrap:
+///
+/// 1. Write mask `0x8003` to x9 (s1) via abstract GPR command — this does
+///    not use the program buffer.
+/// 2. Execute progbuf: `csrrs x0, dcsr, x9` — atomically ORs the mask into
+///    DCSR before the subsequent `ebreak` runs, so the ebreak correctly
+///    enters debug mode.
+///
+/// # Program-buffer memory access
+///
+/// The FU740 System Bus (SB) is absent (sbversion=0), so all memory
+/// accesses go through the program buffer.
+///
+/// # QSPI0 XIP re-enable
+///
+/// Linux's SPI NOR driver disables XIP mode (clears `fctrl` bit 0) when it
+/// takes ownership of the QSPI0 controller.  On connect this sequence saves
+/// the current `fctrl` value and sets bit 0, re-enabling the XIP window so
+/// that probe-rs can read from 0x20000000 via program-buffer loads.
+#[derive(Debug)]
+pub struct SifiveSequence {
+    /// Saved `fctrl` value, kept for documentation and potential future restore.
+    saved_fctrl: Mutex<Option<u32>>,
+}
+
+impl SifiveSequence {
+    /// Creates the SiFive FU740 debug sequence.
+    pub fn create() -> Arc<dyn RiscvDebugSequence> {
+        Arc::new(Self {
+            saved_fctrl: Mutex::new(None),
+        })
+    }
+
+    /// Bootstrap `dcsr.ebreakm=1` and `dcsr.prv=M` via program buffer.
+    ///
+    /// The FU740 DM does not support abstract CSR access (cmderr=2 for any
+    /// CSR regno).  Abstract GPR access IS supported natively.  This method
+    /// uses that distinction to set the two critical DCSR bits before any
+    /// program-buffer memory operation is attempted.
+    fn bootstrap_ebreakm(interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
+        // S1 = x9, abstract register address 0x1009.
+        // 0x8003 = ebreakm (bit 15) | prv=M (bits 1:0 = 0b11).
+        const S1_REGNO: RegisterId = RegisterId(0x1009);
+        const DCSR_EBREAKM_PRV_M: u32 = (1 << 15) | 0x3;
+
+        // csrrs x0, dcsr(0x7b0), x9  — OR mask into DCSR, write old value to x0 (discarded).
+        // Encoding: [CSR:12][rs1:5][funct3:3][rd:5][opcode:7]
+        //           [0x7b0][01001][010][00000][1110011] = 0x7B04A073
+        const CSRRS_X0_DCSR_X9: u32 = 0x7B04A073;
+
+        // Step 1: Write the mask to GPR x9 (s1) via abstract GPR command.
+        // Abstract GPR access is implemented natively by the FU740 DM and
+        // does NOT use the program buffer, so ebreakm=0 is not a problem.
+        interface
+            .abstract_cmd_register_write(S1_REGNO, DCSR_EBREAKM_PRV_M)
+            .map_err(crate::Error::Riscv)?;
+
+        // Step 2: Set up the program buffer with the csrrs instruction.
+        // schedule_setup_program_buffer appends ebreak automatically.
+        interface
+            .schedule_setup_program_buffer(&[CSRRS_X0_DCSR_X9])
+            .map_err(crate::Error::Riscv)?;
+
+        // Step 3: Execute the program buffer (no data transfer, postexec=true).
+        // The csrrs instruction sets ebreakm=1 atomically *before* ebreak runs,
+        // so the ebreak correctly enters debug mode.
+        let mut cmd = AccessRegisterCommand(0);
+        cmd.set_cmd_type(0);
+        cmd.set_aarsize(RiscvBusAccess::A32); // ignored when transfer=false
+        cmd.set_postexec(true);
+        cmd.set_transfer(false);
+        interface
+            .execute_abstract_command(cmd.0)
+            .map_err(crate::Error::Riscv)?;
+
+        tracing::debug!("SifiveSequence: dcsr.ebreakm=1 and prv=M set via progbuf bootstrap");
+        Ok(())
+    }
+}
+
+impl RiscvDebugSequence for SifiveSequence {
+    /// Override reset_system_and_halt to avoid ndmreset on the FU740.
+    ///
+    /// The FU740's ndmreset resets ALL harts (including the U74 cores running
+    /// Linux) and can leave the debug module in an inconsistent state.
+    /// Instead we simply halt hart 0 (which is already halted or in OpenSBI's
+    /// WFI loop) and re-bootstrap ebreakm.  The flash algorithm's Init
+    /// function takes care of disabling XIP and configuring the SPI controller.
+    fn reset_system_and_halt(
+        &self,
+        interface: &mut RiscvCommunicationInterface,
+        timeout: Duration,
+    ) -> Result<(), crate::Error> {
+        // Safety: clear stale abstractauto and cmderr from previous sessions.
+        interface.clear_abstractauto();
+
+        // Perform hart reset to return to a clean state.  This is
+        // necessary because a previous flash algorithm session may have
+        // left the hart's PC in the middle of algorithm code that no
+        // longer exists in RAM.
+        interface.reset_hart_and_halt(timeout)?;
+
+        // The reset cleared dcsr.ebreakm.  Re-bootstrap it so that the
+        // flash algorithm's return ebreak enters debug mode.
+        if let Err(e) = Self::bootstrap_ebreakm(interface) {
+            tracing::warn!(
+                "SifiveSequence::reset_system_and_halt: bootstrap_ebreakm failed: {:?}",
+                e
+            );
+        }
+
+        tracing::debug!("SifiveSequence: reset complete, dcsr.ebreakm=1 re-established");
+        Ok(())
+    }
+
+    fn on_connect(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
+        // Safety: clear any stale abstractauto left by a previous session.
+        // If autoexec was enabled and the session crashed, DATA0 reads during
+        // bootstrap would trigger stale abstract commands and cause exceptions.
+        interface.clear_abstractauto();
+
+        // Step 1: Force program buffer for all access widths.
+        // The FU740 has no System Bus (sbversion=0); all memory access must
+        // go through the program buffer.
+        let config = interface.memory_access_config();
+        for width in [
+            RiscvBusAccess::A8,
+            RiscvBusAccess::A16,
+            RiscvBusAccess::A32,
+            RiscvBusAccess::A64,
+            RiscvBusAccess::A128,
+        ] {
+            config.set_default_method(width, MemoryAccessMethod::ProgramBuffer);
+        }
+
+        // Step 2: Bootstrap dcsr.ebreakm=1 and dcsr.prv=M for hart 0 (S7/E51).
+        //
+        // Hart 0 is the only configured core for flashing; it is permanently
+        // parked in OpenSBI's M-mode WFI loop.  Program buffer execution
+        // requires ebreakm=1 so that the ebreak at the end enters debug mode
+        // instead of causing an M-mode exception (cmderr=4 / HaltResume).
+        if let Err(e) = Self::bootstrap_ebreakm(interface) {
+            tracing::warn!(
+                "SifiveSequence: bootstrap_ebreakm failed (will try to continue): {:?}",
+                e
+            );
+        }
+
+        // Step 3: Re-enable QSPI0 XIP mode so that the flash window at
+        // 0x20000000 is readable via program-buffer load instructions.
+        //
+        // Linux's SPI NOR driver clears fctrl[0] when it takes over QSPI0.
+        let fctrl_addr = QSPI0_BASE + QSPI_FCTRL;
+        let current_fctrl = interface.read_word_32(fctrl_addr)?;
+
+        tracing::debug!(
+            "SifiveSequence: QSPI0 fctrl @ {:#010x} = {:#010x}",
+            fctrl_addr,
+            current_fctrl
+        );
+
+        if let Ok(mut saved) = self.saved_fctrl.lock() {
+            *saved = Some(current_fctrl);
+        }
+
+        if current_fctrl & FCTRL_EN == 0 {
+            tracing::info!(
+                "SifiveSequence: QSPI0 XIP disabled (fctrl={:#010x}), re-enabling for flash access",
+                current_fctrl
+            );
+            interface.write_word_32(fctrl_addr, current_fctrl | FCTRL_EN)?;
+        } else {
+            tracing::debug!("SifiveSequence: QSPI0 XIP already enabled");
+        }
+
+        Ok(())
+    }
 }

--- a/probe-rs/src/vendor/sifive/sequences.rs
+++ b/probe-rs/src/vendor/sifive/sequences.rs
@@ -1,0 +1,13 @@
+//! Debug sequences for SiFive RISC-V targets.
+//!
+//! The SiFive FU740 uses RISC-V Debug Spec 0.13.2.  This file is reserved
+//! for chip-specific extensions that will be added in follow-up commits.
+
+use std::sync::Arc;
+
+use crate::architecture::riscv::sequences::{DefaultRiscvSequence, RiscvDebugSequence};
+
+/// Returns the default debug sequence for SiFive chips.
+pub fn sifive_sequence() -> Arc<dyn RiscvDebugSequence> {
+    DefaultRiscvSequence::create()
+}

--- a/probe-rs/src/vendor/sifive/sequences.rs
+++ b/probe-rs/src/vendor/sifive/sequences.rs
@@ -46,7 +46,11 @@ const FCTRL_EN: u32 = 1;
 /// # Program-buffer memory access
 ///
 /// The FU740 System Bus (SB) is absent (sbversion=0), so all memory
-/// accesses go through the program buffer.
+/// accesses go through the program buffer.  When Linux is running, halts
+/// occur in S-mode, and `dcsr.prv` reflects that.  The bootstrap also sets
+/// `prv=M`, and `on_connect` calls `set_force_machine_mode_progbuf(true)`
+/// so `halted_access` refreshes `prv=M` (via abstract GPR CSR access with
+/// the correct aarsize after xlen_64 is set) on every halt.
 ///
 /// # QSPI0 XIP re-enable
 ///
@@ -183,7 +187,37 @@ impl RiscvDebugSequence for SifiveSequence {
             );
         }
 
-        // Step 3: Re-enable QSPI0 XIP mode so that the flash window at
+        // Step 3: Detect XLEN from MISA *before* enabling force_machine_mode_progbuf.
+        //
+        // On RV64 the DM requires aarsize=3 (64-bit) for abstract CSR commands.
+        // `halted_access` reads DCSR to set prv=M; using A32 on an RV64 target
+        // causes cmderr=2.  We must set xlen_64 first so halted_access uses A64.
+        //
+        // Reading MISA via program buffer works because ebreakm is now 1 (from
+        // step 2) and hart 0 is in M-mode (OpenSBI WFI loop).
+        if let Ok(misa) = interface.read_csr_progbuf_64(0x301) {
+            let mxl = misa >> 62;
+            if mxl == 2 {
+                tracing::info!(
+                    "SifiveSequence: detected RV64 (MISA={:#018x}), setting xlen_64",
+                    misa
+                );
+                interface.set_xlen_64(true);
+            } else {
+                tracing::debug!("SifiveSequence: MISA={:#018x}, MXL={}", misa, mxl);
+            }
+        }
+
+        // Step 4: Enable force_machine_mode_progbuf.
+        //
+        // Now that xlen_64 is set, halted_access will use A64 when reading and
+        // writing DCSR, which the FU740 DM requires for abstract CSR commands.
+        // (Hart 0 is parked in OpenSBI's M-mode WFI loop, so prv is already M;
+        // this is a safety net for sessions where Linux halts a U74 core in S-mode.)
+        tracing::debug!("SifiveSequence: enabling force_machine_mode_progbuf");
+        interface.set_force_machine_mode_progbuf(true);
+
+        // Step 5: Re-enable QSPI0 XIP mode so that the flash window at
         // 0x20000000 is readable via program-buffer load instructions.
         //
         // Linux's SPI NOR driver clears fctrl[0] when it takes over QSPI0.

--- a/probe-rs/src/vendor/sifive/sequences.rs
+++ b/probe-rs/src/vendor/sifive/sequences.rs
@@ -46,7 +46,11 @@ const FCTRL_EN: u32 = 1;
 /// # Program-buffer memory access
 ///
 /// The FU740 System Bus (SB) is absent (sbversion=0), so all memory
-/// accesses go through the program buffer.
+/// accesses go through the program buffer.  When Linux is running, halts
+/// occur in S-mode, and `dcsr.prv` reflects that.  The bootstrap also sets
+/// `prv=M`, and `on_connect` calls `set_force_machine_mode_progbuf(true)`
+/// so `halted_access` refreshes `prv=M` (via abstract GPR CSR access with
+/// the correct aarsize after xlen_64 is set) on every halt.
 ///
 /// # QSPI0 XIP re-enable
 ///
@@ -128,7 +132,7 @@ impl RiscvDebugSequence for SifiveSequence {
         interface: &mut RiscvCommunicationInterface,
         timeout: Duration,
     ) -> Result<(), crate::Error> {
-        // Safety: clear stale abstractauto and cmderr from previous sessions.
+        // Clear stale abstractauto and cmderr from previous sessions.
         interface.clear_abstractauto();
 
         // Perform hart reset to return to a clean state.  This is
@@ -151,7 +155,7 @@ impl RiscvDebugSequence for SifiveSequence {
     }
 
     fn on_connect(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
-        // Safety: clear any stale abstractauto left by a previous session.
+        // Clear any stale abstractauto left by a previous session.
         // If autoexec was enabled and the session crashed, DATA0 reads during
         // bootstrap would trigger stale abstract commands and cause exceptions.
         interface.clear_abstractauto();
@@ -183,7 +187,37 @@ impl RiscvDebugSequence for SifiveSequence {
             );
         }
 
-        // Step 3: Re-enable QSPI0 XIP mode so that the flash window at
+        // Step 3: Detect XLEN from MISA *before* enabling force_machine_mode_progbuf.
+        //
+        // On RV64 the DM requires aarsize=3 (64-bit) for abstract CSR commands.
+        // `halted_access` reads DCSR to set prv=M; using A32 on an RV64 target
+        // causes cmderr=2.  We must set xlen_64 first so halted_access uses A64.
+        //
+        // Reading MISA via program buffer works because ebreakm is now 1 (from
+        // step 2) and hart 0 is in M-mode (OpenSBI WFI loop).
+        if let Ok(misa) = interface.read_csr_progbuf_64(0x301) {
+            let mxl = misa >> 62;
+            if mxl == 2 {
+                tracing::info!(
+                    "SifiveSequence: detected RV64 (MISA={:#018x}), setting xlen_64",
+                    misa
+                );
+                interface.set_xlen_64(true);
+            } else {
+                tracing::debug!("SifiveSequence: MISA={:#018x}, MXL={}", misa, mxl);
+            }
+        }
+
+        // Step 4: Enable force_machine_mode_progbuf.
+        //
+        // Now that xlen_64 is set, halted_access will use A64 when reading and
+        // writing DCSR, which the FU740 DM requires for abstract CSR commands.
+        // (Hart 0 is parked in OpenSBI's M-mode WFI loop, so prv is already M;
+        // this is a safety net for sessions where Linux halts a U74 core in S-mode.)
+        tracing::debug!("SifiveSequence: enabling force_machine_mode_progbuf");
+        interface.set_force_machine_mode_progbuf(true);
+
+        // Step 5: Re-enable QSPI0 XIP mode so that the flash window at
         // 0x20000000 is readable via program-buffer load instructions.
         //
         // Linux's SPI NOR driver clears fctrl[0] when it takes over QSPI0.

--- a/probe-rs/targets/SiFive_FU740.yaml
+++ b/probe-rs/targets/SiFive_FU740.yaml
@@ -1,0 +1,83 @@
+name: SiFive FU740
+# JEP106: SiFive, same as fe310
+manufacturer:
+  id: 0x9
+  cc: 0x9
+variants:
+- name: FU740-C000
+  cores:
+  # Hart 0: SiFive S7 M-mode monitor core.
+  # OpenSBI parks this hart in a WFI loop (M-mode), so it is always halted
+  # when JTAG connects.  Its DTIM (8 KB at 0x01000000) provides the work
+  # area for the flash algorithm.  U74 harts (1-4) run Linux in S-mode and
+  # are excluded here because their dcsr.ebreakm bootstrap would require
+  # halting live Linux cores; they can be added later for interactive debug.
+  - name: e51
+    type: riscv64
+    core_access_options: !Riscv
+      hart_id: 0
+  jtag:
+    # FU740 has a single RISC-V JTAG TAP with 5-bit IR (RISC-V Debug Spec default).
+    # IDCODE: 0x20000913 (SiFive, version 2).
+    # force_scan_chain bypasses the JTAG auto-detection DR scan, which can
+    # occasionally be unreliable on first connect after power-up.
+    scan_chain:
+    - ir_len: 5
+    force_scan_chain: true
+  memory_map:
+  # S7 DTIM — 8 KB, hart-0-private, always present.
+  # Used as work area for the flash algorithm (loads here before executing).
+  - !Ram
+    range:
+      start: 0x01000000
+      end: 0x01002000
+    cores:
+    - e51
+  # L2 LIM — up to 2 MB, software-configurable partition of the L2 cache.
+  # At Linux boot some portion (default 2 MB) is mapped as LIM.
+  - !Ram
+    range:
+      start: 0x08000000
+      end: 0x08200000
+    cores:
+    - e51
+  # QSPI0 XIP window — IS25WP256D SPI NOR flash, 32 MB.
+  # Primary boot device; holds FSBL, OpenSBI, U-Boot, and Linux fitImage.
+  - !Nvm
+    range:
+      start: 0x20000000
+      end: 0x22000000
+    cores:
+    - e51
+    access:
+      boot: true
+  flash_algorithms:
+  - fu740-qspi0-flasher
+flash_algorithms:
+- name: fu740-qspi0-flasher
+  description: >
+    SiFive FU740 QSPI0 flash algorithm for IS25WP256D (32 MB).
+    Native RV64 FESPI driver targeting the QSPI0 controller at 0x10040000.
+    Implements Init, EraseSector (4 KB), ProgramPage (256 B), and UnInit
+    with automatic XIP disable/re-enable.
+  default: true
+  instructions: FwUAAANFhSEZ4QVFgoAdZRMFBQ2CgJcFAACDxSUgpclBEQbktwUEELBF408G/hlGsMUD5kUHBYpt3glGkM2wReNPBv4TBgACsMWwReNPBv4TFoUCYZKwxbBF408G/hMWBQNhkrDFsEXjTwb+E3X1D6jFA+VFBwWJbd0jrAUAlwAAAOeAwBQBRaJgQQGCgAVFgoABEQbsIugm5BcFAAATBOUXg0UEADcFBBCJxUxAbNGFRSzRhUV9NpFGIwC0AGN01gRkUQNmBQZ5mjDRNwYEECzJjUUMwrcFCAChBSzBIywFAINlRQeFie3dlwAAAOeAAA4FRSMApABEwAFF4mBCZKJkBWGCgJcAAADngGAQlwYAAIPGphDJxkERBuS3BgQQuEbjTwf+GUe4xgPnRgcFi23fCUeYzrhG408H/glHuMa4RuNPB/4TF4UCYZO4xrhG408H/hMXBQNhk7jGuEbjTwf+E3X1D6jGkc2CFRPVBQIylYNFBgC4RuNPB/4FBqzG4xmm/gPlRgcFiW3dI6wGAJcAAADngKADAUWiYEEBgoAFRYKAFwUAAJMFRQcDxQUAGckBRdBBtwYEEPDSBUaw0iOABQCCgAVFgoA3BQQQg2UFBN2ZLMGJRQzNLEXjzwX+lUUsxWxF488F/ixF488F/iMkBQRsRePPBf6Fif31IywFACxBk+WFACzBgoBBEQbkIuAACAAAAAAAAAAAAAAAAA==
+  pc_init: 0x92
+  pc_uninit: 0x1a4
+  pc_program_page: 0x10e
+  pc_erase_sector: 0x16
+  pc_erase_all: 0x0
+  data_section_offset: 0x218
+  flash_properties:
+    address_range:
+      start: 0x20000000
+      end: 0x22000000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 30000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+  cores:
+  - e51

--- a/probe-rs/targets/SiFive_FU740.yaml
+++ b/probe-rs/targets/SiFive_FU740.yaml
@@ -1,0 +1,84 @@
+name: SiFive FU740
+# JEP106: SiFive, same as fe310
+manufacturer:
+  id: 0x9
+  cc: 0x9
+variants:
+- name: FU740-C000
+  cores:
+  # Hart 0: SiFive S7 M-mode monitor core.
+  # OpenSBI parks this hart in a WFI loop (M-mode), so it is always halted
+  # when JTAG connects.  Its DTIM (8 KB at 0x01000000) provides the work
+  # area for the flash algorithm.  U74 harts (1-4) run Linux in S-mode and
+  # are excluded here because their dcsr.ebreakm bootstrap would require
+  # halting live Linux cores; they can be added later for interactive debug.
+  - name: e51
+    type: riscv64
+    core_access_options: !Riscv
+      hart_id: 0
+  jtag:
+    # FU740 has a single RISC-V JTAG TAP with 5-bit IR (RISC-V Debug Spec default).
+    # IDCODE: 0x20000913 (SiFive, version 2).
+    # force_scan_chain bypasses the JTAG auto-detection DR scan, which can
+    # occasionally be unreliable on first connect after power-up.
+    scan_chain:
+    - ir_len: 5
+    force_scan_chain: true
+  memory_map:
+  # S7 DTIM — 8 KB, hart-0-private, always present.
+  # Used as work area for the flash algorithm (loads here before executing).
+  - !Ram
+    range:
+      start: 0x01000000
+      end: 0x01002000
+    cores:
+    - e51
+  # L2 LIM — up to 2 MB, software-configurable partition of the L2 cache.
+  # At Linux boot some portion (default 2 MB) is mapped as LIM.
+  - !Ram
+    range:
+      start: 0x08000000
+      end: 0x08200000
+    cores:
+    - e51
+  # QSPI0 XIP window — IS25WP256D SPI NOR flash, 32 MB.
+  # Primary boot device; holds FSBL, OpenSBI, U-Boot, and Linux fitImage.
+  - !Nvm
+    range:
+      start: 0x20000000
+      end: 0x22000000
+    cores:
+    - e51
+    access:
+      boot: true
+  flash_algorithms:
+  - fu740-qspi0-flasher
+flash_algorithms:
+- name: fu740-qspi0-flasher
+  description: >
+    SiFive FU740 QSPI0 flash algorithm for IS25WP256D (32 MB).
+    Native RV64 FESPI driver targeting the QSPI0 controller at 0x10040000.
+    Implements Init, EraseSector (4 KB), ProgramPage (256 B), and UnInit
+    with automatic XIP disable/re-enable.
+  default: true
+  load_address: 0x01000020
+  instructions: FwUAAANFhSEZ4QVFgoAdZRMFBQ2CgJcFAACDxSUgpclBEQbktwUEELBF408G/hlGsMUD5kUHBYpt3glGkM2wReNPBv4TBgACsMWwReNPBv4TFoUCYZKwxbBF408G/hMWBQNhkrDFsEXjTwb+E3X1D6jFA+VFBwWJbd0jrAUAlwAAAOeAwBQBRaJgQQGCgAVFgoABEQbsIugm5BcFAAATBOUXg0UEADcFBBCJxUxAbNGFRSzRhUV9NpFGIwC0AGN01gRkUQNmBQZ5mjDRNwYEECzJjUUMwrcFCAChBSzBIywFAINlRQeFie3dlwAAAOeAAA4FRSMApABEwAFF4mBCZKJkBWGCgJcAAADngGAQlwYAAIPGphDJxkERBuS3BgQQuEbjTwf+GUe4xgPnRgcFi23fCUeYzrhG408H/glHuMa4RuNPB/4TF4UCYZO4xrhG408H/hMXBQNhk7jGuEbjTwf+E3X1D6jGkc2CFRPVBQIylYNFBgC4RuNPB/4FBqzG4xmm/gPlRgcFiW3dI6wGAJcAAADngKADAUWiYEEBgoAFRYKAFwUAAJMFRQcDxQUAGckBRdBBtwYEEPDSBUaw0iOABQCCgAVFgoA3BQQQg2UFBN2ZLMGJRQzNLEXjzwX+lUUsxWxF488F/ixF488F/iMkBQRsRePPBf6Fif31IywFACxBk+WFACzBgoBBEQbkIuAACAAAAAAAAAAAAAAAAA==
+  pc_init: 0x92
+  pc_uninit: 0x1a4
+  pc_program_page: 0x10e
+  pc_erase_sector: 0x16
+  pc_erase_all: 0x0
+  data_section_offset: 0x218
+  flash_properties:
+    address_range:
+      start: 0x20000000
+      end: 0x22000000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 30000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+  cores:
+  - e51


### PR DESCRIPTION
This adds the SiFive Unmatched which contains FU740 cores. This was large validated and tested by @ArthurHeymans on actual hardware.