### PR TITLE
fix(cli): correct attach <PATH> help text

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
@@ -20,7 +20,8 @@ pub struct Cmd {
     #[clap(flatten)]
     pub(crate) probe_options: ProbeOptions,
 
-    /// The path to the ELF file to flash and run.
+    /// The path to the ELF file used to locate the RTT control block and decode defmt frames.
+    /// The target is not flashed or reset.
     #[clap(index = 1)]
     pub(crate) path: Option<PathBuf>,
 


### PR DESCRIPTION
Closes #4027

The `<PATH>` argument in `probe-rs attach` had the doc comment copied from `run`:

```
/// The path to the ELF file to flash and run.
```

`attach` does not flash or reset the target — it only uses the ELF to locate the RTT control block and decode defmt frames. Updated the comment to reflect this.