### PR TITLE
cortex-m: keep state during single-step to disambiguate halt reason

### DIFF
--- a/changelog/fixed-cortex-m-step-halt-reason.md
+++ b/changelog/fixed-cortex-m-step-halt-reason.md
@@ -1,0 +1,1 @@
+cortex-m: keep state during single-step to disambiguate halt reason

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -502,6 +502,7 @@ impl CoreInterface for Armv6m<'_> {
                 "The core is in locked up status as a result of an unrecoverable exception"
             );
 
+            self.state.clear_pending_step();
             self.set_core_status(CoreStatus::LockedUp);
             return Ok(CoreStatus::LockedUp);
         }
@@ -522,6 +523,7 @@ impl CoreInterface for Armv6m<'_> {
             let dfsr = Dfsr(self.memory.read_word_32(Dfsr::get_mmio_address())?);
 
             let mut reason = dfsr.halt_reason();
+            reason = self.state.resolve_halt_reason(reason);
 
             // Clear bits from Dfsr register
             self.memory
@@ -576,6 +578,7 @@ impl CoreInterface for Armv6m<'_> {
 
     fn halt(&mut self, timeout: Duration) -> Result<CoreInformation, Error> {
         // TODO: Generic halt support
+        self.state.clear_pending_step();
 
         let mut value = Dhcsr(0);
         value.set_c_halt(true);
@@ -599,6 +602,7 @@ impl CoreInterface for Armv6m<'_> {
     fn run(&mut self) -> Result<(), Error> {
         // Before we run, we always perform a single instruction step, to account for possible breakpoints that might get us stuck on the current instruction.
         self.step()?;
+        self.state.clear_pending_step();
 
         let mut value = Dhcsr(0);
         value.set_c_halt(false);
@@ -616,6 +620,7 @@ impl CoreInterface for Armv6m<'_> {
 
     fn reset(&mut self) -> Result<(), Error> {
         self.state.semihosting_command = None;
+        self.state.clear_pending_step();
 
         self.sequence
             .reset_system(&mut *self.memory, crate::CoreType::Armv6m, None)?;
@@ -627,6 +632,7 @@ impl CoreInterface for Armv6m<'_> {
 
     fn reset_and_halt(&mut self, _timeout: Duration) -> Result<CoreInformation, Error> {
         self.reset_catch_set()?;
+        self.state.clear_pending_step();
 
         self.sequence
             .reset_system(&mut *self.memory, crate::CoreType::Armv6m, None)?;
@@ -685,6 +691,7 @@ impl CoreInterface for Armv6m<'_> {
         let mut value = Dhcsr(0);
         // Leave halted state.
         // Step one instruction.
+        self.state.begin_step();
         value.set_c_step(true);
         value.set_c_halt(false);
         value.set_c_debugen(true);
@@ -698,9 +705,12 @@ impl CoreInterface for Armv6m<'_> {
         // The single-step might put the core in lockup state. Lockup isn't considered "halted"
         // so we can't use `wait_for_core_halted` here.
         // So we wait for halted OR lockup, and if we entered lockup we halt.
-        self.wait_for_status(Duration::from_millis(100), |s| {
+        if let Err(err) = self.wait_for_status(Duration::from_millis(100), |s| {
             matches!(s, CoreStatus::Halted(_) | CoreStatus::LockedUp)
-        })?;
+        }) {
+            self.state.clear_pending_step();
+            return Err(err);
+        }
         if self.status()? == CoreStatus::LockedUp {
             self.halt(Duration::from_millis(100))?;
         }

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -681,6 +681,7 @@ impl CoreInterface for Armv7m<'_> {
                 "The core is in locked up status as a result of an unrecoverable exception"
             );
 
+            self.state.clear_pending_step();
             self.set_core_status(CoreStatus::LockedUp);
 
             return Ok(CoreStatus::LockedUp);
@@ -701,6 +702,7 @@ impl CoreInterface for Armv7m<'_> {
             let dfsr = Dfsr(self.memory.read_word_32(Dfsr::get_mmio_address())?);
 
             let mut reason = dfsr.halt_reason();
+            reason = self.state.resolve_halt_reason(reason);
 
             // Clear bits from Dfsr register
             self.memory
@@ -755,6 +757,7 @@ impl CoreInterface for Armv7m<'_> {
 
     fn halt(&mut self, timeout: Duration) -> Result<CoreInformation, Error> {
         // TODO: Generic halt support
+        self.state.clear_pending_step();
 
         let mut value = Dhcsr(0);
         value.set_c_halt(true);
@@ -778,6 +781,7 @@ impl CoreInterface for Armv7m<'_> {
     fn run(&mut self) -> Result<(), Error> {
         // Before we run, we always perform a single instruction step, to account for possible breakpoints that might get us stuck on the current instruction.
         self.step()?;
+        self.state.clear_pending_step();
 
         let mut dhcsr = Dhcsr(self.memory.read_word_32(Dhcsr::get_mmio_address())?);
 
@@ -806,6 +810,7 @@ impl CoreInterface for Armv7m<'_> {
 
     fn reset(&mut self) -> Result<(), Error> {
         self.state.semihosting_command = None;
+        self.state.clear_pending_step();
 
         self.sequence
             .reset_system(&mut *self.memory, crate::CoreType::Armv7m, None)?;
@@ -819,6 +824,7 @@ impl CoreInterface for Armv7m<'_> {
         // Set the vc_corereset bit in the DEMCR register.
         // This will halt the core after reset.
         self.reset_catch_set()?;
+        self.state.clear_pending_step();
 
         self.sequence
             .reset_system(&mut *self.memory, crate::CoreType::Armv7m, None)?;
@@ -890,6 +896,7 @@ impl CoreInterface for Armv7m<'_> {
 
         // Leave halted state.
         // Step one instruction.
+        self.state.begin_step();
         dhcsr.set_c_step(true);
         dhcsr.set_c_halt(false);
         dhcsr.enable_write();
@@ -900,9 +907,12 @@ impl CoreInterface for Armv7m<'_> {
         // The single-step might put the core in lockup state. Lockup isn't considered "halted"
         // so we can't use `wait_for_core_halted` here.
         // So we wait for halted OR lockup, and if we entered lockup we halt.
-        self.wait_for_status(Duration::from_millis(100), |s| {
+        if let Err(err) = self.wait_for_status(Duration::from_millis(100), |s| {
             matches!(s, CoreStatus::Halted(_) | CoreStatus::LockedUp)
-        })?;
+        }) {
+            self.state.clear_pending_step();
+            return Err(err);
+        }
         if self.status()? == CoreStatus::LockedUp {
             self.halt(Duration::from_millis(100))?;
         }

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -133,6 +133,7 @@ impl CoreInterface for Armv8m<'_> {
                 "The core is in locked up status as a result of an unrecoverable exception"
             );
 
+            self.state.clear_pending_step();
             self.set_core_status(CoreStatus::LockedUp);
 
             return Ok(CoreStatus::LockedUp);
@@ -155,6 +156,7 @@ impl CoreInterface for Armv8m<'_> {
             let dfsr = Dfsr(self.memory.read_word_32(Dfsr::get_mmio_address())?);
 
             let mut reason = dfsr.halt_reason();
+            reason = self.state.resolve_halt_reason(reason);
 
             // Clear bits from Dfsr register
             self.memory
@@ -208,6 +210,8 @@ impl CoreInterface for Armv8m<'_> {
     }
 
     fn halt(&mut self, timeout: Duration) -> Result<CoreInformation, Error> {
+        self.state.clear_pending_step();
+
         let mut value = Dhcsr(0);
         value.set_c_halt(true);
         value.set_c_debugen(true);
@@ -232,6 +236,7 @@ impl CoreInterface for Armv8m<'_> {
     fn run(&mut self) -> Result<(), Error> {
         // Before we run, we always perform a single instruction step, to account for possible breakpoints that might get us stuck on the current instruction.
         self.step()?;
+        self.state.clear_pending_step();
 
         let mut value = Dhcsr(0);
         value.set_c_halt(false);
@@ -250,6 +255,7 @@ impl CoreInterface for Armv8m<'_> {
 
     fn reset(&mut self) -> Result<(), Error> {
         self.state.semihosting_command = None;
+        self.state.clear_pending_step();
 
         self.sequence
             .reset_system(&mut *self.memory, crate::CoreType::Armv8m, None)?;
@@ -263,6 +269,7 @@ impl CoreInterface for Armv8m<'_> {
         // Set the vc_corereset bit in the DEMCR register.
         // This will halt the core after reset.
         self.reset_catch_set()?;
+        self.state.clear_pending_step();
 
         self.sequence
             .reset_system(&mut *self.memory, crate::CoreType::Armv8m, None)?;
@@ -321,6 +328,7 @@ impl CoreInterface for Armv8m<'_> {
         let mut value = Dhcsr(0);
         // Leave halted state.
         // Step one instruction.
+        self.state.begin_step();
         value.set_c_step(true);
         value.set_c_halt(false);
         value.set_c_debugen(true);
@@ -334,9 +342,12 @@ impl CoreInterface for Armv8m<'_> {
         // The single-step might put the core in lockup state. Lockup isn't considered "halted"
         // so we can't use `wait_for_core_halted` here.
         // So we wait for halted OR lockup, and if we entered lockup we halt.
-        self.wait_for_status(Duration::from_millis(100), |s| {
+        if let Err(err) = self.wait_for_status(Duration::from_millis(100), |s| {
             matches!(s, CoreStatus::Halted(_) | CoreStatus::LockedUp)
-        })?;
+        }) {
+            self.state.clear_pending_step();
+            return Err(err);
+        }
         if self.status()? == CoreStatus::LockedUp {
             self.halt(Duration::from_millis(100))?;
         }

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -143,6 +143,13 @@ pub struct CortexMState {
 
     /// The semihosting command that was decoded at the current program counter
     semihosting_command: Option<SemihostingCommand>,
+
+    /// Set after issuing `C_STEP` until `CoreInterface::status()` reads the halt from DFSR.
+    /// Cortex-M DFSR.HALTED is set for halt requests from both `C_HALT` and `C_STEP`, but it cannot
+    /// be determined from registers alone which was the cause.
+    /// `pending_step` tracks whether we're waiting for a step so that `CoreInterface::status()`
+    /// can return `HaltReason::Step` instead of `HaltReason::Request` if a step was pending.
+    pending_step: bool,
 }
 
 impl CortexMState {
@@ -153,6 +160,30 @@ impl CortexMState {
             current_state: CoreStatus::Unknown,
             fp_present: false,
             semihosting_command: None,
+            pending_step: false,
+        }
+    }
+
+    pub(crate) fn begin_step(&mut self) {
+        self.pending_step = true;
+    }
+
+    pub(crate) fn clear_pending_step(&mut self) {
+        self.pending_step = false;
+    }
+
+    /// Apply step context to a halt reason read from DFSR.
+    pub(crate) fn resolve_halt_reason(&mut self, reason: HaltReason) -> HaltReason {
+        if !self.pending_step {
+            return reason;
+        }
+
+        self.pending_step = false;
+
+        if reason == HaltReason::Request {
+            HaltReason::Step
+        } else {
+            reason
         }
     }
 


### PR DESCRIPTION
On Cortex-M, DFSR.HALTED is set by `C_HALT` and `C_STEP`, so GDB single-step completion (C_STEP) looked the same as an explicit halt (C_HALT).
See https://developer.arm.com/documentation/ddi0403/d/Debug-Architecture/ARMv7-M-Debug/Debug-register-support-in-the-SCS/Debug-Fault-Status-Register--DFSR

Add a `pending_step` flag in `CortexMState` for the duration of `C_STEP`, and use that to resolve to the correct halt reason in `CoreInterface::status()`.

Resolves #4030