### PR TITLE
Add WCH CH32H41x (CH32H415/H416/H417) dual-core RISC-V support via WCH-LinkE

### DIFF
--- a/changelog/added-ch32h41x-support.md
+++ b/changelog/added-ch32h41x-support.md
@@ -1,0 +1,1 @@
+Added WCH CH32H41x (CH32H415/CH32H416/CH32H417) dual-core RISC-V target support via WCH-LinkE probe-assisted flash.

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
@@ -343,10 +343,14 @@ impl BootInfo {
                 session.prepare_running_on_ram(*vector_table_addr, core_id)?;
             }
             BootInfo::Other => {
-                // reset the core to leave it in a consistent state after flashing
-                session
-                    .core(core_id)?
-                    .reset_and_halt(Duration::from_millis(100))?;
+                // Probe-assisted flash (WCH-LinkE) already reset and started the
+                // core via the probe's built-in command.  Skip the generic RISC-V
+                // reset here to avoid DMI timeouts.
+                if !session.is_probe_assisted() {
+                    session
+                        .core(core_id)?
+                        .reset_and_halt(Duration::from_millis(100))?;
+                }
             }
         }
 
@@ -442,7 +446,22 @@ fn erase_impl(
 
     match request.command {
         EraseCommand::All => {
-            flashing::erase_all(&mut session, &mut progress, request.read_flasher_rtt)?
+            // Try probe-assisted erase first (e.g., WCH-Link firmware command)
+            match session.try_erase_flash_via_probe() {
+                Ok(true) => {
+                    tracing::info!("Chip erased via probe firmware command.");
+                }
+                Ok(false) => {
+                    flashing::erase_all(&mut session, &mut progress, request.read_flasher_rtt)?;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Probe-assisted erase failed: {:?}, falling back to normal path",
+                        e
+                    );
+                    flashing::erase_all(&mut session, &mut progress, request.read_flasher_rtt)?;
+                }
+            }
         }
     }
 

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -427,6 +427,19 @@ async fn try_read_riscv_info(
 ) -> Result<(), anyhow::Error> {
     if probe.has_riscv_interface() && protocol == WireProtocol::Jtag {
         tracing::debug!("Trying to show RISC-V chip information");
+
+        if let Some(wlink) = probe.try_into::<probe_rs::probe::wlink::WchLink>() {
+            ctx.publish::<TargetInfoDataTopic>(
+                VarSeq::Seq2(0),
+                &InfoEvent::Message(format!(
+                    "Detected: {} (ChipID: {:#010X})",
+                    wlink.chip_family_name(),
+                    wlink.chip_id()
+                )),
+            )
+            .await?;
+        }
+
         let idcode = {
             let factory = probe.try_get_riscv_interface_builder()?;
             let mut state = factory.create_state();

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/memory.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/memory.rs
@@ -167,10 +167,9 @@ pub async fn read_memory<W: Word>(
     let byte_len = request.count as usize * W::byte_size();
     if let Ok(Some(data)) =
         session.try_read_flash_via_probe(request.address as u32, byte_len as u32)
+        && data.len() == byte_len
     {
-        if data.len() == byte_len {
-            return Ok(W::from_bytes(&data));
-        }
+        return Ok(W::from_bytes(&data));
     }
 
     let mut core = session.core(request.core as usize)?;

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/memory.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/memory.rs
@@ -15,6 +15,12 @@ pub trait Word: Copy + Default + Send + Schema {
     ) -> anyhow::Result<()>;
 
     fn write(core: &mut impl MemoryInterface, address: u64, data: &[Self]) -> anyhow::Result<()>;
+
+    /// Size of this word type in bytes.
+    fn byte_size() -> usize;
+
+    /// Convert bytes to words (bytes are in little-endian order).
+    fn from_bytes(bytes: &[u8]) -> Vec<Self>;
 }
 
 impl Word for u8 {
@@ -31,6 +37,14 @@ impl Word for u8 {
         core.write_8(address, data)?;
         Ok(())
     }
+
+    fn byte_size() -> usize {
+        1
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Vec<Self> {
+        bytes.to_vec()
+    }
 }
 impl Word for u16 {
     fn read(
@@ -45,6 +59,17 @@ impl Word for u16 {
     fn write(core: &mut impl MemoryInterface, address: u64, data: &[Self]) -> anyhow::Result<()> {
         core.write_16(address, data)?;
         Ok(())
+    }
+
+    fn byte_size() -> usize {
+        2
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Vec<Self> {
+        bytes
+            .chunks(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect()
     }
 }
 impl Word for u32 {
@@ -61,6 +86,17 @@ impl Word for u32 {
         core.write_32(address, data)?;
         Ok(())
     }
+
+    fn byte_size() -> usize {
+        4
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Vec<Self> {
+        bytes
+            .chunks(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()
+    }
 }
 impl Word for u64 {
     fn read(
@@ -75,6 +111,21 @@ impl Word for u64 {
     fn write(core: &mut impl MemoryInterface, address: u64, data: &[Self]) -> anyhow::Result<()> {
         core.write_64(address, data)?;
         Ok(())
+    }
+
+    fn byte_size() -> usize {
+        8
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Vec<Self> {
+        bytes
+            .chunks(8)
+            .map(|c| {
+                let mut arr = [0u8; 8];
+                arr.copy_from_slice(c);
+                u64::from_le_bytes(arr)
+            })
+            .collect()
     }
 }
 
@@ -111,6 +162,17 @@ pub async fn read_memory<W: Word>(
     request: ReadMemoryRequest,
 ) -> RpcResult<Vec<W>> {
     let mut session = ctx.session(request.sessid).await;
+
+    // Try probe-assisted read for faster flash access
+    let byte_len = request.count as usize * W::byte_size();
+    if let Ok(Some(data)) =
+        session.try_read_flash_via_probe(request.address as u32, byte_len as u32)
+    {
+        if data.len() == byte_len {
+            return Ok(W::from_bytes(&data));
+        }
+    }
+
     let mut core = session.core(request.core as usize)?;
 
     let mut words = vec![W::default(); request.count as usize];

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
@@ -205,14 +205,15 @@ fn monitor_impl(
         cancellation_token: ctx.cancellation_token(),
     };
 
-    {
+    let probe_assisted_done = {
         let mut session = shared_session.session_blocking();
         request.mode.prepare(&mut session, run_loop.core_id)?;
-    }
+        session.is_probe_assisted()
+    };
 
     let poller = client_key.map(|client| RttPoller {
         rtt_client: client,
-        clear_control_block: request.mode.should_clear_rtt_header(),
+        clear_control_block: request.mode.should_clear_rtt_header() && !probe_assisted_done,
         sender: |message| {
             sender
                 .send_rtt_event(message)

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -645,13 +645,27 @@ impl<'state> RiscvCommunicationInterface<'state> {
 
         let control = self.read_dm_register::<Dmcontrol>()?;
 
-        self.state.hartsellen = control.hartsel().count_ones() as u8;
+        let raw_hartsel = control.hartsel().count_ones() as u8;
+        // Guard against garbage reads from a stale DM.  If the previous
+        // session was killed mid-operation (Ctrl+C), the DM may return
+        // all-ones for hartsel, leading to 2^32 iterations below.
+        // The RISC-V Debug Spec defines hartsel as a 20-bit field at most.
+        self.state.hartsellen = if raw_hartsel > 20 {
+            tracing::debug!(
+                "HARTSELLEN out of range ({}), defaulting to 20",
+                raw_hartsel
+            );
+            20
+        } else {
+            raw_hartsel
+        };
 
         tracing::debug!("HARTSELLEN: {}", self.state.hartsellen);
 
         // Determine number of harts
-
-        let max_hart_index = 2u32.pow(self.state.hartsellen as u32);
+        // Cap the search to avoid excessive DMI traffic when the DM
+        // returns garbage hartsel values (e.g. after an unclean kill).
+        let max_hart_index = 2u32.pow(self.state.hartsellen as u32).min(1024);
 
         // Hart 0 exists on every chip
         let mut num_harts = 1;
@@ -941,6 +955,22 @@ impl<'state> RiscvCommunicationInterface<'state> {
     ) -> Result<R, RiscvError> {
         let was_running = self.halt_with_previous(Duration::from_millis(100))?;
 
+        // Clear any stale cmderr from a previous abstract command.
+        // Some targets (e.g. WCH-LinkE) may have a leftover error
+        // from earlier cleanup that poisons subsequent operations.
+        // Per RISC-V Debug Spec: writing the current cmderr value
+        // back to the field clears it to 0; writing a different
+        // value sets cmderr to that value.
+        {
+            let abstractcs = self.read_dm_register::<Abstractcs>()?;
+            let cmderr = abstractcs.cmderr();
+            if cmderr != 0 {
+                let mut clear = Abstractcs(0);
+                clear.set_cmderr(cmderr);
+                self.write_dm_register(clear)?;
+            }
+        }
+
         // If requested, force the program buffer privilege level to machine mode
         // so that memory accesses bypass the MMU and use physical addresses.
         //
@@ -1012,6 +1042,35 @@ impl<'state> RiscvCommunicationInterface<'state> {
                          Core may resume with incorrect privilege level."
                     );
                 }
+            }
+        }
+
+        // Clear the step bit in DCSR before resuming.  Some targets
+        // (e.g. CH32H417 via WCH-LinkE) enter debug mode with step=1
+        // set at the hardware level.  Without this the core only
+        // executes a single instruction after each resume.
+        //
+        // We are inside halted_access so the core is already halted —
+        // read_csr / write_csr are safe to call here (they use a
+        // nested halted_access that sees the core is already halted).
+        //
+        // This must run *before* the was_running check because the core
+        // may enter halted_access already halted (e.g. from a previous
+        // single-step trap), and we must clear step regardless.
+        match self.read_csr(0x7b0) {
+            Ok(raw) => {
+                let mut dcsr = Dcsr(raw as u32);
+                if dcsr.step() {
+                    tracing::debug!("Clearing stale step bit in DCSR (was {:#010x})", raw);
+                    dcsr.set_step(false);
+                    let _ = self.write_csr(0x7b0, u64::from(dcsr.0));
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    "Could not read DCSR to clear step bit: {e}. \
+                     Continuing anyway."
+                );
             }
         }
 

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -631,6 +631,33 @@ impl FlashLoader {
         session: &mut Session,
         progress: &mut FlashProgress<'_>,
     ) -> Result<(), FlashError> {
+        // Try probe-assisted verify first (e.g., WCH-Link firmware commands)
+        let nvm_data: Vec<(u32, &[u8])> = self
+            .memory_map
+            .iter()
+            .filter_map(|region| match region {
+                MemoryRegion::Nvm(nvm) => Some(&nvm.range),
+                _ => None,
+            })
+            .flat_map(|range| self.builder.data_in_range(&(range.start..range.end)))
+            .map(|(addr, data)| (addr as u32, data))
+            .collect();
+
+        if !nvm_data.is_empty() {
+            match session.try_verify_flash_via_probe(&nvm_data) {
+                Ok(true) => {
+                    tracing::info!("Verify completed via probe firmware commands.");
+                    progress.add_progress_bar(ProgressOperation::Verify, Some(0));
+                    progress.started_verifying();
+                    progress.finished_verifying();
+                    self.verify_ram(session)?;
+                    return Ok(());
+                }
+                Ok(false) => { /* fall through to normal path */ }
+                Err(e) => return Err(e),
+            }
+        }
+
         let mut algos = self.prepare_plan(session, false, &[])?;
 
         for flasher in algos.iter_mut() {
@@ -670,6 +697,60 @@ impl FlashLoader {
         mut options: DownloadOptions,
     ) -> Result<(), FlashError> {
         tracing::debug!("Committing FlashLoader!");
+
+        if !options.dry_run && !options.keep_unwritten_bytes {
+            // Collect NVM data blocks for probe-assisted flash path
+            let nvm_data: Vec<(u32, &[u8])> = self
+                .memory_map
+                .iter()
+                .filter_map(|region| match region {
+                    MemoryRegion::Nvm(nvm) => Some(&nvm.range),
+                    _ => None,
+                })
+                .flat_map(|range| self.builder.data_in_range(&(range.start..range.end)))
+                .map(|(addr, data)| (addr as u32, data))
+                .collect();
+
+            if !nvm_data.is_empty() {
+                match session.try_flash_via_probe(
+                    &nvm_data,
+                    options.do_chip_erase,
+                    options.skip_erase,
+                ) {
+                    Ok(true) => {
+                        tracing::info!("Flash completed via probe firmware commands.");
+                        options.progress.finished_erasing();
+                        options.progress.finished_programming();
+                        if options.verify {
+                            match session.try_verify_flash_via_probe(&nvm_data) {
+                                Ok(true) => {
+                                    tracing::info!("Probe-assisted verify passed.");
+                                    options.progress.finished_verifying();
+                                }
+                                Ok(false) => {
+                                    // Probe doesn't support standalone verify, skip.
+                                }
+                                Err(e) => {
+                                    tracing::warn!("Probe-assisted verify failed: {:?}", e);
+                                    return Err(e);
+                                }
+                            }
+                        }
+                        return Ok(());
+                    }
+                    Ok(false) => {
+                        // Probe doesn't support it, fall through to normal path
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Probe-assisted flash failed: {:?}, falling back to normal path",
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
         let mut algos = self.prepare_plan(
             session,
             options.keep_unwritten_bytes,

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -518,6 +518,12 @@ impl Probe {
         self.inner.speed_khz()
     }
 
+    /// Provides mutable access to the inner probe for downcasting.
+    /// Used internally by probe-assisted flash operations (e.g., WCH-Link).
+    pub(crate) fn inner_mut(&mut self) -> &mut dyn DebugProbe {
+        self.inner.as_mut()
+    }
+
     /// Check if the probe has an interface to
     /// debug Xtensa chips.
     pub fn has_xtensa_interface(&self) -> bool {

--- a/probe-rs/src/probe/wlink/commands.rs
+++ b/probe-rs/src/probe/wlink/commands.rs
@@ -7,8 +7,8 @@ use super::{DMI_OP_NOP, DMI_OP_READ, DMI_OP_WRITE, RiscvChip, WchLinkError, WchL
 pub enum CommandId {
     /// Probe control
     Control = 0x0D,
-    /// Config chip, flash protection, etc
-    ConfigChip = 0x01,
+    /// Config chip, flash protection, etc (wlink protocol: command 0x06)
+    ConfigChip = 0x06,
     /// Chip reset
     Reset = 0x0b,
     /// Set chip type and connection speed
@@ -317,5 +317,114 @@ impl WchLinkCommand for UnprotectFlash {
 
     fn payload(&self) -> Vec<u8> {
         vec![0x02]
+    }
+}
+
+// ── Flash / Memory Programming Commands ────────────────────
+
+/// Sub-commands for the Program command (command ID 0x02).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ProgramCommand {
+    /// Erase the entire code flash.
+    EraseFlash = 0x01,
+    /// Start flash write operation.
+    WriteFlash = 0x02,
+    /// Write flash algorithm binary to probe internal buffer.
+    WriteFlashOp = 0x05,
+    /// Acknowledge flash OP written (required after WriteFlashOp).
+    AckFlashOpWritten = 0x07,
+    /// End programming session.
+    End = 0x08,
+    /// Read memory section via probe.
+    ReadMemory = 0x0C,
+}
+
+/// Flash program command (command ID 0x02).
+#[derive(Debug)]
+pub struct FlashProgram {
+    sub_cmd: ProgramCommand,
+}
+
+impl FlashProgram {
+    pub fn new(cmd: ProgramCommand) -> Self {
+        Self { sub_cmd: cmd }
+    }
+}
+
+impl WchLinkCommand for FlashProgram {
+    const COMMAND_ID: CommandId = CommandId::ConfigChip; // overridden in to_bytes
+    type Response = u8;
+
+    fn payload(&self) -> Vec<u8> {
+        vec![self.sub_cmd as u8]
+    }
+
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, super::WchLinkError> {
+        let payload = self.payload();
+        let payload_len = payload.len();
+        buffer[0] = 0x81;
+        buffer[1] = 0x02; // Program command ID
+        buffer[2] = payload_len as u8;
+        buffer[3..payload_len + 3].copy_from_slice(&payload);
+        Ok(payload_len + 3)
+    }
+}
+
+/// Memory write region command (command ID 0x01).
+#[derive(Debug)]
+pub struct FlashSetWriteRegion {
+    pub start_addr: u32,
+    pub len: u32,
+}
+
+impl WchLinkCommand for FlashSetWriteRegion {
+    const COMMAND_ID: CommandId = CommandId::ConfigChip; // overridden in to_bytes
+    type Response = ();
+
+    fn payload(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(8);
+        bytes.extend_from_slice(&self.start_addr.to_be_bytes());
+        bytes.extend_from_slice(&self.len.to_be_bytes());
+        bytes
+    }
+
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, super::WchLinkError> {
+        let payload = self.payload();
+        let payload_len = payload.len();
+        buffer[0] = 0x81;
+        buffer[1] = 0x01; // SetWriteMemoryRegion command ID
+        buffer[2] = payload_len as u8;
+        buffer[3..payload_len + 3].copy_from_slice(&payload);
+        Ok(payload_len + 3)
+    }
+}
+
+/// Memory read region command (command ID 0x03).
+#[derive(Debug)]
+pub struct FlashSetReadRegion {
+    pub start_addr: u32,
+    pub len: u32,
+}
+
+impl WchLinkCommand for FlashSetReadRegion {
+    const COMMAND_ID: CommandId = CommandId::ConfigChip; // overridden in to_bytes
+    type Response = ();
+
+    fn payload(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(8);
+        bytes.extend_from_slice(&self.start_addr.to_be_bytes());
+        bytes.extend_from_slice(&self.len.to_be_bytes());
+        bytes
+    }
+
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, super::WchLinkError> {
+        let payload = self.payload();
+        let payload_len = payload.len();
+        buffer[0] = 0x81;
+        buffer[1] = 0x03; // SetReadMemoryRegion command ID
+        buffer[2] = payload_len as u8;
+        buffer[3..payload_len + 3].copy_from_slice(&payload);
+        Ok(payload_len + 3)
     }
 }

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -543,7 +543,11 @@ impl WchLink {
         let timeout = std::time::Duration::from_secs(10);
 
         // Align length to 4 bytes as required by the firmware
-        let read_len = if len % 4 == 0 { len } else { (len / 4 + 1) * 4 };
+        let read_len = if len.is_multiple_of(4) {
+            len
+        } else {
+            (len / 4 + 1) * 4
+        };
 
         // Set read memory region
         self.device.send_command_with_timeout(

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -114,6 +114,8 @@ pub enum RiscvChip {
     CH32L103 = 0x0E, // 14
     /// CH641 Qingke-V2A series, USB-PD, fallback as CH32V003
     CH641 = 0x49,
+    /// CH32H415/CH32H416/CH32H417 Qingke-V5F+Qingke-V3F series
+    CH32H41X = 0xC6,
 }
 
 impl RiscvChip {
@@ -132,6 +134,7 @@ impl RiscvChip {
             0x0D => Some(RiscvChip::CH32X035),
             0x0E => Some(RiscvChip::CH32L103),
             0x49 => Some(RiscvChip::CH641),
+            0xC6 => Some(RiscvChip::CH32H41X),
             _ => None,
         }
     }
@@ -147,6 +150,7 @@ impl RiscvChip {
                 | RiscvChip::CH32L103
                 | RiscvChip::CH32X035
                 | RiscvChip::CH641
+                | RiscvChip::CH32H41X
         )
     }
 }
@@ -195,7 +199,7 @@ pub struct WchLink {
     v_major: u8,
     v_minor: u8,
     /// Chip family
-    chip_family: RiscvChip,
+    pub(crate) chip_family: RiscvChip,
     /// Chip id to identify the target chip variant
     chip_id: u32,
     // Hack to support NOP after READ
@@ -278,6 +282,297 @@ impl WchLink {
         let resp = self.device.send_command(commands::DmiOp::nop())?;
 
         Ok((resp.addr, resp.data, resp.op))
+    }
+
+    // ── Probe-assisted Flash Operations ──────────────────
+
+    /// Returns the raw chip ID as detected by the firmware (e.g. 0x4170052D).
+    pub fn chip_id(&self) -> u32 {
+        self.chip_id
+    }
+
+    /// Returns the chip family name (e.g. "CH32H41X") as detected by the firmware.
+    pub fn chip_family_name(&self) -> &str {
+        match self.chip_family {
+            RiscvChip::CH32V103 => "CH32V103",
+            RiscvChip::CH57X => "CH57X",
+            RiscvChip::CH56X => "CH56X",
+            RiscvChip::CH32V20X => "CH32V20X",
+            RiscvChip::CH32V30X => "CH32V30X",
+            RiscvChip::CH58X => "CH58X",
+            RiscvChip::CH32V003 => "CH32V003",
+            RiscvChip::CH8571 => "CH8571",
+            RiscvChip::CH59X => "CH59X",
+            RiscvChip::CH643 => "CH643",
+            RiscvChip::CH32X035 => "CH32X035",
+            RiscvChip::CH32L103 => "CH32L103",
+            RiscvChip::CH641 => "CH641",
+            RiscvChip::CH32H41X => "CH32H41X (CH32H415/CH32H416/CH32H417)",
+        }
+    }
+
+    /// Returns true if the currently attached chip supports probe-assisted
+    /// flash operations (erase + program + verify via firmware commands).
+    pub(crate) fn supports_probe_assisted_flash(&self) -> bool {
+        matches!(self.chip_family, RiscvChip::CH32H41X)
+    }
+
+    /// CH32H417 flash algorithm binary, taken from wlink flash_op::CH32H417.
+    /// This 618-byte binary is sent to the WCH-Link probe firmware,
+    /// which handles loading and executing it on the target.
+    const CH32H417_FLASH_OP: &'static [u8] = &[
+        0x01, 0x11, 0x02, 0xce, 0x93, 0x77, 0x15, 0x00, 0x99, 0xcf, 0xb7, 0x06, 0x67, 0x45, 0xb7,
+        0x27, 0x02, 0x40, 0x93, 0x86, 0x36, 0x12, 0x37, 0x97, 0xef, 0xcd, 0xd4, 0xc3, 0x13, 0x07,
+        0xb7, 0x9a, 0xd8, 0xc3, 0xd4, 0xd3, 0xd8, 0xd3, 0x93, 0x77, 0x25, 0x00, 0xc1, 0xe3, 0x93,
+        0x77, 0x45, 0x00, 0xed, 0xe7, 0x93, 0x77, 0x85, 0x00, 0x63, 0x8d, 0x07, 0x1c, 0x93, 0x07,
+        0xf6, 0x0f, 0x2e, 0xc6, 0xa1, 0x83, 0x3e, 0xca, 0x37, 0x27, 0x02, 0x40, 0x1c, 0x4b, 0xc1,
+        0x66, 0x41, 0x68, 0xd5, 0x8f, 0x1c, 0xcb, 0xb7, 0x16, 0x10, 0x20, 0xb7, 0x27, 0x02, 0x40,
+        0x93, 0x08, 0x00, 0x04, 0x37, 0x03, 0x20, 0x00, 0x98, 0x4b, 0x33, 0x67, 0x07, 0x01, 0x98,
+        0xcb, 0xd8, 0x47, 0x05, 0x8b, 0x75, 0xff, 0x32, 0x47, 0x3a, 0xc8, 0x46, 0xcc, 0x62, 0x47,
+        0x63, 0x1e, 0x07, 0x14, 0x98, 0x4b, 0x33, 0x67, 0x67, 0x00, 0x98, 0xcb, 0xd8, 0x47, 0x05,
+        0x8b, 0x75, 0xff, 0xd8, 0x47, 0x41, 0x8b, 0x63, 0x03, 0x07, 0x16, 0xd8, 0x47, 0xc1, 0x76,
+        0xfd, 0x16, 0x13, 0x67, 0x07, 0x01, 0xd8, 0xc7, 0x98, 0x4b, 0x21, 0x45, 0x75, 0x8f, 0x98,
+        0xcb, 0x05, 0x61, 0x02, 0x90, 0x85, 0x68, 0xad, 0x66, 0x37, 0x08, 0xfc, 0xff, 0x02, 0xca,
+        0x39, 0x43, 0xb7, 0x27, 0x02, 0x40, 0x13, 0x8e, 0x08, 0x80, 0xb7, 0x0e, 0x04, 0x00, 0x37,
+        0x3f, 0x00, 0x40, 0x93, 0x86, 0xa6, 0xaa, 0x7d, 0x18, 0x52, 0x47, 0xe3, 0x6f, 0xe3, 0xf4,
+        0xd8, 0x57, 0x93, 0x1f, 0x37, 0x00, 0x52, 0x47, 0x63, 0xda, 0x0f, 0x02, 0x72, 0x97, 0x42,
+        0x07, 0x3a, 0xc6, 0x98, 0x4b, 0x33, 0x67, 0xd7, 0x01, 0x98, 0xcb, 0x32, 0x47, 0xd8, 0xcb,
+        0x98, 0x4b, 0x13, 0x67, 0x07, 0x04, 0x98, 0xcb, 0xd8, 0x47, 0x05, 0x8b, 0x01, 0xef, 0x98,
+        0x4b, 0x33, 0x77, 0x07, 0x01, 0x98, 0xcb, 0x52, 0x47, 0x05, 0x07, 0x3a, 0xca, 0xc1, 0xb7,
+        0x46, 0x97, 0x3e, 0x07, 0xc1, 0xbf, 0x23, 0x20, 0xdf, 0x00, 0xc5, 0xb7, 0xb7, 0x27, 0x02,
+        0x40, 0xdc, 0x57, 0x13, 0x97, 0x37, 0x00, 0x63, 0x5f, 0x07, 0x04, 0x93, 0x97, 0x35, 0x01,
+        0xe3, 0xc3, 0x07, 0xf0, 0x85, 0x67, 0xfd, 0x17, 0xb2, 0x97, 0xb1, 0x83, 0x2e, 0xc6, 0xad,
+        0x66, 0x3e, 0xca, 0xb7, 0x38, 0x00, 0x40, 0xb7, 0x27, 0x02, 0x40, 0x93, 0x86, 0xa6, 0xaa,
+        0x05, 0x68, 0x98, 0x4b, 0x13, 0x67, 0x27, 0x00, 0x98, 0xcb, 0x32, 0x47, 0xd8, 0xcb, 0x98,
+        0x4b, 0x13, 0x67, 0x07, 0x04, 0x98, 0xcb, 0xd8, 0x47, 0x05, 0x8b, 0x01, 0xef, 0x98, 0x4b,
+        0x75, 0x9b, 0x98, 0xcb, 0x32, 0x47, 0x42, 0x97, 0x3a, 0xc6, 0x52, 0x47, 0x7d, 0x17, 0x3a,
+        0xca, 0x71, 0xfb, 0x65, 0xbd, 0x23, 0xa0, 0xd8, 0x00, 0xc5, 0xb7, 0x85, 0x67, 0xfd, 0x17,
+        0xb2, 0x97, 0xb1, 0x83, 0x2e, 0xc6, 0xad, 0x66, 0x3e, 0xca, 0xb7, 0x38, 0x00, 0x40, 0xb7,
+        0x27, 0x02, 0x40, 0x93, 0x86, 0xa6, 0xaa, 0x05, 0x68, 0x98, 0x4b, 0x13, 0x67, 0x27, 0x00,
+        0x98, 0xcb, 0x32, 0x47, 0xd8, 0xcb, 0x98, 0x4b, 0x13, 0x67, 0x07, 0x04, 0x98, 0xcb, 0xd8,
+        0x47, 0x05, 0x8b, 0x01, 0xef, 0x98, 0x4b, 0x75, 0x9b, 0x98, 0xcb, 0x32, 0x47, 0x42, 0x97,
+        0x3a, 0xc6, 0x52, 0x47, 0x7d, 0x17, 0x3a, 0xca, 0x71, 0xfb, 0x9d, 0xb5, 0x23, 0xa0, 0xd8,
+        0x00, 0xc5, 0xb7, 0x42, 0x47, 0x13, 0x8e, 0x46, 0x00, 0x94, 0x42, 0x14, 0xc3, 0x42, 0x47,
+        0x11, 0x07, 0x3a, 0xc8, 0x62, 0x47, 0x7d, 0x17, 0x3a, 0xcc, 0xd8, 0x47, 0x09, 0x8b, 0x75,
+        0xff, 0xf2, 0x86, 0x51, 0xb5, 0x32, 0x47, 0x13, 0x07, 0x07, 0x10, 0x3a, 0xc6, 0x52, 0x47,
+        0x7d, 0x17, 0x3a, 0xca, 0xe3, 0x10, 0x07, 0xe6, 0x98, 0x4b, 0xc1, 0x76, 0xfd, 0x16, 0x75,
+        0x8f, 0x98, 0xcb, 0x41, 0x89, 0x19, 0xe1, 0x01, 0x45, 0x41, 0xbd, 0x2e, 0xc6, 0x0d, 0x06,
+        0x02, 0xca, 0x09, 0x82, 0x32, 0xcc, 0xb7, 0x17, 0x10, 0x20, 0x98, 0x43, 0x13, 0x86, 0x47,
+        0x00, 0xd2, 0x47, 0xb2, 0x46, 0x8a, 0x07, 0xb6, 0x97, 0x9c, 0x43, 0x63, 0x18, 0xf7, 0x02,
+        0xd2, 0x47, 0x32, 0x47, 0x8a, 0x07, 0xba, 0x97, 0x98, 0x43, 0xf2, 0x47, 0xba, 0x97, 0x3e,
+        0xce, 0xd2, 0x47, 0x85, 0x07, 0x3e, 0xca, 0xd2, 0x46, 0x62, 0x47, 0xb2, 0x87, 0xe3, 0xe8,
+        0xe6, 0xfc, 0xb7, 0x27, 0x10, 0x20, 0x98, 0x4b, 0xf2, 0x47, 0xe3, 0x09, 0xf7, 0xfa, 0x41,
+        0x45, 0x3d, 0xbd,
+    ];
+
+    /// Erase the entire code flash using the WCH-Link firmware's built-in erase command.
+    /// This bypasses the normal probe-rs flash algorithm flow and uses the probe's
+    /// proprietary command instead, which is more reliable for WCH chips.
+    pub fn erase_flash(&mut self) -> Result<(), DebugProbeError> {
+        tracing::info!("Erasing chip flash via WCH-Link firmware command...");
+
+        let long_timeout = std::time::Duration::from_secs(10);
+
+        // Check and handle flash protection first
+        if self.chip_family.support_flash_protect() {
+            match self
+                .device
+                .send_command_with_timeout(commands::CheckFlashProtection, long_timeout)
+            {
+                Ok(0x01) => {
+                    tracing::info!("Flash is protected, unprotecting...");
+                    self.device
+                        .send_command_with_timeout(commands::UnprotectFlash, long_timeout)?;
+                    self.device
+                        .send_command_with_timeout(commands::AttachChip, long_timeout)?;
+                }
+                Ok(status) => {
+                    tracing::debug!("Flash protection status: {:#04x}", status);
+                }
+                Err(e) => {
+                    tracing::warn!("Could not check flash protection: {:?}", e);
+                }
+            }
+        }
+
+        // Send the EraseFlash command (0x02, 0x01)
+        self.device.send_command_with_timeout(
+            commands::FlashProgram::new(commands::ProgramCommand::EraseFlash),
+            long_timeout,
+        )?;
+
+        // Re-attach to the chip after erase
+        self.device
+            .send_command_with_timeout(commands::AttachChip, long_timeout)?;
+
+        tracing::info!("Chip erase completed.");
+        Ok(())
+    }
+
+    /// Write firmware data to flash using the WCH-Link firmware's programming commands.
+    /// `data` - the firmware binary data.
+    /// `address` - the target flash address (typically 0x08000000 for CH32H417).
+    pub fn program_flash(&mut self, data: &[u8], address: u32) -> Result<(), DebugProbeError> {
+        tracing::info!(
+            "Programming {} bytes to 0x{:08X} via WCH-Link firmware...",
+            data.len(),
+            address
+        );
+
+        // Unprotect flash if needed
+        if self.chip_family.support_flash_protect() {
+            let long_timeout = std::time::Duration::from_secs(10);
+            match self
+                .device
+                .send_command_with_timeout(commands::CheckFlashProtection, long_timeout)
+            {
+                Ok(0x01) => {
+                    self.device
+                        .send_command_with_timeout(commands::UnprotectFlash, long_timeout)?;
+                    self.device
+                        .send_command_with_timeout(commands::AttachChip, long_timeout)?;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!("Could not check flash protection: {:?}", e);
+                }
+            }
+        }
+
+        let data_packet_size: usize = 256; // CH32H41x data packet size
+        let write_pack_size: usize = 4096; // CH32H41x write pack size (wlink default)
+        let timeout = std::time::Duration::from_secs(10);
+
+        // Step 1: Set write memory region (wlink does NOT send Prepare for CH32H41X)
+        self.device.send_command_with_timeout(
+            commands::FlashSetWriteRegion {
+                start_addr: address,
+                len: data.len() as u32,
+            },
+            timeout,
+        )?;
+
+        // Step 2: Write flash OP (algorithm binary)
+        self.device.send_command_with_timeout(
+            commands::FlashProgram::new(commands::ProgramCommand::WriteFlashOp),
+            timeout,
+        )?;
+
+        // Step 3: Send flash algorithm binary via data endpoint
+        self.device
+            .write_data_endpoint(Self::CH32H417_FLASH_OP, data_packet_size)?;
+
+        // Step 4: Acknowledge flash OP written
+        let ack = self.device.send_command_with_timeout(
+            commands::FlashProgram::new(commands::ProgramCommand::AckFlashOpWritten),
+            timeout,
+        )?;
+        if ack != 0x07 {
+            tracing::warn!("Unexpected Flash OP ack: {:#04x}", ack);
+        }
+
+        // Step 5: Start flash write
+        self.device.send_command_with_timeout(
+            commands::FlashProgram::new(commands::ProgramCommand::WriteFlash),
+            timeout,
+        )?;
+
+        // Step 6: Send data chunks via data endpoint, reading status after each
+        for chunk in data.chunks(write_pack_size) {
+            self.device.write_data_endpoint(chunk, data_packet_size)?;
+
+            let status = self.device.read_data_endpoint(4)?;
+            if status.len() >= 4 && status[3] != 0x04 {
+                return Err(DebugProbeError::Other(format!(
+                    "Flash write chunk failed: status {:02x?}",
+                    status
+                )));
+            }
+        }
+
+        // Step 7: End programming
+        self.device.send_command_with_timeout(
+            commands::FlashProgram::new(commands::ProgramCommand::End),
+            timeout,
+        )?;
+
+        tracing::info!("Flash programming completed.");
+        Ok(())
+    }
+
+    /// Reset the target via DMI ndmreset and let it run.
+    /// This is the proper reset sequence for RISC-V targets after flashing.
+    ///
+    /// `hart_ids` are the hart indices to reset.  On multi-hart systems
+    /// (e.g. CH32H41X with V5F+V3F), a single-hart ndmreset leaves the
+    /// other hart in whatever state the previous debug session left it,
+    /// causing attach failures on the next run.  The CH32H41X DM does not
+    /// support `hasel`, so we issue ndmreset to each hart individually.
+    pub fn reset_and_run(&mut self, hart_ids: &[u32]) -> Result<(), DebugProbeError> {
+        for &hart_id in hart_ids {
+            let hartsel = (hart_id & 0x3FF) << 16;
+
+            // Clear haltreq, keep dmactive
+            self.dmi_op_write(0x10, 0x00000001 | hartsel)?;
+            // Trigger ndmreset
+            self.dmi_op_write(0x10, 0x00000003 | hartsel)?;
+            // Hold reset for a few ms so it propagates through the chip
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            // Release ndmreset, keep dmactive (core comes out of reset)
+            self.dmi_op_write(0x10, 0x00000001 | hartsel)?;
+            // Give the debug module time to re-initialise after ndmreset.
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            // Acknowledge havereset
+            self.dmi_op_write(0x10, 0x10000001 | hartsel)?;
+
+            tracing::debug!("ndmreset issued to hart {}", hart_id);
+        }
+        Ok(())
+    }
+
+    /// Read flash memory contents via the WCH-Link firmware's read command.
+    /// The firmware returns data in big-endian word order; we convert to
+    /// little-endian and trim to the requested length.
+    pub fn read_flash(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError> {
+        tracing::info!(
+            "Reading {} bytes from 0x{:08X} via WCH-Link firmware...",
+            len,
+            address
+        );
+
+        let timeout = std::time::Duration::from_secs(10);
+
+        // Align length to 4 bytes as required by the firmware
+        let read_len = if len % 4 == 0 { len } else { (len / 4 + 1) * 4 };
+
+        // Set read memory region
+        self.device.send_command_with_timeout(
+            commands::FlashSetReadRegion {
+                start_addr: address,
+                len: read_len,
+            },
+            timeout,
+        )?;
+
+        // Trigger read
+        self.device.send_command_with_timeout(
+            commands::FlashProgram::new(commands::ProgramCommand::ReadMemory),
+            timeout,
+        )?;
+
+        // Read data back from the data endpoint
+        let mut data = self.device.read_data_endpoint(read_len as usize)?;
+
+        // Fix endian: firmware returns big-endian words, reverse each 4-byte chunk
+        for chunk in data.chunks_exact_mut(4) {
+            chunk.reverse();
+        }
+
+        // Trim to requested length
+        data.truncate(len as usize);
+
+        tracing::info!("Flash read completed, got {} bytes.", data.len());
+        Ok(data)
     }
 }
 

--- a/probe-rs/src/probe/wlink/usb_interface.rs
+++ b/probe-rs/src/probe/wlink/usb_interface.rs
@@ -11,11 +11,13 @@ use super::{WchLinkError, commands::WchLinkCommand, get_wlink_info};
 const ENDPOINT_OUT: u8 = 0x01;
 const ENDPOINT_IN: u8 = 0x81;
 
-// const RAW_ENDPOINT_OUT: u8 = 0x02;
-// const RAW_ENDPOINT_IN: u8 = 0x82;
+const DATA_ENDPOINT_OUT: u8 = 0x02;
+const DATA_ENDPOINT_IN: u8 = 0x82;
 
 pub struct WchLinkUsbDevice {
     device_handle: Interface,
+    data_ep_out: u8,
+    data_ep_in: u8,
 }
 
 impl WchLinkUsbDevice {
@@ -50,6 +52,8 @@ impl WchLinkUsbDevice {
 
         let mut endpoint_out = None;
         let mut endpoint_in = None;
+        let mut data_ep_out = None;
+        let mut data_ep_in = None;
         for endpoint in altsetting.endpoints() {
             if endpoint.transfer_type() != TransferType::Bulk {
                 continue;
@@ -62,6 +66,12 @@ impl WchLinkUsbDevice {
                 Direction::In if endpoint.address() == ENDPOINT_IN => {
                     endpoint_in = Some(endpoint.address());
                 }
+                Direction::Out if endpoint.address() == DATA_ENDPOINT_OUT => {
+                    data_ep_out = Some(endpoint.address());
+                }
+                Direction::In if endpoint.address() == DATA_ENDPOINT_IN => {
+                    data_ep_in = Some(endpoint.address());
+                }
                 _ => {}
             }
         }
@@ -70,6 +80,9 @@ impl WchLinkUsbDevice {
             return Err(WchLinkError::EndpointNotFound.into());
         }
 
+        let data_ep_out = data_ep_out.unwrap_or(DATA_ENDPOINT_OUT);
+        let data_ep_in = data_ep_in.unwrap_or(DATA_ENDPOINT_IN);
+
         tracing::trace!("Acquired handle for probe");
         let device_handle = device
             .claim_interface(interface.interface_number())
@@ -77,7 +90,11 @@ impl WchLinkUsbDevice {
             .map_err(|e| ProbeCreationError::Usb(e.into()))?;
         tracing::trace!("Claimed interface 0 of USB device.");
 
-        let usb_wlink = Self { device_handle };
+        let usb_wlink = Self {
+            device_handle,
+            data_ep_out,
+            data_ep_in,
+        };
 
         tracing::debug!("Successfully attached to WCH-Link.");
 
@@ -88,12 +105,20 @@ impl WchLinkUsbDevice {
         &mut self,
         cmd: C,
     ) -> Result<C::Response, DebugProbeError> {
+        self.send_command_with_timeout(cmd, Duration::from_millis(100))
+    }
+
+    /// Send a command with a custom timeout. Used for flash operations that may
+    /// take longer (e.g., EraseFlash can take several seconds).
+    pub(crate) fn send_command_with_timeout<C: WchLinkCommand + std::fmt::Debug>(
+        &mut self,
+        cmd: C,
+        timeout: Duration,
+    ) -> Result<C::Response, DebugProbeError> {
         tracing::trace!("Sending command: {:?}", cmd);
 
         let mut rxbuf = [0u8; 64];
         let len = cmd.to_bytes(&mut rxbuf)?;
-
-        let timeout = Duration::from_millis(100);
 
         let written_bytes = self
             .device_handle
@@ -132,5 +157,56 @@ impl WchLinkUsbDevice {
         let response = cmd.parse_response(&rxbuf[..read_bytes])?;
 
         Ok(response)
+    }
+
+    /// Write data to the probe via the data endpoint (0x02 OUT).
+    /// Used for sending flash algorithm binary and firmware data.
+    pub(crate) fn write_data_endpoint(
+        &mut self,
+        buf: &[u8],
+        packet_size: usize,
+    ) -> Result<(), DebugProbeError> {
+        let timeout = Duration::from_secs(10);
+
+        for chunk in buf.chunks(packet_size) {
+            let mut padded = chunk.to_vec();
+            if padded.len() < packet_size {
+                padded.resize(packet_size, 0xff);
+            }
+            let written = self
+                .device_handle
+                .write_bulk(self.data_ep_out, &padded, timeout)
+                .map_err(DebugProbeError::Usb)?;
+            if written != padded.len() {
+                return Err(WchLinkError::NotEnoughBytesWritten {
+                    is: written,
+                    should: padded.len(),
+                }
+                .into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Read data from the probe via the data endpoint (0x82 IN).
+    /// Used for receiving data during flash verify or memory read.
+    pub(crate) fn read_data_endpoint(&mut self, len: usize) -> Result<Vec<u8>, DebugProbeError> {
+        let timeout = Duration::from_secs(10);
+        let mut buf = vec![0u8; len];
+        let mut total = 0;
+        while total < len {
+            let chunk_size = std::cmp::min(64, len - total);
+            let n = self
+                .device_handle
+                .read_bulk(
+                    self.data_ep_in,
+                    &mut buf[total..total + chunk_size],
+                    timeout,
+                )
+                .map_err(DebugProbeError::Usb)?;
+            total += n;
+        }
+        buf.truncate(total);
+        Ok(buf)
     }
 }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -53,6 +53,10 @@ pub struct Session {
     interfaces: ArchitectureInterface,
     cores: Vec<CombinedCoreState>,
     configured_trace_sink: Option<TraceSink>,
+    /// Set to true when a probe-assisted flash operation (erase/program) was performed.
+    /// During drop, we skip halt/cleanup to avoid errors since the probe may have
+    /// left the target in a state where standard debug operations fail.
+    probe_assisted_done: bool,
 }
 
 /// The `SessionConfig` struct is used to configure a new `Session` during auto-attach.
@@ -208,7 +212,12 @@ impl Session {
             Self::attach_jtag(probe, target, attach_method, permissions, cores)?
         };
 
-        session.clear_all_hw_breakpoints()?;
+        if let Err(e) = session.clear_all_hw_breakpoints() {
+            tracing::warn!(
+                "Could not clear all hardware breakpoints during attach: {:?}",
+                e
+            );
+        }
 
         Ok(session)
     }
@@ -333,6 +342,7 @@ impl Session {
                 interfaces,
                 cores,
                 configured_trace_sink: None,
+                probe_assisted_done: false,
             };
 
             {
@@ -375,6 +385,7 @@ impl Session {
                 interfaces,
                 cores,
                 configured_trace_sink: None,
+                probe_assisted_done: false,
             })
         }
     }
@@ -516,6 +527,7 @@ impl Session {
             interfaces,
             cores,
             configured_trace_sink: None,
+            probe_assisted_done: false,
         };
 
         // Connect to the cores
@@ -918,6 +930,217 @@ impl Session {
         &self.target
     }
 
+    /// Try to erase flash using the probe's built-in flash commands.
+    /// Currently only supported for WCH-Link probes.
+    /// Returns Ok(true) if the probe handled the erase, Ok(false) if not.
+    pub fn try_erase_flash_via_probe(&mut self) -> Result<bool, Error> {
+        // Check if the connected probe is a WCH-Link and use its firmware flash commands.
+        let ArchitectureInterface::Jtag(probe, _) = &mut self.interfaces else {
+            return Ok(false);
+        };
+        let inner = probe.inner_mut();
+
+        // Check if the probe is a WCH-Link by comparing TypeId
+        {
+            let any_ref: &dyn std::any::Any = inner;
+            if any_ref.type_id() != std::any::TypeId::of::<crate::probe::wlink::WchLink>() {
+                return Ok(false);
+            }
+        }
+
+        // Downcast mutably to access WchLink's erase_flash method
+        let any_mut: &mut dyn std::any::Any = inner;
+        let wlink = any_mut
+            .downcast_mut::<crate::probe::wlink::WchLink>()
+            .expect("TypeId matched but downcast failed");
+        tracing::info!("Using WCH-Link firmware erase command");
+        wlink.erase_flash()?;
+        self.probe_assisted_done = true;
+        Ok(true)
+    }
+
+    /// Try to program flash using the probe's built-in flash commands.
+    /// Currently only supported for WCH-Link probes.
+    /// Returns Ok(true) if the probe handled the programming, Ok(false) if not.
+    pub fn try_program_flash_via_probe(
+        &mut self,
+        data: &[u8],
+        address: u32,
+    ) -> Result<bool, Error> {
+        use std::any::Any;
+        if let ArchitectureInterface::Jtag(probe, _) = &mut self.interfaces {
+            let inner: &mut dyn crate::probe::DebugProbe = probe.inner_mut();
+            let any: &mut dyn Any = inner;
+            if let Some(wlink) = any.downcast_mut::<crate::probe::wlink::WchLink>() {
+                tracing::info!("Using WCH-Link firmware program command");
+                wlink.program_flash(data, address)?;
+                self.probe_assisted_done = true;
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Combined probe-assisted flash: erase then program all NVM data.
+    /// Returns Ok(true) if the probe handled everything, Ok(false) if not applicable.
+    pub fn try_flash_via_probe(
+        &mut self,
+        nvm_data: &[(u32, &[u8])],
+        do_chip_erase: bool,
+        skip_erase: bool,
+    ) -> Result<bool, Error> {
+        if nvm_data.is_empty() {
+            return Ok(false);
+        }
+
+        // Probe-assisted flash only works for CH32H41X via WCH-Link.
+        let ArchitectureInterface::Jtag(probe, _) = &mut self.interfaces else {
+            return Ok(false);
+        };
+        {
+            let inner = probe.inner_mut();
+            let any_ref: &dyn std::any::Any = inner;
+            if any_ref.type_id() != std::any::TypeId::of::<crate::probe::wlink::WchLink>() {
+                return Ok(false);
+            }
+            let wlink = any_ref
+                .downcast_ref::<crate::probe::wlink::WchLink>()
+                .expect("TypeId matched but downcast failed");
+            if !wlink.supports_probe_assisted_flash() {
+                tracing::info!(
+                    "Probe-assisted flash not supported for this chip ({:?}), using normal path",
+                    wlink.chip_family
+                );
+                return Ok(false);
+            }
+        }
+
+        // Erase
+        if !skip_erase {
+            if do_chip_erase {
+                self.try_erase_flash_via_probe()?;
+            } else {
+                // Sector erase not supported via probe yet; only chip erase.
+                // Fall back to normal path for sector-level erase.
+                return Ok(false);
+            }
+        }
+
+        // Program each data block
+        for &(address, data) in nvm_data {
+            if data.is_empty() {
+                continue;
+            }
+            self.try_program_flash_via_probe(data, address)?;
+        }
+
+        // Reset chip via DMI ndmreset so it boots the new firmware.
+        // probe.target_reset() sends a firmware-level reset which may not
+        // properly restart the RISC-V core; we need a DM-level reset.
+        // Collect all RISC-V hart_ids so we can reset every hart
+        // individually.  A single-hart ndmreset leaves other harts in
+        // whatever state the previous debug session left them, causing
+        // attach failures on the next run (e.g. CH32H417 V3F stays halted
+        // while V5F resets and boots).
+        tracing::info!("Resetting chip via DMI ndmreset after probe-assisted flash...");
+        {
+            let ArchitectureInterface::Jtag(probe, _) = &mut self.interfaces else {
+                return Ok(true);
+            };
+            use probe_rs_target::CoreAccessOptions;
+            let mut hart_ids: Vec<u32> = self
+                .target
+                .cores
+                .iter()
+                .filter_map(|core| {
+                    if let CoreAccessOptions::Riscv(opts) = &core.core_access_options {
+                        Some(opts.hart_id.unwrap_or(0))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            // Reset coprocessor harts first, then the boot core last.
+            // If we reset the boot core first, it may start loading the
+            // coprocessor while we are still resetting it.
+            hart_ids.sort();
+            let inner = probe.inner_mut();
+            let any: &mut dyn std::any::Any = inner;
+            if let Some(wlink) = any.downcast_mut::<crate::probe::wlink::WchLink>() {
+                wlink.reset_and_run(&hart_ids)?;
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Returns true if the probe handled flash operations (erase/program)
+    /// via built-in firmware commands and the target is already running.
+    pub fn is_probe_assisted(&self) -> bool {
+        self.probe_assisted_done
+    }
+
+    /// Try to read flash memory via the probe's built-in commands.
+    /// Currently only supported for WCH-Link probes.
+    /// Returns Ok(Some(data)) if the probe handled the read, Ok(None) if not.
+    pub fn try_read_flash_via_probe(
+        &mut self,
+        address: u32,
+        len: u32,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        let ArchitectureInterface::Jtag(probe, _) = &mut self.interfaces else {
+            return Ok(None);
+        };
+        let inner = probe.inner_mut();
+        let any_ref: &dyn std::any::Any = inner;
+        if any_ref.type_id() != std::any::TypeId::of::<crate::probe::wlink::WchLink>() {
+            return Ok(None);
+        }
+        let any_mut: &mut dyn std::any::Any = inner;
+        let wlink = any_mut
+            .downcast_mut::<crate::probe::wlink::WchLink>()
+            .expect("TypeId matched but downcast failed");
+        wlink.read_flash(address, len).map(Some).map_err(Into::into)
+    }
+
+    /// Try to verify flash contents via the probe's built-in commands.
+    /// Currently only supported for WCH-Link probes.
+    /// Returns Ok(true) if the probe verified successfully, Ok(false) if not,
+    /// Err(FlashError::Verify) on mismatch or other flash errors.
+    pub fn try_verify_flash_via_probe(
+        &mut self,
+        expected: &[(u32, &[u8])],
+    ) -> Result<bool, crate::flashing::FlashError> {
+        if expected.is_empty() {
+            return Ok(false);
+        }
+
+        for &(address, data) in expected {
+            if data.is_empty() {
+                continue;
+            }
+            let actual = match self
+                .try_read_flash_via_probe(address, data.len() as u32)
+                .map_err(|e| crate::flashing::FlashError::ChipEraseFailed {
+                    source: Box::new(e),
+                })? {
+                Some(d) => d,
+                None => return Ok(false),
+            };
+            if actual != data {
+                tracing::warn!(
+                    "Verify mismatch at 0x{:08X}: expected {:02x?}, got {:02x?}",
+                    address,
+                    &data[..data.len().min(16)],
+                    &actual[..actual.len().min(16)]
+                );
+                return Err(crate::flashing::FlashError::Verify);
+            }
+        }
+
+        Ok(true)
+    }
+
     /// Configure the target and probe for serial wire view (SWV) tracing.
     pub fn setup_tracing(
         &mut self,
@@ -1054,6 +1277,13 @@ const _: fn() = || {
 impl Drop for Session {
     #[tracing::instrument(name = "session_drop", skip(self))]
     fn drop(&mut self) {
+        // After a probe-assisted flash operation, the target may be in a state
+        // where standard debug halt operations fail. Skip cleanup in that case.
+        if self.probe_assisted_done {
+            tracing::info!("Skipping session cleanup after probe-assisted flash operation");
+            return;
+        }
+
         if let Err(err) = self.clear_all_hw_breakpoints() {
             tracing::warn!(
                 "Could not clear all hardware breakpoints: {:?}",

--- a/probe-rs/targets/CH32H4_Series.yaml
+++ b/probe-rs/targets/CH32H4_Series.yaml
@@ -1,0 +1,121 @@
+name: CH32H4 Series
+variants:
+- name: CH32H417
+  cores:
+  - name: main
+    type: riscv
+    core_access_options: !Riscv
+      hart_id: 1
+      jtag_tap: 0
+  - name: v3f_coprocessor
+    type: riscv
+    core_access_options: !Riscv
+      hart_id: 0
+      jtag_tap: 0
+  memory_map:
+  - !Nvm
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - v3f_coprocessor
+    - main
+    access:
+      boot: true
+  - !Ram
+    range:
+      start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    range:
+      start: 0x200a0000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    range:
+      start: 0x200c0000
+      end: 0x20100000
+    cores:
+    - main
+  - !Ram
+    range:
+      start: 0x20100000
+      end: 0x20180000
+    cores:
+    - main
+    - v3f_coprocessor
+  flash_algorithms: []
+- name: CH32H415
+  cores:
+  - name: main
+    type: riscv
+    core_access_options: !Riscv
+      hart_id: 0
+  memory_map:
+  - !Nvm
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - v3f_coprocessor
+    - main
+    access:
+      boot: true
+  - !Ram
+    range:
+      start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    range:
+      start: 0x200a0000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    range:
+      start: 0x200c0400
+      end: 0x20100000
+    cores:
+    - main
+  flash_algorithms: []
+- name: CH32H416
+  cores:
+  - name: main
+    type: riscv
+    core_access_options: !Riscv
+      hart_id: 0
+  memory_map:
+  - !Nvm
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - v3f_coprocessor
+    - main
+    access:
+      boot: true
+  - !Ram
+    range:
+      start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Ram
+    range:
+      start: 0x200a0000
+      end: 0x200c0000
+    cores:
+    - main
+  - !Ram
+    range:
+      start: 0x200c0400
+      end: 0x20100000
+    cores:
+    - main
+  flash_algorithms: []
+flash_algorithms: []

--- a/probe-rs/targets/CH32H4_Series.yaml
+++ b/probe-rs/targets/CH32H4_Series.yaml
@@ -60,7 +60,6 @@ variants:
       start: 0x8000000
       end: 0x8078000
     cores:
-    - v3f_coprocessor
     - main
     access:
       boot: true
@@ -95,7 +94,6 @@ variants:
       start: 0x8000000
       end: 0x8078000
     cores:
-    - v3f_coprocessor
     - main
     access:
       boot: true


### PR DESCRIPTION
Adds target support for the CH32H41x series — dual-core RISC-V MCUs (QingKe-V5F main + QingKe-V3F coprocessor) debugged via WCH-LinkE.

## Flash approach

The CH32H417 cannot use standard DMI-based flash algorithms: setting dmactive=1 on V5F locks the debug module, and V3F has no D-Code bus to flash. This PR uses probe-assisted flash — the WCH-LinkE firmware performs erase/program/verify via USB commands, which bypasses the DM entirely.

The flash operation binary embedded in the driver (`CH32H417_FLASH_OP`) is from the [wlink](https://github.com/ch32-rs/wlink) open-source project (`flash_op::CH32H417`).

## Changes

- New `CH32H4_Series.yaml` target definition with dual-core memory map
- Probe-assisted flash: erase, program, read, verify via WCH-LinkE firmware
- Multi-hart reset after flash (V3F first, then V5F)
- RISC-V DM fixes: cmderr safe clear per Debug Spec, hartsellen guard, DCSR step bit clear
- Flash loader falls back to DMI path when not using WCH-LinkE
- `probe-rs info` shows WCH ChipID

## Tested

- Flash 120KB firmware via `probe-rs download` (~0.7s)
- RTT attach with boot message verification
- 10-cycle stress test with unclean exit recovery
- Only CH32H417 physically tested; H415/H416 follow the same spec