### PR TITLE
Fix: CH32H4 SYS region marked as read-only

### DIFF
--- a/changelog/fixed-ch32h4-sys-region-writable.md
+++ b/changelog/fixed-ch32h4-sys-region-writable.md
@@ -1,0 +1,1 @@
+Fixed `CH32H4_Series` SYS region marked as read-only; aligned with other CH32 families and added the `ch32-h4-sys` flash algorithm.

--- a/probe-rs/targets/CH32F1_Series.yaml
+++ b/probe-rs/targets/CH32F1_Series.yaml
@@ -1,43 +1,18 @@
 name: CH32F1 Series
-manufacturer: null
 chip_detection:
 - !WchLink
   mask: 0xffffff0f
   variants:
     0x20004102: CH32F103C8T6
     0x2000410f: CH32F103R8T6
-  ob_code_ram_splits: {}
-generated_from_pack: false
-pack_file_release: null
 variants:
 - name: CH32F103C6T6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: armv7m
     core_access_options: !Arm
       ap: !v1 0
-      targetsel: null
-      debug_base: null
-      cti_base: null
-      jtag_tap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8008000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -46,11 +21,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    cores:
+    - main
   - !Nvm
     name: SYS_1
     range:
@@ -59,11 +36,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -73,10 +45,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -86,10 +55,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: SYS_2
     range:
@@ -98,11 +65,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -110,49 +72,19 @@ variants:
       end: 0x20002800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v1-usr
   - ch32-v1-usr-legacy
   - ch32-v1-sys-1
   - ch32-v1-opt
   - ch32-v1-sys-2
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32F103C8T6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: armv7m
     core_access_options: !Arm
       ap: !v1 0
-      targetsel: null
-      debug_base: null
-      cti_base: null
-      jtag_tap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8010000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -161,11 +93,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
   - !Nvm
     name: SYS_1
     range:
@@ -174,11 +108,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -188,10 +117,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -201,10 +127,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: SYS_2
     range:
@@ -213,11 +137,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -225,49 +144,19 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v1-usr
   - ch32-v1-usr-legacy
   - ch32-v1-sys-1
   - ch32-v1-opt
   - ch32-v1-sys-2
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32F103R8T6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: armv7m
     core_access_options: !Arm
       ap: !v1 0
-      targetsel: null
-      debug_base: null
-      cti_base: null
-      jtag_tap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8010000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -276,11 +165,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
   - !Nvm
     name: SYS_1
     range:
@@ -289,11 +180,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -303,10 +189,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -316,10 +199,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: SYS_2
     range:
@@ -328,11 +209,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -340,40 +216,24 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v1-usr
   - ch32-v1-usr-legacy
   - ch32-v1-sys-1
   - ch32-v1-opt
   - ch32-v1-sys-2
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 flash_algorithms:
 - name: ch32-v1-opt
   description: ch32-v1-opt
   default: true
   instructions: gLVvRgEggL1A8nYQwvIAAAB4ASgcvwEgcEeAtW9GQvIMAMTyAgABaMkH/NEgIQFgQWhB8CABQWBBaEHwQAFBYAFoyQf80SAhAWBBaCHwIAFBYAAggL2AtW9GQPJ2HkLyBAHC8gAOxPICAZ74ADAzsdH4DMBI8oADQ+oMA8tgASMBOo74ADAEKj+/QPIjEsTyZ1IKYEj2qxA/v8z271AIYEpgjvgAMD6/SGAAIIC9APBO+EDydhPC8gADG3gBKwS/QeoAA1/qw3MB0AEgcEdf6lEMBL8AIHBHsLUCr0LyDAEAI8TyAgFP8CAOFIgNaO0H/NHB+ADgTWhF8BAFTWAEgAxo5Af80cH4AOABM0xoAjICMGNFJPAQBExg5tEAILC9QPJ2EcLyAAEIeAEoHL8BIHBHgLVvRgAgSPKAAwhwQvIQAcTyAgEKaBpDCmCAvYC1b0YA3v7eANQ=
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x57
   pc_uninit: 0x121
   pc_program_page: 0xb3
   pc_erase_sector: 0x9
   pc_erase_all: 0x1
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x158
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1ffff800
@@ -385,29 +245,16 @@ flash_algorithms:
     sectors:
     - size: 0x80
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v1-sys-1
   description: ch32-v1-sys-1
   default: true
   instructions: gLVvRgEggL1A8rgRwvIAAQl4ASkcvwEgcEeAtW9GQvIMAcTyAgEKaNIH/NEgIgpgT/QAMkpgQCLA8gICiGBKYApo0gf80SAigPSAUApgSmgi9AAySmAAaIhiACCAvYC1b0ZA8rgeQvIEAcLyAA7E8gIBnvgAMDOx0fgMwEjygAND6gwDy2ABIwE6jvgAMAQqP79A8iMSxPJnUgpgSParED+/zPbvUAhgCmKO+AAwPr8IYgAggL0A8Gv4QPK4E8LyAAMbeAErHL8BIHBH8LUDr034BI1C8gwDxPICAx5o9gf80SAmHmBP9IA2XmBP9BAmXmAeaPYH/NEg8H8MT/AgDokIw/gA4BXQACRP9KAoACZS+ARbBDRA+ARbFPAMDwbRw/gEgB1o7Qf80cP4AOABNo5C7dFAIMP4CMDA8gEAWGAYaMAH/NEgIBhgWGgg9IAwWGCM9IBQAGiYYgAgXfgEi/C9QPK4EcLyAAEIeAEoHL8BIHBHgLVvRgAgSPKAAwhwQvIQAcTyAgEKaBpDCmCAvYC1b0YA3v7eANTU1A==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x5f
   pc_uninit: 0x163
   pc_program_page: 0xbb
   pc_erase_sector: 0x9
-  pc_erase_all: null
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x19c
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1ffff000
@@ -419,29 +266,16 @@ flash_algorithms:
     sectors:
     - size: 0x80
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v1-sys-2
   description: ch32-v1-sys-2
   default: true
   instructions: gLVvRgEggL1A8rgRwvIAAQl4ASkcvwEgcEeAtW9GQvIMAcTyAgEKaNIH/NEgIgpgT/QAMkpgQCLA8gICiGBKYApo0gf80SAigPSAUApgSmgi9AAySmAAaIhiACCAvYC1b0ZA8rgeQvIEAcLyAA7E8gIBnvgAMDOx0fgMwEjygAND6gwDy2ABIwE6jvgAMAQqP79A8iMSxPJnUgpgSParED+/zPbvUAhgCmKO+AAwPr8IYgAggL0A8Gv4QPK4E8LyAAMbeAErHL8BIHBH8LUDr034BI1C8gwDxPICAx5o9gf80SAmHmBP9IA2XmBP9BAmXmAeaPYH/NEg8H8MT/AgDokIw/gA4BXQACRP9KAoACZS+ARbBDRA+ARbFPAMDwbRw/gEgB1o7Qf80cP4AOABNo5C7dFAIMP4CMDA8gEAWGAYaMAH/NEgIBhgWGgg9IAwWGCM9IBQAGiYYgAgXfgEi/C9QPK4EcLyAAEIeAEoHL8BIHBHgLVvRgAgSPKAAwhwQvIQAcTyAgEKaBpDCmCAvYC1b0YA3v7eANTU1A==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x5f
   pc_uninit: 0x163
   pc_program_page: 0xbb
   pc_erase_sector: 0x9
-  pc_erase_all: null
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x19c
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1ffff900
@@ -453,29 +287,17 @@ flash_algorithms:
     sectors:
     - size: 0x80
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v1-usr
   description: ch32-v1-usr
   default: true
   instructions: QPISIMLyAAAAeAEoHL8BIHBHgLVvRkLyDADE8gIAAWjJB/zRICEBYEFoQfAEAUFgQWhB8EABQWABaMkH/NEgIQFgQWgh8AQBQWBB8gABwPYAAQlogWIAIIC9QPISIcLyAAEJeAEpHL8BIHBHgLVvRkLyDAHE8gIBCmjSB/zRICJA8ABgCmBP9AAySmBAIsDyAgKIYEpgCmjSB/zRICKA9IBQCmBKaCL0ADJKYABoiGIAIIC9gLVvRkDyEi5C8gQBwvIADsTyAgGe+AAwM7HR+AzASPKAA0PqDAPLYAEjATqO+AAwBCo/v0DyIxLE8mdSCmBI9qsQP7/M9u9QCGAKYo74ADA+vwhiACCAvQDwbfhA8hIjwvIAAxt4ASscvwEgcEfwtQOvTfgEjULyDAPE8gIDHmj2B/zRICYeYE/0gDZeYE/0ECZeYB5o9gf80UDwAGBP8CAMIPB/DokIw/gAwBXQACRP9KAoACZS+ARbBDRA+ARbFPAMDwbRw/gEgB1o7Qf80cP4AMABNo5C7dFAIMP4CODA8gEAWGAYaMAH/NEgIBhgWGgg9IAwWGCO9IBQAGiYYgAgXfgEi/C9QPISIcLyAAEIeAEoHL8BIHBHgLVvRgAgSPKAAwhwQvIQAcTyAgEKaBpDCmCAvYC1b0YA3v7eANQ=
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0xb5
   pc_uninit: 0x1bd
   pc_program_page: 0x111
   pc_erase_sector: 0x5b
   pc_erase_all: 0x1
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x1f4
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x8000000
@@ -487,29 +309,17 @@ flash_algorithms:
     sectors:
     - size: 0x80
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v1-usr-legacy
   description: ch32-v1-usr-legacy
   default: true
   instructions: QPISIMLyAAAAeAEoHL8BIHBHgLVvRkLyDADE8gIAAWjJB/zRICEBYEFoQfAEAUFgQWhB8EABQWABaMkH/NEgIQFgQWgh8AQBQWBB8gABwPYAAQlogWIAIIC9QPISIcLyAAEJeAEpHL8BIHBHgLVvRkLyDAHE8gIBCmjSB/zRICJA8ABgCmBP9AAySmBAIsDyAgKIYEpgCmjSB/zRICKA9IBQCmBKaCL0ADJKYABoiGIAIIC9gLVvRkDyEi5C8gQBwvIADsTyAgGe+AAwM7HR+AzASPKAA0PqDAPLYAEjATqO+AAwBCo/v0DyIxLE8mdSCmBI9qsQP7/M9u9QCGAKYo74ADA+vwhiACCAvQDwbfhA8hIjwvIAAxt4ASscvwEgcEfwtQOvTfgEjULyDAPE8gIDHmj2B/zRICYeYE/0gDZeYE/0ECZeYB5o9gf80UDwAGBP8CAMIPB/DokIw/gAwBXQACRP9KAoACZS+ARbBDRA+ARbFPAMDwbRw/gEgB1o7Qf80cP4AMABNo5C7dFAIMP4CODA8gEAWGAYaMAH/NEgIBhgWGgg9IAwWGCO9IBQAGiYYgAgXfgEi/C9QPISIcLyAAEIeAEoHL8BIHBHgLVvRgAgSPKAAwhwQvIQAcTyAgEKaBpDCmCAvYC1b0YA3v7eANQ=
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0xb5
   pc_uninit: 0x1bd
   pc_program_page: 0x111
   pc_erase_sector: 0x5b
   pc_erase_all: 0x1
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x1f4
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x0
@@ -521,8 +331,3 @@ flash_algorithms:
     sectors:
     - size: 0x80
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false

--- a/probe-rs/targets/CH32H4_Series.yaml
+++ b/probe-rs/targets/CH32H4_Series.yaml
@@ -1,5 +1,4 @@
 name: CH32H4 Series
-manufacturer: null
 chip_detection:
 - !WchLink
   mask: 0xffffff0f
@@ -9,36 +8,14 @@ chip_detection:
     0x4171050d: CH32H417MEU6
     0x4170050d: CH32H417QEU6
     0x4172050d: CH32H417WEU6
-  ob_code_ram_splits: {}
-generated_from_pack: false
-pack_file_release: null
 variants:
 - name: CH32H415REU6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x80f0000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -47,11 +24,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x80f0000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -60,11 +39,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: false
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -74,10 +48,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -87,10 +59,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: ITCM
     range:
@@ -98,12 +67,6 @@ variants:
       end: 0x200c0000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: DTCM
     range:
@@ -111,12 +74,6 @@ variants:
       end: 0x20100000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: SRAM_SHARED
     range:
@@ -124,45 +81,18 @@ variants:
       end: 0x20180000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-h4-usr
   - ch32-h4-usr-legacy
+  - ch32-h4-sys
   - ch32-h4-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32H416RDU6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -171,11 +101,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -184,11 +116,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: false
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -198,10 +125,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -211,10 +136,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: ITCM
     range:
@@ -222,12 +144,6 @@ variants:
       end: 0x200c0000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: DTCM
     range:
@@ -235,12 +151,6 @@ variants:
       end: 0x20100000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: SRAM_SHARED
     range:
@@ -248,45 +158,18 @@ variants:
       end: 0x20180000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-h4-usr
   - ch32-h4-usr-legacy
+  - ch32-h4-sys
   - ch32-h4-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32H417MEU6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x80f0000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -295,11 +178,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x80f0000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -308,11 +193,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: false
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -322,10 +202,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -335,10 +213,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: ITCM
     range:
@@ -346,12 +221,6 @@ variants:
       end: 0x200c0000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: DTCM
     range:
@@ -359,12 +228,6 @@ variants:
       end: 0x20100000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: SRAM_SHARED
     range:
@@ -372,45 +235,18 @@ variants:
       end: 0x20180000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-h4-usr
   - ch32-h4-usr-legacy
+  - ch32-h4-sys
   - ch32-h4-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32H417QEU6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x80f0000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -419,11 +255,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x80f0000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -432,11 +270,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: false
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -446,10 +279,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -459,10 +290,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: ITCM
     range:
@@ -470,12 +298,6 @@ variants:
       end: 0x200c0000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: DTCM
     range:
@@ -483,12 +305,6 @@ variants:
       end: 0x20100000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: SRAM_SHARED
     range:
@@ -496,45 +312,18 @@ variants:
       end: 0x20180000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-h4-usr
   - ch32-h4-usr-legacy
+  - ch32-h4-sys
   - ch32-h4-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32H417WEU6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x80f0000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -543,11 +332,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x80f0000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -556,11 +347,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: false
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -570,10 +356,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -583,10 +367,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: ITCM
     range:
@@ -594,12 +375,6 @@ variants:
       end: 0x200c0000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: DTCM
     range:
@@ -607,12 +382,6 @@ variants:
       end: 0x20100000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: SRAM_SHARED
     range:
@@ -620,38 +389,23 @@ variants:
       end: 0x20180000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-h4-usr
   - ch32-h4-usr-legacy
+  - ch32-h4-sys
   - ch32-h4-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 flash_algorithms:
 - name: ch32-h4-opt
   description: ch32-h4-opt
   default: true
   instructions: BUWCgDcFCiADRWUUBc23JQJAyEUFiXX9EwUAAsjFiEkTZQUCiMmISRNlBQSIychFBYl1/RMGAALQxZBJE3b2/ZDJgoAFRYKAtwYKIIPFZhQ3JQJAmcUMSSFnEwcHCNmNDMmFRX0WEUcjg7YUY3TmAjcGZ0W3lu/NEwY2EpOGtppQwVTBEMU3BgogFMUjA7YUAUWCgJcAAADngOAItwYKIAPHZhSFRinLM+elAAWLKecT2BUAYwEIBIFGNycCQJMIAAKDVQYAXEeFi/X/IyYXARxLk+cHARzLIxC1AExHhYn1/SMmFwEMS4UGCQW9mQzLCQbjmAb9gUY2hYKAtwUKIAPFZRQJzQFFNyYCQBRKIWcTBwcI2Y4UyiODBRSCgAVFgoAAAAAAAAA=
   load_address: 0x200a0020
-  data_load_address: null
   pc_init: 0x48
   pc_uninit: 0xfc
   pc_program_page: 0x9c
   pc_erase_sector: 0x4
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x128
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1ffff800
@@ -663,29 +417,38 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
+- name: ch32-h4-sys
+  description: ch32-h4-sys
+  default: true
+  instructions: BUWCgLcFCiCDxYUVhc23JQJA0EUFinX+EwYAAtDFkEkTZiYAkMnIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEl1mpDJgoAFRYKAtwYKIIPFhhU3JQJAkclMRSFn2Y1MxQxJEwcHCNmNDMmFRX0WEUcjjLYUY3bmAjcGZ0W3lu/NEwY2EpOGtppQwVTBUNFU0RDVNwYKIBTVIwy2FAFFgoCXAAAA54BgCbcGCiCDxoYVucq3JgJA2EYFi3X/EwcAAtjGmErBZ12PiYGYyoHNAUccQhzB3EaJi/X/BQcRBREG4xi3/ohKtwUgAE2NiMrIRgWJdf2TBQACzMaMSkF2fRbxjYzKgoAFRYKAtwUKIAPFhRUFwQFFNyYCQFRGIWfZjlTGFEoTBwcI2Y4UyiOMBRSCgAVFgoAAAAAAAAAAAA==
+  load_address: 0x200a0020
+  pc_init: 0x48
+  pc_uninit: 0x108
+  pc_program_page: 0xa6
+  pc_erase_sector: 0x4
+  data_section_offset: 0x13c
+  flash_properties:
+    address_range:
+      start: 0x1fff0000
+      end: 0x1fffe000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 2000
+    sectors:
+    - size: 0x2000
+      address: 0x0
 - name: ch32-h4-usr
   description: ch32-h4-usr
   default: true
   instructions: BUWCgLcFCiCDxUUVnc23JQJA0EUFinX+EwYAAtDFkEm3BgAIVY0TZiYAkMnIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEl1mpDJgoAFRYKAtwYKIIPFRhU3JQJAmcUMSSFnEwcHCNmNDMmFRX0WEUcjirYUY3TmAjcGZ0W3lu/NEwY2EpOGtppQwVTBUNE3BgogVNEjCrYUAUWCgJcAAADngGAJtwYKIIPGRhWxzrcmAkDYRgWLdf8TBwAC2MaYSsFnXY+JgZjKmc0BR7cHAAhdjRxCHMHcRomL9f8FBxEFEQbjGLf+iEq3BSAATY2IyshGBYl1/ZMFAALMxoxKQXZ9FvGNjMqCgAVFgoC3BQogA8VFFQnNAUU3JgJAFEohZxMHBwjZjhTKI4oFFIKABUWCgAAAAAAAAAAA
   load_address: 0x200a0020
-  data_load_address: null
   pc_init: 0x4e
   pc_uninit: 0x10a
   pc_program_page: 0xa2
   pc_erase_sector: 0x4
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x138
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x8000000
@@ -697,29 +460,17 @@ flash_algorithms:
     sectors:
     - size: 0x2000
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-h4-usr-legacy
   description: ch32-h4-usr-legacy
   default: true
   instructions: BUWCgLcFCiCDxUUVnc23JQJA0EUFinX+EwYAAtDFkEm3BgAIVY0TZiYAkMnIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEl1mpDJgoAFRYKAtwYKIIPFRhU3JQJAmcUMSSFnEwcHCNmNDMmFRX0WEUcjirYUY3TmAjcGZ0W3lu/NEwY2EpOGtppQwVTBUNE3BgogVNEjCrYUAUWCgJcAAADngGAJtwYKIIPGRhWxzrcmAkDYRgWLdf8TBwAC2MaYSsFnXY+JgZjKmc0BR7cHAAhdjRxCHMHcRomL9f8FBxEFEQbjGLf+iEq3BSAATY2IyshGBYl1/ZMFAALMxoxKQXZ9FvGNjMqCgAVFgoC3BQogA8VFFQnNAUU3JgJAFEohZxMHBwjZjhTKI4oFFIKABUWCgAAAAAAAAAAA
   load_address: 0x200a0020
-  data_load_address: null
   pc_init: 0x4e
   pc_uninit: 0x10a
   pc_program_page: 0xa2
   pc_erase_sector: 0x4
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x138
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x0
@@ -731,8 +482,3 @@ flash_algorithms:
     sectors:
     - size: 0x2000
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false

--- a/probe-rs/targets/CH32L1_Series.yaml
+++ b/probe-rs/targets/CH32L1_Series.yaml
@@ -1,5 +1,4 @@
 name: CH32L1 Series
-manufacturer: null
 chip_detection:
 - !WchLink
   mask: 0xffffff0f
@@ -10,36 +9,14 @@ chip_detection:
     0x103d0700: CH32L103F8U6
     0x103b0700: CH32L103G8R6
     0x10320700: CH32L103K8U6
-  ob_code_ram_splits: {}
-generated_from_pack: false
-pack_file_release: null
 variants:
 - name: CH32L103C8T6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8010000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -48,11 +25,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -61,11 +40,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -75,10 +49,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -88,10 +60,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -99,46 +68,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-l1-usr
   - ch32-l1-usr-legacy
   - ch32-l1-sys
   - ch32-l1-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32L103F7P6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800c000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -147,11 +88,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800c000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -160,11 +103,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -174,10 +112,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -187,10 +123,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -198,46 +131,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-l1-usr
   - ch32-l1-usr-legacy
   - ch32-l1-sys
   - ch32-l1-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32L103F8P6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8010000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -246,11 +151,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -259,11 +166,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -273,10 +175,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -286,10 +186,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -297,46 +194,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-l1-usr
   - ch32-l1-usr-legacy
   - ch32-l1-sys
   - ch32-l1-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32L103F8U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8010000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -345,11 +214,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -358,11 +229,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -372,10 +238,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -385,10 +249,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -396,46 +257,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-l1-usr
   - ch32-l1-usr-legacy
   - ch32-l1-sys
   - ch32-l1-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32L103G8R6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8010000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -444,11 +277,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -457,11 +292,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -471,10 +301,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -484,10 +312,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -495,46 +320,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-l1-usr
   - ch32-l1-usr-legacy
   - ch32-l1-sys
   - ch32-l1-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32L103K8U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8010000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -543,11 +340,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -556,11 +355,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -570,10 +364,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -583,10 +375,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -594,39 +383,23 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-l1-usr
   - ch32-l1-usr-legacy
   - ch32-l1-sys
   - ch32-l1-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 flash_algorithms:
 - name: ch32-l1-opt
   description: ch32-l1-opt
   default: true
   instructions: BUWCgDcFACADRUUYBc23JQJAyEUFiXX9EwUAAsjFiEkTZQUCiMmISRNlBQSIychFBYl1/RMGAALQxZBJE3b2/ZDJgoAFRYKAtwYAIIPFRhg3JQJAmcUMSSFnEwcHCNmNDMmFRX0WEUcjgrYYY3bmAjcGZ0W3lu/NEwY2EpOGtppQwVTBUNFU0RDFNwYAIBTFIwK2GAFFgoCXAAAA54CADLcGACADx0YYhUZRxzPnpQANi1HjNycCQFRHhYr1/pMGAAJUxxRLwWfdjhTLFEu3BwgA3Y4Uy1RHhYr1/hMIAAKT0iUAIyYHAWOGAgKBR7cIBACqhgxCjMIMS7PlFQEMy0xHhYn1/YUHIyYHAZEGEQbjklf+SMsISxNlBQQIy0hHBYl1/YFGEwUAAkjHCEvBdf0VbY0IyzaFgoC3BQAgA8VFGAnNAUU3JgJAFEohZxMHBwjZjhTKI4IFGIKABUWCgAAAAAAAAAAA
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x48
   pc_uninit: 0x13a
   pc_program_page: 0xa0
   pc_erase_sector: 0x4
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x168
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1ffff800
@@ -638,29 +411,16 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-l1-sys
   description: ch32-l1-sys
   default: true
   instructions: BUWCgLcFACCDxcUXnc23JQJA0EUFinX+EwYAAtDFkEm3BgIAVY6QycjJiEkTZQUEiMnIRQWJdf0TBgAC0MWQSYF2/RZ1jpDJgoAFRYKAtwYAIIPFxhc3JQJAmcUMSSFnEwcHCNmNDMmFRX0WEUcjjrYWY3TmAjcGZ0W3lu/NEwY2EpOGtppQwVTBUNE3BgAgVNEjDrYWAUWCgJcAAADngOALtwYAIIPGxhfRwrcmAkDYRgWLdf8TBwAC2MaYSsFnXY+YyphKtwcIAF2PmMrYRgWLdf8TCAACk9IlACOmBgFjhgICgUe3CAQAKocMQgzDjEqz5RUBjMrMRoWJ9f2FByOmBgERBxEG45JX/sjKiEoTZQUEiMrIRgWJdf2TBQACzMaMSkF2fRbxjYzKgoAFRYKAtwUAIAPFxRcJzQFFNyYCQBRKIWcTBwcI2Y4UyiOOBRaCgAVFgoAAAAAAAAAAAA==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x4e
   pc_uninit: 0x132
   pc_program_page: 0xa2
   pc_erase_sector: 0x4
-  pc_erase_all: null
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x160
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1fff0000
@@ -672,29 +432,17 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-l1-usr
   description: ch32-l1-usr
   default: true
   instructions: NwUAIANFZRwdybclAkDIRQWJdf0TBQACyMWISRNlRQCIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEltmpDJgoAFRYKAtwUAIIPFZRyxwbclAkDQRQWKdf4TBgAC0MWQSbcGAAhVjbcGAgBVjpDJyMmISRNlBQSIychFBYl1/RMGAALQxZBJgXb9FnWOkMmCgAVFgoC3BgAgg8VmHDclAkCZxQxJIWcTBwcI2Y0MyYVFfRYRRyODthxjdOYCNwZnRbeW780TBjYSk4a2mlDBVMFQ0TcGACBU0SMDthwBRYKAlwAAAOeAQAy3BgAgg8ZmHMnGtyYCQNhGBYt1/xMHAALYxphKwWddj5jKmEq3BwgAXY+YythGBYt1/zcHAAgzaOUAkwgAAomBI6YWAY3FgUe3AgQAQocIQgjDiEozZVUAiMrIRgWJdf2FByOmFgERBxEG45K3/iOqBgGIShNlBQSIyshGBYl1/ZMFAALMxoxKQXZ9FvGNjMqCgAVFgoC3BQAgA8VlHAnNAUU3JgJAFEohZxMHBwjZjhTKI4MFHIKABUWCgAAAAAAAAA==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x92
   pc_uninit: 0x17c
   pc_program_page: 0xe6
   pc_erase_sector: 0x42
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x1a8
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x8000000
@@ -706,29 +454,17 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-l1-usr-legacy
   description: ch32-l1-usr-legacy
   default: true
   instructions: NwUAIANFZRwdybclAkDIRQWJdf0TBQACyMWISRNlRQCIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEltmpDJgoAFRYKAtwUAIIPFZRyxwbclAkDQRQWKdf4TBgAC0MWQSbcGAAhVjbcGAgBVjpDJyMmISRNlBQSIychFBYl1/RMGAALQxZBJgXb9FnWOkMmCgAVFgoC3BgAgg8VmHDclAkCZxQxJIWcTBwcI2Y0MyYVFfRYRRyODthxjdOYCNwZnRbeW780TBjYSk4a2mlDBVMFQ0TcGACBU0SMDthwBRYKAlwAAAOeAQAy3BgAgg8ZmHMnGtyYCQNhGBYt1/xMHAALYxphKwWddj5jKmEq3BwgAXY+YythGBYt1/zcHAAgzaOUAkwgAAomBI6YWAY3FgUe3AgQAQocIQgjDiEozZVUAiMrIRgWJdf2FByOmFgERBxEG45K3/iOqBgGIShNlBQSIyshGBYl1/ZMFAALMxoxKQXZ9FvGNjMqCgAVFgoC3BQAgA8VlHAnNAUU3JgJAFEohZxMHBwjZjhTKI4MFHIKABUWCgAAAAAAAAA==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x92
   pc_uninit: 0x17c
   pc_program_page: 0xe6
   pc_erase_sector: 0x42
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x1a8
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x0
@@ -740,8 +476,3 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false

--- a/probe-rs/targets/CH32V003_CH641_Series.yaml
+++ b/probe-rs/targets/CH32V003_CH641_Series.yaml
@@ -1,5 +1,4 @@
 name: CH32V003 / CH641 Series
-manufacturer: null
 chip_detection:
 - !WchLink
   mask: 0xffffff0f
@@ -13,36 +12,14 @@ chip_detection:
     0x64110500: CH641D
     0x64120500: CH641X
     0x64160500: CH641P
-  ob_code_ram_splits: {}
-generated_from_pack: false
-pack_file_release: null
 variants:
 - name: CH32V003J4M6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8004000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -51,11 +28,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -64,11 +43,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -78,10 +52,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -91,10 +63,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -102,46 +71,18 @@ variants:
       end: 0x20000800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v0-usr
   - ch32-v0-usr-legacy
   - ch32-v0-sys
   - ch32-v0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V003A4M6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8004000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -150,11 +91,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -163,11 +106,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -177,10 +115,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -190,10 +126,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -201,46 +134,18 @@ variants:
       end: 0x20000800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v0-usr
   - ch32-v0-usr-legacy
   - ch32-v0-sys
   - ch32-v0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V003F4U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8004000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -249,11 +154,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -262,11 +169,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -276,10 +178,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -289,10 +189,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -300,46 +197,18 @@ variants:
       end: 0x20000800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v0-usr
   - ch32-v0-usr-legacy
   - ch32-v0-sys
   - ch32-v0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V003F4P6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8004000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -348,11 +217,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -361,11 +232,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -375,10 +241,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -388,10 +252,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -399,46 +260,18 @@ variants:
       end: 0x20000800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v0-usr
   - ch32-v0-usr-legacy
   - ch32-v0-sys
   - ch32-v0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH641F
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8004000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -447,11 +280,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -460,11 +295,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -474,10 +304,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -487,10 +315,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -498,46 +323,18 @@ variants:
       end: 0x20000800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v0-usr
   - ch32-v0-usr-legacy
   - ch32-v0-sys
   - ch32-v0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH641U
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8004000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -546,11 +343,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -559,11 +358,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -573,10 +367,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -586,10 +378,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -597,46 +386,18 @@ variants:
       end: 0x20000800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v0-usr
   - ch32-v0-usr-legacy
   - ch32-v0-sys
   - ch32-v0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH641D
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8004000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -645,11 +406,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -658,11 +421,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -672,10 +430,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -685,10 +441,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -696,46 +449,18 @@ variants:
       end: 0x20000800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v0-usr
   - ch32-v0-usr-legacy
   - ch32-v0-sys
   - ch32-v0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH641X
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8004000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -744,11 +469,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -757,11 +484,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -771,10 +493,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -784,10 +504,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -795,46 +512,18 @@ variants:
       end: 0x20000800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v0-usr
   - ch32-v0-usr-legacy
   - ch32-v0-sys
   - ch32-v0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH641P
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8004000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -843,11 +532,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -856,11 +547,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -870,10 +556,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -883,10 +567,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -894,39 +575,23 @@ variants:
       end: 0x20000800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v0-usr
   - ch32-v0-usr-legacy
   - ch32-v0-sys
   - ch32-v0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 flash_algorithms:
 - name: ch32-v0-opt
   description: ch32-v0-opt
   default: true
   instructions: BUWCgDcFACADReUTBc23JQJAyEUFiXX9EwUAAsjFiEkTZQUCiMmISRNlBQSIychFBYl1/RMGAALQxZBJE3b2/ZDJgoAFRYKAtwYAIIPF5hM3JQJAicWhZZOFBQgMyYVFfRYRRyOPthJjdOYCNwZnRbeW780TBjYSk4a2mlDBVMEQxTcGACAUxSMPthIBRYKAlwAAAOeAoAi3BgAgA8fmE4VGKcsz56UABYsp55PSFQBjgQIEgUY3JwJAEwMAAoNVBgBcR4WL9f8jJmcAHEuT5wcBHMsjELUATEeFifX9IyZnAAxLhQYJBb2ZDMsJBuOYVvyBRjaFgoC3BQAgA8XlExnJAUUhZrcmAkATBgYIkMojjwUSgoAFRYKAAAAAAAAA
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x48
   pc_uninit: 0xf8
   pc_program_page: 0x98
   pc_erase_sector: 0x4
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x120
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1ffff800
@@ -938,29 +603,16 @@ flash_algorithms:
     sectors:
     - size: 0x40
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v0-sys
   description: ch32-v0-sys
   default: true
   instructions: BUWCgLcFACCDxVUahc23JQJA0EUFinX+EwYAAtDFNwYCAJDJyMkTBQYEiMnIRQWJdf0TBgAC0MWQSYF2/RZ1jpDJgoAFRYKAt5XvzTcFACATBUUag0cVAJOFtZo3B2dFEwc3ErcmAkCJz7cHACCDx0camNaM1roH3MahZ5OHBwicyoVCfRaRR6MAVQBjc/YC0EbYwszC2NLM0pjWjNaRZczGRgZ9giMAxQCjAFUAAUWCgJcAAADngOAMtwYAIIPGVhqlzrcmAkDYRgWLdf8TBwAC2MZBZ5jKNwcJAJjK2EYFi3X/k3IF/BMDAAKJgSOmZgCVwQFHtwMFABxCHMEjqHYA3EaFi/X/BQcjpmYAEQURBuMUt/4jqlYAQWUTBQUEiMrIRgWJdf2TBQACzMaMSkF2fRbxjYzKgoAFRYKAtwUAIJOFRRoDxRUADckBRQPGBQC3BmdFNycCQJOGNhIU17eW782ThraaFNc6BlDHIWYTBgYIEMujgAUAgoAFRYKAAAAAAAAAAAA=
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x48
   pc_uninit: 0x13e
   pc_program_page: 0xba
   pc_erase_sector: 0x4
-  pc_erase_all: null
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x188
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1ffff000
@@ -972,29 +624,17 @@ flash_algorithms:
     sectors:
     - size: 0x40
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v0-usr
   description: ch32-v0-usr
   default: true
   instructions: NwUAIANFxRodybclAkDIRQWJdf0TBQACyMWISRNlRQCIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEltmpDJgoAFRYKAtwUAIIPFxRqdzbclAkDQRQWKdf43BgAIUY0TBgAC0MU3BgIAkMkTBgYEyMmQychFBYl1/RMGAALQxZBJgXb9FnWOkMmCgAVFgoC3BgAgg8XGGjclAkCJxaFlk4UFCAzJhUV9FhFHI4a2GmN05gI3BmdFt5bvzRMGNhKThraaUMFUwVDRNwYAIFTRIwa2GgFFgoCXAAAA54BAC7cGACCDxsYavc63JgJA2EYFi3X/EwcAAtjGQWeYyjcHCQCYythGBYt1/7cHAAgTAwACiYHJj5PyB/wjpmYAlcEBRbcDBQAYQpjDI6h2ANhGBYt1/wUFI6ZmAJEHEQbjFLX+I6pWAEFlEwUFBIjKyEYFiXX9kwUAAszGjEpBdn0W8Y2MyoKABUWCgLcFACADxcUaGckBRSFmtyYCQBMGBgiQyiOGBRqCgAVFgoAAAAAAAAAAAA==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x8c
   pc_uninit: 0x166
   pc_program_page: 0xdc
   pc_erase_sector: 0x42
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x190
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x8000000
@@ -1006,29 +646,17 @@ flash_algorithms:
     sectors:
     - size: 0x40
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v0-usr-legacy
   description: ch32-v0-usr-legacy
   default: true
   instructions: NwUAIANFxRodybclAkDIRQWJdf0TBQACyMWISRNlRQCIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEltmpDJgoAFRYKAtwUAIIPFxRqdzbclAkDQRQWKdf43BgAIUY0TBgAC0MU3BgIAkMkTBgYEyMmQychFBYl1/RMGAALQxZBJgXb9FnWOkMmCgAVFgoC3BgAgg8XGGjclAkCJxaFlk4UFCAzJhUV9FhFHI4a2GmN05gI3BmdFt5bvzRMGNhKThraaUMFUwVDRNwYAIFTRIwa2GgFFgoCXAAAA54BAC7cGACCDxsYavc63JgJA2EYFi3X/EwcAAtjGQWeYyjcHCQCYythGBYt1/7cHAAgTAwACiYHJj5PyB/wjpmYAlcEBRbcDBQAYQpjDI6h2ANhGBYt1/wUFI6ZmAJEHEQbjFLX+I6pWAEFlEwUFBIjKyEYFiXX9kwUAAszGjEpBdn0W8Y2MyoKABUWCgLcFACADxcUaGckBRSFmtyYCQBMGBgiQyiOGBRqCgAVFgoAAAAAAAAAAAA==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x8c
   pc_uninit: 0x166
   pc_program_page: 0xdc
   pc_erase_sector: 0x42
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x190
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x0
@@ -1040,8 +668,3 @@ flash_algorithms:
     sectors:
     - size: 0x40
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false

--- a/probe-rs/targets/CH32V00X_Series.yaml
+++ b/probe-rs/targets/CH32V00X_Series.yaml
@@ -1,5 +1,4 @@
 name: CH32V00X Series
-manufacturer: null
 chip_detection:
 - !WchLink
   mask: 0xffffff0f
@@ -24,36 +23,14 @@ chip_detection:
     0x630600: CH32V006F8P6
     0x710600: CH32V007E8R6
     0x720600: CH32V007K8U6
-  ob_code_ram_splits: {}
-generated_from_pack: false
-pack_file_release: null
 variants:
 - name: CH32M007E8R6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -62,11 +39,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -75,11 +54,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -89,10 +63,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -102,10 +74,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -113,46 +82,18 @@ variants:
       end: 0x20002000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32M007E8U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -161,11 +102,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -174,11 +117,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -188,10 +126,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -201,10 +137,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -212,46 +145,18 @@ variants:
       end: 0x20002000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32M007G8R6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -260,11 +165,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -273,11 +180,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -287,10 +189,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -300,10 +200,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -311,46 +208,18 @@ variants:
       end: 0x20002000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32M007K8U7
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -359,11 +228,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -372,11 +243,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -386,10 +252,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -399,10 +263,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -410,46 +271,18 @@ variants:
       end: 0x20002000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V002F4P6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8004000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -458,11 +291,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -471,11 +306,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -485,10 +315,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -498,10 +326,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -509,46 +334,18 @@ variants:
       end: 0x20001000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V002F4U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8004000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -557,11 +354,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -570,11 +369,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -584,10 +378,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -597,10 +389,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -608,46 +397,18 @@ variants:
       end: 0x20001000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V002A4M6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8004000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -656,11 +417,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -669,11 +432,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -683,10 +441,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -696,10 +452,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -707,46 +460,18 @@ variants:
       end: 0x20001000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V002D4U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8004000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -755,11 +480,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -768,11 +495,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -782,10 +504,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -795,10 +515,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -806,46 +523,18 @@ variants:
       end: 0x20001000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V002J4M6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8004000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -854,11 +543,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -867,11 +558,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -881,10 +567,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -894,10 +578,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -905,46 +586,18 @@ variants:
       end: 0x20001000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V004F6P1
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8008000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -953,11 +606,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -966,11 +621,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -980,10 +630,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -993,10 +641,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1004,46 +649,18 @@ variants:
       end: 0x20001800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V004F6U1
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8008000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1052,11 +669,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1065,11 +684,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1079,10 +693,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1092,10 +704,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1103,46 +712,18 @@ variants:
       end: 0x20001800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V005E6R6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8008000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1151,11 +732,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1164,11 +747,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1178,10 +756,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1191,10 +767,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1202,46 +775,18 @@ variants:
       end: 0x20001800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V005F6U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8008000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1250,11 +795,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1263,11 +810,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1277,10 +819,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1290,10 +830,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1301,46 +838,18 @@ variants:
       end: 0x20001800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V005F6P6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8008000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1349,11 +858,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1362,11 +873,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1376,10 +882,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1389,10 +893,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1400,46 +901,18 @@ variants:
       end: 0x20001800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V005D6U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8008000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1448,11 +921,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1461,11 +936,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1475,10 +945,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1488,10 +956,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1499,46 +964,18 @@ variants:
       end: 0x20001800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V006K8U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1547,11 +984,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1560,11 +999,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1574,10 +1008,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1587,10 +1019,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1598,46 +1027,18 @@ variants:
       end: 0x20002000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V006E8R6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1646,11 +1047,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1659,11 +1062,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1673,10 +1071,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1686,10 +1082,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1697,46 +1090,18 @@ variants:
       end: 0x20002000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V006F8U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1745,11 +1110,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1758,11 +1125,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1772,10 +1134,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1785,10 +1145,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1796,46 +1153,18 @@ variants:
       end: 0x20002000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V006F8P6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1844,11 +1173,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1857,11 +1188,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1871,10 +1197,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1884,10 +1208,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1895,46 +1216,18 @@ variants:
       end: 0x20002000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V007E8R6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1943,11 +1236,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1956,11 +1251,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1970,10 +1260,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1983,10 +1271,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1994,46 +1279,18 @@ variants:
       end: 0x20002000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V007K8U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -2042,11 +1299,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -2055,11 +1314,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -2069,10 +1323,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -2082,10 +1334,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -2093,39 +1342,23 @@ variants:
       end: 0x20002000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v00x-usr
   - ch32-v00x-usr-legacy
   - ch32-v00x-sys
   - ch32-v00x-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 flash_algorithms:
 - name: ch32-v00x-opt
   description: ch32-v00x-opt
   default: true
   instructions: BUWCgDcFACADRQUXBc23JQJAyEUFiXX9EwUAAsjFiEkTZQUCiMmISRNlBQSIychFBYl1/RMGAALQxZBJE3b2/ZDJgoAFRYKAtwYAIIPFBhc3JQJAicWhZZOFBQgMyYVFfRYRRyOIthZjduYCNwZnRbeW780TBjYSk4a2mlDBVMFQ0VTREMU3BgAgFMUjCLYWAUWCgJcAAADngIALtwYAIAPHBheFRkHDM+elAA2LJe83JwJAVEeFivX+kwYAAlTHwWYUy7cGCQAUy1RHhYr1/pNyBfATAwACiYEjJmcAlcGBRrcDBQAcQhzBIyh3AFxHhYv1/4UGIyZnABEFEQbjlLb+IypXAEFlEwUFBAjLSEcFiXX9gUYTBQACSMcIS8F1/RVtjQjLNoWCgLcFACADxQUXGckBRSFmtyYCQBMGBgiQyiOIBRaCgAVFgoAAAAAAAAAAAA==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x48
   pc_uninit: 0x12a
   pc_program_page: 0x9c
   pc_erase_sector: 0x4
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x154
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1ffff800
@@ -2137,29 +1370,16 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v00x-sys
   description: ch32-v00x-sys
   default: true
   instructions: BUWCgLcFACCDxVUahc23JQJA0EUFinX+EwYAAtDFNwYCAJDJyMkTBQYEiMnIRQWJdf0TBgAC0MWQSYF2/RZ1jpDJgoAFRYKAt5XvzTcFACATBUUag0cVAJOFtZo3B2dFEwc3ErcmAkCJz7cHACCDx0camNaM1roH3MahZ5OHBwicyoVCfRaRR6MAVQBjc/YC0EbYwszC2NLM0pjWjNaRZczGRgZ9giMAxQCjAFUAAUWCgJcAAADngOAMtwYAIIPGVhqlzrcmAkDYRgWLdf8TBwAC2MZBZ5jKNwcJAJjK2EYFi3X/k3IF8BMDAAKJgSOmZgCVwQFHtwMFABxCHMEjqHYA3EaFi/X/BQcjpmYAEQURBuMUt/4jqlYAQWUTBQUEiMrIRgWJdf2TBQACzMaMSkF2fRbxjYzKgoAFRYKAtwUAIJOFRRoDxRUADckBRQPGBQC3BmdFNycCQJOGNhIU17eW782ThraaFNc6BlDHIWYTBgYIEMujgAUAgoAFRYKAAAAAAAAAAAA=
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x48
   pc_uninit: 0x13e
   pc_program_page: 0xba
   pc_erase_sector: 0x4
-  pc_erase_all: null
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x188
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1fff0000
@@ -2171,29 +1391,17 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v00x-usr
   description: ch32-v00x-usr
   default: true
   instructions: NwUAIANFxRodybclAkDIRQWJdf0TBQACyMWISRNlRQCIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEltmpDJgoAFRYKAtwUAIIPFxRqdzbclAkDQRQWKdf43BgAIUY0TBgAC0MU3BgIAkMkTBgYEyMmQychFBYl1/RMGAALQxZBJgXb9FnWOkMmCgAVFgoC3BgAgg8XGGjclAkCJxaFlk4UFCAzJhUV9FhFHI4a2GmN05gI3BmdFt5bvzRMGNhKThraaUMFUwVDRNwYAIFTRIwa2GgFFgoCXAAAA54BAC7cGACCDxsYavc63JgJA2EYFi3X/EwcAAtjGQWeYyjcHCQCYythGBYt1/7cHAAgTAwACiYHJj5PyB/AjpmYAlcEBRbcDBQAYQpjDI6h2ANhGBYt1/wUFI6ZmAJEHEQbjFLX+I6pWAEFlEwUFBIjKyEYFiXX9kwUAAszGjEpBdn0W8Y2MyoKABUWCgLcFACADxcUaGckBRSFmtyYCQBMGBgiQyiOGBRqCgAVFgoAAAAAAAAAAAA==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x8c
   pc_uninit: 0x166
   pc_program_page: 0xdc
   pc_erase_sector: 0x42
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x190
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x8000000
@@ -2205,29 +1413,17 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v00x-usr-legacy
   description: ch32-v00x-usr-legacy
   default: true
   instructions: NwUAIANFxRodybclAkDIRQWJdf0TBQACyMWISRNlRQCIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEltmpDJgoAFRYKAtwUAIIPFxRqdzbclAkDQRQWKdf43BgAIUY0TBgAC0MU3BgIAkMkTBgYEyMmQychFBYl1/RMGAALQxZBJgXb9FnWOkMmCgAVFgoC3BgAgg8XGGjclAkCJxaFlk4UFCAzJhUV9FhFHI4a2GmN05gI3BmdFt5bvzRMGNhKThraaUMFUwVDRNwYAIFTRIwa2GgFFgoCXAAAA54BAC7cGACCDxsYavc63JgJA2EYFi3X/EwcAAtjGQWeYyjcHCQCYythGBYt1/7cHAAgTAwACiYHJj5PyB/AjpmYAlcEBRbcDBQAYQpjDI6h2ANhGBYt1/wUFI6ZmAJEHEQbjFLX+I6pWAEFlEwUFBIjKyEYFiXX9kwUAAszGjEpBdn0W8Y2MyoKABUWCgLcFACADxcUaGckBRSFmtyYCQBMGBgiQyiOGBRqCgAVFgoAAAAAAAAAAAA==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x8c
   pc_uninit: 0x166
   pc_program_page: 0xdc
   pc_erase_sector: 0x42
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x190
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x0
@@ -2239,8 +1435,3 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false

--- a/probe-rs/targets/CH32V1_Series.yaml
+++ b/probe-rs/targets/CH32V1_Series.yaml
@@ -1,41 +1,18 @@
 name: CH32V1 Series
-manufacturer: null
 chip_detection:
 - !WchLink
   mask: 0xffffff0f
   variants:
     0x25004102: CH32V103C8T6
     0x2500410f: CH32V103R8T6
-  ob_code_ram_splits: {}
-generated_from_pack: false
-pack_file_release: null
 variants:
 - name: CH32V103C6T6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8008000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -44,11 +21,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    cores:
+    - main
   - !Nvm
     name: SYS_1
     range:
@@ -57,11 +36,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -71,10 +45,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -84,10 +55,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: SYS_2
     range:
@@ -96,11 +65,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -108,47 +72,19 @@ variants:
       end: 0x20002800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v1-usr
   - ch32-v1-usr-legacy
   - ch32-v1-sys-1
   - ch32-v1-opt
   - ch32-v1-sys-2
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V103C8T6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8010000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -157,11 +93,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
   - !Nvm
     name: SYS_1
     range:
@@ -170,11 +108,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -184,10 +117,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -197,10 +127,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: SYS_2
     range:
@@ -209,11 +137,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -221,47 +144,19 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v1-usr
   - ch32-v1-usr-legacy
   - ch32-v1-sys-1
   - ch32-v1-opt
   - ch32-v1-sys-2
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V103C8U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8010000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -270,11 +165,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
   - !Nvm
     name: SYS_1
     range:
@@ -283,11 +180,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -297,10 +189,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -310,10 +199,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: SYS_2
     range:
@@ -322,11 +209,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -334,47 +216,19 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v1-usr
   - ch32-v1-usr-legacy
   - ch32-v1-sys-1
   - ch32-v1-opt
   - ch32-v1-sys-2
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V103R8T6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8010000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -383,11 +237,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    cores:
+    - main
   - !Nvm
     name: SYS_1
     range:
@@ -396,11 +252,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -410,10 +261,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -423,10 +271,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: SYS_2
     range:
@@ -435,11 +281,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -447,40 +288,24 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v1-usr
   - ch32-v1-usr-legacy
   - ch32-v1-sys-1
   - ch32-v1-opt
   - ch32-v1-sys-2
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 flash_algorithms:
 - name: ch32-v1-opt
   description: ch32-v1-opt
   default: true
   instructions: BUWCgDcFACADRWUUBc23JQJAyEUFiXX9EwUAAsjFiEkTZQUCiMmISRNlBQSIychFBYl1/RMGAALQxZBJE3b2/ZDJgoAFRYKAtwYAIIPFZhQ3JQJAmcUMSSFnEwcHCNmNDMmFRX0WEUcjg7YUY3TmAjcGZ0W3lu/NEwY2EpOGtppQwVTBEMU3BgAgFMUjA7YUAUWCgJcAAADngOAItwYAIAPHZhSFRinLM+elAAWLKecT2BUAYwEIBIFGNycCQJMIAAKDVQYAXEeFi/X/IyYXARxLk+cHARzLIxC1AExHhYn1/SMmFwEMS4UGCQW9mQzLCQbjmAb9gUY2hYKAtwUAIAPFZRQJzQFFNyYCQBRKIWcTBwcI2Y4UyiODBRSCgAVFgoAAAAAAAAA=
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x48
   pc_uninit: 0xfc
   pc_program_page: 0x9c
   pc_erase_sector: 0x4
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x128
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1ffff800
@@ -492,29 +317,16 @@ flash_algorithms:
     sectors:
     - size: 0x80
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v1-sys-1
   description: ch32-v1-sys-1
   default: true
   instructions: BUWCgLcFACCDxcUYocE3JgJATEaFifX9kwUAAkzGtwUCAAzKSMqThQUEDMpMRoWJ9f2TBgACVMYUSgF3fRf5jhTKhWY1jQhBSNoRoIVFLoWCgLcGACCDxcYYNyUCQJnFDEkhZxMHBwjZjQzJhUV9FhFHI4a2GGN05gI3BmdFt5bvzRMGNhKThraaUMFUwVDRNwYAIFTRIwa2GAFFgoCXAAAA54CgDLcGACCDxsYYwcq3JgJA2EYFi3X/EwcAAtjGQWeYyjcHCQCYythGBYt1/xN4BfiTCAACE9MlACOmFgFjCAMCgUOBR7cCBQAMQpEDE/fDAAzBAesjqFYAzEaFifX9I6YWAYUHEQURBuOQZ/4jqgYBQWUTBQUEiMrIRgWJdf2TBQACzMaMSkF2fRbxjYzKhWWzRbgAjEHM2oKABUWCgLcFACADxcUYCc0BRTcmAkAUSiFnEwcHCNmOFMojhgUYgoAFRYKAAAAAAAAAAAA=
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x52
   pc_uninit: 0x142
   pc_program_page: 0xa6
   pc_erase_sector: 0x4
-  pc_erase_all: null
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x170
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1ffff000
@@ -526,29 +338,16 @@ flash_algorithms:
     sectors:
     - size: 0x80
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v1-sys-2
   description: ch32-v1-sys-2
   default: true
   instructions: BUWCgLcFACCDxcUYocE3JgJATEaFifX9kwUAAkzGtwUCAAzKSMqThQUEDMpMRoWJ9f2TBgACVMYUSgF3fRf5jhTKhWY1jQhBSNoRoIVFLoWCgLcGACCDxcYYNyUCQJnFDEkhZxMHBwjZjQzJhUV9FhFHI4a2GGN05gI3BmdFt5bvzRMGNhKThraaUMFUwVDRNwYAIFTRIwa2GAFFgoCXAAAA54CgDLcGACCDxsYYwcq3JgJA2EYFi3X/EwcAAtjGQWeYyjcHCQCYythGBYt1/xN4BfiTCAACE9MlACOmFgFjCAMCgUOBR7cCBQAMQpEDE/fDAAzBAesjqFYAzEaFifX9I6YWAYUHEQURBuOQZ/4jqgYBQWUTBQUEiMrIRgWJdf2TBQACzMaMSkF2fRbxjYzKhWWzRbgAjEHM2oKABUWCgLcFACADxcUYCc0BRTcmAkAUSiFnEwcHCNmOFMojhgUYgoAFRYKAAAAAAAAAAAA=
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x52
   pc_uninit: 0x142
   pc_program_page: 0xa6
   pc_erase_sector: 0x4
-  pc_erase_all: null
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x170
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1ffff900
@@ -560,29 +359,17 @@ flash_algorithms:
     sectors:
     - size: 0x80
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v1-usr
   description: ch32-v1-usr
   default: true
   instructions: NwUAIANFxR0dzbclAkDIRQWJdf0TBQACyMWISRNlRQCIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEltmpDJNxYACBBC0NmCgAVFgoC3BQAgg8XFHbnBtyUCQNBFBYp1/jcGAAhJjhMFAALIxTcFAgCIyRMFBQTQyYjJyEUFiXX9kwYAAtTFlEkBd30X+Y6UyYVmNY4QQtDZgoAFRYKAtwYAIIPFxh03JQJAmcUMSSFnEwcHCNmNDMmFRX0WEUcjjrYcY3TmAjcGZ0W3lu/NEwY2EpOGtppQwVTBUNE3BgAgVNEjDrYcAUWCgJcAAADngAANtwYAIIPGxh3ZyrcmAkDYRgWLdf8TBwAC2MZBZ5jKNwcJAJjK2EYFi3X/NwcACJMIAAIT0yUAWY0TeAX4I6YWAWMIAwKBQwFHtwIFABxCkQOT9cMAHMGB6SOoVgDMRoWJ9f0jphYBBQcRBREG4xBn/iOqBgFBZRMFBQSIyshGBYl1/ZMFAALMxoxKQXZ9FvGNjMqFZbNFuACMQczagoAFRYKAtwUAIAPFxR0JzQFFNyYCQBRKIWcTBwcI2Y4UyiOOBRyCgAVFgoAAAAAAAAAAAA==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x9c
   pc_uninit: 0x192
   pc_program_page: 0xf0
   pc_erase_sector: 0x4a
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x1c0
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x8000000
@@ -594,29 +381,17 @@ flash_algorithms:
     sectors:
     - size: 0x80
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v1-usr-legacy
   description: ch32-v1-usr-legacy
   default: true
   instructions: NwUAIANFxR0dzbclAkDIRQWJdf0TBQACyMWISRNlRQCIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEltmpDJNxYACBBC0NmCgAVFgoC3BQAgg8XFHbnBtyUCQNBFBYp1/jcGAAhJjhMFAALIxTcFAgCIyRMFBQTQyYjJyEUFiXX9kwYAAtTFlEkBd30X+Y6UyYVmNY4QQtDZgoAFRYKAtwYAIIPFxh03JQJAmcUMSSFnEwcHCNmNDMmFRX0WEUcjjrYcY3TmAjcGZ0W3lu/NEwY2EpOGtppQwVTBUNE3BgAgVNEjDrYcAUWCgJcAAADngAANtwYAIIPGxh3ZyrcmAkDYRgWLdf8TBwAC2MZBZ5jKNwcJAJjK2EYFi3X/NwcACJMIAAIT0yUAWY0TeAX4I6YWAWMIAwKBQwFHtwIFABxCkQOT9cMAHMGB6SOoVgDMRoWJ9f0jphYBBQcRBREG4xBn/iOqBgFBZRMFBQSIyshGBYl1/ZMFAALMxoxKQXZ9FvGNjMqFZbNFuACMQczagoAFRYKAtwUAIAPFxR0JzQFFNyYCQBRKIWcTBwcI2Y4UyiOOBRyCgAVFgoAAAAAAAAAAAA==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x9c
   pc_uninit: 0x192
   pc_program_page: 0xf0
   pc_erase_sector: 0x4a
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x1c0
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x0
@@ -628,8 +403,3 @@ flash_algorithms:
     sectors:
     - size: 0x80
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false

--- a/probe-rs/targets/CH32V2_CH32V3_Series.yaml
+++ b/probe-rs/targets/CH32V2_CH32V3_Series.yaml
@@ -1,5 +1,4 @@
 name: CH32V2 / CH32V3 Series
-manufacturer: null
 chip_detection:
 - !WchLink
   mask: 0xffffff0f
@@ -176,35 +175,14 @@ chip_detection:
         0xa0: CH32V317WCU6
         0xc0: CH32V317WCU6_c128_r192
         0xe0: CH32V317WCU6_c288_r32
-generated_from_pack: false
-pack_file_release: null
 variants:
 - name: CH32V203C6T6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8038000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -213,11 +191,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8038000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -226,11 +206,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -240,10 +215,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -253,10 +226,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -264,46 +234,18 @@ variants:
       end: 0x20002800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V203C8T6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8038000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -312,11 +254,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8038000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -325,11 +269,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -339,10 +278,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -352,10 +289,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -363,46 +297,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V203C8U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8038000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -411,11 +317,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8038000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -424,11 +332,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -438,10 +341,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -451,10 +352,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -462,46 +360,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V203F6P6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8038000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -510,11 +380,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8038000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -523,11 +395,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -537,10 +404,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -550,10 +415,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -561,46 +423,18 @@ variants:
       end: 0x20002800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V203F8P6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8038000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -609,11 +443,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8038000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -622,11 +458,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -636,10 +467,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -649,10 +478,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -660,46 +486,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V203F8U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8038000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -708,11 +506,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8038000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -721,11 +521,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -735,10 +530,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -748,10 +541,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -759,46 +549,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V203G6U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8038000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -807,11 +569,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8038000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -820,11 +584,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -834,10 +593,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -847,10 +604,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -858,46 +612,18 @@ variants:
       end: 0x20002800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V203G8R6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8038000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -906,11 +632,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8038000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -919,11 +647,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -933,10 +656,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -946,10 +667,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -957,46 +675,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V203K6T6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8038000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1005,11 +695,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8038000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1018,11 +710,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1032,10 +719,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1045,10 +730,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1056,46 +738,18 @@ variants:
       end: 0x20002800
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V203K8T6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8038000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1104,11 +758,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8038000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1117,11 +773,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1131,10 +782,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1144,10 +793,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1155,46 +801,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V203RBT6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8038000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1203,11 +821,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8038000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1216,11 +836,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1230,10 +845,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1243,10 +856,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1254,46 +864,18 @@ variants:
       end: 0x20010000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V203RBT6_c144_r48
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8038000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1302,11 +884,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8038000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1315,11 +899,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1329,10 +908,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1342,10 +919,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1353,46 +927,18 @@ variants:
       end: 0x2000c000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V203RBT6_c160_r32
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8038000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1401,11 +947,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8038000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1414,11 +962,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1428,10 +971,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1441,10 +982,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1452,46 +990,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V208CBU6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1500,11 +1010,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1513,11 +1025,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1527,10 +1034,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1540,10 +1045,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1551,46 +1053,18 @@ variants:
       end: 0x20010000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V208CBU6_c144_r48
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1599,11 +1073,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1612,11 +1088,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1626,10 +1097,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1639,10 +1108,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1650,46 +1116,18 @@ variants:
       end: 0x2000c000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V208CBU6_c160_r32
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1698,11 +1136,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1711,11 +1151,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1725,10 +1160,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1738,10 +1171,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1749,46 +1179,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V208GBU6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1797,11 +1199,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1810,11 +1214,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1824,10 +1223,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1837,10 +1234,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1848,46 +1242,18 @@ variants:
       end: 0x20010000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V208GBU6_c144_r48
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1896,11 +1262,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1909,11 +1277,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1923,10 +1286,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1936,10 +1297,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1947,46 +1305,18 @@ variants:
       end: 0x2000c000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V208GBU6_c160_r32
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1995,11 +1325,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -2008,11 +1340,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -2022,10 +1349,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -2035,10 +1360,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -2046,46 +1368,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V208RBT6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -2094,11 +1388,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -2107,11 +1403,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -2121,10 +1412,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -2134,10 +1423,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -2145,46 +1431,18 @@ variants:
       end: 0x20010000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V208RBT6_c144_r48
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -2193,11 +1451,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -2206,11 +1466,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -2220,10 +1475,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -2233,10 +1486,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -2244,46 +1494,18 @@ variants:
       end: 0x2000c000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V208RBT6_c160_r32
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -2292,11 +1514,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -2305,11 +1529,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -2319,10 +1538,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -2332,10 +1549,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -2343,46 +1557,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V208WBU6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -2391,11 +1577,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -2404,11 +1592,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -2418,10 +1601,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -2431,10 +1612,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -2442,46 +1620,18 @@ variants:
       end: 0x20010000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V208WBU6_c144_r48
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -2490,11 +1640,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -2503,11 +1655,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -2517,10 +1664,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -2530,10 +1675,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -2541,46 +1683,18 @@ variants:
       end: 0x2000c000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V208WBU6_c160_r32
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -2589,11 +1703,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -2602,11 +1718,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -2616,10 +1727,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -2629,10 +1738,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -2640,46 +1746,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V303CBT6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -2688,11 +1766,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -2701,11 +1781,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -2715,10 +1790,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -2728,10 +1801,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -2739,46 +1809,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V303RBT6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -2787,11 +1829,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -2800,11 +1844,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -2814,10 +1853,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -2827,10 +1864,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -2838,46 +1872,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V303RCT6_c192_r128
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -2886,11 +1892,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -2899,11 +1907,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -2913,10 +1916,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -2926,10 +1927,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -2937,46 +1935,18 @@ variants:
       end: 0x20020000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V303RCT6_c224_r96
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -2985,11 +1955,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -2998,11 +1970,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -3012,10 +1979,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -3025,10 +1990,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -3036,46 +1998,18 @@ variants:
       end: 0x20018000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V303RCT6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -3084,11 +2018,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -3097,11 +2033,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -3111,10 +2042,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -3124,10 +2053,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -3135,46 +2061,18 @@ variants:
       end: 0x20010000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V303RCT6_c128_r192
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -3183,11 +2081,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -3196,11 +2096,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -3210,10 +2105,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -3223,10 +2116,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -3234,46 +2124,18 @@ variants:
       end: 0x20030000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V303RCT6_c288_r32
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -3282,11 +2144,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -3295,11 +2159,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -3309,10 +2168,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -3322,10 +2179,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -3333,46 +2187,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V303VCT6_c192_r128
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -3381,11 +2207,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -3394,11 +2222,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -3408,10 +2231,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -3421,10 +2242,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -3432,46 +2250,18 @@ variants:
       end: 0x20020000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V303VCT6_c224_r96
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -3480,11 +2270,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -3493,11 +2285,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -3507,10 +2294,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -3520,10 +2305,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -3531,46 +2313,18 @@ variants:
       end: 0x20018000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V303VCT6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -3579,11 +2333,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -3592,11 +2348,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -3606,10 +2357,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -3619,10 +2368,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -3630,46 +2376,18 @@ variants:
       end: 0x20010000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V303VCT6_c128_r192
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -3678,11 +2396,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -3691,11 +2411,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -3705,10 +2420,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -3718,10 +2431,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -3729,46 +2439,18 @@ variants:
       end: 0x20030000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V303VCT6_c288_r32
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -3777,11 +2459,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -3790,11 +2474,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -3804,10 +2483,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -3817,10 +2494,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -3828,46 +2502,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V305FBP6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -3876,11 +2522,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -3889,11 +2537,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -3903,10 +2546,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -3916,10 +2557,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -3927,46 +2565,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V305GBU6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -3975,11 +2585,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -3988,11 +2600,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -4002,10 +2609,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -4015,10 +2620,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -4026,46 +2628,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V305RBT6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -4074,11 +2648,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -4087,11 +2663,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -4101,10 +2672,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -4114,10 +2683,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -4125,46 +2691,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307RCT6_c192_r128
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -4173,11 +2711,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -4186,11 +2726,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -4200,10 +2735,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -4213,10 +2746,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -4224,46 +2754,18 @@ variants:
       end: 0x20020000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307RCT6_c224_r96
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -4272,11 +2774,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -4285,11 +2789,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -4299,10 +2798,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -4312,10 +2809,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -4323,46 +2817,18 @@ variants:
       end: 0x20018000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307RCT6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -4371,11 +2837,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -4384,11 +2852,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -4398,10 +2861,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -4411,10 +2872,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -4422,46 +2880,18 @@ variants:
       end: 0x20010000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307RCT6_c128_r192
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -4470,11 +2900,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -4483,11 +2915,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -4497,10 +2924,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -4510,10 +2935,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -4521,46 +2943,18 @@ variants:
       end: 0x20030000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307RCT6_c288_r32
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -4569,11 +2963,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -4582,11 +2978,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -4596,10 +2987,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -4609,10 +2998,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -4620,46 +3006,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307VCT6_c192_r128
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -4668,11 +3026,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -4681,11 +3041,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -4695,10 +3050,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -4708,10 +3061,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -4719,46 +3069,18 @@ variants:
       end: 0x20020000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307VCT6_c224_r96
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -4767,11 +3089,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -4780,11 +3104,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -4794,10 +3113,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -4807,10 +3124,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -4818,46 +3132,18 @@ variants:
       end: 0x20018000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307VCT6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -4866,11 +3152,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -4879,11 +3167,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -4893,10 +3176,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -4906,10 +3187,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -4917,46 +3195,18 @@ variants:
       end: 0x20010000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307VCT6_c128_r192
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -4965,11 +3215,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -4978,11 +3230,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -4992,10 +3239,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -5005,10 +3250,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -5016,46 +3258,18 @@ variants:
       end: 0x20030000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307VCT6_c288_r32
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -5064,11 +3278,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -5077,11 +3293,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -5091,10 +3302,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -5104,10 +3313,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -5115,46 +3321,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307WCU6_c192_r128
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -5163,11 +3341,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -5176,11 +3356,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -5190,10 +3365,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -5203,10 +3376,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -5214,46 +3384,18 @@ variants:
       end: 0x20020000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307WCU6_c224_r96
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -5262,11 +3404,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -5275,11 +3419,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -5289,10 +3428,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -5302,10 +3439,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -5313,46 +3447,18 @@ variants:
       end: 0x20018000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307WCU6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -5361,11 +3467,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -5374,11 +3482,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -5388,10 +3491,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -5401,10 +3502,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -5412,46 +3510,18 @@ variants:
       end: 0x20010000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307WCU6_c128_r192
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -5460,11 +3530,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -5473,11 +3545,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -5487,10 +3554,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -5500,10 +3565,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -5511,46 +3573,18 @@ variants:
       end: 0x20030000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V307WCU6_c288_r32
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -5559,11 +3593,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -5572,11 +3608,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -5586,10 +3617,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -5599,10 +3628,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -5610,46 +3636,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V317VCT6_c192_r128
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -5658,11 +3656,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -5671,11 +3671,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -5685,10 +3680,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -5698,10 +3691,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -5709,46 +3699,18 @@ variants:
       end: 0x20020000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V317VCT6_c224_r96
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -5757,11 +3719,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -5770,11 +3734,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -5784,10 +3743,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -5797,10 +3754,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -5808,46 +3762,18 @@ variants:
       end: 0x20018000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V317VCT6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -5856,11 +3782,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -5869,11 +3797,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -5883,10 +3806,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -5896,10 +3817,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -5907,46 +3825,18 @@ variants:
       end: 0x20010000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V317VCT6_c128_r192
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -5955,11 +3845,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -5968,11 +3860,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -5982,10 +3869,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -5995,10 +3880,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -6006,46 +3888,18 @@ variants:
       end: 0x20030000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V317VCT6_c288_r32
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -6054,11 +3908,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -6067,11 +3923,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -6081,10 +3932,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -6094,10 +3943,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -6105,46 +3951,18 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V317WCU6_c192_r128
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -6153,11 +3971,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -6166,11 +3986,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -6180,10 +3995,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -6193,10 +4006,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -6204,46 +4014,18 @@ variants:
       end: 0x20020000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V317WCU6_c224_r96
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -6252,11 +4034,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -6265,11 +4049,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -6279,10 +4058,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -6292,10 +4069,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -6303,46 +4077,18 @@ variants:
       end: 0x20018000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V317WCU6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -6351,11 +4097,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -6364,11 +4112,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -6378,10 +4121,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -6391,10 +4132,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -6402,46 +4140,18 @@ variants:
       end: 0x20010000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V317WCU6_c128_r192
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -6450,11 +4160,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -6463,11 +4175,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -6477,10 +4184,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -6490,10 +4195,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -6501,46 +4203,18 @@ variants:
       end: 0x20030000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32V317WCU6_c288_r32
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x8078000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -6549,11 +4223,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x8078000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -6562,11 +4238,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -6576,10 +4247,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -6589,10 +4258,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -6600,39 +4266,23 @@ variants:
       end: 0x20008000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-v3-usr
   - ch32-v3-usr-legacy
   - ch32-v3-sys
   - ch32-v3-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 flash_algorithms:
 - name: ch32-v3-opt
   description: ch32-v3-opt
   default: true
   instructions: BUWCgDcFACADRWUUBc23JQJAyEUFiXX9EwUAAsjFiEkTZQUCiMmISRNlBQSIychFBYl1/RMGAALQxZBJE3b2/ZDJgoAFRYKAtwYAIIPFZhQ3JQJAmcUMSSFnEwcHCNmNDMmFRX0WEUcjg7YUY3TmAjcGZ0W3lu/NEwY2EpOGtppQwVTBEMU3BgAgFMUjA7YUAUWCgJcAAADngOAItwYAIAPHZhSFRinLM+elAAWLKecT2BUAYwEIBIFGNycCQJMIAAKDVQYAXEeFi/X/IyYXARxLk+cHARzLIxC1AExHhYn1/SMmFwEMS4UGCQW9mQzLCQbjmAb9gUY2hYKAtwUAIAPFZRQJzQFFNyYCQBRKIWcTBwcI2Y4UyiODBRSCgAVFgoAAAAAAAAA=
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x48
   pc_uninit: 0xfc
   pc_program_page: 0x9c
   pc_erase_sector: 0x4
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x128
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1ffff800
@@ -6644,29 +4294,16 @@ flash_algorithms:
     sectors:
     - size: 0x80
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v3-sys
   description: ch32-v3-sys
   default: true
   instructions: BUWCgLcFACCDxWUVqcG3JQJA0EUFinX+EwYAAtDFkEm3BgBAiQZVjpDJyMmISRNlBQSIychFBYl1/RMGAALQxZBJtwYAwPUWdY6QyYKABUWCgLcGACCDxWYVNyUCQJnFDEkhZxMHBwjZjQzJhUV9FhFHI4u2FGN05gI3BmdFt5bvzRMGNhKThraaUMFUwVDRNwYAIFTRIwu2FAFFgoCXAAAA54BACbcGACCDxmYVqc63JgJA2EYFi3X/EwcAAtjGmEq3BwEgXY+JgZjKgc0BRxxCHMHcRomL9f8FBxEFEQbjGLf+iEq3BSAATY2IyshGBYl1/ZMFAALMxoxKNwb/330W8Y2MyoKABUWCgLcFACADxWUVCc0BRTcmAkAUSiFnEwcHCNmOFMojiwUUgoAFRYKAAAAAAAAA
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x52
   pc_uninit: 0x10c
   pc_program_page: 0xa6
   pc_erase_sector: 0x4
-  pc_erase_all: null
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x138
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1fff8000
@@ -6678,29 +4315,17 @@ flash_algorithms:
     sectors:
     - size: 0x1000
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v3-usr
   description: ch32-v3-usr
   default: true
   instructions: NwUAIANFhRkdybclAkDIRQWJdf0TBQACyMWISRNlRQCIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEltmpDJgoAFRYKAtwUAIIPFhRmxwbclAkDQRQWKdf4TBgAC0MWQSbcGAAhVjbcGAgBVjpDJyMmISRNlBQSIychFBYl1/RMGAALQxZBJgXb9FnWOkMmCgAVFgoC3BgAgg8WGGTclAkCZxQxJIWcTBwcI2Y0MyYVFfRYRRyOMthhjdOYCNwZnRbeW780TBjYSk4a2mlDBVMFQ0TcGACBU0SMMthgBRYKAlwAAAOeAYAm3BgAgg8aGGbHOtyYCQNhGBYt1/xMHAALYxphKwWddj4mBmMqZzQFHtwcACF2NHEIcwdxGiYv1/wUHEQURBuMYt/6ISrcFIABNjYjKyEYFiXX9kwUAAszGjEpBdn0W8Y2MyoKABUWCgLcFACADxYUZCc0BRTcmAkAUSiFnEwcHCNmOFMojjAUYgoAFRYKAAAAAAAAAAAA=
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x92
   pc_uninit: 0x14e
   pc_program_page: 0xe6
   pc_erase_sector: 0x42
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x17c
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x8000000
@@ -6712,29 +4337,17 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-v3-usr-legacy
   description: ch32-v3-usr-legacy
   default: true
   instructions: NwUAIANFhRkdybclAkDIRQWJdf0TBQACyMWISRNlRQCIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEltmpDJgoAFRYKAtwUAIIPFhRmxwbclAkDQRQWKdf4TBgAC0MWQSbcGAAhVjbcGAgBVjpDJyMmISRNlBQSIychFBYl1/RMGAALQxZBJgXb9FnWOkMmCgAVFgoC3BgAgg8WGGTclAkCZxQxJIWcTBwcI2Y0MyYVFfRYRRyOMthhjdOYCNwZnRbeW780TBjYSk4a2mlDBVMFQ0TcGACBU0SMMthgBRYKAlwAAAOeAYAm3BgAgg8aGGbHOtyYCQNhGBYt1/xMHAALYxphKwWddj4mBmMqZzQFHtwcACF2NHEIcwdxGiYv1/wUHEQURBuMYt/6ISrcFIABNjYjKyEYFiXX9kwUAAszGjEpBdn0W8Y2MyoKABUWCgLcFACADxYUZCc0BRTcmAkAUSiFnEwcHCNmOFMojjAUYgoAFRYKAAAAAAAAAAAA=
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x92
   pc_uninit: 0x14e
   pc_program_page: 0xe6
   pc_erase_sector: 0x42
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x17c
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x0
@@ -6746,8 +4359,3 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false

--- a/probe-rs/targets/CH32X0_CH643_Series.yaml
+++ b/probe-rs/targets/CH32X0_CH643_Series.yaml
@@ -1,5 +1,4 @@
 name: CH32X0 / CH643 Series
-manufacturer: null
 chip_detection:
 - !WchLink
   mask: 0xffffff0f
@@ -11,7 +10,6 @@ chip_detection:
     0x35b0601: CH32X035G8R6
     0x3560601: CH32X035G8U6
     0x3500601: CH32X035R8T6
-  ob_code_ram_splits: {}
 - !WchLink
   mask: 0xffffffff
   variants:
@@ -19,36 +17,14 @@ chip_detection:
     0x64310601: CH643Q
     0x64330601: CH643L
     0x64340601: CH643U
-  ob_code_ram_splits: {}
-generated_from_pack: false
-pack_file_release: null
 variants:
 - name: CH32X033F8P6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -57,11 +33,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -70,11 +48,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -84,10 +57,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -97,10 +68,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -108,46 +76,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-x0-usr
   - ch32-x0-usr-legacy
   - ch32-x0-sys
   - ch32-x0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32X034F8P6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -156,11 +96,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -169,11 +111,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -183,10 +120,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -196,10 +131,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -207,46 +139,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-x0-usr
   - ch32-x0-usr-legacy
   - ch32-x0-sys
   - ch32-x0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32X034F8U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -255,11 +159,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -268,11 +174,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -282,10 +183,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -295,10 +194,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -306,46 +202,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-x0-usr
   - ch32-x0-usr-legacy
   - ch32-x0-sys
   - ch32-x0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32X035C8T6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -354,11 +222,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -367,11 +237,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -381,10 +246,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -394,10 +257,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -405,46 +265,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-x0-usr
   - ch32-x0-usr-legacy
   - ch32-x0-sys
   - ch32-x0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32X035F7P6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800c000
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -453,11 +285,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800c000
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -466,11 +300,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -480,10 +309,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -493,10 +320,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -504,46 +328,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-x0-usr
   - ch32-x0-usr-legacy
   - ch32-x0-sys
   - ch32-x0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32X035F8U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -552,11 +348,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -565,11 +363,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -579,10 +372,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -592,10 +383,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -603,46 +391,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-x0-usr
   - ch32-x0-usr-legacy
   - ch32-x0-sys
   - ch32-x0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32X035G8R6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -651,11 +411,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -664,11 +426,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -678,10 +435,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -691,10 +446,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -702,46 +454,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-x0-usr
   - ch32-x0-usr-legacy
   - ch32-x0-sys
   - ch32-x0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32X035G8U6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -750,11 +474,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -763,11 +489,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -777,10 +498,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -790,10 +509,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -801,46 +517,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-x0-usr
   - ch32-x0-usr-legacy
   - ch32-x0-sys
   - ch32-x0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH32X035R8T6
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -849,11 +537,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -862,11 +552,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -876,10 +561,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -889,10 +572,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -900,46 +580,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-x0-usr
   - ch32-x0-usr-legacy
   - ch32-x0-sys
   - ch32-x0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH643W
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -948,11 +600,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -961,11 +615,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -975,10 +624,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -988,10 +635,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -999,46 +643,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-x0-usr
   - ch32-x0-usr-legacy
   - ch32-x0-sys
   - ch32-x0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH643Q
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1047,11 +663,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1060,11 +678,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1074,10 +687,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1087,10 +698,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1098,46 +706,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-x0-usr
   - ch32-x0-usr-legacy
   - ch32-x0-sys
   - ch32-x0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH643L
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1146,11 +726,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1159,11 +741,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1173,10 +750,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1186,10 +761,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1197,46 +769,18 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-x0-usr
   - ch32-x0-usr-legacy
   - ch32-x0-sys
   - ch32-x0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 - name: CH643U
-  part: null
-  svd: null
-  documentation: {}
-  package_variants: []
   cores:
   - name: main
     type: riscv
     core_access_options: !Riscv
       hart_id: 0
-      jtag_tap: null
-      mem_ap: null
   memory_map:
-  - !Nvm
-    name: USR
-    range:
-      start: 0x8000000
-      end: 0x800f800
-    cores:
-    - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: USR_LEGACY
     range:
@@ -1245,11 +789,13 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
+  - !Nvm
+    name: USR
+    range:
+      start: 0x8000000
+      end: 0x800f800
+    cores:
+    - main
   - !Nvm
     name: SYS
     range:
@@ -1258,11 +804,6 @@ variants:
     cores:
     - main
     is_alias: true
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   - !Nvm
     name: VND
     range:
@@ -1272,10 +813,8 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
       write: false
       execute: false
-      boot: false
   - !Nvm
     name: OPT
     range:
@@ -1285,10 +824,7 @@ variants:
     - main
     is_alias: true
     access:
-      read: true
-      write: true
       execute: false
-      boot: false
   - !Ram
     name: RAM
     range:
@@ -1296,39 +832,23 @@ variants:
       end: 0x20005000
     cores:
     - main
-    is_alias: false
-    access:
-      read: true
-      write: true
-      execute: true
-      boot: false
   flash_algorithms:
   - ch32-x0-usr
   - ch32-x0-usr-legacy
   - ch32-x0-sys
   - ch32-x0-opt
-  rtt_scan_ranges: null
-  jtag: null
-  default_binary_format: null
 flash_algorithms:
 - name: ch32-x0-opt
   description: ch32-x0-opt
   default: true
   instructions: BUWCgDcFACADRQUXBc23JQJAyEUFiXX9EwUAAsjFiEkTZQUCiMmISRNlBQSIychFBYl1/RMGAALQxZBJE3b2/ZDJgoAFRYKAtwYAIIPFBhc3JQJAicWhZZOFBQgMyYVFfRYRRyOIthZjduYCNwZnRbeW780TBjYSk4a2mlDBVMFQ0VTREMU3BgAgFMUjCLYWAUWCgJcAAADngIALtwYAIAPHBheFRkHDM+elAA2LJe83JwJAVEeFivX+kwYAAlTHwWYUy7cGCQAUy1RHhYr1/hN4BfCTCAACiYEjJhcBlcGBRrcCBQAcQhzBIyhXAFxHhYv1/4UGIyYXAREFEQbjlLb+IyoHAUFlEwUFBAjLSEcFiXX9gUYTBQACSMcIS8F1/RVtjQjLNoWCgLcFACADxQUXGckBRSFmtyYCQBMGBgiQyiOIBRaCgAVFgoAAAAAAAAAAAA==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x48
   pc_uninit: 0x12a
   pc_program_page: 0x9c
   pc_erase_sector: 0x4
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x154
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1ffff800
@@ -1340,29 +860,16 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-x0-sys
   description: ch32-x0-sys
   default: true
   instructions: BUWCgLcFACCDxVUahc23JQJA0EUFinX+EwYAAtDFNwYCAJDJyMkTBQYEiMnIRQWJdf0TBgAC0MWQSYF2/RZ1jpDJgoAFRYKAt5XvzTcFACATBUUag0cVAJOFtZo3B2dFEwc3ErcmAkCJz7cHACCDx0camNaM1roH3MahZ5OHBwicygVIfRaRR6MABQFjc/YC0EbYwszC2NLM0pjWjNaRZczGRgZ9giMAxQCjAAUBAUWCgJcAAADngOAMtwYAIIPGVhqlzrcmAkDYRgWLdf8TBwAC2MZBZ5jKNwcJAJjK2EYFi3X/E3gF8JMIAAKJgSOmFgGVwQFHtwIFABxCHMEjqFYA3EaFi/X/BQcjphYBEQURBuMUt/4jqgYBQWUTBQUEiMrIRgWJdf2TBQACzMaMSkF2fRbxjYzKgoAFRYKAtwUAIJOFRRoDxRUADckBRQPGBQC3BmdFNycCQJOGNhIU17eW782ThraaFNc6BlDHIWYTBgYIEMujgAUAgoAFRYKAAAAAAAAAAAA=
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x48
   pc_uninit: 0x13e
   pc_program_page: 0xba
   pc_erase_sector: 0x4
-  pc_erase_all: null
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x188
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x1fff0000
@@ -1374,29 +881,17 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-x0-usr
   description: ch32-x0-usr
   default: true
   instructions: NwUAIANFxRodybclAkDIRQWJdf0TBQACyMWISRNlRQCIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEltmpDJgoAFRYKAtwUAIIPFxRqdzbclAkDQRQWKdf43BgAIUY0TBgAC0MU3BgIAkMkTBgYEyMmQychFBYl1/RMGAALQxZBJgXb9FnWOkMmCgAVFgoC3BgAgg8XGGjclAkCJxaFlk4UFCAzJhUV9FhFHI4a2GmN05gI3BmdFt5bvzRMGNhKThraaUMFUwVDRNwYAIFTRIwa2GgFFgoCXAAAA54BAC7cGACCDxsYavc63JgJA2EYFi3X/EwcAAtjGQWeYyjcHCQCYythGBYt1/7cHAAiTCAACiYHJjxP4B/AjphYBlcEBRbcCBQAYQpjDI6hWANhGBYt1/wUFI6YWAZEHEQbjFLX+I6oGAUFlEwUFBIjKyEYFiXX9kwUAAszGjEpBdn0W8Y2MyoKABUWCgLcFACADxcUaGckBRSFmtyYCQBMGBgiQyiOGBRqCgAVFgoAAAAAAAAAAAA==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x8c
   pc_uninit: 0x166
   pc_program_page: 0xdc
   pc_erase_sector: 0x42
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x190
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x8000000
@@ -1408,29 +903,17 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false
 - name: ch32-x0-usr-legacy
   description: ch32-x0-usr-legacy
   default: true
   instructions: NwUAIANFxRodybclAkDIRQWJdf0TBQACyMWISRNlRQCIyYhJE2UFBIjJyEUFiXX9EwYAAtDFkEltmpDJgoAFRYKAtwUAIIPFxRqdzbclAkDQRQWKdf43BgAIUY0TBgAC0MU3BgIAkMkTBgYEyMmQychFBYl1/RMGAALQxZBJgXb9FnWOkMmCgAVFgoC3BgAgg8XGGjclAkCJxaFlk4UFCAzJhUV9FhFHI4a2GmN05gI3BmdFt5bvzRMGNhKThraaUMFUwVDRNwYAIFTRIwa2GgFFgoCXAAAA54BAC7cGACCDxsYavc63JgJA2EYFi3X/EwcAAtjGQWeYyjcHCQCYythGBYt1/7cHAAiTCAACiYHJjxP4B/AjphYBlcEBRbcCBQAYQpjDI6hWANhGBYt1/wUFI6YWAZEHEQbjFLX+I6oGAUFlEwUFBIjKyEYFiXX9kwUAAszGjEpBdn0W8Y2MyoKABUWCgLcFACADxcUaGckBRSFmtyYCQBMGBgiQyiOGBRqCgAVFgoAAAAAAAAAAAA==
   load_address: 0x20000020
-  data_load_address: null
   pc_init: 0x8c
   pc_uninit: 0x166
   pc_program_page: 0xdc
   pc_erase_sector: 0x42
   pc_erase_all: 0x0
-  pc_verify: null
-  pc_blank_check: null
-  pc_read: null
-  vendor_functions: {}
   data_section_offset: 0x190
-  rtt_location: null
-  rtt_poll_interval: 20
   flash_properties:
     address_range:
       start: 0x0
@@ -1442,8 +925,3 @@ flash_algorithms:
     sectors:
     - size: 0x100
       address: 0x0
-  cores: []
-  stack_size: null
-  stack_overflow_check: null
-  transfer_encoding: null
-  big_endian: false


### PR DESCRIPTION
Small follow-up to #4056: the `CH32H4_Series` yaml had its SYS region marked read-only, blocking writes to the H4 system flash. This regenerates the yaml so SYS is writable, matching every other CH32 family.