### PR TITLE
Let `serialport` be optional

### DIFF
--- a/changelog/changed-optional-serialport.md
+++ b/changelog/changed-optional-serialport.md
@@ -1,0 +1,1 @@
+- `serialport` is now an optional dependency. Targets using `serialport` will be compiled out when the feature is missing.

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -21,12 +21,13 @@ rust-version.workspace = true
 exclude = ["tests/"]
 
 [features]
-default = ["builtin-targets", "cmsisdap_v1", "builtin-formats", "coredump"]
+default = ["builtin-targets", "cmsisdap_v1", "builtin-formats", "coredump", "serialport"]
 flate2 = ["dep:flate2"]
 
 # Enable all built in targets.
 builtin-targets = ["dep:bincode", "dep:probe-rs-target"]
 cmsisdap_v1 = ["dep:hidapi"]
+serialport = ["dep:serialport"]
 
 # Enables the bin, hex, elf image formats
 builtin-formats = ["dep:uf2-decode", "object", "flate2", "dep:ihex"]
@@ -61,9 +62,10 @@ object = { version = "0.39", default-features = false, features = [
 nusb.workspace = true
 futures-lite = { version = "2", default-features = false }
 scroll = "0.13"
+# Optional for some targets
 serialport = { version = "4.7.0", default-features = false, features = [
     "usbportinfo-interface",
-] }
+], optional = true }
 tracing = "0.1"
 parking_lot = "0.12.2"
 zerocopy = { version = "0.8.0", features = ["derive"] }

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -2,6 +2,7 @@
 pub(crate) mod common;
 pub mod usb_util;
 
+#[cfg(feature = "serialport")]
 pub mod blackmagic;
 pub mod ch347usbjtag;
 pub mod cmsisdap;
@@ -12,6 +13,7 @@ pub mod jlink;
 pub mod list;
 pub(crate) mod queue;
 mod selector;
+#[cfg(feature = "serialport")]
 pub mod sifliuart;
 pub mod stlink;
 pub mod wlink;
@@ -46,12 +48,14 @@ const LOW_TARGET_VOLTAGE_WARNING_THRESHOLD: f32 = 1.4;
 
 static DRIVERS: LazyLock<RwLock<Vec<&'static dyn ProbeFactory>>> = LazyLock::new(|| {
     let probes: Vec<&'static dyn ProbeFactory> = vec![
+        #[cfg(feature = "serialport")]
         &blackmagic::BlackMagicProbeFactory,
         &cmsisdap::CmsisDapFactory,
         &ftdi::FtdiProbeFactory,
         &stlink::StLinkFactory,
         &jlink::JLinkFactory,
         &wlink::WchLinkFactory,
+        #[cfg(feature = "serialport")]
         &sifliuart::SifliUartFactory,
         &glasgow::GlasgowFactory,
         &ch347usbjtag::Ch347UsbJtagFactory,


### PR DESCRIPTION
Not all probes require serial access. Make this dependency optional.