### PR TITLE
Target-gen fixes for missing RTT output

### DIFF
--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -172,6 +172,12 @@ impl Flasher {
         })
     }
 
+    /// Builder method to enable RTT.
+    pub fn with_rtt(mut self) -> Self {
+        self.read_rtt_output(true);
+        self
+    }
+
     fn ensure_loaded(&mut self, session: &mut Session) -> Result<(), FlashError> {
         if !self.loaded {
             self.load(session)?;

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -178,6 +178,7 @@ pub fn cmd_test(
     println!("{test}: Writing two pages ...");
 
     let mut loader = session.target().flash_loader();
+    loader.read_rtt_output(true);
     let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
     loader.add_data(test_start_sector_address + 1, &data)?;
     run_flash_download(&mut session, loader, true)?;
@@ -203,6 +204,7 @@ pub fn cmd_test(
 
     println!("{test}: Writing two pages ...");
     let mut loader = session.target().flash_loader();
+    loader.read_rtt_output(true);
     let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
     loader.add_data(test_start_sector_address + 1, &data)?;
     run_flash_download(&mut session, loader, true)?;
@@ -235,6 +237,7 @@ pub fn cmd_test(
 
     println!("{test}: Writing two pages ...");
     let mut loader = session.target().flash_loader();
+    loader.read_rtt_output(true);
     let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
     loader.add_data(test_start_sector_address + 1, &data)?;
     run_flash_download(&mut session, loader, false)?;


### PR DESCRIPTION
* the loader is created without RTT support by default, this forces RTT to be used in the loader.
* a public builder method is also added here, so that `target-gen` can call it.