### PR TITLE
Semihosting: Fixed truncate flag being incorrectly set

### DIFF
--- a/fixed-semihosting.md
+++ b/fixed-semihosting.md
@@ -1,0 +1,1 @@
+Fixed `truncate` flag in semihosting, which was incorrectly set for cases that didn't require write access. 

--- a/probe-rs-tools/src/bin/probe-rs/rpc/utils/semihosting.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/utils/semihosting.rs
@@ -225,7 +225,11 @@ impl SemihostingFileManager {
     fn open_file(&self, path: &str, mode: &str) -> Option<FileHandle> {
         let mut options = File::options();
         match mode {
-            "r" | "rb" => options.read(true).write(false).truncate(true).create(false),
+            "r" | "rb" => options
+                .read(true)
+                .write(false)
+                .truncate(false)
+                .create(false),
             "r+" | "r+b" => options.read(true).write(true).truncate(true).create(false),
             "w" | "wb" => options.read(false).write(true).truncate(true).create(true),
             "w+" | "w+b" => options.read(true).write(true).truncate(true).create(true),


### PR DESCRIPTION
The 'truncate' flag was set incorrectly here for the read operation, causing it to fail. 

Looking at std::fs, for implementation of at least the unix and windows file drivers:

For unix, at `sys/fs/unix.rs:1306`, we require that `!truncate || !create || !create_new` if `!write`
For windows, at `sys/fs/windows.rs:312 => sys/fs/windows.rs:289`, we require the same. 

Hence, I conclude that it's always illegal to have the `truncate` flag set, if !write. 

I've only tested this on MacOS, and only for the read case.