### PR TITLE
Add --reset flag to `download` subcommand

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -307,6 +307,7 @@ async fn main_try(args: Vec<OsString>, config: Config, offset: UtcOffset) -> Res
             chip_erase: config.flashing.do_chip_erase,
             read_flasher_rtt: config.flashing.read_flasher_rtt,
             prefer_flash_algorithm: Vec::new(),
+            reset: false,
         };
         let loader = build_loader(&mut session, &path, format_options, image_instr_set)?;
 

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -472,6 +472,11 @@ pub async fn flash(
         _ = visualizer.write_svg(visualizer_output);
     }
 
+    if download_options.reset {
+        let core = session.core(0);
+        core.reset().await?;
+    }
+
     logging::eprintln(format!(
         "     {} in {:.02}s",
         "Finished".green().bold(),

--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -57,6 +57,10 @@ pub struct BinaryDownloadOptions {
         help_heading = "PROBE CONFIGURATION"
     )]
     pub prefer_flash_algorithm: Vec<String>,
+
+    /// Whether to reset the chip after downloading.
+    #[arg(long, help_heading = "DOWNLOAD CONFIGURATION")]
+    pub reset: bool,
 }
 
 /// Supported bit-widths for read/write commands (not every device may support each width).


### PR DESCRIPTION
It is really convenient to be able to reset the target after downloading, instead of leaving it in a halted state.

I'm not entirely sure whether this is the correct approach, since there is now also a `probe-rs run --reset` option which I think will reset the target twice (`run` already resets the target by default).

(First PR here, not sure whether I did things correctly - for example, I think I should add an entry to the CHANGELOG?)