### PR TITLE
Fix Xtensa unwinding in presence of unwind info

### DIFF
--- a/changelog/fixed-xtensa-debuginfo-unwinding.md
+++ b/changelog/fixed-xtensa-debuginfo-unwinding.md
@@ -1,0 +1,1 @@
+Fixed unwinding Xtensa stack frames when unwind info is available.

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -12,10 +12,7 @@ use gimli::{
     read::RegisterRule,
 };
 use object::read::{Object, ObjectSection};
-use probe_rs::{
-    CoreRegister, Error, InstructionSet, MemoryInterface, RegisterDataType, RegisterRole,
-    RegisterValue, UnwindRule,
-};
+use probe_rs::{CoreRegister, Error, InstructionSet, MemoryInterface, RegisterRole, RegisterValue};
 use std::{
     borrow, cmp::Ordering, num::NonZeroU64, ops::ControlFlow, path::Path, rc::Rc, str::from_utf8,
 };
@@ -735,6 +732,7 @@ impl DebugInfo {
                     unwind_info,
                     cfa,
                     memory,
+                    exception_handler,
                 ) {
                     Err(error) => {
                         tracing::error!("{:?}", &error);
@@ -1151,6 +1149,7 @@ pub fn unwind_register(
     unwind_info: &gimli::UnwindTableRow<GimliReaderOffset>,
     unwind_cfa: Option<u64>,
     memory: &mut dyn MemoryInterface,
+    exception_handler: &dyn ExceptionInterface,
 ) -> Result<Option<RegisterValue>, Error> {
     // If we do not have unwind info, or there is no register rule, then use UnwindRule::Undefined.
     let register_rule = debug_register
@@ -1164,6 +1163,7 @@ pub fn unwind_register(
         unwind_cfa,
         memory,
         register_rule,
+        exception_handler,
     )
 }
 
@@ -1173,101 +1173,25 @@ fn unwind_register_using_rule(
     unwind_cfa: Option<u64>,
     memory: &mut dyn MemoryInterface,
     register_rule: gimli::RegisterRule<usize>,
+    exception_handler: &dyn ExceptionInterface,
 ) -> Result<Option<RegisterValue>, Error> {
     use gimli::read::RegisterRule;
 
     let mut register_rule_string = format!("{register_rule:?}");
 
     let new_value = match register_rule {
-        RegisterRule::Undefined => {
-            // In many cases, the DWARF has `Undefined` rules for variables like frame pointer, program counter, etc.,
-            // so we hard-code some rules here to make sure unwinding can continue. If there is a valid rule, it will bypass these hardcoded ones.
-            match &debug_register {
-                fp if fp.register_has_role(RegisterRole::FramePointer) => {
-                    register_rule_string = "FP=CFA (dwarf Undefined)".to_string();
-                    unwind_cfa.map(|unwind_cfa| {
-                        if fp.data_type == RegisterDataType::UnsignedInteger(32) {
-                            RegisterValue::U32(unwind_cfa as u32 & !0b11)
-                        } else {
-                            RegisterValue::U64(unwind_cfa & !0b11)
-                        }
-                    })
-                }
-                sp if sp.register_has_role(RegisterRole::StackPointer) => {
-                    // NOTE: [ARMv7-M Architecture Reference Manual](https://developer.arm.com/documentation/ddi0403/ee), Section B.1.4.1: Treat bits [1:0] as `Should be Zero or Preserved`
-                    // - Applying this logic to RISC-V has no adverse effects, since all incoming addresses are already 32-bit aligned.
-                    register_rule_string = "SP=CFA (dwarf Undefined)".to_string();
-                    unwind_cfa.map(|unwind_cfa| {
-                        if sp.data_type == RegisterDataType::UnsignedInteger(32) {
-                            RegisterValue::U32(unwind_cfa as u32 & !0b11)
-                        } else {
-                            RegisterValue::U64(unwind_cfa & !0b11)
-                        }
-                    })
-                }
-                lr if lr.register_has_role(RegisterRole::ReturnAddress) => {
-                    let Ok(current_pc) = callee_frame_registers
-                        .get_register_value_by_role(&RegisterRole::ProgramCounter)
-                    else {
-                        return Err(
-                            Error::Other(
-                                "UNWIND: Tried to unwind return address value where current program counter is unknown.".to_string()
-                            )
-                        );
-                    };
-                    let Some(current_lr) = callee_frame_registers
-                        .get_register_by_role(&RegisterRole::ReturnAddress)
-                        .ok()
-                        .and_then(|lr| lr.value)
-                    else {
-                        return Err(
-                            Error::Other(
-                                "UNWIND: Tried to unwind return address value where current return address is unknown.".to_string()
-                            )
-                        );
-                    };
-
-                    let current_lr_value: u64 = current_lr.try_into()?;
-
-                    if current_pc == current_lr_value & !0b1 {
-                        // If the previous PC is the same as the half-word aligned current LR,
-                        // we have no way of inferring the previous frames LR until we have the PC.
-                        register_rule_string = "LR=Undefined (dwarf Undefined)".to_string();
-                        None
-                    } else {
-                        // We can attempt to continue unwinding with the current LR value, e.g. inlined code.
-                        register_rule_string = "LR=Current LR (dwarf Undefined)".to_string();
-                        Some(current_lr)
-                    }
-                }
-                pc if pc.register_has_role(RegisterRole::ProgramCounter) => {
-                    unreachable!("The program counter is handled separately")
-                }
-                other_register => {
-                    // If the the register rule was not specified, then we either carry the previous value forward,
-                    // or we clear the register value, depending on the architecture and register type.
-                    match other_register.unwind_rule {
-                        UnwindRule::Preserve => {
-                            register_rule_string = "Preserve".to_string();
-                            callee_frame_registers
-                                .get_register(other_register.id)
-                                .and_then(|reg| reg.value)
-                        }
-                        UnwindRule::Clear => {
-                            register_rule_string = "Clear".to_string();
-                            None
-                        }
-                        UnwindRule::SpecialRule => {
-                            // When no DWARF rules are available, and it is not a special register like PC, SP, FP, etc.,
-                            // we will clear the value. It is possible it might have its value set later if
-                            // exception frame information is available.
-                            register_rule_string = "Clear (no unwind rules specified)".to_string();
-                            None
-                        }
-                    }
-                }
-            }
-        }
+        RegisterRule::Undefined => exception_handler
+            .unwind_undefined_register(
+                debug_register,
+                callee_frame_registers,
+                unwind_cfa,
+                memory,
+                &mut register_rule_string,
+            )
+            .map_err(|e| match e {
+                crate::DebugError::Probe(err) => err,
+                other => Error::Other(other.to_string()),
+            })?,
 
         RegisterRule::SameValue => callee_frame_registers
             .get_register(debug_register.id)
@@ -2134,6 +2058,7 @@ mod test {
             None,
             &mut memory,
             rule,
+            &ArmV7MExceptionHandler,
         )
         .unwrap();
 
@@ -2174,6 +2099,7 @@ mod test {
             Some(cfa),
             &mut memory,
             rule,
+            &ArmV7MExceptionHandler,
         )
         .unwrap();
 
@@ -2206,6 +2132,7 @@ mod test {
             Some(cfa),
             &mut memory,
             RegisterRule::Undefined,
+            &ArmV7MExceptionHandler,
         )
         .unwrap();
 

--- a/probe-rs-debug/src/exception_handling.rs
+++ b/probe-rs-debug/src/exception_handling.rs
@@ -6,7 +6,10 @@ use std::ops::ControlFlow;
 use probe_rs_target::CoreType;
 
 use crate::unwind_pc_without_debuginfo;
-use probe_rs::{InstructionSet, MemoryInterface};
+use probe_rs::{
+    CoreRegister, InstructionSet, MemoryInterface, RegisterDataType, RegisterRole, RegisterValue,
+    UnwindRule,
+};
 
 use super::{DebugError, DebugInfo, DebugRegisters, StackFrame};
 
@@ -115,4 +118,106 @@ pub trait ExceptionInterface {
     ) -> ControlFlow<Option<DebugError>> {
         unwind_pc_without_debuginfo(unwind_registers, frame_pc, instruction_set)
     }
+
+    /// Compute the caller-frame value of `debug_register` when DWARF has no rule for it.
+    ///
+    /// `register_rule` is updated with a short description of the rule that was applied,
+    /// for inclusion in unwind trace logs.
+    ///
+    /// In many cases, the DWARF has `Undefined` rules for variables like frame pointer, program counter, etc.,
+    /// so the default implementation hard-codes ARM/RISC-V style heuristics here to make sure unwinding can continue.
+    /// If there is a valid rule, it will bypass these hardcoded ones.
+    fn unwind_undefined_register(
+        &self,
+        debug_register: &CoreRegister,
+        callee_frame_registers: &DebugRegisters,
+        unwind_cfa: Option<u64>,
+        _memory: &mut dyn MemoryInterface,
+        register_rule: &mut String,
+    ) -> Result<Option<RegisterValue>, DebugError> {
+        if debug_register.register_has_role(RegisterRole::FramePointer) {
+            *register_rule = "FP=CFA (dwarf Undefined)".to_string();
+            return Ok(cfa_as_register(debug_register, unwind_cfa));
+        }
+
+        if debug_register.register_has_role(RegisterRole::StackPointer) {
+            // NOTE: [ARMv7-M Architecture Reference Manual](https://developer.arm.com/documentation/ddi0403/ee), Section B.1.4.1: Treat bits [1:0] as `Should be Zero or Preserved`
+            // - Applying this logic to RISC-V has no adverse effects, since all incoming addresses are already 32-bit aligned.
+            *register_rule = "SP=CFA (dwarf Undefined)".to_string();
+            return Ok(cfa_as_register(debug_register, unwind_cfa));
+        }
+
+        if debug_register.register_has_role(RegisterRole::ReturnAddress) {
+            let current_pc = callee_frame_registers
+                .get_register_value_by_role(&RegisterRole::ProgramCounter)
+                .map_err(|_| {
+                    DebugError::Other(
+                        "UNWIND: Tried to unwind return address value where current program counter is unknown."
+                            .to_string(),
+                    )
+                })?;
+            let current_lr = callee_frame_registers
+                .get_register_by_role(&RegisterRole::ReturnAddress)
+                .ok()
+                .and_then(|lr| lr.value)
+                .ok_or_else(|| {
+                    DebugError::Other(
+                        "UNWIND: Tried to unwind return address value where current return address is unknown."
+                            .to_string(),
+                    )
+                })?;
+
+            let current_lr_value: u64 = current_lr.try_into()?;
+
+            return Ok(if current_pc == current_lr_value & !0b1 {
+                // If the previous PC is the same as the half-word aligned current LR,
+                // we have no way of inferring the previous frames LR until we have the PC.
+                *register_rule = "LR=Undefined (dwarf Undefined)".to_string();
+                None
+            } else {
+                // We can attempt to continue unwinding with the current LR value, e.g. inlined code.
+                *register_rule = "LR=Current LR (dwarf Undefined)".to_string();
+                Some(current_lr)
+            });
+        }
+
+        if debug_register.register_has_role(RegisterRole::ProgramCounter) {
+            unreachable!("The program counter is handled separately")
+        }
+
+        // If the register rule was not specified, then we either carry the previous value forward,
+        // or we clear the register value, depending on the architecture and register type.
+        Ok(match debug_register.unwind_rule {
+            UnwindRule::Preserve => {
+                *register_rule = "Preserve".to_string();
+                callee_frame_registers
+                    .get_register(debug_register.id)
+                    .and_then(|reg| reg.value)
+            }
+            UnwindRule::Clear => {
+                *register_rule = "Clear".to_string();
+                None
+            }
+            UnwindRule::SpecialRule => {
+                // When no DWARF rules are available, and it is not a special register like PC, SP, FP, etc.,
+                // we will clear the value. It is possible it might have its value set later if
+                // exception frame information is available.
+                *register_rule = "Clear (no unwind rules specified)".to_string();
+                None
+            }
+        })
+    }
+}
+
+fn cfa_as_register(
+    debug_register: &CoreRegister,
+    unwind_cfa: Option<u64>,
+) -> Option<RegisterValue> {
+    unwind_cfa.map(|cfa| {
+        if debug_register.data_type == RegisterDataType::UnsignedInteger(32) {
+            RegisterValue::U32(cfa as u32 & !0b11)
+        } else {
+            RegisterValue::U64(cfa & !0b11)
+        }
+    })
 }

--- a/probe-rs-debug/src/exception_handling.rs
+++ b/probe-rs-debug/src/exception_handling.rs
@@ -30,7 +30,7 @@ pub fn exception_handler_for_core(core_type: CoreType) -> Box<dyn ExceptionInter
         CoreType::Armv6m => Box::new(armv6m::ArmV6MExceptionHandler),
         CoreType::Armv7m | CoreType::Armv7em => Box::new(armv7m::ArmV7MExceptionHandler),
         CoreType::Armv8m => Box::new(armv8m::ArmV8MExceptionHandler),
-        CoreType::Xtensa => Box::new(xtensa::XtensaExceptionHandler),
+        CoreType::Xtensa => Box::<xtensa::XtensaExceptionHandler>::default(),
         CoreType::Riscv | CoreType::Riscv64 => Box::new(riscv::RiscvExceptionHandler),
         CoreType::Armv7a | CoreType::Armv7r | CoreType::Armv8a => {
             Box::new(UnimplementedExceptionHandler)

--- a/probe-rs-debug/src/exception_handling/xtensa.rs
+++ b/probe-rs-debug/src/exception_handling/xtensa.rs
@@ -5,7 +5,9 @@ use crate::{
     unwind_pc_without_debuginfo,
 };
 
-use probe_rs::{InstructionSet, MemoryInterface, RegisterRole, RegisterValue};
+use probe_rs::{
+    CoreRegister, InstructionSet, MemoryInterface, RegisterRole, RegisterValue, UnwindRule,
+};
 
 pub struct XtensaExceptionHandler;
 
@@ -130,5 +132,50 @@ impl ExceptionInterface for XtensaExceptionHandler {
             Ok(_) => ControlFlow::Continue(()),
             Err(error) => ControlFlow::Break(Some(error)),
         }
+    }
+
+    fn unwind_undefined_register(
+        &self,
+        debug_register: &CoreRegister,
+        callee_frame_registers: &DebugRegisters,
+        _unwind_cfa: Option<u64>,
+        memory: &mut dyn MemoryInterface,
+        register_rule: &mut String,
+    ) -> Result<Option<RegisterValue>, DebugError> {
+        if debug_register.register_has_role(RegisterRole::ProgramCounter) {
+            unreachable!("The program counter is handled separately")
+        }
+
+        let mut scratch = callee_frame_registers.clone();
+        if self.unwind_registers(memory, &mut scratch).is_ok() {
+            let new = scratch
+                .get_register(debug_register.id)
+                .and_then(|r| r.value);
+            let old = callee_frame_registers
+                .get_register(debug_register.id)
+                .and_then(|r| r.value);
+
+            if new != old {
+                *register_rule = "Xtensa window spill (dwarf Undefined)".to_string();
+                return Ok(new);
+            }
+        }
+
+        Ok(match debug_register.unwind_rule {
+            UnwindRule::Preserve => {
+                *register_rule = "Preserve (dwarf Undefined)".to_string();
+                callee_frame_registers
+                    .get_register(debug_register.id)
+                    .and_then(|reg| reg.value)
+            }
+            UnwindRule::Clear => {
+                *register_rule = "Clear (dwarf Undefined)".to_string();
+                None
+            }
+            UnwindRule::SpecialRule => {
+                *register_rule = "Clear (no unwind rules specified)".to_string();
+                None
+            }
+        })
     }
 }

--- a/probe-rs-debug/src/exception_handling/xtensa.rs
+++ b/probe-rs-debug/src/exception_handling/xtensa.rs
@@ -1,4 +1,4 @@
-use std::ops::ControlFlow;
+use std::{cell::RefCell, ops::ControlFlow};
 
 use crate::{
     DebugError, DebugRegisters, StackFrame, exception_handling::ExceptionInterface,
@@ -9,9 +9,43 @@ use probe_rs::{
     CoreRegister, InstructionSet, MemoryInterface, RegisterRole, RegisterValue, UnwindRule,
 };
 
-pub struct XtensaExceptionHandler;
+#[derive(Default)]
+pub struct XtensaExceptionHandler {
+    /// Single-entry cache of the most recent windowed-ABI unwind, keyed by the callee's stack
+    /// pointer. Avoids re-reading the spill area for each register when
+    /// [`Self::unwind_undefined_register`] is invoked repeatedly for the same frame.
+    cache: RefCell<Option<UnwindCache>>,
+}
+
+struct UnwindCache {
+    sp: u64,
+    unwound: DebugRegisters,
+}
 
 impl XtensaExceptionHandler {
+    /// Populate [`Self::cache`] with the windowed-ABI unwind result for `callee_frame_registers`,
+    /// reusing the previous result if the callee SP matches.
+    fn ensure_cached_unwind(
+        &self,
+        memory: &mut dyn MemoryInterface,
+        callee_frame_registers: &DebugRegisters,
+    ) -> Result<(), DebugError> {
+        let sp = callee_frame_registers.get_register_value_by_role(&RegisterRole::StackPointer)?;
+
+        if matches!(self.cache.borrow().as_ref(), Some(c) if c.sp == sp) {
+            return Ok(());
+        }
+
+        let mut scratch = callee_frame_registers.clone();
+        self.unwind_registers(memory, &mut scratch)?;
+        *self.cache.borrow_mut() = Some(UnwindCache {
+            sp,
+            unwound: scratch,
+        });
+
+        Ok(())
+    }
+
     fn unwind_registers(
         &self,
         memory: &mut dyn MemoryInterface,
@@ -146,10 +180,14 @@ impl ExceptionInterface for XtensaExceptionHandler {
             unreachable!("The program counter is handled separately")
         }
 
-        let mut scratch = callee_frame_registers.clone();
-        if self.unwind_registers(memory, &mut scratch).is_ok() {
-            let new = scratch
-                .get_register(debug_register.id)
+        if self
+            .ensure_cached_unwind(memory, callee_frame_registers)
+            .is_ok()
+        {
+            let cache = self.cache.borrow();
+            let new = cache
+                .as_ref()
+                .and_then(|c| c.unwound.get_register(debug_register.id))
                 .and_then(|r| r.value);
             let old = callee_frame_registers
                 .get_register(debug_register.id)


### PR DESCRIPTION
One of the latest Xtensa-enabled Rust compilers started emitting unwind info. probe-rs didn't have the concept of unwinding windowed ABI programs using debug info - this PR aims at improving this situation.

Register unwinding is now architecture specific, which allows us to load caller registers from a different register window, or the stack to where it had been spilled.

The relevant log output can now look like this:

```
TRACE probe_rs_debug::debug_info: UNWIND - Preparing to unwind the registers for the previous frame.
TRACE probe_rs_debug::debug_info: UNWIND: Found unwind info for address 0x420206ce
TRACE probe_rs_debug::debug_info: UNWIND - a0/LR: Caller: 0x82020cc1	Callee: 0x820206d1	Rule: Xtensa window spill (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - sp/a1/SP: Caller: 0x3fcdb6c0	Callee: 0x3fcdae80	Rule: Xtensa window spill (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - a2: Caller: 0x00000020	Callee: 0x72646461	Rule: Xtensa window spill (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - a3: Caller: 0x00000001	Callee: 0x5f6e7572	Rule: Xtensa window spill (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - a4: Caller: 0x0000088a	Callee: 0x00000013	Rule: Xtensa window spill (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - a5: Caller: 0x00000018	Callee: 0x000000ff	Rule: Xtensa window spill (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - a6: Caller: 0x00000003	Callee: 0x00000000	Rule: Xtensa window spill (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - fp/a7/FP: Caller: 0x3c007e74	Callee: 0x00000000	Rule: Xtensa window spill (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - a8: Caller: 0x00000000	Callee: 0x00000000	Rule: Clear (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - a9: Caller: 0x00000000	Callee: 0x00000000	Rule: Clear (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - a10: Caller: 0x00000000	Callee: 0x00000000	Rule: Clear (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - a11: Caller: 0x00000000	Callee: 0x00000000	Rule: Clear (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - a12: Caller: 0x00000000	Callee: 0x00000000	Rule: Clear (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - a13: Caller: 0x00000000	Callee: 0x00000000	Rule: Clear (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - a14: Caller: 0x00000000	Callee: 0x00000000	Rule: Clear (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - a15: Caller: 0x00000000	Callee: 0x00000000	Rule: Clear (dwarf Undefined)
TRACE probe_rs_debug::debug_info: UNWIND - ps/PSR: Caller: 0x00000000	Callee: 0x00000000	Rule: Clear (dwarf Undefined)
```