### PR TITLE
Fix deadlock caused by mutex cross-locking

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use crate::{
     rpc::{
-        Key, ObjectStorage,
+        Key, ObjectStorageSlot,
         functions::{
             MonitorEndpoint, MultiTopicPublisher, MultiTopicWriter, RpcResult, RpcSpawnContext,
             RttTopic, SemihostingTopic, WireTxImpl, flash::BootInfo,
@@ -211,7 +211,7 @@ fn monitor_impl(
     }
 
     let poller = client_key.map(|client| RttPoller {
-        rtt_client: client,
+        rtt_client: shared_session.object_storage().cell(client),
         clear_control_block: request.mode.should_clear_rtt_header(),
         sender: |message| {
             sender
@@ -245,7 +245,7 @@ pub struct RttPoller<S>
 where
     S: FnMut(RttEvent) -> anyhow::Result<()>,
 {
-    pub rtt_client: Key<RttClient>,
+    pub rtt_client: ObjectStorageSlot<RttClient>,
     pub clear_control_block: bool,
     pub sender: S,
 }
@@ -254,16 +254,16 @@ impl<S> RunLoopPoller for RttPoller<S>
 where
     S: FnMut(RttEvent) -> anyhow::Result<()>,
 {
-    fn start(&mut self, objs: &ObjectStorage, core: &mut Core<'_>) -> anyhow::Result<()> {
+    fn start(&mut self, core: &mut Core<'_>) -> anyhow::Result<()> {
         if self.clear_control_block {
-            let mut rtt_client = objs.object_mut_blocking(self.rtt_client);
+            let mut rtt_client = self.rtt_client.get_blocking();
             rtt_client.clear_control_block(core)?;
         }
         Ok(())
     }
 
-    fn poll(&mut self, objs: &ObjectStorage, core: &mut Core<'_>) -> anyhow::Result<Duration> {
-        let mut rtt_client = objs.object_mut_blocking(self.rtt_client);
+    fn poll(&mut self, core: &mut Core<'_>) -> anyhow::Result<Duration> {
+        let mut rtt_client = self.rtt_client.get_blocking();
         if !rtt_client.is_attached() && matches!(rtt_client.try_attach(core), Ok(true)) {
             tracing::debug!("Attached to RTT");
             let up_channels = rtt_client
@@ -308,8 +308,8 @@ where
         Ok(next_poll)
     }
 
-    fn exit(&mut self, objs: &ObjectStorage, core: &mut Core<'_>) -> anyhow::Result<()> {
-        let mut rtt_client = objs.object_mut_blocking(self.rtt_client);
+    fn exit(&mut self, core: &mut Core<'_>) -> anyhow::Result<()> {
+        let mut rtt_client = self.rtt_client.get_blocking();
         rtt_client.clean_up(core)?;
         Ok(())
     }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
@@ -155,7 +155,7 @@ fn list_tests_impl(
     }
 
     let poller = request.rtt_client.map(|client| RttPoller {
-        rtt_client: client,
+        rtt_client: shared_session.object_storage().cell(client),
         clear_control_block: true,
         sender: |message| {
             sender
@@ -253,7 +253,7 @@ fn run_test_impl(
     };
 
     let poller = request.rtt_client.map(|client| RttPoller {
-        rtt_client: client,
+        rtt_client: shared_session.object_storage().cell(client),
         clear_control_block: true,
         sender: |message| {
             sender

--- a/probe-rs-tools/src/bin/probe-rs/rpc/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/mod.rs
@@ -97,6 +97,32 @@ pub(crate) struct ObjectStorage {
     storage: HashMap<u64, Arc<Mutex<dyn Any + Send>>>,
 }
 
+/// A reference to an object in ObjectStorage.
+pub(crate) struct ObjectStorageSlot<T: Any + Send> {
+    obj: Arc<Mutex<dyn Any + Send>>,
+    _type: PhantomData<fn() -> T>,
+}
+
+impl<T: Any + Send> ObjectStorageSlot<T> {
+    /// Returns a mutable reference to the object.
+    pub async fn get(&self) -> impl DerefMut<Target = T> + Send + use<T> {
+        let guard = self.obj.clone().lock_owned().await;
+        tokio::sync::OwnedMutexGuard::map(guard, |e: &mut (dyn Any + Send)| {
+            e.downcast_mut::<T>().unwrap()
+        })
+    }
+
+    /// Returns a mutable reference to the object.
+    ///
+    /// This is a blocking operation and should only be used in synchronous contexts.
+    pub fn get_blocking(&self) -> impl DerefMut<Target = T> + Send + use<T> {
+        let guard = self.obj.clone().blocking_lock_owned();
+        tokio::sync::OwnedMutexGuard::map(guard, |e: &mut (dyn Any + Send)| {
+            e.downcast_mut::<T>().unwrap()
+        })
+    }
+}
+
 impl ObjectStorage {
     fn new() -> Self {
         Self {
@@ -110,26 +136,15 @@ impl ObjectStorage {
         key
     }
 
-    pub async fn object_mut<T: Any + Send>(
-        &self,
-        key: Key<T>,
-    ) -> impl DerefMut<Target = T> + Send + use<T> {
+    /// Returns an [`ObjectStorageSlot`] for the given key.
+    ///
+    /// This function is intended to ensure that locks on ObjectStorage are held for as short a time as possible.
+    pub fn cell<T: Any + Send>(&self, key: Key<T>) -> ObjectStorageSlot<T> {
         let obj = self.storage.get(&key.key).unwrap();
-        let guard = obj.clone().lock_owned().await;
-        tokio::sync::OwnedMutexGuard::map(guard, |e: &mut (dyn Any + Send)| {
-            e.downcast_mut::<T>().unwrap()
-        })
-    }
-
-    pub fn object_mut_blocking<T: Any + Send>(
-        &self,
-        key: Key<T>,
-    ) -> impl DerefMut<Target = T> + Send + use<T> {
-        let obj = self.storage.get(&key.key).unwrap();
-        let guard = obj.clone().blocking_lock_owned();
-        tokio::sync::OwnedMutexGuard::map(guard, |e: &mut (dyn Any + Send)| {
-            e.downcast_mut::<T>().unwrap()
-        })
+        ObjectStorageSlot {
+            obj: obj.clone(),
+            _type: PhantomData,
+        }
     }
 }
 
@@ -161,14 +176,18 @@ impl ConnectionState {
         &self,
         key: Key<T>,
     ) -> impl DerefMut<Target = T> + Send + use<T> {
-        self.object_storage.lock().await.object_mut(key).await
+        // MUST be two separate statements so that the lock is released.
+        let locked_cell = self.object_storage.lock().await.cell(key);
+        locked_cell.get().await
     }
 
     pub fn object_mut_blocking<T: Any + Send>(
         &self,
         key: Key<T>,
     ) -> impl DerefMut<Target = T> + Send + use<T> {
-        self.object_storage.blocking_lock().object_mut_blocking(key)
+        // MUST be two separate statements so that the lock is released.
+        let locked_cell = self.object_storage.blocking_lock().cell(key);
+        locked_cell.get_blocking()
     }
 
     pub async fn set_session(&mut self, session: Session, dry_run: bool) -> Key<Session> {
@@ -208,7 +227,9 @@ impl SessionState<'_> {
     ///
     /// This function blocks while other users hold the session.
     pub fn session_blocking(&self) -> impl DerefMut<Target = Session> + Send + use<> {
-        self.object_storage().object_mut_blocking(self.session)
+        // MUST be two separate statements so that the lock is released.
+        let obj_cell = self.object_storage().cell(self.session);
+        obj_cell.get_blocking()
     }
 
     /// Returns whether the session is in dry-run mode.

--- a/probe-rs-tools/src/bin/probe-rs/rpc/utils/run_loop.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/utils/run_loop.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use probe_rs::{Core, CoreType, Error, HaltReason, VectorCatchCondition};
 
-use crate::rpc::{ObjectStorage, SessionState};
+use crate::rpc::SessionState;
 
 pub struct RunLoop {
     pub core_id: usize,
@@ -110,8 +110,7 @@ impl RunLoop {
                 }
             }
 
-            let object_storage = shared_session.object_storage();
-            poller.start(&object_storage, &mut core)?;
+            poller.start(&mut core)?;
 
             if core.core_halted()? {
                 core.run()?;
@@ -123,9 +122,8 @@ impl RunLoop {
         // Clean up run loop
         let mut session = shared_session.session_blocking();
         let mut core = session.core(self.core_id)?;
-        let object_storage = shared_session.object_storage();
         // Always clean up after RTT but don't overwrite the original result.
-        let poller_exit_result = poller.exit(&object_storage, &mut core);
+        let poller_exit_result = poller.exit(&mut core);
         if result.is_ok() {
             // If the result is Ok, we return the potential error during cleanup.
             poller_exit_result?;
@@ -177,7 +175,6 @@ impl RunLoop {
         let mut core = session.core(self.core_id)?;
 
         let mut next_poll = Duration::from_millis(100);
-        let object_storage = shared_session.object_storage();
 
         // check for halt first, poll rtt after.
         // this is important so we do one last poll after halt, so we flush all messages
@@ -204,7 +201,7 @@ impl RunLoop {
             probe_rs::CoreStatus::LockedUp => Some(Ok(ReturnReason::LockedUp)),
         };
 
-        let poller_result = poller.poll(&object_storage, &mut core);
+        let poller_result = poller.poll(&mut core);
 
         if let Some(reason) = return_reason {
             return reason.map(ControlFlow::Break);
@@ -222,23 +219,23 @@ impl RunLoop {
 }
 
 pub trait RunLoopPoller {
-    fn start(&mut self, objs: &ObjectStorage, core: &mut Core<'_>) -> Result<()>;
-    fn poll(&mut self, objs: &ObjectStorage, core: &mut Core<'_>) -> Result<Duration>;
-    fn exit(&mut self, objs: &ObjectStorage, core: &mut Core<'_>) -> Result<()>;
+    fn start(&mut self, core: &mut Core<'_>) -> Result<()>;
+    fn poll(&mut self, core: &mut Core<'_>) -> Result<Duration>;
+    fn exit(&mut self, core: &mut Core<'_>) -> Result<()>;
 }
 
 pub struct NoopPoller;
 
 impl RunLoopPoller for NoopPoller {
-    fn start(&mut self, _: &ObjectStorage, _core: &mut Core<'_>) -> Result<()> {
+    fn start(&mut self, _core: &mut Core<'_>) -> Result<()> {
         Ok(())
     }
 
-    fn poll(&mut self, _: &ObjectStorage, _core: &mut Core<'_>) -> Result<Duration> {
+    fn poll(&mut self, _core: &mut Core<'_>) -> Result<Duration> {
         Ok(Duration::from_secs(u64::MAX))
     }
 
-    fn exit(&mut self, _: &ObjectStorage, _core: &mut Core<'_>) -> Result<()> {
+    fn exit(&mut self, _core: &mut Core<'_>) -> Result<()> {
         Ok(())
     }
 }
@@ -247,27 +244,27 @@ impl<T> RunLoopPoller for Option<T>
 where
     T: RunLoopPoller,
 {
-    fn start(&mut self, objs: &ObjectStorage, core: &mut Core<'_>) -> Result<()> {
+    fn start(&mut self, core: &mut Core<'_>) -> Result<()> {
         if let Some(poller) = self {
-            poller.start(objs, core)
+            poller.start(core)
         } else {
-            NoopPoller.start(objs, core)
+            NoopPoller.start(core)
         }
     }
 
-    fn poll(&mut self, objs: &ObjectStorage, core: &mut Core<'_>) -> Result<Duration> {
+    fn poll(&mut self, core: &mut Core<'_>) -> Result<Duration> {
         if let Some(poller) = self {
-            poller.poll(objs, core)
+            poller.poll(core)
         } else {
-            NoopPoller.poll(objs, core)
+            NoopPoller.poll(core)
         }
     }
 
-    fn exit(&mut self, objs: &ObjectStorage, core: &mut Core<'_>) -> Result<()> {
+    fn exit(&mut self, core: &mut Core<'_>) -> Result<()> {
         if let Some(poller) = self {
-            poller.exit(objs, core)
+            poller.exit(core)
         } else {
-            NoopPoller.exit(objs, core)
+            NoopPoller.exit(core)
         }
     }
 }


### PR DESCRIPTION
This PR fixes a deadlock, and simplifies the poller trait - by basically forcing prefetching an ObjectStorageSlot object.

The main change in this PR is that the object storage's mutex is no longer held overlapping with the stored objects' lock.