### PR TITLE
Handle legacy AP0 addresses on DPv3

### DIFF
--- a/changelog/fixed-dpv3-legacy-ap0.md
+++ b/changelog/fixed-dpv3-legacy-ap0.md
@@ -1,0 +1,1 @@
+Handle DPv3 target descriptions that use legacy AP index 0 as APv2 base address 0x0.

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -471,6 +471,22 @@ impl ArmCommunicationInterface {
                 s.set_addr(((address >> 4) & 0xFFFF_FFFF) as u32);
                 s1.set_addr((address >> 32) as u32);
             }
+            (ApAddress::V1(port), SelectCache::DPv3(s, s1)) if *port == 0 => {
+                // Some externally generated target descriptions still model the root APv2
+                // memory interface as legacy AP index 0. Treat that as base address 0x0
+                // so DPv3/MINDP targets remain usable.
+                tracing::warn!(
+                    "DPv3 target was configured with legacy AP index 0; treating it as APv2 base 0x0"
+                );
+                let address = ap_register_address;
+                s.set_addr(((address >> 4) & 0xFFFF_FFFF) as u32);
+                s1.set_addr((address >> 32) as u32);
+            }
+            (ApAddress::V1(port), SelectCache::DPv3(_, _)) => {
+                return Err(ArmError::Other(format!(
+                    "DPv3 targets require APv2 addresses in target descriptions; got legacy AP index {port}. Use `ap: !v2 0x...`."
+                )));
+            }
             _ => unreachable!(
                 "Did not expect to be called with {ap:x?}. This is a bug, please report it."
             ),


### PR DESCRIPTION
  ## Summary

  This handles DPv3 targets whose target description still uses the legacy AP index `0` for the root memory AP.

  For `ApAddress::V1(0)` on DPv3, this treats the AP as APv2 base address `0x0`. Other legacy AP indexes on DPv3 now return a clearer error telling users to use `ap: !v2 0x...`.

  ## Motivation

  Some externally generated target descriptions still model the root APv2 memory interface as legacy AP index 0. Without this compatibility path, DPv3/MINDP targets can hit the existing `unreachable!` path instead of working or giving a useful error.
