### PR TITLE
fix: handle `x 0x0` correctly in probe-rs debug REPL

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/inspect.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/inspect.rs
@@ -110,11 +110,11 @@ fn examine_memory(
     // 1. Specified address
     // 2. Frame address
     // 3. Program counter
-    let mut input_address = 0_u64;
+    let mut input_address = None;
 
     for input_argument in input_arguments {
         if let Ok(MemoryAddress(addr)) = MemoryAddress::try_from(input_argument) {
-            input_address = addr;
+            input_address = Some(addr);
         } else if input_argument.starts_with('/') {
             let Some(gdb_nuf_string) = input_argument.strip_prefix('/') else {
                 return Err(DebuggerError::UserMessage(
@@ -145,19 +145,21 @@ fn examine_memory(
                     "Undefined register ${reg:?}."
                 )));
             };
-            input_address = target_core.core.read_core_reg(register)?;
+            input_address = Some(target_core.core.read_core_reg(register)?);
         } else {
             return Err(DebuggerError::UserMessage(
                 "Invalid parameters. See the `help` command for more information.".to_string(),
             ));
         }
     }
-    if input_address == 0 {
+    let input_address = if let Some(input_address) = input_address {
+        input_address
+    } else {
         // No address was specified, so we'll use the frame address, if available.
 
         let frame_id = request_arguments.frame_id.map(ObjectRef::from);
 
-        input_address = if let Some(frame_pc) = frame_id
+        if let Some(frame_pc) = frame_id
             .and_then(|frame_id| {
                 target_core
                     .core_data
@@ -173,7 +175,7 @@ fn examine_memory(
                 .core
                 .read_core_reg(target_core.core.program_counter())?
         }
-    }
+    };
 
     memory_read(input_address, gdb_nuf, target_core)
 }


### PR DESCRIPTION
### Summary

Fix the `probe-rs debug` REPL `x` command so that `x 0x0` reads memory at address `0x0` instead of falling back to the current frame address or program counter.

### Root Cause

The REPL used `0_u64` as the sentinel for “no address provided”, so a valid address of `0x0` was treated the same as an omitted address.

### Fix

Store the parsed address as `Option<u64>` instead of `u64`, so `Some(0)` is handled as a real address and only `None` falls back to frame address / current PC.