### PR TITLE
Downgrade gdbstub to version 0.7.8 to restore basic gdb usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,16 +1458,16 @@ dependencies = [
 
 [[package]]
 name = "gdbstub"
-version = "0.7.10"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bafc7e33650ab9f05dcc16325f05d56b8d10393114e31a19a353b86fa60cfe7"
+checksum = "72742d2b395902caf8a5d520d0dd3334ba6d1138938429200e58d5174e275f3f"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
  "log",
  "managed",
  "num-traits",
- "pastey",
+ "paste",
 ]
 
 [[package]]
@@ -2679,12 +2679,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pastey"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pear"

--- a/changelog/fixed-gdbstub-0.7.8-downgrade.md
+++ b/changelog/fixed-gdbstub-0.7.8-downgrade.md
@@ -1,0 +1,1 @@
+Downgrade gdbstub to version 0.7.8 to avoid MultiThread regression #3805

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -119,7 +119,9 @@ sha2 = "0.11"
 nusb = { workspace = true, features = ["tokio"] }
 
 # gdb server
-gdbstub = "0.7.6"
+# 0.7.9 causes this regression:
+# https://github.com/probe-rs/probe-rs/issues/3805
+gdbstub = "=0.7.8"
 
 # profiling
 fxprof-processed-profile = { version = "0.8.1", default-features = false }


### PR DESCRIPTION
As advised by the corresponding gdbstub developer in #3805, temporarily block gdbstub version 0.7.9 until either probe-rs is made compatible with 0.7.9, or with the even bigger and more incompatible changes in gdbstub 0.8.

This restores the most basic gdb functionality on my microbit v2 - and likely many other systems.

Fixes regression in v0.31.0 commit f51b94ee0ce5 ("Update Non-breaking updates (#3987)")