### PR TITLE
Faster flashing for Edge 84

### DIFF
--- a/probe-rs/src/probe/cmsisdap/commands/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/mod.rs
@@ -6,8 +6,12 @@ pub mod swo;
 pub mod transfer;
 
 use crate::probe::cmsisdap::commands::general::info::PacketSizeCommand;
-use crate::probe::usb_util::InterfaceExt;
+use crate::probe::usb_util::{read_bulk_endpoint, write_bulk_endpoint};
 use crate::probe::{ProbeError, WireProtocol};
+use nusb::{
+    Endpoint,
+    transfer::{Bulk, In, Out},
+};
 use std::io::ErrorKind;
 use std::str::Utf8Error;
 use std::time::Duration;
@@ -168,14 +172,20 @@ pub enum CmsisDapDevice {
     },
 
     /// CMSIS-DAP v2 over WinUSB/Bulk.
-    /// Stores an usb device handle, out/in EP addresses, maximum DAP packet size,
-    /// and an optional SWO streaming EP address and SWO maximum packet size.
+    /// Stores the usb interface handle, persistent bulk out/in endpoints, the
+    /// maximum DAP packet size, and an optional persistent SWO streaming
+    /// endpoint.
+    ///
+    /// The endpoints are claimed once when the device is opened and reused for
+    /// every transfer, rather than being re-claimed per transfer. This both
+    /// removes per-transfer setup/teardown cost and provides a stable place to
+    /// keep multiple transfers in flight (see FAST_USB.md).
     V2 {
         handle: nusb::Interface,
-        out_ep: u8,
-        in_ep: u8,
+        out_ep: Endpoint<Bulk, Out>,
+        in_ep: Endpoint<Bulk, In>,
         max_packet_size: usize,
-        swo_ep: Option<(u8, usize)>,
+        swo_ep: Option<Endpoint<Bulk, In>>,
         usb_timeout: Duration,
     },
 }
@@ -198,30 +208,40 @@ impl CmsisDapDevice {
     }
 
     /// Read from the probe into `buf`, returning the number of bytes read on success.
-    fn read(&self, buf: &mut [u8]) -> Result<usize, SendError> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, SendError> {
         match self {
             #[cfg(feature = "cmsisdap_v1")]
-            CmsisDapDevice::V1 { handle, .. } => {
-                match handle.read_timeout(buf, self.usb_timeout().as_millis() as i32)? {
+            CmsisDapDevice::V1 {
+                handle,
+                usb_timeout,
+                ..
+            } => {
+                match handle.read_timeout(buf, usb_timeout.as_millis() as i32)? {
                     // Timeout is not indicated by error, but by returning 0 read bytes
                     0 => Err(SendError::Timeout),
                     n => Ok(n),
                 }
             }
-            CmsisDapDevice::V2 { handle, in_ep, .. } => {
-                Ok(handle.read_bulk(*in_ep, buf, self.usb_timeout())?)
-            }
+            CmsisDapDevice::V2 {
+                in_ep,
+                usb_timeout,
+                ..
+            } => Ok(read_bulk_endpoint(in_ep, buf, *usb_timeout)?),
         }
     }
 
     /// Write `buf` to the probe, returning the number of bytes written on success.
-    fn write(&self, buf: &[u8]) -> Result<usize, SendError> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, SendError> {
         match self {
             #[cfg(feature = "cmsisdap_v1")]
             CmsisDapDevice::V1 { handle, .. } => Ok(handle.write(buf)?),
-            CmsisDapDevice::V2 { handle, out_ep, .. } => {
+            CmsisDapDevice::V2 {
+                out_ep,
+                usb_timeout,
+                ..
+            } => {
                 // Skip first byte as it's set to 0 for HID transfers
-                Ok(handle.write_bulk(*out_ep, &buf[1..], self.usb_timeout())?)
+                Ok(write_bulk_endpoint(out_ep, &buf[1..], *usb_timeout)?)
             }
         }
     }
@@ -229,7 +249,7 @@ impl CmsisDapDevice {
     /// Drain any pending data from the probe, ensuring future responses are
     /// synchronised to requests. Swallows any errors, which are expected if
     /// there is no pending data to read.
-    pub(super) fn drain(&self) {
+    pub(super) fn drain(&mut self) {
         tracing::debug!("Draining probe of any pending data.");
 
         match self {
@@ -239,7 +259,7 @@ impl CmsisDapDevice {
                 report_size,
                 ..
             } => loop {
-                let mut discard = vec![0u8; report_size + 1];
+                let mut discard = vec![0u8; *report_size + 1];
                 match handle.read_timeout(&mut discard, 1) {
                     Ok(n) if n != 0 => continue,
                     _ => break,
@@ -247,7 +267,6 @@ impl CmsisDapDevice {
             },
 
             CmsisDapDevice::V2 {
-                handle,
                 in_ep,
                 max_packet_size,
                 ..
@@ -255,7 +274,7 @@ impl CmsisDapDevice {
                 let timeout = Duration::from_millis(1);
                 let mut discard = vec![0u8; *max_packet_size];
                 loop {
-                    match handle.read_bulk(*in_ep, &mut discard, timeout) {
+                    match read_bulk_endpoint(in_ep, &mut discard, timeout) {
                         Ok(n) if n != 0 => continue,
                         _ => break,
                     }
@@ -335,14 +354,14 @@ impl CmsisDapDevice {
     /// Returns SWOModeNotAvailable if this device does not support SWO streaming.
     ///
     /// On timeout, returns a zero-length buffer.
-    pub(super) fn read_swo_stream(&self, timeout: Duration) -> Result<Vec<u8>, CmsisDapError> {
+    pub(super) fn read_swo_stream(&mut self, timeout: Duration) -> Result<Vec<u8>, CmsisDapError> {
         match self {
             #[cfg(feature = "cmsisdap_v1")]
             CmsisDapDevice::V1 { .. } => Err(CmsisDapError::SwoModeNotAvailable),
-            CmsisDapDevice::V2 { handle, swo_ep, .. } => match swo_ep {
-                Some((ep, len)) => {
-                    let mut buf = vec![0u8; *len];
-                    match handle.read_bulk(*ep, &mut buf, timeout) {
+            CmsisDapDevice::V2 { swo_ep, .. } => match swo_ep {
+                Some(ep) => {
+                    let mut buf = vec![0u8; ep.max_packet_size()];
+                    match read_bulk_endpoint(ep, &mut buf, timeout) {
                         Ok(n) => {
                             buf.truncate(n);
                             Ok(buf)

--- a/probe-rs/src/probe/cmsisdap/commands/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/mod.rs
@@ -10,7 +10,7 @@ use crate::probe::usb_util::{read_bulk_endpoint, write_bulk_endpoint};
 use crate::probe::{ProbeError, WireProtocol};
 use nusb::{
     Endpoint,
-    transfer::{Bulk, In, Out},
+    transfer::{Buffer, Bulk, BulkOrInterrupt, EndpointDirection, In, Out},
 };
 use std::io::ErrorKind;
 use std::str::Utf8Error;
@@ -179,7 +179,7 @@ pub enum CmsisDapDevice {
     /// The endpoints are claimed once when the device is opened and reused for
     /// every transfer, rather than being re-claimed per transfer. This both
     /// removes per-transfer setup/teardown cost and provides a stable place to
-    /// keep multiple transfers in flight (see FAST_USB.md).
+    /// keep multiple transfers in flight.
     V2 {
         handle: nusb::Interface,
         out_ep: Endpoint<Bulk, Out>,
@@ -511,6 +511,153 @@ fn send_command_inner<Req: Request>(
             response_data[0],
             Req::COMMAND_ID,
         ))
+    }
+}
+
+/// Send a batch of same-typed commands, keeping up to `depth` of them in flight
+/// on the probe's bulk endpoints, and return the parsed responses in order.
+///
+/// This hides USB round-trip latency: instead of waiting for each response
+/// before sending the next request, up to `depth` requests are outstanding at
+/// once. CMSIS-DAP guarantees responses are returned in the order commands were
+/// sent, so a simple FIFO of in-flight transfers is sufficient.
+///
+/// Only v2 (bulk) probes can pipeline; v1 (HID) probes fall back to sending one
+/// command at a time. The caller should pass the probe's reported packet count
+/// so the probe's command buffer is never overrun.
+pub(crate) fn send_commands_pipelined<Req: Request>(
+    device: &mut CmsisDapDevice,
+    requests: &[Req],
+    depth: usize,
+) -> Result<Vec<Req::Response>, CmsisDapError> {
+    send_commands_pipelined_inner(device, requests, depth).map_err(|e| CmsisDapError::Send {
+        command_id: Req::COMMAND_ID,
+        source: e,
+    })
+}
+
+fn send_commands_pipelined_inner<Req: Request>(
+    device: &mut CmsisDapDevice,
+    requests: &[Req],
+    depth: usize,
+) -> Result<Vec<Req::Response>, SendError> {
+    if requests.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Extract the persistent v2 endpoints. HID probes can't pipeline, so send
+    // them serially through the existing single-command path.
+    let (out_ep, in_ep, max_packet_size, usb_timeout) = match device {
+        #[cfg(feature = "cmsisdap_v1")]
+        CmsisDapDevice::V1 { .. } => {
+            return requests
+                .iter()
+                .map(|req| send_command_inner(device, req))
+                .collect();
+        }
+        CmsisDapDevice::V2 {
+            out_ep,
+            in_ep,
+            max_packet_size,
+            usb_timeout,
+            ..
+        } => (out_ep, in_ep, *max_packet_size, *usb_timeout),
+    };
+
+    let n = requests.len();
+    let depth = depth.max(1).min(n);
+
+    // Pre-encode every request into its on-the-wire bytes (command id + body).
+    let mut request_bytes: Vec<Vec<u8>> = Vec::with_capacity(n);
+    for req in requests {
+        let mut buf = vec![0u8; max_packet_size];
+        buf[0] = Req::COMMAND_ID as u8;
+        let size = req.to_bytes(&mut buf[1..])? + 1;
+        buf.truncate(size);
+        request_bytes.push(buf);
+    }
+
+    // Each IN buffer holds one full DAP packet, rounded up to the endpoint's USB
+    // max packet size as required by nusb.
+    let in_packet = in_ep.max_packet_size().max(1);
+    let in_len = max_packet_size.div_ceil(in_packet) * in_packet;
+
+    // Submit the initial window of `depth` commands and matching read buffers.
+    for bytes in request_bytes.iter().take(depth) {
+        submit_out(out_ep, bytes);
+        in_ep.submit(Buffer::new(in_len));
+    }
+
+    let mut responses = Vec::with_capacity(n);
+    let mut next = depth;
+
+    for req in requests {
+        // Reclaim the OUT transfer for this command (it completes before the
+        // probe can produce its response, so this returns promptly) and read
+        // the response.
+        let out_done = reap(out_ep, usb_timeout);
+        let in_done = reap(in_ep, usb_timeout);
+
+        let parsed = (|| {
+            out_done?.status.map_err(std::io::Error::from)?;
+            let completion = in_done?;
+            completion.status.map_err(std::io::Error::from)?;
+
+            let data = &completion.buffer[..completion.actual_len];
+            if data.is_empty() {
+                return Err(SendError::NotEnoughData);
+            }
+            if data[0] != Req::COMMAND_ID as u8 {
+                return Err(SendError::CommandIdMismatch(data[0], Req::COMMAND_ID));
+            }
+            req.parse_response(&data[1..])
+        })();
+
+        match parsed {
+            Ok(response) => responses.push(response),
+            Err(e) => {
+                // Abort: stop submitting and discard anything still in flight so
+                // the endpoints are left clean for the next command.
+                drain_pending(out_ep);
+                drain_pending(in_ep);
+                return Err(e);
+            }
+        }
+
+        // Keep the pipeline full by submitting the next command, if any.
+        if next < n {
+            submit_out(out_ep, &request_bytes[next]);
+            in_ep.submit(Buffer::new(in_len));
+            next += 1;
+        }
+    }
+
+    Ok(responses)
+}
+
+/// Submit `bytes` as a single transfer on a bulk OUT endpoint.
+fn submit_out(ep: &mut Endpoint<Bulk, Out>, bytes: &[u8]) {
+    let mut buffer = Buffer::new(bytes.len());
+    buffer.extend_from_slice(bytes);
+    ep.submit(buffer);
+}
+
+/// Wait for the next completion on `ep`, mapping a timeout to [`SendError::Timeout`].
+fn reap<E: BulkOrInterrupt, D: EndpointDirection>(
+    ep: &mut Endpoint<E, D>,
+    timeout: Duration,
+) -> Result<nusb::transfer::Completion, SendError> {
+    ep.wait_next_complete(timeout).ok_or(SendError::Timeout)
+}
+
+/// Cancel and reap all outstanding transfers on `ep`, leaving it with no
+/// pending transfers.
+fn drain_pending<E: BulkOrInterrupt, D: EndpointDirection>(ep: &mut Endpoint<E, D>) {
+    ep.cancel_all();
+    while ep.pending() > 0 {
+        if ep.wait_next_complete(Duration::from_millis(100)).is_none() {
+            break;
+        }
     }
 }
 

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -141,6 +141,7 @@ impl CmsisDap {
 
         // Read remaining probe information.
         let packet_count = commands::send_command(&mut device, &PacketCountCommand {})?;
+        tracing::debug!("Probe reported packet count: {}", packet_count);
         let caps: Capabilities = commands::send_command(&mut device, &CapabilitiesCommand {})?;
         tracing::debug!("Detected probe capabilities: {:?}", caps);
         let mut swo_buffer_size = None;
@@ -662,6 +663,16 @@ impl CmsisDap {
         }
     }
 
+    /// Number of CMSIS-DAP commands to keep in flight on the bulk endpoints
+    /// when pipelining block transfers.
+    ///
+    /// Uses the probe's reported packet count so its internal command buffer is
+    /// not overrun; [`commands::send_commands_pipelined`] applies its own upper
+    /// bound on top of this.
+    fn pipeline_depth(&self) -> usize {
+        (self.packet_count as usize).max(1)
+    }
+
     /// Set SWO port to use requested transport.
     ///
     /// Check the probe capabilities to determine which transports are available.
@@ -1131,19 +1142,28 @@ impl RawDapAccess for CmsisDap {
         let data_chunk_len = max_packet_size_words as usize;
 
         let total_writes = values.len();
+        let dap_index = self.jtag_state.chain_params.index as u8;
 
-        for (i, chunk) in values.chunks(data_chunk_len).enumerate() {
-            let mut request = TransferBlockRequest::write_request(address, Vec::from(chunk));
-            request.dap_index = self.jtag_state.chain_params.index as u8;
+        // Build one TransferBlock request per chunk, then send them as a
+        // pipeline so several are in flight at once instead of paying a USB
+        // round-trip per chunk.
+        let requests = values
+            .chunks(data_chunk_len)
+            .map(|chunk| {
+                let mut request = TransferBlockRequest::write_request(address, Vec::from(chunk));
+                request.dap_index = dap_index;
+                request
+            })
+            .collect::<Vec<_>>();
 
-            tracing::debug!("Transfer block: chunk={}, len={} bytes", i, chunk.len() * 4);
+        let depth = self.pipeline_depth();
+        let responses = commands::send_commands_pipelined(&mut self.device, &requests, depth)
+            .map_err(DebugProbeError::from)?;
 
-            let resp: TransferBlockResponse = commands::send_command(&mut self.device, &request)
-                .map_err(DebugProbeError::from)?;
-
+        for (i, resp) in responses.iter().enumerate() {
             let executed_writes = i * data_chunk_len + usize::from(resp.transfer_count);
 
-            self.handle_transfer_block_response(address, &resp, executed_writes, total_writes)?;
+            self.handle_transfer_block_response(address, resp, executed_writes, total_writes)?;
         }
 
         Ok(())
@@ -1171,19 +1191,32 @@ impl RawDapAccess for CmsisDap {
         let data_chunk_len = max_packet_size_words as usize;
 
         let total_num_reads = values.len();
+        let dap_index = self.jtag_state.chain_params.index as u8;
 
-        for (i, chunk) in values.chunks_mut(data_chunk_len).enumerate() {
-            let mut request = TransferBlockRequest::read_request(address, chunk.len() as u16);
-            request.dap_index = self.jtag_state.chain_params.index as u8;
+        // Build one TransferBlock request per chunk, then send them as a
+        // pipeline so several are in flight at once instead of paying a USB
+        // round-trip per chunk.
+        let requests = values
+            .chunks(data_chunk_len)
+            .map(|chunk| {
+                let mut request = TransferBlockRequest::read_request(address, chunk.len() as u16);
+                request.dap_index = dap_index;
+                request
+            })
+            .collect::<Vec<_>>();
 
-            tracing::debug!("Transfer block: chunk={}, len={} bytes", i, chunk.len() * 4);
+        let depth = self.pipeline_depth();
+        let responses = commands::send_commands_pipelined(&mut self.device, &requests, depth)
+            .map_err(DebugProbeError::from)?;
 
-            let resp: TransferBlockResponse = commands::send_command(&mut self.device, &request)
-                .map_err(DebugProbeError::from)?;
-
+        for (i, (chunk, resp)) in values
+            .chunks_mut(data_chunk_len)
+            .zip(responses.iter())
+            .enumerate()
+        {
             let executed_reads = i * data_chunk_len + usize::from(resp.transfer_count);
 
-            self.handle_transfer_block_response(address, &resp, executed_reads, total_num_reads)?;
+            self.handle_transfer_block_response(address, resp, executed_reads, total_num_reads)?;
 
             chunk.clone_from_slice(&resp.transfer_data[..]);
         }

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -5,7 +5,12 @@ use crate::probe::{
 };
 #[cfg(feature = "cmsisdap_v1")]
 use hidapi::HidApi;
-use nusb::{DeviceInfo, MaybeFuture, descriptors::TransferType, transfer::Direction};
+use nusb::{
+    DeviceInfo, MaybeFuture,
+    descriptors::TransferType,
+    transfer::{Bulk, Direction, In, Out},
+};
+use std::io;
 
 const USB_CLASS_HID: u8 = 0x03;
 const USB_CMSIS_DAP_CLASS: u8 = 0xFF;
@@ -276,14 +281,19 @@ pub fn open_v2_device(
             }
 
             // Detect a third bulk EP which will be for SWO streaming
-            let mut swo_ep = None;
+            let mut swo_ep_addr = None;
 
             if eps.len() > 2
                 && eps[2].transfer_type() == TransferType::Bulk
                 && eps[2].direction() == Direction::In
             {
-                swo_ep = Some((eps[2].address(), eps[2].max_packet_size()));
+                swo_ep_addr = Some(eps[2].address());
             }
+
+            let out_ep_addr = eps[0].address();
+            let in_ep_addr = eps[1].address();
+            let max_packet_size = eps[1].max_packet_size();
+
             // Attempt to claim this interface
             match device.claim_interface(interface.interface_number()).wait() {
                 Ok(handle) => {
@@ -293,12 +303,31 @@ pub fn open_v2_device(
                         device_info.product_id(),
                         device_info.device_version(),
                     )?;
+
+                    // Claim the bulk endpoints once and keep them for the
+                    // lifetime of the device, so transfers don't pay the
+                    // per-call endpoint setup/teardown cost.
+                    let out_ep = handle
+                        .endpoint::<Bulk, Out>(out_ep_addr)
+                        .map_err(|e| ProbeCreationError::Usb(io::Error::from(e)))?;
+                    let in_ep = handle
+                        .endpoint::<Bulk, In>(in_ep_addr)
+                        .map_err(|e| ProbeCreationError::Usb(io::Error::from(e)))?;
+                    let swo_ep = match swo_ep_addr {
+                        Some(addr) => Some(
+                            handle
+                                .endpoint::<Bulk, In>(addr)
+                                .map_err(|e| ProbeCreationError::Usb(io::Error::from(e)))?,
+                        ),
+                        None => None,
+                    };
+
                     return Ok(Some(CmsisDapDevice::V2 {
                         handle,
-                        out_ep: eps[0].address(),
-                        in_ep: eps[1].address(),
+                        out_ep,
+                        in_ep,
                         swo_ep,
-                        max_packet_size: eps[1].max_packet_size(),
+                        max_packet_size,
                         usb_timeout: DEFAULT_USB_TIMEOUT,
                     }));
                 }

--- a/probe-rs/src/probe/usb_util.rs
+++ b/probe-rs/src/probe/usb_util.rs
@@ -1,7 +1,7 @@
 //! USB bulk transfer utilities.
 
 use nusb::{
-    Interface,
+    Endpoint, Interface,
     transfer::{Buffer, Bulk, In, Out},
 };
 use std::fmt::Write;
@@ -15,7 +15,97 @@ pub(crate) fn to_hex(s: &str) -> String {
     })
 }
 
+/// Submit a single buffer to a bulk OUT endpoint and wait for it to complete.
+///
+/// On timeout, the pending transfer is cancelled and drained so the endpoint is
+/// left with no outstanding transfers, and a `TimedOut` error is returned.
+pub fn write_bulk_endpoint(
+    endpoint: &mut Endpoint<Bulk, Out>,
+    buf: &[u8],
+    timeout: Duration,
+) -> io::Result<usize> {
+    let mut transfer_buffer = Buffer::new(buf.len());
+    transfer_buffer.extend_from_slice(buf);
+
+    endpoint.submit(transfer_buffer);
+
+    let Some(completion) = endpoint.wait_next_complete(timeout) else {
+        // Request cancellation...
+        endpoint.cancel_all();
+
+        // ...and then immediately drain the completion. Whether the the response is the
+        // result of the original write, the cancellation, or a timeout of the cancellation, we
+        // drop it and return a timeout.
+        let _ = endpoint.wait_next_complete(Duration::from_millis(100));
+
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "bulk write timed out",
+        ));
+    };
+
+    completion.status.map_err(io::Error::from)?;
+
+    Ok(completion.actual_len)
+}
+
+/// Submit a read to a bulk IN endpoint and wait for it to complete, copying the
+/// received bytes into `buf`.
+///
+/// On timeout, the pending transfer is cancelled and drained so the endpoint is
+/// left with no outstanding transfers, and a `TimedOut` error is returned.
+pub fn read_bulk_endpoint(
+    endpoint: &mut Endpoint<Bulk, In>,
+    buf: &mut [u8],
+    timeout: Duration,
+) -> io::Result<usize> {
+    let max_packet_size = endpoint.max_packet_size().max(1);
+    let requested_len = buf.len().div_ceil(max_packet_size) * max_packet_size;
+
+    let transfer_buffer = Buffer::new(requested_len);
+    endpoint.submit(transfer_buffer);
+
+    let Some(completion) = endpoint.wait_next_complete(timeout) else {
+        // Request cancellation...
+        endpoint.cancel_all();
+
+        // ...and then immediately drain the completion. Whether the the response is the
+        // result of the original read, the cancellation, or a timeout of the cancellation, we
+        // drop it and return a timeout.
+        let _ = endpoint.wait_next_complete(Duration::from_millis(100));
+
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "bulk read timed out",
+        ));
+    };
+
+    completion.status.map_err(io::Error::from)?;
+
+    let actual_len = completion.actual_len;
+    let data = completion.buffer;
+
+    if actual_len > buf.len() || data.len() > buf.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "device returned {actual_len} bytes, buffer length is {}",
+                buf.len()
+            ),
+        ));
+    }
+
+    buf[..actual_len].copy_from_slice(&data[..actual_len]);
+
+    Ok(actual_len)
+}
+
 /// USB bulk transfer utility functions.
+///
+/// These claim a fresh endpoint for every transfer. For hot paths where the
+/// same endpoint is used repeatedly, claim an [`Endpoint`] once and use
+/// [`write_bulk_endpoint`] / [`read_bulk_endpoint`] instead to avoid the
+/// per-transfer endpoint setup/teardown cost.
 pub trait InterfaceExt {
     /// Reads data from the given bulk endpoint into the provided buffer.
     fn read_bulk(&self, endpoint: u8, buf: &mut [u8], timeout: Duration) -> io::Result<usize>;
@@ -30,29 +120,7 @@ impl InterfaceExt for Interface {
             .endpoint::<Bulk, Out>(endpoint)
             .map_err(io::Error::from)?;
 
-        let mut transfer_buffer = Buffer::new(buf.len());
-        transfer_buffer.extend_from_slice(buf);
-
-        endpoint.submit(transfer_buffer);
-
-        let Some(completion) = endpoint.wait_next_complete(timeout) else {
-            // Request cancellation...
-            endpoint.cancel_all();
-
-            // ...and then immediately drain the completion. Whether the the response is the
-            // result of the original write, the cancellation, or a timeout of the cancellation, we
-            // drop it and return a timeout.
-            let _ = endpoint.wait_next_complete(Duration::from_millis(100));
-
-            return Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                "bulk write timed out",
-            ));
-        };
-
-        completion.status.map_err(io::Error::from)?;
-
-        Ok(completion.actual_len)
+        write_bulk_endpoint(&mut endpoint, buf, timeout)
     }
 
     fn read_bulk(&self, endpoint: u8, buf: &mut [u8], timeout: Duration) -> io::Result<usize> {
@@ -60,44 +128,6 @@ impl InterfaceExt for Interface {
             .endpoint::<Bulk, In>(endpoint)
             .map_err(io::Error::from)?;
 
-        let max_packet_size = endpoint.max_packet_size().max(1);
-        let requested_len = buf.len().div_ceil(max_packet_size) * max_packet_size;
-
-        let transfer_buffer = Buffer::new(requested_len);
-        endpoint.submit(transfer_buffer);
-
-        let Some(completion) = endpoint.wait_next_complete(timeout) else {
-            // Request cancellation...
-            endpoint.cancel_all();
-
-            // ...and then immediately drain the completion. Whether the the response is the
-            // result of the original read, the cancellation, or a timeout of the cancellation, we
-            // drop it and return a timeout.
-            let _ = endpoint.wait_next_complete(Duration::from_millis(100));
-
-            return Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                "bulk read timed out",
-            ));
-        };
-
-        completion.status.map_err(io::Error::from)?;
-
-        let actual_len = completion.actual_len;
-        let data = completion.buffer;
-
-        if actual_len > buf.len() || data.len() > buf.len() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "device returned {actual_len} bytes, buffer length is {}",
-                    buf.len()
-                ),
-            ));
-        }
-
-        buf[..actual_len].copy_from_slice(&data[..actual_len]);
-
-        Ok(actual_len)
+        read_bulk_endpoint(&mut endpoint, buf, timeout)
     }
 }


### PR DESCRIPTION
Retains endpoints (~2%/noise improvement in performance), pipelines requests (~12% improvements).

All of this adds up to matching the flash performance of the forked OpenOCD from Infineon on this part family for me if I set the SWD speed appropriately.

I'll be the first to admit I threw AI at this problem (with supervision!) so maybe a more elegant solution is around the corner, but I figured it might be worth a look to see if some ideas here could be recycled if that shows up.