### PR TITLE
Update target-gen to use the flash-algo API to read the flash.

### DIFF
--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -172,6 +172,12 @@ impl Flasher {
         })
     }
 
+    /// Builder method to enable RTT.
+    pub fn with_rtt(mut self) -> Self {
+        self.read_rtt_output(true);
+        self
+    }
+
     fn ensure_loaded(&mut self, session: &mut Session) -> Result<(), FlashError> {
         if !self.loaded {
             self.load(session)?;

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -1165,6 +1165,7 @@ impl<O: Operation> ActiveFlasher<'_, '_, O> {
         Ok(())
     }
 
+    /// Do not use, only exposed with `pub` visibility for target-gen.
     pub fn read_flash(&mut self, address: u64, data: &mut [u8]) -> Result<(), FlashError> {
         if let Some(read_flash) = self.flash_algorithm.pc_read {
             let page_size = self.flash_algorithm.flash_properties.page_size;

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -379,6 +379,22 @@ impl Flasher {
         Ok(r)
     }
 
+    /// Initializes the flashing algorithm for the [`Read`] operation and provides an interface to it via the callback.
+    pub fn run_read<'p, T, F>(
+        &mut self,
+        session: &mut Session,
+        progress: &mut FlashProgress<'p>,
+        f: F,
+    ) -> Result<T, FlashError>
+    where
+        F: FnOnce(&mut ActiveFlasher<'_, 'p, Verify>, &mut [LoadedRegion]) -> Result<T, FlashError>,
+    {
+        let (mut active, data) = self.init(session, progress, None)?;
+        let r = f(&mut active, data)?;
+        active.uninit()?;
+        Ok(r)
+    }
+
     pub(super) fn is_chip_erase_supported(&self, session: &Session) -> bool {
         session.has_sequence_erase_all() || self.flash_algorithm().pc_erase_all.is_some()
     }
@@ -1149,7 +1165,7 @@ impl<O: Operation> ActiveFlasher<'_, '_, O> {
         Ok(())
     }
 
-    pub(super) fn read_flash(&mut self, address: u64, data: &mut [u8]) -> Result<(), FlashError> {
+    pub fn read_flash(&mut self, address: u64, data: &mut [u8]) -> Result<(), FlashError> {
         if let Some(read_flash) = self.flash_algorithm.pc_read {
             let page_size = self.flash_algorithm.flash_properties.page_size;
             let buffer_address = self.flash_algorithm.page_buffers[0];

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -142,6 +142,7 @@ pub fn cmd_test(
     };
 
     let have_read = flash_algorithm.pc_read.is_some();
+    let have_verify = flash_algorithm.pc_verify.is_some();
 
     let flash_properties = &flash_algorithm.flash_properties;
     let start_address = flash_properties.address_range.start;
@@ -185,7 +186,7 @@ pub fn cmd_test(
     loader.read_rtt_output(true);
     let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
     loader.add_data(test_start_sector_address + 1, &data)?;
-    run_flash_download(&mut session, loader, true)?;
+    run_flash_download(&mut session, &mut loader, true)?;
 
     println!("{test}: Write done");
 
@@ -219,7 +220,7 @@ pub fn cmd_test(
     loader.read_rtt_output(true);
     let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
     loader.add_data(test_start_sector_address + 1, &data)?;
-    run_flash_download(&mut session, loader, true)?;
+    run_flash_download(&mut session, &mut loader, true)?;
 
     println!("{test}: Write done");
 
@@ -259,8 +260,15 @@ pub fn cmd_test(
     loader.read_rtt_output(true);
     let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
     loader.add_data(test_start_sector_address + 1, &data)?;
-    run_flash_download(&mut session, loader, false)?;
+    run_flash_download(&mut session, &mut loader, false)?;
     println!("{test}: Write done");
+
+    if have_verify {
+        println!("{test}: Verifying");
+        let mut progress = progress_callbacks();
+        loader.verify(&mut session, &mut progress)?;
+        println!("{test}: verification done");
+    }
 
     let mut readback = vec![0; data_size as usize];
     if have_read {
@@ -324,7 +332,7 @@ fn ensure_is_file(file_path: &Path) -> Result<()> {
 /// This function also manages the update and display of progress bars.
 pub fn run_flash_download(
     session: &mut Session,
-    loader: FlashLoader,
+    loader: &mut FlashLoader,
     disable_double_buffering: bool,
 ) -> Result<()> {
     let mut download_option = DownloadOptions::default();

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -178,6 +178,7 @@ pub fn cmd_test(
     println!("{test}: Writing two pages ...");
 
     let mut loader = session.target().flash_loader();
+    loader.read_rtt_output(true);
     let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
     loader.add_data(test_start_sector_address + 1, &data)?;
     run_flash_download(&mut session, loader, true)?;
@@ -203,6 +204,7 @@ pub fn cmd_test(
 
     println!("{test}: Writing two pages ...");
     let mut loader = session.target().flash_loader();
+    loader.read_rtt_output(true);
     let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
     loader.add_data(test_start_sector_address + 1, &data)?;
     run_flash_download(&mut session, loader, true)?;
@@ -235,6 +237,7 @@ pub fn cmd_test(
 
     println!("{test}: Writing two pages ...");
     let mut loader = session.target().flash_loader();
+    loader.read_rtt_output(true);
     let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
     loader.add_data(test_start_sector_address + 1, &data)?;
     run_flash_download(&mut session, loader, false)?;

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -14,7 +14,7 @@ use probe_rs::{
 };
 use probe_rs_target::RawFlashAlgorithm;
 use xshell::{Shell, cmd};
-
+use probe_rs::flashing::Flasher;
 use crate::commands::elf::cmd_elf;
 
 #[expect(clippy::too_many_arguments)]
@@ -124,8 +124,8 @@ pub fn cmd_test(
     // Register callback to update the progress.
     let mut progress = progress_callbacks();
 
-    let flash_algorithm = if let Some(test_start_sector_address) = test_start_sector_address {
-        let predicate = |x: &&RawFlashAlgorithm| {
+    let (algo_index, flash_algorithm) = if let Some(test_start_sector_address) = test_start_sector_address {
+        let predicate = |(_, x): &(usize, &RawFlashAlgorithm)| {
             x.flash_properties.address_range.start <= test_start_sector_address
                 && test_start_sector_address < x.flash_properties.address_range.end
         };
@@ -134,11 +134,15 @@ pub fn cmd_test(
             .target()
             .flash_algorithms
             .iter()
+            .enumerate()
             .find(predicate)
             .ok_or(error_message)?
     } else {
-        &session.target().flash_algorithms[0]
+        (0, &session.target().flash_algorithms[0])
     };
+
+    let have_read = flash_algorithm.pc_read.is_some();
+
     let flash_properties = &flash_algorithm.flash_properties;
     let start_address = flash_properties.address_range.start;
     let end_address = flash_properties.address_range.end;
@@ -186,10 +190,18 @@ pub fn cmd_test(
     println!("{test}: Write done");
 
     let mut readback = vec![0; data_size as usize];
-    session
-        .core(0)?
-        .read(test_start_sector_address + 1, &mut readback)?;
+
+    if have_read {
+        println!("{test}: Reading back two pages (via API) ...");
+        run_read(&mut session, algo_index, test_start_sector_address + 1, &mut readback)?;
+    } else {
+        println!("{test}: Reading back two pages (via core) ...");
+        session
+            .core(0)?
+            .read(test_start_sector_address + 1, &mut readback)?;
+    }
     assert_eq!(readback, data);
+    println!("{test}: Write verified OK");
 
     println!("{test}: Erasing the entire chip and writing two pages ...");
     run_flash_erase(&mut session, EraseType::EraseAll)?;
@@ -212,10 +224,17 @@ pub fn cmd_test(
     println!("{test}: Write done");
 
     let mut readback = vec![0; data_size as usize];
-    session
-        .core(0)?
-        .read_8(test_start_sector_address + 1, &mut readback)?;
+    if have_read {
+        println!("{test}: Reading back two pages (via API) ...");
+        run_read(&mut session, algo_index, test_start_sector_address + 1, &mut readback)?;
+    } else {
+        println!("{test}: Reading back two pages (via core) ...");
+        session
+            .core(0)?
+            .read_8(test_start_sector_address + 1, &mut readback)?;
+    }
     assert_eq!(readback, data);
+    println!("{test}: Write verified OK");
 
     println!("{test}: Erasing sectorwise and writing two pages double buffered ...");
     run_flash_erase(
@@ -244,10 +263,17 @@ pub fn cmd_test(
     println!("{test}: Write done");
 
     let mut readback = vec![0; data_size as usize];
-    session
-        .core(0)?
-        .read_8(test_start_sector_address + 1, &mut readback)?;
+    if have_read {
+        println!("{test}: Reading back two pages (via API) ...");
+        run_read(&mut session, algo_index, test_start_sector_address + 1, &mut readback)?;
+    } else {
+        println!("{test}: Reading back two pages (via core) ...");
+        session
+            .core(0)?
+            .read_8(test_start_sector_address + 1, &mut readback)?;
+    }
     assert_eq!(readback, data);
+    println!("{test}: Write verified OK");
 
     Ok(())
 }
@@ -327,6 +353,19 @@ pub fn run_flash_erase(session: &mut Session, erase_type: EraseType) -> Result<(
         erase_all(session, &mut progress, true)?;
     }
 
+    Ok(())
+}
+
+pub fn run_read(session: &mut Session, algo_index: usize, address: u64, data: &mut [u8]) -> Result<()> {
+    let mut progress = progress_callbacks();
+
+    let raw_flash_algorithm = &session.target().flash_algorithms[algo_index];
+    let mut flasher = Flasher::new(session.target(), 0, &raw_flash_algorithm)?
+        .with_rtt();
+
+    flasher.run_read(session, &mut progress, |active, _region| {
+        active.read_flash(address, data)
+    })?;
     Ok(())
 }
 


### PR DESCRIPTION
This builds on https://github.com/probe-rs/probe-rs/pull/4013.

Prior to this `read_flash` would not be used even if the algo supported it.  This can manifest as bus errors or hard-faults, e.g. when the algo is using a memory region that is reserved for memory-mapped flash without the external flash memory actually being mapped to the region; since the algo implemented read_flash instead.

example log from target-gen when using an algo that supports it:

```
2026-05-18T13:59:42.335144Z DEBUG wait_for_completion: probe_rs::flashing::flasher: RTT(Terminal): Blank check. logical_address: 0x70000000, size: 0x00001000 (4096), pattern: 0xff (0b11111111)
Reading: 0x00000000, size: 0x00001000 (4096)
read_quad_output. address: 0x00000000, data_length: 4096
 timeout=10s
Message: Blank check. logical_address: 0x70000000, size: 0x00001000 (4096), pattern: 0xff (0b11111111)
Reading: 0x00000000, size: 0x00001000 (4096)
read_quad_output. address: 0x00000000, data_length: 4096
2026-05-18T13:59:42.336741Z DEBUG wait_for_completion: probe_rs::flashing::flasher: Routine returned 0. timeout=10s
```

Tested on a MakerPnPControl-CORE board, RevA1 and this algo impl: https://github.com/MakerPnP/dev-tools/tree/master/makerpnpcore-w25q16jv
