### PR TITLE
Allow disassembling and examining functions and globals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3049,6 +3049,7 @@ dependencies = [
  "pretty_assertions",
  "probe-rs",
  "probe-rs-target",
+ "rustc-demangle",
  "serde",
  "termtree",
  "test-case",

--- a/changelog/added-examine-symbols.md
+++ b/changelog/added-examine-symbols.md
@@ -1,0 +1,1 @@
+Added syntax for examining memory described by an ELF symbol, e.g. `x/i main`, `x/b fmt::vtable`.  When the Nuf doesn't have an explicit count (like x/i), use the symbol's size.  Support both .symtab and DWARF symbols, both functions and global variables.

--- a/probe-rs-debug/Cargo.toml
+++ b/probe-rs-debug/Cargo.toml
@@ -22,6 +22,7 @@ object = "0.39"
 parse_int = "0.9.0"
 probe-rs = { workspace = true }
 probe-rs-target.workspace = true
+rustc-demangle = "0.1.26"
 serde = { version = "1.0.217", features = ["derive"] }
 thiserror.workspace = true
 tracing = "0.1.41"

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -33,6 +33,7 @@ pub(crate) type GimliAttribute = gimli::Attribute<GimliReader>;
 
 pub(crate) type DwarfReader = gimli::read::EndianRcSlice<RunTimeEndian>;
 
+#[derive(Clone)]
 pub enum SymbolType {
     // Non-inlined functions can still be split across several byte ranges; a
     // hot/cold code split is one reason.  So we need a set of ranges, not just
@@ -47,6 +48,7 @@ pub enum SymbolType {
     Variable { range: Range<u64> },
 }
 
+#[derive(Clone)]
 pub struct Symbol {
     pub name: String,
     pub symbol_type: SymbolType,
@@ -1070,6 +1072,37 @@ impl DebugInfo {
                 "Unimplemented attribute value {other_attribute_value:?}"
             ))),
         }
+    }
+
+    pub fn find_symbols(&self, query: &str) -> Vec<Symbol> {
+        fn break_up<'a>(s: &'a str) -> impl Iterator<Item = &'a str> + Clone + 'a {
+            s.split(|c: char| !c.is_alphanumeric() && c != '_')
+                .filter(|s| !s.is_empty())
+        }
+        let query_iter = break_up(query);
+        if query_iter.clone().next().is_none() {
+            return vec![];
+        }
+
+        let mut matching = vec![];
+
+        for symbol in &self.symbols {
+            let mut query_iter = query_iter.clone();
+            let candidate = break_up(&symbol.name);
+            let mut query_term = query_iter.next();
+            // match terms in order, but potentially separated by identifiers in
+            // the candidate
+            for identifier in candidate {
+                if query_term.is_some() && identifier == query_term.unwrap() {
+                    query_term = query_iter.next();
+                }
+            }
+            if query_term.is_none() {
+                matching.push(symbol.clone());
+            }
+        }
+
+        matching
     }
 }
 

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -14,7 +14,14 @@ use gimli::{
 use object::read::{Object, ObjectSection};
 use probe_rs::{CoreRegister, Error, InstructionSet, MemoryInterface, RegisterRole, RegisterValue};
 use std::{
-    borrow, cmp::Ordering, num::NonZeroU64, ops::ControlFlow, path::Path, rc::Rc, str::from_utf8,
+    borrow,
+    cmp::Ordering,
+    collections::HashMap,
+    num::NonZeroU64,
+    ops::{ControlFlow, Range},
+    path::Path,
+    rc::Rc,
+    str::from_utf8,
 };
 use typed_path::{TypedPath, TypedPathBuf};
 
@@ -25,6 +32,25 @@ pub(crate) type GimliReaderOffset =
 pub(crate) type GimliAttribute = gimli::Attribute<GimliReader>;
 
 pub(crate) type DwarfReader = gimli::read::EndianRcSlice<RunTimeEndian>;
+
+pub enum SymbolType {
+    // Non-inlined functions can still be split across several byte ranges; a
+    // hot/cold code split is one reason.  So we need a set of ranges, not just
+    // a start and end.
+    Function { ranges: Vec<Range<u64>> },
+    // The value here is the concrete function that eventually calls this
+    // inlined function.
+    // If it's called by several others in a call stack, the value is the final
+    // (top level) concrete function; put another way, the symbol in here is not
+    // an inline function.
+    InlinedFunction { concrete_caller: String },
+    Variable { range: Range<u64> },
+}
+
+pub struct Symbol {
+    pub name: String,
+    pub symbol_type: SymbolType,
+}
 
 /// Debug information which is parsed from DWARF debugging information.
 pub struct DebugInfo {
@@ -38,6 +64,8 @@ pub struct DebugInfo {
     pub(crate) endianness: gimli::RunTimeEndian,
 
     pub(crate) addr2line: Option<addr2line::Loader>,
+
+    pub(crate) symbols: Vec<Symbol>,
 }
 
 impl DebugInfo {
@@ -52,7 +80,31 @@ impl DebugInfo {
 
     /// Parse debug information directly from a buffer containing an ELF file.
     pub fn from_raw(data: &[u8]) -> Result<Self, DebugError> {
+        use object::ObjectSymbol;
+
         let object = object::File::parse(data)?;
+
+        let mut sym_hash = HashMap::new();
+
+        // We add all the symbols from both the symtab and the debug info to the
+        // list that we'll use for disassembly.  Drop them into a hashmap at
+        // first, so we de-duplicate, then drop them into a sorted vector at the
+        // end.
+        for symbol in object.symbols() {
+            let name = rustc_demangle::demangle(symbol.name()?).to_string();
+            sym_hash.insert(
+                name.clone(),
+                Symbol {
+                    name: name,
+                    symbol_type: SymbolType::Function {
+                        ranges: vec![Range {
+                            start: symbol.address(),
+                            end: symbol.address() + symbol.size(),
+                        }],
+                    },
+                },
+            );
+        }
 
         let endianness = if object.is_little_endian() {
             RunTimeEndian::Little
@@ -98,9 +150,12 @@ impl DebugInfo {
                 // The frame section address size is only used for CIE versions before 4.
                 frame_section.set_address_size(unit.encoding().address_size);
 
-                unit_infos.push(UnitInfo::new(unit, &dwarf_cow));
+                unit_infos.push(UnitInfo::new(unit, &dwarf_cow, &mut sym_hash));
             };
         }
+
+        let sym_vec = sym_hash.into_values().collect::<Vec<_>>();
+        //sym_vec.sort_by(|sym| sym.name());
 
         Ok(DebugInfo {
             dwarf: dwarf_cow,
@@ -111,6 +166,7 @@ impl DebugInfo {
             unit_infos,
             endianness,
             addr2line: None,
+            symbols: sym_vec,
         })
     }
 

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -8,15 +8,15 @@ use super::{
 };
 use crate::{SourceLocation, VerifiedBreakpoint, stack_frame::StackFrameInfo, unit_info::RangeExt};
 use gimli::{
-    BaseAddresses, DebugFrame, RunTimeEndian, UnwindContext, UnwindSection, UnwindTableRow,
-    read::RegisterRule,
+    BaseAddresses, DebugFrame, RunTimeEndian, UnitOffset, UnwindContext, UnwindSection,
+    UnwindTableRow, read::RegisterRule,
 };
 use object::read::{Object, ObjectSection};
 use probe_rs::{CoreRegister, Error, InstructionSet, MemoryInterface, RegisterRole, RegisterValue};
 use std::{
     borrow,
     cmp::Ordering,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     num::NonZeroU64,
     ops::{ControlFlow, Range},
     path::Path,
@@ -34,24 +34,59 @@ pub(crate) type GimliAttribute = gimli::Attribute<GimliReader>;
 pub(crate) type DwarfReader = gimli::read::EndianRcSlice<RunTimeEndian>;
 
 #[derive(Clone)]
-pub enum SymbolType {
+pub enum SymbolName {
+    // The name of this symbol is known: either present in the DIE directly, or
+    // contained in a DW_AT_abstract_origin whose target is present in the
+    // full_names map.
+    Known(String),
+    // This symbol's name is not known at DIE iteration time; instead, it can be
+    // looked up by finding the given offset in the full_names map after the DIE
+    // iteration has finished.
+    Deferred(UnitOffset),
+    // This symbol's name exists in the DIE's name attribute but we still need
+    // to calculate it.
+    GenerateFromNameAttr,
+    // This symbol had a name stored in another DIE, but we didn't have a DIE
+    // at that offset.
+    LinkNotFound(UnitOffset),
+}
+
+impl std::fmt::Display for SymbolName {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            SymbolName::Known(name) => {
+                f.write_str(name)?;
+            }
+            SymbolName::Deferred(offset) => {
+                write!(f, "deferred symbol @{offset:?}")?;
+            }
+            SymbolName::GenerateFromNameAttr => {
+                f.write_str("z_can't happen: could not find a name attribute")?;
+            }
+            SymbolName::LinkNotFound(offset) => {
+                write!(f, "z_symbol name link not found at offset {offset:?}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub enum SymbolKind {
     // Non-inlined functions can still be split across several byte ranges; a
     // hot/cold code split is one reason.  So we need a set of ranges, not just
     // a start and end.
-    Function { ranges: Vec<Range<u64>> },
-    // The value here is the concrete function that eventually calls this
-    // inlined function.
-    // If it's called by several others in a call stack, the value is the final
-    // (top level) concrete function; put another way, the symbol in here is not
-    // an inline function.
-    InlinedFunction { concrete_caller: String },
-    Variable { range: Range<u64> },
+    Function(Vec<Range<u64>>),
+    // The value here is the "concrete", as in "not inlined itself", caller.
+    // That symbol should show up as a Function() variant above.
+    InlinedFunction(String),
+    Variable(Range<u64>),
 }
 
 #[derive(Clone)]
 pub struct Symbol {
-    pub name: String,
-    pub symbol_type: SymbolType,
+    pub name: SymbolName,
+    pub kind: SymbolKind,
 }
 
 /// Debug information which is parsed from DWARF debugging information.
@@ -80,13 +115,48 @@ impl DebugInfo {
         Ok(this)
     }
 
+    fn append_hash_if_present(
+        name: &mut SymbolName,
+        ranges: &[Range<u64>],
+        symtab_hash: &mut HashMap<u64, Symbol>,
+    ) {
+        if let SymbolName::Known(name) = name
+            && !ranges.is_empty()
+            && let Some(ref symtab_sym) = symtab_hash.remove(&ranges[0].start)
+            && let Some((_, suffix)) = symtab_sym.name.to_string().rsplit_once("::")
+            && suffix.starts_with('h')
+            && suffix[1..].chars().all(|c| c.is_ascii_hexdigit())
+        {
+            let symtab_name = symtab_sym.name.to_string();
+            let hash_with_colons = &symtab_name[symtab_name.len() - suffix.len() - 2..];
+            name.push_str(hash_with_colons);
+        }
+    }
+
+    fn get_symbol_kind(symbol: &object::Symbol) -> Option<SymbolKind> {
+        use object::ObjectSymbol;
+
+        match symbol.kind() {
+            object::SymbolKind::Text => Some(SymbolKind::Function(vec![Range {
+                start: symbol.address(),
+                end: symbol.address() + symbol.size(),
+            }])),
+            object::SymbolKind::Data => Some(SymbolKind::Variable(Range {
+                start: symbol.address(),
+                end: symbol.address() + symbol.size(),
+            })),
+            _ => None,
+        }
+    }
+
     /// Parse debug information directly from a buffer containing an ELF file.
     pub fn from_raw(data: &[u8]) -> Result<Self, DebugError> {
         use object::ObjectSymbol;
 
         let object = object::File::parse(data)?;
 
-        let mut sym_hash = HashMap::new();
+        let mut dwarf_symbols = HashMap::new();
+        let mut symtab_hash = HashMap::new();
 
         // We add all the symbols from both the symtab and the debug info to the
         // list that we'll use for disassembly.  Drop them into a hashmap at
@@ -94,18 +164,15 @@ impl DebugInfo {
         // end.
         for symbol in object.symbols() {
             let name = rustc_demangle::demangle(symbol.name()?).to_string();
-            sym_hash.insert(
-                name.clone(),
-                Symbol {
-                    name: name,
-                    symbol_type: SymbolType::Function {
-                        ranges: vec![Range {
-                            start: symbol.address(),
-                            end: symbol.address() + symbol.size(),
-                        }],
+            if let Some(kind) = Self::get_symbol_kind(&symbol) {
+                symtab_hash.insert(
+                    symbol.address(),
+                    Symbol {
+                        name: SymbolName::Known(name),
+                        kind,
                     },
-                },
-            );
+                );
+            }
         }
 
         let endianness = if object.is_little_endian() {
@@ -152,12 +219,58 @@ impl DebugInfo {
                 // The frame section address size is only used for CIE versions before 4.
                 frame_section.set_address_size(unit.encoding().address_size);
 
-                unit_infos.push(UnitInfo::new(unit, &dwarf_cow, &mut sym_hash));
-            };
+                unit_infos.push(UnitInfo::new(unit, &dwarf_cow, &mut dwarf_symbols));
+            }
         }
 
-        let sym_vec = sym_hash.into_values().collect::<Vec<_>>();
-        //sym_vec.sort_by(|sym| sym.name());
+        // Now merge symtab_hash and dwarf_symbols -- match them up by address, and
+        // pull the ::hXXXX disambiguator off the symtab version of the name, if
+        // present there.  Prefer all other name elements from the DWARF data.
+
+        let mut sym_vec = Vec::with_capacity(dwarf_symbols.len());
+        let mut inlined = Vec::with_capacity(dwarf_symbols.len());
+        let mut surviving_callers = HashSet::new();
+
+        for (sym_key, mut sym) in dwarf_symbols {
+            match sym.kind {
+                SymbolKind::Function(ref ranges) => {
+                    Self::append_hash_if_present(&mut sym.name, ranges, &mut symtab_hash);
+                    // If there are no ranges after all the processing we did in
+                    // unit_info.rs, then this must have been optimized all the
+                    // way out.  Don't emit an entry for it.
+                    if !ranges.is_empty() {
+                        sym_vec.push(sym);
+                        surviving_callers.insert(sym_key);
+                    }
+                }
+                SymbolKind::InlinedFunction(..) => {
+                    inlined.push(sym);
+                }
+                SymbolKind::Variable(_) => {
+                    sym_vec.push(sym);
+                }
+            }
+        }
+
+        sym_vec.extend_from_slice(
+            &inlined
+                .into_iter()
+                .filter(|sym| {
+                    if let SymbolKind::InlinedFunction(ref concrete_caller) = sym.kind {
+                        surviving_callers.contains(concrete_caller)
+                    } else {
+                        false
+                    }
+                })
+                .collect::<Vec<_>>(),
+        );
+
+        // If there's anything left in the symtab hash, add it to the output too
+        for sym in symtab_hash.into_values() {
+            sym_vec.push(sym);
+        }
+
+        sym_vec.sort_by_key(|sym| sym.name.to_string());
 
         Ok(DebugInfo {
             dwarf: dwarf_cow,
@@ -1075,25 +1188,30 @@ impl DebugInfo {
     }
 
     pub fn find_symbols(&self, query: &str) -> Vec<Symbol> {
-        fn break_up<'a>(s: &'a str) -> impl Iterator<Item = &'a str> + Clone + 'a {
+        fn break_up(s: &str) -> impl Iterator<Item = &str> + Clone + '_ {
             s.split(|c: char| !c.is_alphanumeric() && c != '_')
                 .filter(|s| !s.is_empty())
         }
-        let query_iter = break_up(query);
-        if query_iter.clone().next().is_none() {
-            return vec![];
+        let mut query_iter = break_up(query).peekable();
+        let mut matching = vec![];
+        if query_iter.peek().is_none() {
+            return matching;
         }
 
-        let mut matching = vec![];
-
         for symbol in &self.symbols {
+            if symbol.name.to_string() == query {
+                // If there's a single full-match, return just it, even if its
+                // terms also match a sub-sequence of other symbols.
+                return vec![symbol.clone()];
+            }
             let mut query_iter = query_iter.clone();
-            let candidate = break_up(&symbol.name);
+            let name = &symbol.name.to_string();
+            let candidate = break_up(name);
             let mut query_term = query_iter.next();
-            // match terms in order, but potentially separated by identifiers in
+            // Match terms in order, but potentially separated by identifiers in
             // the candidate
             for identifier in candidate {
-                if query_term.is_some() && identifier == query_term.unwrap() {
+                if query_term.is_some_and(|t| t == identifier) {
                     query_term = query_iter.next();
                 }
             }

--- a/probe-rs-debug/src/unit_info.rs
+++ b/probe-rs-debug/src/unit_info.rs
@@ -18,20 +18,32 @@ pub(crate) enum ExpressionResult {
     Location(VariableLocation),
 }
 
+#[derive(Clone)]
+struct ParentLink {
+    /// The offet of the *parent* DIE
+    offset: UnitOffset,
+    /// The partial name of the *child*
+    partial_name: String,
+}
+
 /// A struct containing information about a single compilation unit.
 pub struct UnitInfo {
     pub(crate) unit: gimli::Unit<GimliReader, usize>,
     dwarf_language: gimli::DwLang,
     language: Box<dyn language::ProgrammingLanguage>,
-    // A mapping from child die to parent die.
-    parents: HashMap<UnitOffset, UnitOffset>,
+    // A mapping from child die to parent die + parent partial name.
+    parents: HashMap<UnitOffset, ParentLink>,
     // Address => function DIE offset
     function_dies: Vec<(Range<u64>, UnitOffset)>,
 }
 
 impl UnitInfo {
     /// Create a new `UnitInfo` from a `gimli::Unit`.
-    pub fn new(unit: gimli::Unit<GimliReader, usize>, dwarf: &gimli::Dwarf<GimliReader>) -> Self {
+    pub fn new(
+        unit: gimli::Unit<GimliReader, usize>,
+        dwarf: &gimli::Dwarf<GimliReader>,
+        symbols: &mut HashMap<String, Symbol>,
+    ) -> Self {
         let dwarf_language = if let Some(AttributeValue::Language(unit_language)) = unit
             .entry(unit.root_offset())
             .ok()
@@ -51,12 +63,78 @@ impl UnitInfo {
             function_dies: Vec::new(),
         };
 
-        this.process_unit(dwarf);
+        this.process_unit(dwarf, symbols);
 
         this
     }
 
-    fn process_unit(&mut self, dwarf: &gimli::Dwarf<GimliReader>) {
+    fn process_variable(
+        &self,
+        dwarf: &gimli::Dwarf<GimliReader>,
+        entry: &DebuggingInformationEntry<GimliReader>,
+    ) -> Option<SymbolType> {
+        let addr = entry
+            .attr(gimli::DW_AT_location)
+            .and_then(|attr| {
+                if let AttributeValue::Exprloc(expression) = attr.value() {
+                    Some(expression)
+                } else {
+                    None
+                }
+            })
+            .and_then(|expr| {
+                let mut evaluation = expr.evaluation(self.unit.encoding());
+                let mut result = evaluation.evaluate().ok()?;
+                loop {
+                    match result {
+                        EvaluationResult::Complete => {
+                            return evaluation.value_result();
+                        }
+                        EvaluationResult::RequiresIndexedAddress { index, relocate: _ } => {
+                            let address = dwarf.address(&self.unit, index).ok()?;
+                            result = evaluation.resume_with_indexed_address(address).ok()?;
+                        }
+                        EvaluationResult::RequiresRelocatedAddress(address) => {
+                            // microcontroller binaries aren't relocated; we
+                            // very likely won't see this.
+                            result = evaluation.resume_with_relocated_address(address).ok()?;
+                        }
+                        _ => {
+                            return None;
+                        }
+                    }
+                }
+            })
+            .and_then(|value| value.to_u64(!0).ok())?;
+        let size = entry
+            .attr(gimli::DW_AT_type)
+            .and_then(|type_attr| {
+                if let AttributeValue::UnitRef(offset) = type_attr.value() {
+                    Some(offset)
+                } else {
+                    None
+                }
+            })
+            .and_then(|offset| {
+                self.unit
+                    .entry(offset)
+                    .ok()?
+                    .attr(gimli::DW_AT_byte_size)
+                    .and_then(|size_attr| size_attr.udata_value())
+            })?;
+        Some(SymbolType::Variable {
+            range: Range {
+                start: addr,
+                end: addr + size,
+            },
+        })
+    }
+
+    fn process_unit(
+        &mut self,
+        dwarf: &gimli::Dwarf<GimliReader>,
+        symbols: &mut HashMap<String, Symbol>,
+    ) {
         let mut entries_cursor = self.unit.entries();
 
         let mut prev_offset = None;
@@ -71,9 +149,11 @@ impl UnitInfo {
                     let walk_up = |mut levels| {
                         // If 0:  Previous die is a sibling, we have the same parent.
                         // If <0: Previous die is a child of one of our siblings. Trace back as many levels as needed, and grab the parent.
-                        let mut cursor = prev_offset.map(|off| self.parents.get(&off).copied())?;
+                        let mut cursor = prev_offset
+                            .map(|off| self.parents.get(&off).map(|link| link.offset))?;
                         while levels != 0 {
-                            cursor = cursor.map(|off| self.parents.get(&off).copied())?;
+                            cursor =
+                                cursor.map(|off| self.parents.get(&off).map(|link| link.offset))?;
                             levels += 1;
                         }
                         cursor
@@ -83,20 +163,105 @@ impl UnitInfo {
                 _ => unreachable!("DFS algorithms never jump down multiple levels in the graph"),
             };
 
+            let extract_name = |die: &DebuggingInformationEntry<GimliReader>| -> Option<String> {
+                use gimli::Reader;
+                let attr = die.attr_value(gimli::DW_AT_name)?;
+                let name_as_bytes = dwarf.attr_string(&self.unit, attr).ok()?;
+                name_as_bytes.to_string_lossy().ok().map(|s| s.into_owned())
+            };
+
             if let Some(offset) = parent_offset {
-                self.parents.insert(current.offset(), offset);
+                let parent_name = self
+                    .parents
+                    .get(&offset)
+                    .map(|link| link.partial_name.clone())
+                    .unwrap_or_default();
+
+                let name_opt = extract_name(current).unwrap_or_default();
+                let mut current_name =
+                    String::with_capacity(parent_name.len() + 2 + name_opt.len());
+                current_name.push_str(&parent_name);
+                current_name.push_str("::");
+                current_name.push_str(&name_opt);
+
+                self.parents.insert(
+                    current.offset(),
+                    ParentLink {
+                        offset,
+                        partial_name: current_name,
+                    },
+                );
             }
             previous_depth = current.depth();
             prev_offset = Some(current.offset());
 
-            // Cache the address ranges if this DIE is a function.
-            if current.tag() == gimli::DW_TAG_subprogram
-                && let Ok(Some(ranges)) = FunctionDie::function_ranges(current, self, dwarf)
-            {
-                for range in ranges {
-                    self.function_dies.push((range, current.offset()));
+            // Cache the address ranges if this DIE is a function, and add it to
+            // the symbols map if it's a function, inlined function, or variable
+            match current.tag() {
+                gimli::DW_TAG_subprogram => {
+                    let ranges = if let Ok(Some(ranges)) =
+                        FunctionDie::function_ranges(current, self, dwarf)
+                    {
+                        for range in &ranges {
+                            self.function_dies.push((range.clone(), current.offset()));
+                        }
+                        ranges
+                    } else {
+                        vec![]
+                    };
+                    Some(SymbolType::Function { ranges })
                 }
+                gimli::DW_TAG_inlined_subroutine => {
+                    let mut offset = current.offset();
+                    let mut concrete_partial_name = None;
+                    while let Some(link) = self.parents.get(&offset) {
+                        match self.unit.entry(link.offset).ok().and_then(|entry| {
+                            if entry.tag() == gimli::DW_TAG_subprogram {
+                                self.parents
+                                    .get(&entry.offset())
+                                    .map(|link| link.partial_name.clone())
+                            } else {
+                                None
+                            }
+                        }) {
+                            Some(concrete_name) => {
+                                concrete_partial_name = Some(concrete_name);
+                            }
+                            None => {
+                                offset = link.offset;
+                            }
+                        }
+                        if concrete_partial_name.is_some() {
+                            break;
+                        }
+                    }
+                    concrete_partial_name.map(|name| SymbolType::InlinedFunction {
+                        concrete_caller: name,
+                    })
+                }
+                gimli::DW_TAG_variable => self.process_variable(dwarf, current),
+                _ => None,
             }
+            .map(|symbol_type| {
+                let mut name = self.parents[&current.offset()].partial_name.clone();
+                if let SymbolType::InlinedFunction { concrete_caller: _ } = symbol_type
+                    && let Ok(Some(ranges)) = FunctionDie::function_ranges(current, self, dwarf)
+                    && ranges.len() > 0
+                {
+                    // Inlined functions aren't in the .symtab, so we don't need
+                    // to worry about matching the format of rustc_demangle.  We
+                    // just need to make sure the string is unique across all
+                    // instances of the inlined function.
+                    name = format!("{} @{:#010X}", name, ranges[0].start)
+                }
+                symbols.insert(
+                    name.clone(),
+                    Symbol {
+                        name: name,
+                        symbol_type,
+                    },
+                );
+            });
 
             // TODO: assuming the ranges don't overlap, sort function dies by start address
         }
@@ -2310,7 +2475,7 @@ impl UnitInfo {
     }
 
     pub(crate) fn parent_offset(&self, offset: UnitOffset) -> Option<UnitOffset> {
-        self.parents.get(&offset).copied()
+        self.parents.get(&offset).map(|link| link.offset)
     }
 }
 

--- a/probe-rs-debug/src/unit_info.rs
+++ b/probe-rs-debug/src/unit_info.rs
@@ -18,21 +18,15 @@ pub(crate) enum ExpressionResult {
     Location(VariableLocation),
 }
 
-#[derive(Clone)]
-struct ParentLink {
-    /// The offet of the *parent* DIE
-    offset: UnitOffset,
-    /// The partial name of the *child*
-    partial_name: String,
-}
-
 /// A struct containing information about a single compilation unit.
 pub struct UnitInfo {
     pub(crate) unit: gimli::Unit<GimliReader, usize>,
     dwarf_language: gimli::DwLang,
     language: Box<dyn language::ProgrammingLanguage>,
-    // A mapping from child die to parent die + parent partial name.
-    parents: HashMap<UnitOffset, ParentLink>,
+    // A mapping from child die to parent die.
+    parents: HashMap<UnitOffset, UnitOffset>,
+    // A mapping from die to its full name.
+    full_names: HashMap<UnitOffset, String>,
     // Address => function DIE offset
     function_dies: Vec<(Range<u64>, UnitOffset)>,
 }
@@ -60,6 +54,7 @@ impl UnitInfo {
             dwarf_language,
             language: language::from_dwarf(dwarf_language),
             parents: HashMap::new(),
+            full_names: HashMap::new(),
             function_dies: Vec::new(),
         };
 
@@ -68,11 +63,58 @@ impl UnitInfo {
         this
     }
 
+    fn process_subprogram(
+        &self,
+        dwarf: &gimli::Dwarf<GimliReader>,
+        entry: &DebuggingInformationEntry<GimliReader>,
+        function_dies: &mut Vec<(Range<u64>, UnitOffset)>,
+    ) -> Option<Symbol> {
+        let ranges = if let Ok(Some(ranges)) = FunctionDie::function_ranges(entry, self, dwarf) {
+            for range in &ranges {
+                function_dies.push((range.clone(), entry.offset()));
+            }
+            ranges
+        } else {
+            vec![]
+        };
+        if entry.has_attr(gimli::DW_AT_inline) {
+            None
+        } else {
+            Some(Symbol {
+                name: SymbolName::GenerateFromNameAttr,
+                kind: SymbolKind::Function(ranges),
+            })
+        }
+    }
+
+    fn process_inlined(
+        &self,
+        entry: &DebuggingInformationEntry<GimliReader>,
+        current_subprogram: Option<&(String, isize)>,
+    ) -> Option<Symbol> {
+        let origin = entry
+            .attr(gimli::DW_AT_abstract_origin)
+            .and_then(|origin_attr| {
+                if let gimli::AttributeValue::UnitRef(unit_ref_offset) = origin_attr.value() {
+                    self.full_names
+                        .get(&unit_ref_offset)
+                        .map(|name| SymbolName::Known(name.clone()))
+                        .or(Some(SymbolName::Deferred(unit_ref_offset)))
+                } else {
+                    None
+                }
+            })?;
+        Some(Symbol {
+            name: origin,
+            kind: SymbolKind::InlinedFunction(current_subprogram?.0.clone()),
+        })
+    }
+
     fn process_variable(
         &self,
         dwarf: &gimli::Dwarf<GimliReader>,
         entry: &DebuggingInformationEntry<GimliReader>,
-    ) -> Option<SymbolType> {
+    ) -> Option<Symbol> {
         let addr = entry
             .attr(gimli::DW_AT_location)
             .and_then(|attr| {
@@ -120,14 +162,69 @@ impl UnitInfo {
                     .entry(offset)
                     .ok()?
                     .attr(gimli::DW_AT_byte_size)
-                    .and_then(|size_attr| size_attr.udata_value())
+                    .and_then(gimli::Attribute::udata_value)
             })?;
-        Some(SymbolType::Variable {
-            range: Range {
+        Some(Symbol {
+            name: SymbolName::GenerateFromNameAttr,
+            kind: SymbolKind::Variable(Range {
                 start: addr,
                 end: addr + size,
-            },
+            }),
         })
+    }
+
+    fn extract_name(
+        &self,
+        die: &DebuggingInformationEntry<GimliReader>,
+        dwarf: &gimli::Dwarf<GimliReader>,
+    ) -> Option<String> {
+        use gimli::Reader;
+        let attr = die.attr_value(gimli::DW_AT_name)?;
+        let name_as_bytes = dwarf.attr_string(&self.unit, attr).ok()?;
+        name_as_bytes
+            .to_string_lossy()
+            .ok()
+            .map(std::borrow::Cow::into_owned)
+    }
+
+    fn canonicalize_ranges(ranges: &mut Vec<Range<u64>>) {
+        ranges.sort_unstable_by_key(|r| r.start);
+        let mut merged_ranges = Vec::with_capacity(ranges.len());
+        let mut range_iter = ranges.iter_mut();
+        if let Some(prev) = range_iter.next() {
+            for r in range_iter {
+                if r.start <= prev.end {
+                    prev.end = prev.end.max(r.end);
+                } else {
+                    merged_ranges.push(r.clone());
+                    prev.clone_from(r);
+                }
+            }
+        }
+        ranges.clear();
+        ranges.extend_from_slice(&merged_ranges);
+    }
+
+    fn build_name(
+        &self,
+        offset: UnitOffset,
+        dwarf: &gimli::Dwarf<GimliReader>,
+        entry: &DebuggingInformationEntry<GimliReader>,
+    ) -> String {
+        let parent_name = self.full_names.get(&offset).cloned().unwrap_or_default();
+
+        let name_opt = self.extract_name(entry, dwarf).unwrap_or_default();
+        let mut current_name = String::with_capacity(parent_name.len() + 2 + name_opt.len());
+        if !parent_name.is_empty() {
+            current_name.push_str(&parent_name);
+        }
+        if !parent_name.is_empty() && !name_opt.is_empty() {
+            current_name.push_str("::");
+        }
+        if !name_opt.is_empty() {
+            current_name.push_str(&name_opt);
+        }
+        current_name
     }
 
     fn process_unit(
@@ -139,6 +236,7 @@ impl UnitInfo {
 
         let mut prev_offset = None;
         let mut previous_depth = entries_cursor.depth();
+        let mut current_subprogram = None;
         while let Ok(Some(current)) = entries_cursor.next_dfs() {
             let parent_offset = match current.depth() - previous_depth {
                 1 => {
@@ -149,11 +247,9 @@ impl UnitInfo {
                     let walk_up = |mut levels| {
                         // If 0:  Previous die is a sibling, we have the same parent.
                         // If <0: Previous die is a child of one of our siblings. Trace back as many levels as needed, and grab the parent.
-                        let mut cursor = prev_offset
-                            .map(|off| self.parents.get(&off).map(|link| link.offset))?;
+                        let mut cursor = prev_offset.map(|off| self.parents.get(&off).copied())?;
                         while levels != 0 {
-                            cursor =
-                                cursor.map(|off| self.parents.get(&off).map(|link| link.offset))?;
+                            cursor = cursor.map(|off| self.parents.get(&off).copied())?;
                             levels += 1;
                         }
                         cursor
@@ -163,108 +259,99 @@ impl UnitInfo {
                 _ => unreachable!("DFS algorithms never jump down multiple levels in the graph"),
             };
 
-            let extract_name = |die: &DebuggingInformationEntry<GimliReader>| -> Option<String> {
-                use gimli::Reader;
-                let attr = die.attr_value(gimli::DW_AT_name)?;
-                let name_as_bytes = dwarf.attr_string(&self.unit, attr).ok()?;
-                name_as_bytes.to_string_lossy().ok().map(|s| s.into_owned())
-            };
+            if let Some((ref name, ref depth)) = current_subprogram
+                && *depth >= current.depth()
+            {
+                // We stepped back up out of the current_subprogram tree, so we
+                // need to merge all the ranges from called functions that might
+                // be inlined into this (full) subprogram
+                if let Some(sym) = symbols.get_mut(name)
+                    && let SymbolKind::Function(ref mut ranges) = sym.kind
+                {
+                    Self::canonicalize_ranges(ranges);
+                }
+                current_subprogram = None;
+            }
 
             if let Some(offset) = parent_offset {
-                let parent_name = self
-                    .parents
-                    .get(&offset)
-                    .map(|link| link.partial_name.clone())
-                    .unwrap_or_default();
+                let current_name = self.build_name(offset, dwarf, current);
 
-                let name_opt = extract_name(current).unwrap_or_default();
-                let mut current_name =
-                    String::with_capacity(parent_name.len() + 2 + name_opt.len());
-                current_name.push_str(&parent_name);
-                current_name.push_str("::");
-                current_name.push_str(&name_opt);
+                self.parents.insert(current.offset(), offset);
+                self.full_names
+                    .insert(current.offset(), current_name.clone());
 
-                self.parents.insert(
-                    current.offset(),
-                    ParentLink {
-                        offset,
-                        partial_name: current_name,
-                    },
-                );
+                if current.tag() == gimli::DW_TAG_subprogram {
+                    current_subprogram = Some((current_name, current.depth()));
+                }
             }
             previous_depth = current.depth();
             prev_offset = Some(current.offset());
 
             // Cache the address ranges if this DIE is a function, and add it to
             // the symbols map if it's a function, inlined function, or variable
-            match current.tag() {
+            if let Some(mut symbol) = match current.tag() {
                 gimli::DW_TAG_subprogram => {
-                    let ranges = if let Ok(Some(ranges)) =
-                        FunctionDie::function_ranges(current, self, dwarf)
-                    {
-                        for range in &ranges {
-                            self.function_dies.push((range.clone(), current.offset()));
-                        }
-                        ranges
-                    } else {
-                        vec![]
-                    };
-                    Some(SymbolType::Function { ranges })
+                    let mut function_dies = vec![];
+                    let sym = self.process_subprogram(dwarf, current, &mut function_dies);
+                    self.function_dies.extend_from_slice(&function_dies);
+                    sym
                 }
                 gimli::DW_TAG_inlined_subroutine => {
-                    let mut offset = current.offset();
-                    let mut concrete_partial_name = None;
-                    while let Some(link) = self.parents.get(&offset) {
-                        match self.unit.entry(link.offset).ok().and_then(|entry| {
-                            if entry.tag() == gimli::DW_TAG_subprogram {
-                                self.parents
-                                    .get(&entry.offset())
-                                    .map(|link| link.partial_name.clone())
-                            } else {
-                                None
-                            }
-                        }) {
-                            Some(concrete_name) => {
-                                concrete_partial_name = Some(concrete_name);
-                            }
-                            None => {
-                                offset = link.offset;
-                            }
-                        }
-                        if concrete_partial_name.is_some() {
-                            break;
-                        }
-                    }
-                    concrete_partial_name.map(|name| SymbolType::InlinedFunction {
-                        concrete_caller: name,
-                    })
+                    self.process_inlined(current, current_subprogram.as_ref())
                 }
                 gimli::DW_TAG_variable => self.process_variable(dwarf, current),
                 _ => None,
+            } {
+                symbol.name = match symbol.name {
+                    SymbolName::GenerateFromNameAttr => {
+                        self.full_names
+                            .get(&current.offset())
+                            .map(|name| {
+                                if let SymbolKind::InlinedFunction(concrete_caller) = &symbol.kind {
+                                    // Inlined functions aren't in the .symtab, so we don't need
+                                    // to worry about matching the format of rustc_demangle.  We
+                                    // just need to make sure the string only points to one target
+                                    // concrete function.
+                                    format!("{name} (inlined into {concrete_caller})")
+                                } else {
+                                    name.clone()
+                                }
+                            })
+                            .map(SymbolName::Known)
+                            .unwrap_or(SymbolName::LinkNotFound(current.offset()))
+                    }
+                    other => other,
+                };
+                symbols.insert(symbol.name.to_string(), symbol);
             }
-            .map(|symbol_type| {
-                let mut name = self.parents[&current.offset()].partial_name.clone();
-                if let SymbolType::InlinedFunction { concrete_caller: _ } = symbol_type
-                    && let Ok(Some(ranges)) = FunctionDie::function_ranges(current, self, dwarf)
-                    && ranges.len() > 0
-                {
-                    // Inlined functions aren't in the .symtab, so we don't need
-                    // to worry about matching the format of rustc_demangle.  We
-                    // just need to make sure the string is unique across all
-                    // instances of the inlined function.
-                    name = format!("{} @{:#010X}", name, ranges[0].start)
-                }
-                symbols.insert(
-                    name.clone(),
-                    Symbol {
-                        name: name,
-                        symbol_type,
-                    },
-                );
-            });
 
             // TODO: assuming the ranges don't overlap, sort function dies by start address
         }
+
+        // If the last tag in the DFS traversal was a child of a subprogram, we
+        // might not have postprocessed that subprogram on the way out of the
+        // loop, so do it now.
+        if let Some((ref name, _)) = current_subprogram
+            && let Some(sym) = symbols.get_mut(name)
+            && let SymbolKind::Function(ref mut ranges) = sym.kind
+        {
+            Self::canonicalize_ranges(ranges);
+        }
+
+        // Now postprocess to handle the Deferred names
+        for symbol in symbols.values_mut() {
+            symbol.name = match &symbol.name {
+                SymbolName::Deferred(offset) => self
+                    .full_names
+                    .get(offset)
+                    .map(|name| SymbolName::Known(name.clone()))
+                    .unwrap_or(SymbolName::LinkNotFound(*offset)),
+                other => other.clone(),
+            }
+        }
+
+        // Code in debug_info.rs will handle merging this DWARF data with the
+        // data from the .symtab ELF section
     }
 
     /// Retrieve the value of the `DW_AT_language` attribute of the compilation unit.
@@ -2475,7 +2562,7 @@ impl UnitInfo {
     }
 
     pub(crate) fn parent_offset(&self, offset: UnitOffset) -> Option<UnitOffset> {
-        self.parents.get(&offset).map(|link| link.offset)
+        self.parents.get(&offset).copied()
     }
 }
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/inspect.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/inspect.rs
@@ -2,7 +2,7 @@ use std::{fmt::Write as _, ops::Range, path::Path, str::FromStr};
 
 use linkme::distributed_slice;
 use probe_rs::CoreDump;
-use probe_rs_debug::{ObjectRef, VariableName};
+use probe_rs_debug::{ObjectRef, SymbolType, VariableName};
 
 use crate::cmd::dap_server::{
     DebuggerError,
@@ -110,11 +110,14 @@ fn examine_memory(
     // 1. Specified address
     // 2. Frame address
     // 3. Program counter
-    let mut input_address = 0_u64;
+    let mut input_ranges = vec![Range {
+        start: 0_u64,
+        end: 0u64,
+    }];
 
     for input_argument in input_arguments {
         if let Ok(MemoryAddress(addr)) = MemoryAddress::try_from(input_argument) {
-            input_address = addr;
+            input_ranges[0].start = addr;
         } else if input_argument.starts_with('/') {
             let Some(gdb_nuf_string) = input_argument.strip_prefix('/') else {
                 return Err(DebuggerError::UserMessage(
@@ -145,19 +148,70 @@ fn examine_memory(
                     "Undefined register ${reg:?}."
                 )));
             };
-            input_address = target_core.core.read_core_reg(register)?;
+            input_ranges[0].start = target_core.core.read_core_reg(register)?;
         } else {
-            return Err(DebuggerError::UserMessage(
-                "Invalid parameters. See the `help` command for more information.".to_string(),
-            ));
+            // attempt to look up the string as a symbol
+            if let Some(ref debug_info) = target_core.core_data.debug_info {
+                let matches = debug_info.find_symbols(input_argument);
+                if matches.len() == 0 {
+                    return Err(DebuggerError::UserMessage(format!(
+                        "Symbol {} did not match any in the binary",
+                        input_argument
+                    )));
+                }
+                if matches.len() > 1 {
+                    return Err(DebuggerError::UserMessage(format!(
+                        "Symbol {} matched multiple from the binary, please disambiguate.  Found:\n  {}",
+                        input_argument,
+                        matches
+                            .iter()
+                            .map(|symbol| {
+                                if let SymbolType::InlinedFunction { concrete_caller } =
+                                    &symbol.symbol_type
+                                {
+                                    format!("{} called from {}", symbol.name, concrete_caller)
+                                } else {
+                                    symbol.name.clone()
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n  ")
+                    )));
+                }
+                match &matches[0].symbol_type {
+                    SymbolType::Function { ranges } => {
+                        if ranges.len() > 0 {
+                            input_ranges = ranges.clone();
+                        } else {
+                            return Err(DebuggerError::UserMessage(format!(
+                                "Symbol {} matched an entry {} with no byte ranges, likely a \"template\", used to store the inlined fn args and return type but no code.",
+                                input_argument, matches[0].name
+                            )));
+                        }
+                    }
+                    SymbolType::InlinedFunction { concrete_caller } => {
+                        return Err(DebuggerError::UserMessage(format!(
+                            "Symbol {} matched an inline function {}, please use its container {}.",
+                            input_argument, matches[0].name, concrete_caller
+                        )));
+                    }
+                    SymbolType::Variable { range } => {
+                        input_ranges[0] = range.clone();
+                    }
+                }
+            } else {
+                return Err(DebuggerError::UserMessage(
+                    "No debug info loaded, so no symbol resolution is possible.".to_string(),
+                ));
+            }
         }
     }
-    if input_address == 0 {
+    if input_ranges[0].start == 0 {
         // No address was specified, so we'll use the frame address, if available.
 
         let frame_id = request_arguments.frame_id.map(ObjectRef::from);
 
-        input_address = if let Some(frame_pc) = frame_id
+        input_ranges[0].start = if let Some(frame_pc) = frame_id
             .and_then(|frame_id| {
                 target_core
                     .core_data
@@ -175,7 +229,7 @@ fn examine_memory(
         }
     }
 
-    memory_read(input_address, gdb_nuf, target_core)
+    memory_read(input_ranges, gdb_nuf, target_core)
 }
 
 fn dump_core(

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/inspect.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/inspect.rs
@@ -2,7 +2,7 @@ use std::{fmt::Write as _, ops::Range, path::Path, str::FromStr};
 
 use linkme::distributed_slice;
 use probe_rs::CoreDump;
-use probe_rs_debug::{ObjectRef, SymbolType, VariableName};
+use probe_rs_debug::{ObjectRef, SymbolKind, VariableName};
 
 use crate::cmd::dap_server::{
     DebuggerError,
@@ -96,6 +96,75 @@ fn print_variables(
     get_local_variable(evaluate_arguments, target_core, variable_name, gdb_nuf)
 }
 
+fn process_register(
+    reg: &str,
+    target_core: &mut CoreHandle<'_>,
+    input_ranges: &mut [Range<u64>],
+) -> Result<(), DebuggerError> {
+    let Some(register) = target_core.core.registers().all_registers().find(|r| {
+        std::iter::once(r.name().to_string())
+            .chain(r.roles.iter().map(std::string::ToString::to_string))
+            .any(|name| name.eq_ignore_ascii_case(reg))
+    }) else {
+        return Err(DebuggerError::UserMessage(format!(
+            "Undefined register ${reg:?}."
+        )));
+    };
+    input_ranges[0].start = target_core.core.read_core_reg(register)?;
+    Ok(())
+}
+
+fn process_symbol(
+    input_argument: &str,
+    target_core: &mut CoreHandle<'_>,
+    input_ranges: &mut Vec<Range<u64>>,
+) -> Result<(), DebuggerError> {
+    // attempt to look up the string as a symbol
+    if let Some(ref debug_info) = target_core.core_data.debug_info {
+        let matches = debug_info.find_symbols(input_argument);
+        if matches.is_empty() {
+            return Err(DebuggerError::UserMessage(format!(
+                "Symbol {input_argument} did not match any in the binary"
+            )));
+        }
+        if matches.len() > 1 {
+            return Err(DebuggerError::UserMessage(format!(
+                "Symbol {input_argument} matched multiple from the binary, please disambiguate.  Found:\n  {}",
+                matches
+                    .iter()
+                    .map(|symbol| symbol.name.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n  ")
+            )));
+        }
+        match &matches[0].kind {
+            SymbolKind::Function(ranges) => {
+                if ranges.is_empty() {
+                    return Err(DebuggerError::UserMessage(format!(
+                        "Symbol {input_argument} matched an entry {} with no byte ranges, which should not be possible.",
+                        matches[0].name
+                    )));
+                }
+                input_ranges.clone_from(ranges);
+            }
+            SymbolKind::InlinedFunction(_) => {
+                return Err(DebuggerError::UserMessage(format!(
+                    "Symbol {input_argument} matched an inline function {}; please use its container.",
+                    matches[0].name
+                )));
+            }
+            SymbolKind::Variable(range) => {
+                input_ranges[0].clone_from(range);
+            }
+        }
+    } else {
+        return Err(DebuggerError::UserMessage(
+            "No debug info loaded, so no symbol resolution is possible.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn examine_memory(
     target_core: &mut CoreHandle<'_>,
     command_arguments: &str,
@@ -139,71 +208,9 @@ fn examine_memory(
                     ))
                 })?;
         } else if let Some(reg) = input_argument.strip_prefix('$') {
-            let Some(register) = target_core.core.registers().all_registers().find(|r| {
-                std::iter::once(r.name().to_string())
-                    .chain(r.roles.iter().map(|role| role.to_string()))
-                    .any(|name| name.eq_ignore_ascii_case(reg))
-            }) else {
-                return Err(DebuggerError::UserMessage(format!(
-                    "Undefined register ${reg:?}."
-                )));
-            };
-            input_ranges[0].start = target_core.core.read_core_reg(register)?;
+            process_register(reg, target_core, &mut input_ranges)?;
         } else {
-            // attempt to look up the string as a symbol
-            if let Some(ref debug_info) = target_core.core_data.debug_info {
-                let matches = debug_info.find_symbols(input_argument);
-                if matches.len() == 0 {
-                    return Err(DebuggerError::UserMessage(format!(
-                        "Symbol {} did not match any in the binary",
-                        input_argument
-                    )));
-                }
-                if matches.len() > 1 {
-                    return Err(DebuggerError::UserMessage(format!(
-                        "Symbol {} matched multiple from the binary, please disambiguate.  Found:\n  {}",
-                        input_argument,
-                        matches
-                            .iter()
-                            .map(|symbol| {
-                                if let SymbolType::InlinedFunction { concrete_caller } =
-                                    &symbol.symbol_type
-                                {
-                                    format!("{} called from {}", symbol.name, concrete_caller)
-                                } else {
-                                    symbol.name.clone()
-                                }
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n  ")
-                    )));
-                }
-                match &matches[0].symbol_type {
-                    SymbolType::Function { ranges } => {
-                        if ranges.len() > 0 {
-                            input_ranges = ranges.clone();
-                        } else {
-                            return Err(DebuggerError::UserMessage(format!(
-                                "Symbol {} matched an entry {} with no byte ranges, likely a \"template\", used to store the inlined fn args and return type but no code.",
-                                input_argument, matches[0].name
-                            )));
-                        }
-                    }
-                    SymbolType::InlinedFunction { concrete_caller } => {
-                        return Err(DebuggerError::UserMessage(format!(
-                            "Symbol {} matched an inline function {}, please use its container {}.",
-                            input_argument, matches[0].name, concrete_caller
-                        )));
-                    }
-                    SymbolType::Variable { range } => {
-                        input_ranges[0] = range.clone();
-                    }
-                }
-            } else {
-                return Err(DebuggerError::UserMessage(
-                    "No debug info loaded, so no symbol resolution is possible.".to_string(),
-                ));
-            }
+            process_symbol(input_argument, target_core, &mut input_ranges)?;
         }
     }
     if input_ranges[0].start == 0 {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
@@ -103,22 +103,31 @@ pub(crate) fn get_local_variable(
 
 /// Read memory at the specified address (hex), using the [`GdbNuf`] specifiers to determine size and format.
 pub(crate) fn memory_read(
-    address: u64,
+    ranges: Vec<std::ops::Range<u64>>,
     gdb_nuf: GdbNuf,
     target_core: &mut CoreHandle<'_>,
 ) -> EvalResult {
     if gdb_nuf.format_specifier == GdbFormat::Instruction {
-        let assembly_lines = disassemble_target_memory(
-            target_core,
-            0_i64,
-            0_i64,
-            address,
-            DisassemblyAmount::Instructions(gdb_nuf.unit_count as i64),
-        )?;
-        if assembly_lines.is_empty() {
-            return Err(DebuggerError::UserMessage(format!(
-                "Cannot disassemble memory at address {address:#010x}"
-            )));
+        let mut assembly_lines = vec![];
+        for range in ranges {
+            let mut lines = disassemble_target_memory(
+                target_core,
+                0_i64,
+                0_i64,
+                range.start,
+                if gdb_nuf.count_was_default && range.end != 0 {
+                    DisassemblyAmount::Bytes(range.end - range.start)
+                } else {
+                    DisassemblyAmount::Instructions(gdb_nuf.unit_count as i64)
+                },
+            )?;
+            if lines.is_empty() {
+                return Err(DebuggerError::UserMessage(format!(
+                    "Cannot disassemble memory at address {:#010x}",
+                    range.start
+                )));
+            }
+            assembly_lines.append(&mut lines);
         }
         let mut formatted_output = "".to_string();
         for assembly_line in &assembly_lines {
@@ -128,7 +137,7 @@ pub(crate) fn memory_read(
         Ok(EvalResponse::Message(formatted_output))
     } else {
         let mut memory_result = vec![0u8; gdb_nuf.get_size()];
-        match target_core.core.read_8(address, &mut memory_result) {
+        match target_core.core.read_8(ranges[0].start, &mut memory_result) {
             Ok(()) => Ok(EvalResponse::Message(
                 GdbNufMemoryResult {
                     nuf: &gdb_nuf,
@@ -137,7 +146,8 @@ pub(crate) fn memory_read(
                 .to_string(),
             )),
             Err(err) => Err(DebuggerError::UserMessage(format!(
-                "Cannot read memory at address {address:#010x}: {err:?}"
+                "Cannot read memory at address {:#010x}: {err:?}",
+                ranges[0].start
             ))),
         }
     }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
@@ -108,9 +108,11 @@ pub(crate) fn memory_read(
     target_core: &mut CoreHandle<'_>,
 ) -> EvalResult {
     if gdb_nuf.format_specifier == GdbFormat::Instruction {
-        let mut assembly_lines = vec![];
+        use std::fmt::Write;
+
+        let mut formatted_output = "".to_string();
         for range in ranges {
-            let mut lines = disassemble_target_memory(
+            let instructions = disassemble_target_memory(
                 target_core,
                 0_i64,
                 0_i64,
@@ -121,22 +123,34 @@ pub(crate) fn memory_read(
                     DisassemblyAmount::Instructions(gdb_nuf.unit_count as i64)
                 },
             )?;
-            if lines.is_empty() {
+            if instructions.is_empty() {
                 return Err(DebuggerError::UserMessage(format!(
                     "Cannot disassemble memory at address {:#010x}",
                     range.start
                 )));
             }
-            assembly_lines.append(&mut lines);
-        }
-        let mut formatted_output = "".to_string();
-        for assembly_line in &assembly_lines {
-            formatted_output.push_str(&assembly_line.to_string());
+            for instruction in instructions {
+                write!(formatted_output, "{}", instruction).map_err(|err| {
+                    DebuggerError::UserMessage(format!("Formatting an instruction: {err:?}"))
+                })?
+            }
         }
 
         Ok(EvalResponse::Message(formatted_output))
     } else {
-        let mut memory_result = vec![0u8; gdb_nuf.get_size()];
+        let bytes: usize = if gdb_nuf.count_was_default {
+            (ranges[0].end - ranges[0].start)
+                .try_into()
+                .map_err(|err| {
+                    DebuggerError::UserMessage(format!(
+                        "Symbol size {} was bigger than a usize: {err:?}",
+                        ranges[0].end - ranges[0].start
+                    ))
+                })?
+        } else {
+            gdb_nuf.get_size()
+        };
+        let mut memory_result = vec![0u8; bytes];
         match target_core.core.read_8(ranges[0].start, &mut memory_result) {
             Ok(()) => Ok(EvalResponse::Message(
                 GdbNufMemoryResult {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_types.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_types.rs
@@ -111,6 +111,7 @@ impl Display for GdbUnit {
 /// The term 'Nuf' is borrowed from gdb's `x` command arguments, and stands for N(umber or count of units), U(nit size), and F(ormat specifier).
 pub(crate) struct GdbNuf {
     pub(crate) unit_count: usize,
+    pub(crate) count_was_default: bool,
     pub(crate) unit_specifier: GdbUnit,
     pub(crate) format_specifier: GdbFormat,
 }
@@ -146,6 +147,7 @@ impl Default for GdbNuf {
     fn default() -> Self {
         Self {
             unit_count: 1,
+            count_was_default: true,
             unit_specifier: GdbUnit::Word,
             format_specifier: GdbFormat::Hex,
         }
@@ -208,6 +210,7 @@ impl FromStr for GdbNuf {
                     "Invalid unit count specifier: {value} - {error}"
                 ))
             })?;
+            result.count_was_default = false;
         }
 
         Ok(result)

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_types.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_types.rs
@@ -234,7 +234,11 @@ impl Display for GdbNufMemoryResult<'_> {
 
         let byte_per_unit = self.nuf.unit_specifier.get_size();
         let width = 2 + byte_width * byte_per_unit;
-        let total_bytes = byte_per_unit * self.nuf.unit_count;
+        let total_bytes = if self.nuf.count_was_default {
+            self.memory.len()
+        } else {
+            byte_per_unit * self.nuf.unit_count
+        };
 
         for bytes in self.memory[..total_bytes].chunks_exact(byte_per_unit) {
             match self.nuf.format_specifier {


### PR DESCRIPTION
At ELF parse time, pull everything from .symtab to get the ::hXXXXX crate disambiguator suffixes, then pull everything from DWARF to get the correct generic arguments (symtab often drops info from the generic types or consts).  Match the two up by address.  Include inlined functions from DWARF as well, but only as a pointer to their containing concrete function; this way they can at least be requested, and the user can be told they're inlined.

Fold the DWARF ranges for inlined functions into their concrete parents.  When we're done looking at DWARF, any inlined functions whose parents still have no ranges, and any concrete functions with no ranges themselves, get dropped, as they've been optimized out of the binary but left in the debug info.

At runtime, query the table of symbols by splitting the query and each symbol into a sequence of identifiers (alphanumeric-or-underscore), separated by anything else.  If the sequence of identifiers matches, using full-string matching at each identifier, then the symbol is a candidate.

If there's more than one candidate, dump all of them and ask for a more fully specified query.  Inlined symbols point to the container and don't allow disassembly or dumping.

Tested this on the RP2040_full_unwind.elf file in the repo, using the dummy probe code that always returns 0 for memory bytes.  Disassembling main works, as does dumping one of the appropriately disambiguated vtable symbols.  (As does dumping main, in fact.)