### PR TITLE
REPL: Set breakpoints on `file:line[:col]`

### DIFF
--- a/changelog/added-repl-breakpoint-location.md
+++ b/changelog/added-repl-breakpoint-location.md
@@ -1,0 +1,1 @@
+Added `file:line` as a breakpoint location format option to the debug console.

--- a/changelog/added-repl-breakpoint-location.md
+++ b/changelog/added-repl-breakpoint-location.md
@@ -1,1 +1,1 @@
-Added `file:line` as a breakpoint location format option to the debug console.
+Added `file:line[:column]` as a breakpoint location format option to the debug console.

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -1022,6 +1022,32 @@ pub(crate) fn canonical_path_eq(primary_path: TypedPath, secondary_path: TypedPa
     primary_path.normalize() == secondary_path.normalize()
 }
 
+/// Returns `true` if `full_path` matches `partial_path`.
+///
+/// When `partial_path` is absolute the comparison is normalized equality).
+/// When `partial_path` is relative the function additionally accepts a suffix match at
+/// a component boundary, so that a caller can supply just a filename (`main.rs`) or a partial
+/// sub-path (`src/main.rs`) and still resolve to the correct compilation unit.
+///
+/// Separators are normalized to `/` before comparison so that cross-OS paths (e.g. DWARF info
+/// embedded by a Windows compiler, inspected on Linux) are handled correctly.
+pub(crate) fn path_matches(full_path: TypedPath, partial_path: TypedPath) -> bool {
+    if canonical_path_eq(full_path, partial_path) {
+        return true;
+    }
+    if partial_path.is_relative() {
+        let full_buf = full_path.normalize();
+        let full_str = full_buf.to_string_lossy().replace('\\', "/");
+        let partial_buf = partial_path.normalize();
+        let partial_str = partial_buf.to_string_lossy().replace('\\', "/");
+        full_str.ends_with(&*partial_str)
+            && (full_str.len() == partial_str.len()
+                || full_str[..full_str.len() - partial_str.len()].ends_with('/'))
+    } else {
+        false
+    }
+}
+
 /// Get a handle to the [`gimli::UnwindTableRow`] for this call frame, so that we can reference it to unwind register values.
 pub fn get_unwind_info<'a>(
     unwind_context: &'a mut UnwindContext<GimliReaderOffset>,

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -1024,7 +1024,7 @@ pub(crate) fn canonical_path_eq(primary_path: TypedPath, secondary_path: TypedPa
 
 /// Returns `true` if `full_path` matches `partial_path`.
 ///
-/// When `partial_path` is absolute the comparison is normalized equality).
+/// When `partial_path` is absolute, the comparison is normalized equality).
 /// When `partial_path` is relative the function additionally accepts a suffix match at
 /// a component boundary, so that a caller can supply just a filename (`main.rs`) or a partial
 /// sub-path (`src/main.rs`) and still resolve to the correct compilation unit.

--- a/probe-rs-debug/src/source_instructions.rs
+++ b/probe-rs-debug/src/source_instructions.rs
@@ -1,5 +1,5 @@
 use super::{
-    ColumnType, DebugError, DebugInfo, GimliReader, canonical_path_eq,
+    ColumnType, DebugError, DebugInfo, GimliReader, path_matches,
     unit_info::{self, UnitInfo},
 };
 use gimli::LineSequence;
@@ -59,6 +59,13 @@ impl VerifiedBreakpoint {
     ///   - The requested location may not be a valid source location, e.g. when the
     ///     debug information has been optimized away. In this case we will return an appropriate error.
     ///
+    /// #### Path matching
+    /// `path` may be an absolute path or a **partial (relative) path**.  A relative path such as
+    /// `src/main.rs` or simply `main.rs` is matched against the tail of each DWARF-embedded
+    /// absolute path at a component boundary, so the caller does not need to know the full path
+    /// that was recorded at compile time.  When `path` is absolute, only normalized exact equality
+    /// is accepted (the previous behaviour).
+    ///
     /// #### The logic used to find the "most relevant" source location is as follows:
     /// 1. Filter  [`UnitInfo`], by using [`gimli::LineProgramHeader`] to match units that include
     ///    the requested path.
@@ -104,7 +111,7 @@ impl VerifiedBreakpoint {
                     debug_info
                         .get_path(&program_unit.unit, file_index)
                         .and_then(|combined_path: TypedPathBuf| {
-                            if canonical_path_eq(path, combined_path.to_path()) {
+                            if path_matches(combined_path.to_path(), path) {
                                 tracing::debug!(
                                     "Found matching file index: {file_index} for path: {path}",
                                     file_index = file_index,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/breakpoint.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/breakpoint.rs
@@ -27,7 +27,7 @@ static BREAK: ReplCommand = ReplCommand {
     help_text: "Set a breakpoint at a location, or halt the target if unspecified.",
     requires_target_halted: false,
     sub_commands: &[],
-    args: &[ReplCommandArgs::Optional("*address | file:line")],
+    args: &[ReplCommandArgs::Optional("*address | file.rs:line")],
     handler: create_breakpoint,
 };
 
@@ -37,7 +37,7 @@ static CLEAR: ReplCommand = ReplCommand {
     help_text: "Clear a breakpoint.",
     requires_target_halted: false,
     sub_commands: &[],
-    args: &[ReplCommandArgs::Required("*address | file:line")],
+    args: &[ReplCommandArgs::Required("*address | file.rs:line")],
     handler: clear_breakpoint,
 };
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/breakpoint.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/breakpoint.rs
@@ -1,5 +1,6 @@
 use linkme::distributed_slice;
 use probe_rs::{CoreStatus, HaltReason};
+use typed_path::TypedPath;
 
 use crate::cmd::dap_server::{
     DebuggerError,
@@ -9,7 +10,7 @@ use crate::cmd::dap_server::{
             core_status::DapStatus,
             dap_types::{
                 Breakpoint, BreakpointEventBody, EvaluateArguments, InstructionBreakpoint,
-                MemoryAddress,
+                MemoryAddress, Source,
             },
             repl_commands::{EvalResponse, EvalResult, REPL_COMMANDS, ReplCommand},
             repl_types::ReplCommandArgs,
@@ -23,23 +24,46 @@ use crate::cmd::dap_server::{
 #[distributed_slice(REPL_COMMANDS)]
 static BREAK: ReplCommand = ReplCommand {
     command: "break",
-    // Strictly speaking, gdb refers to this as an expression, but we only support variables.
-    help_text: "Sets a breakpoint specified location, or next instruction if unspecified.",
+    help_text: "Set a breakpoint at a location, or halt the target if unspecified.",
     requires_target_halted: false,
     sub_commands: &[],
-    args: &[ReplCommandArgs::Optional("*address")],
+    args: &[ReplCommandArgs::Optional("*address | file:line")],
     handler: create_breakpoint,
 };
 
 #[distributed_slice(REPL_COMMANDS)]
 static CLEAR: ReplCommand = ReplCommand {
     command: "clear",
-    help_text: "Clear a breakpoint",
+    help_text: "Clear a breakpoint.",
     requires_target_halted: false,
     sub_commands: &[],
-    args: &[ReplCommandArgs::Required("*address")],
+    args: &[ReplCommandArgs::Required("*address | file:line")],
     handler: clear_breakpoint,
 };
+
+enum BreakpointLocation<'a> {
+    Address(u64),
+    FileLine { path: &'a str, line: u64 },
+}
+
+/// Parse `*<address>` or `<file>:<line>` from a single REPL argument token.
+fn parse_breakpoint_location(input: &str) -> Result<BreakpointLocation<'_>, DebuggerError> {
+    if let Some(addr_str) = input.strip_prefix('*') {
+        let MemoryAddress(address) = addr_str.try_into()?;
+        return Ok(BreakpointLocation::Address(address));
+    }
+
+    // Use rsplit so Windows drive letters (e.g. `C:\foo.rs:42`) are handled correctly.
+    if let Some((path, line_str)) = input.rsplit_once(':')
+        && let Ok(line) = line_str.parse::<u64>()
+    {
+        return Ok(BreakpointLocation::FileLine { path, line });
+    }
+
+    Err(DebuggerError::UserMessage(format!(
+        "Invalid argument {input:?}. Expected `*<address>` or `<file>:<line>`. See `help`."
+    )))
+}
 
 fn create_breakpoint(
     target_core: &mut CoreHandle<'_>,
@@ -56,41 +80,74 @@ fn create_breakpoint(
         ));
     }
 
-    let mut input_arguments = command_arguments.split_whitespace();
-    let Some(address_str) = input_arguments.next().and_then(|arg| arg.strip_prefix('*')) else {
-        return Err(DebuggerError::UserMessage(format!(
-            "Invalid parameters {command_arguments:?}. See the `help` command for more information."
-        )));
+    let Some(token) = command_arguments.split_whitespace().next() else {
+        return Err(DebuggerError::UserMessage(
+            "Missing argument. See `help`.".to_string(),
+        ));
     };
 
-    let result = set_instruction_breakpoint(
-        InstructionBreakpoint {
-            instruction_reference: address_str.to_string(),
-            condition: None,
-            hit_condition: None,
-            offset: None,
-            mode: None,
-        },
-        target_core,
-    );
+    match parse_breakpoint_location(token)? {
+        BreakpointLocation::Address(address) => {
+            let result = set_instruction_breakpoint(
+                InstructionBreakpoint {
+                    instruction_reference: format!("{address:#x}"),
+                    condition: None,
+                    hit_condition: None,
+                    offset: None,
+                    mode: None,
+                },
+                target_core,
+            );
 
-    let body = if result.verified {
-        // The caller will catch this event body and use it to synch the UI breakpoint list.
-        serde_json::to_value(BreakpointEventBody {
-            breakpoint: result.clone(),
-            reason: "new".to_string(),
-        })
-        .ok()
-    } else {
-        None
-    };
+            let body = if result.verified {
+                serde_json::to_value(BreakpointEventBody {
+                    breakpoint: result.clone(),
+                    reason: "new".to_string(),
+                })
+                .ok()
+            } else {
+                None
+            };
 
-    // Synch the DAP client UI.
-    adapter.dyn_send_event("breakpoint", body)?;
+            adapter.dyn_send_event("breakpoint", body)?;
 
-    Ok(EvalResponse::Message(result.message.unwrap_or_else(|| {
-        format!("Unexpected error creating breakpoint at {address_str}.")
-    })))
+            Ok(EvalResponse::Message(result.message.unwrap_or_else(|| {
+                format!("Unexpected error creating breakpoint at {address:#x}.")
+            })))
+        }
+
+        BreakpointLocation::FileLine { path, line } => {
+            let source = source_from_path(path);
+            let verified = target_core
+                .verify_and_set_breakpoint(TypedPath::derive(path), line, None, &source)
+                .map_err(|e| DebuggerError::UserMessage(e.to_string()))?;
+
+            let body = serde_json::to_value(BreakpointEventBody {
+                breakpoint: Breakpoint {
+                    id: Some(verified.address as i64),
+                    verified: true,
+                    line: verified.source_location.line.map(|l| l as i64),
+                    source: Some(source),
+                    message: Some(format!("Source breakpoint at {:#010X}", verified.address)),
+                    column: None,
+                    end_column: None,
+                    end_line: None,
+                    instruction_reference: None,
+                    offset: None,
+                    reason: None,
+                },
+                reason: "new".to_string(),
+            })
+            .ok();
+
+            adapter.dyn_send_event("breakpoint", body)?;
+
+            Ok(EvalResponse::Message(format!(
+                "Breakpoint set at {:#010X}",
+                verified.address
+            )))
+        }
+    }
 }
 
 fn clear_breakpoint(
@@ -99,30 +156,35 @@ fn clear_breakpoint(
     _: &EvaluateArguments,
     adapter: &mut DebugAdapter<dyn ProtocolAdapter + '_>,
 ) -> EvalResult {
-    let mut input_arguments = command_arguments.split_whitespace();
-    let Some(input_argument) = input_arguments.next() else {
+    let Some(token) = command_arguments.split_whitespace().next() else {
         return Err(DebuggerError::UserMessage(
-            "Missing breakpoint address to clear. See the `help` command for more information."
-                .to_string(),
+            "Missing argument. See `help`.".to_string(),
         ));
     };
 
-    let Some(address_str) = input_argument.strip_prefix('*') else {
-        return Err(DebuggerError::UserMessage(format!(
-            "Invalid input argument {input_argument}. See the `help` command for more information."
-        )));
-    };
-    let Ok(MemoryAddress(address)) = address_str.try_into() else {
-        return Err(DebuggerError::UserMessage(format!(
-            "Invalid memory address {address_str}. See the `help` command for more information."
-        )));
+    let address = match parse_breakpoint_location(token)? {
+        BreakpointLocation::Address(addr) => addr,
+
+        BreakpointLocation::FileLine { path, line } => {
+            let Some(ref debug_info) = target_core.core_data.debug_info else {
+                return Err(DebuggerError::UserMessage(
+                    "Cannot resolve file:line without debug information.".to_string(),
+                ));
+            };
+            debug_info
+                .get_breakpoint_location(TypedPath::derive(path), line, None)
+                .map_err(|e| {
+                    DebuggerError::UserMessage(format!("Cannot resolve {path}:{line}: {e}"))
+                })?
+                .address
+        }
     };
 
     if !target_core.clear_breakpoint(address)? {
         return Err(DebuggerError::UserMessage(format!(
-            "Breakpoint not found at address {address:#x}."
+            "No breakpoint found at {address:#x}."
         )));
-    };
+    }
 
     let body = serde_json::to_value(BreakpointEventBody {
         breakpoint: Breakpoint {
@@ -142,8 +204,23 @@ fn clear_breakpoint(
     })
     .ok();
 
-    // Synch the DAP client UI.
     adapter.dyn_send_event("breakpoint", body)?;
 
     Ok(EvalResponse::Message("Breakpoint cleared".to_string()))
+}
+
+fn source_from_path(path: &str) -> Source {
+    Source {
+        name: std::path::Path::new(path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(str::to_owned),
+        path: Some(path.to_string()),
+        source_reference: None,
+        presentation_hint: None,
+        origin: None,
+        sources: None,
+        adapter_data: None,
+        checksums: None,
+    }
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/breakpoint.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/breakpoint.rs
@@ -20,6 +20,7 @@ use crate::cmd::dap_server::{
     },
     server::core_data::CoreHandle,
 };
+use probe_rs_debug::ColumnType;
 
 #[distributed_slice(REPL_COMMANDS)]
 static BREAK: ReplCommand = ReplCommand {
@@ -27,7 +28,7 @@ static BREAK: ReplCommand = ReplCommand {
     help_text: "Set a breakpoint at a location, or halt the target if unspecified.",
     requires_target_halted: false,
     sub_commands: &[],
-    args: &[ReplCommandArgs::Optional("*address | file.rs:line")],
+    args: &[ReplCommandArgs::Optional("*address | file:line[:column]")],
     handler: create_breakpoint,
 };
 
@@ -37,31 +38,55 @@ static CLEAR: ReplCommand = ReplCommand {
     help_text: "Clear a breakpoint.",
     requires_target_halted: false,
     sub_commands: &[],
-    args: &[ReplCommandArgs::Required("*address | file.rs:line")],
+    args: &[ReplCommandArgs::Required("*address | file:line[:column]")],
     handler: clear_breakpoint,
 };
 
 enum BreakpointLocation<'a> {
     Address(u64),
-    FileLine { path: &'a str, line: u64 },
+    FileLine {
+        path: &'a str,
+        line: u64,
+        column: Option<u64>,
+    },
 }
 
-/// Parse `*<address>` or `<file>:<line>` from a single REPL argument token.
+/// Parse `*<address>`, `<file>:<line>`, or `<file>:<line>:<column>` from a single REPL token.
+///
+/// Splitting is done from the right so that Windows drive letters
+/// (e.g. `C:\foo.rs:42` or `C:\foo.rs:42:5`) are handled correctly.
 fn parse_breakpoint_location(input: &str) -> Result<BreakpointLocation<'_>, DebuggerError> {
     if let Some(addr_str) = input.strip_prefix('*') {
         let MemoryAddress(address) = addr_str.try_into()?;
         return Ok(BreakpointLocation::Address(address));
     }
 
-    // Use rsplit so Windows drive letters (e.g. `C:\foo.rs:42`) are handled correctly.
-    if let Some((path, line_str)) = input.rsplit_once(':')
-        && let Ok(line) = line_str.parse::<u64>()
+    // Peel the rightmost colon-separated token.
+    if let Some((left, rightmost)) = input.rsplit_once(':')
+        && let Ok(rightmost_num) = rightmost.parse::<u64>()
     {
-        return Ok(BreakpointLocation::FileLine { path, line });
+        // Check whether the next token to the left is also a number — if so we have
+        // `<file>:<line>:<column>` (the rightmost is the column, the next is the line).
+        if let Some((path, middle)) = left.rsplit_once(':')
+            && let Ok(line) = middle.parse::<u64>()
+        {
+            return Ok(BreakpointLocation::FileLine {
+                path,
+                line,
+                column: Some(rightmost_num),
+            });
+        }
+
+        // Only one numeric suffix: `<file>:<line>`.
+        return Ok(BreakpointLocation::FileLine {
+            path: left,
+            line: rightmost_num,
+            column: None,
+        });
     }
 
     Err(DebuggerError::UserMessage(format!(
-        "Invalid argument {input:?}. Expected `*<address>` or `<file>:<line>`. See `help`."
+        "Invalid argument {input:?}. Expected `*<address>` or `<file>:<line>[:<column>]`. See `help`."
     )))
 }
 
@@ -116,10 +141,10 @@ fn create_breakpoint(
             })))
         }
 
-        BreakpointLocation::FileLine { path, line } => {
+        BreakpointLocation::FileLine { path, line, column } => {
             let source = source_from_path(path);
             let verified = target_core
-                .verify_and_set_breakpoint(TypedPath::derive(path), line, None, &source)
+                .verify_and_set_breakpoint(TypedPath::derive(path), line, column, &source)
                 .map_err(|e| DebuggerError::UserMessage(e.to_string()))?;
 
             let body = serde_json::to_value(BreakpointEventBody {
@@ -129,7 +154,10 @@ fn create_breakpoint(
                     line: verified.source_location.line.map(|l| l as i64),
                     source: Some(source),
                     message: Some(format!("Source breakpoint at {:#010X}", verified.address)),
-                    column: None,
+                    column: verified.source_location.column.map(|col| match col {
+                        ColumnType::LeftEdge => 0_i64,
+                        ColumnType::Column(c) => c as i64,
+                    }),
                     end_column: None,
                     end_line: None,
                     instruction_reference: None,
@@ -165,14 +193,14 @@ fn clear_breakpoint(
     let address = match parse_breakpoint_location(token)? {
         BreakpointLocation::Address(addr) => addr,
 
-        BreakpointLocation::FileLine { path, line } => {
+        BreakpointLocation::FileLine { path, line, column } => {
             let Some(ref debug_info) = target_core.core_data.debug_info else {
                 return Err(DebuggerError::UserMessage(
                     "Cannot resolve file:line without debug information.".to_string(),
                 ));
             };
             debug_info
-                .get_breakpoint_location(TypedPath::derive(path), line, None)
+                .get_breakpoint_location(TypedPath::derive(path), line, column)
                 .map_err(|e| {
                     DebuggerError::UserMessage(format!("Cannot resolve {path}:{line}: {e}"))
                 })?
@@ -211,10 +239,9 @@ fn clear_breakpoint(
 
 fn source_from_path(path: &str) -> Source {
     Source {
-        name: std::path::Path::new(path)
+        name: TypedPath::derive(path)
             .file_name()
-            .and_then(|n| n.to_str())
-            .map(str::to_owned),
+            .map(|b| String::from_utf8_lossy(b).to_string()),
         path: Some(path.to_string()),
         source_reference: None,
         presentation_hint: None,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
@@ -334,7 +334,7 @@ mod test {
             &[
                 (
                     "break ",
-                    "break [*address | file:line]: Set a breakpoint at a location, or halt the target if unspecified.",
+                    "break [*address | file:line[:column]]: Set a breakpoint at a location, or halt the target if unspecified.",
                 ),
                 (
                     "bt ",
@@ -348,14 +348,14 @@ mod test {
             "br",
             &[(
                 "break ",
-                "break [*address | file:line]: Set a breakpoint at a location, or halt the target if unspecified.",
+                "break [*address | file:line[:column]]: Set a breakpoint at a location, or halt the target if unspecified.",
             )],
         );
         assert_completion_result(
             "break",
             &[(
                 "break ",
-                "break [*address | file:line]: Set a breakpoint at a location, or halt the target if unspecified.",
+                "break [*address | file:line[:column]]: Set a breakpoint at a location, or halt the target if unspecified.",
             )],
         );
         assert_completion_result(

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
@@ -334,7 +334,7 @@ mod test {
             &[
                 (
                     "break ",
-                    "break [*address]: Sets a breakpoint specified location, or next instruction if unspecified.",
+                    "break [*address | file:line]: Set a breakpoint at a location, or halt the target if unspecified.",
                 ),
                 (
                     "bt ",
@@ -348,14 +348,14 @@ mod test {
             "br",
             &[(
                 "break ",
-                "break [*address]: Sets a breakpoint specified location, or next instruction if unspecified.",
+                "break [*address | file:line]: Set a breakpoint at a location, or halt the target if unspecified.",
             )],
         );
         assert_completion_result(
             "break",
             &[(
                 "break ",
-                "break [*address]: Sets a breakpoint specified location, or next instruction if unspecified.",
+                "break [*address | file:line]: Set a breakpoint at a location, or halt the target if unspecified.",
             )],
         );
         assert_completion_result(


### PR DESCRIPTION
This PR makes it possible to actually use breakpoints without ghidra, by resolving file paths. Paths are tail-matched, i.e. `src/main.rs:line` will resolve, not just absolute paths that the old implementation required.