### PR TITLE
fix: select JTAG TAP after manual scan-chain override

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -316,6 +316,7 @@ async fn try_show_info(
             })
             .collect::<Vec<_>>();
         jtag.set_scan_chain(&chain)?;
+        jtag.select_target(0)?;
     }
 
     if connect_under_reset {


### PR DESCRIPTION
## Summary
- initialize JTAG chain parameters after applying a manual `--scan-chain` override
- ensure `probe-rs info --scan-chain ... --protocol jtag` uses the provided IR length immediately
- fix the `Invalid instruction register access: 1` failure reported in the issue

## Testing
- `cargo fmt --check`
- `cargo test -p probe-rs-tools info -- --nocapture`
- `git diff --check`

Fixes #3979
