### PR TITLE
Add support for Infineon TLE987x and TLE988x_9x families

### DIFF
--- a/changelog/added-infineon-tle-debug-sequence.md
+++ b/changelog/added-infineon-tle-debug-sequence.md
@@ -1,0 +1,1 @@
+Added a debug sequence that drives the Infineon MOTIX™ TLE98xx/TLE99xx BootROM into debug mode so probe-rs can attach to and flash these devices.

--- a/changelog/added-infineon-tle-support.md
+++ b/changelog/added-infineon-tle-support.md
@@ -1,0 +1,1 @@
+Added target support for the Infineon TLE987x and TLE988x/TLE989x motor controller families.

--- a/changelog/added-jlink-swclk-swdio-pin-control.md
+++ b/changelog/added-jlink-swclk-swdio-pin-control.md
@@ -1,0 +1,1 @@
+Added support for controlling the SWCLK/TCK and SWDIO/TMS pins of J-Link probes via `swj_pins`, which is required for pin-level debug sequences such as the Infineon TLE BootROM debug-mode entry.

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -337,6 +337,8 @@ enum Command {
     ResetTarget = 0x03,
     HwReleaseResetStopEx = 0xD0,
     HwReleaseResetStopTimed = 0xD1,
+    HwTck0 = 0xDA,
+    HwTck1 = 0xDB,
     HwReset0 = 0xDC,
     HwReset1 = 0xDD,
     GetCpuCaps = 0xE9,
@@ -657,6 +659,32 @@ impl JLink {
             Command::HwReset1
         } else {
             Command::HwReset0
+        };
+        self.write_cmd(&[cmd as u8])
+    }
+
+    /// Changes the state of the TMS pin (pin 7).
+    ///
+    /// **Note**: Some embedded J-Link probes may not expose this pin or may not allow controlling
+    /// it using this function.
+    fn set_tms(&mut self, tms: bool) -> Result<(), JlinkError> {
+        let cmd = if tms {
+            Command::HwTms1
+        } else {
+            Command::HwTms0
+        };
+        self.write_cmd(&[cmd as u8])
+    }
+
+    /// Changes the state of the TCK pin (pin 9).
+    ///
+    /// **Note**: Some embedded J-Link probes may not expose this pin or may not allow controlling
+    /// it using this function.
+    fn set_tck(&mut self, tck: bool) -> Result<(), JlinkError> {
+        let cmd = if tck {
+            Command::HwTck1
+        } else {
+            Command::HwTck0
         };
         self.write_cmd(&[cmd as u8])
     }
@@ -1172,17 +1200,32 @@ impl RawSwdIo for JLink {
         pin_select: u32,
         pin_wait: u32,
     ) -> Result<u32, DebugProbeError> {
-        let mut nreset = Pins(0);
-        nreset.set_nreset(true);
-        let nreset_mask = nreset.0 as u32;
+        let mut unsupported_pins = Pins(0);
+        unsupported_pins.set_ntrst(true);
+        unsupported_pins.set_tdi(true);
+        unsupported_pins.set_tdo(true);
+        let unsupported_pins_mask = unsupported_pins.0 as u32;
 
-        // If only the reset pin is selected we perform the reset.
-        // If something else is selected return an error as this is not supported on J-Links.
-        if pin_select == nreset_mask {
-            if Pins(pin_out as u8).nreset() {
-                self.target_reset_deassert()?;
-            } else {
-                self.target_reset_assert()?;
+        // Only RESET, TCK and TMS are supported at the moment
+        if pin_select & unsupported_pins_mask == 0 {
+            let pin_select = Pins(pin_select as u8);
+            let pin_out = Pins(pin_out as u8);
+
+            if pin_select.swclk_tck() {
+                self.set_tck(pin_out.swclk_tck())?;
+            }
+
+            if pin_select.swdio_tms() {
+                self.set_tms(pin_out.swdio_tms())?;
+            }
+
+            // Set reset as last of the pins as some chips might sample tms and tck on release of reset
+            if pin_select.nreset() {
+                if pin_out.nreset() {
+                    self.target_reset_deassert()?;
+                } else {
+                    self.target_reset_assert()?;
+                }
             }
 
             // Normally this would be the timeout we pass to the probe to settle the pins.

--- a/probe-rs/src/vendor/infineon/mod.rs
+++ b/probe-rs/src/vendor/infineon/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     error::Error,
     vendor::{
         Vendor,
-        infineon::sequences::{psoc_edge, xmc4000::XMC4000},
+        infineon::sequences::{psoc_edge, tle::InfineonTle, xmc4000::XMC4000},
     },
 };
 
@@ -32,6 +32,10 @@ impl Vendor for Infineon {
             DebugSequence::Arm(XMC4000::create())
         } else if chip.name.starts_with("PSE84") {
             DebugSequence::Arm(psoc_edge::PsocEdge::create(chip))
+        } else if chip.name.starts_with("TLE98") || chip.name.starts_with("TLE99") {
+            // MOTIX™ TLE98xx/TLE99xx motor-control MCUs gate SWD behind their
+            // BootROM and need a special debug-mode entry sequence.
+            DebugSequence::Arm(InfineonTle::create())
         } else {
             return None;
         };

--- a/probe-rs/src/vendor/infineon/sequences/mod.rs
+++ b/probe-rs/src/vendor/infineon/sequences/mod.rs
@@ -1,4 +1,5 @@
 //! Infineon debug sequences.
 
 pub mod psoc_edge;
+pub mod tle;
 pub mod xmc4000;

--- a/probe-rs/src/vendor/infineon/sequences/tle.rs
+++ b/probe-rs/src/vendor/infineon/sequences/tle.rs
@@ -1,0 +1,121 @@
+//! Debug sequences for Infineon MOTIX™ TLE98xx / TLE99xx motor-control MCUs.
+//!
+//! These devices gate the SWD debug interface behind their BootROM. After every
+//! cold or warm reset the BootROM samples the TMS (SWDIO) and SWDCLK pins: only
+//! if both are read high does it continue start-up in *debug mode* and enable
+//! the debug interface. Otherwise it boots into user mode with debug disabled,
+//! and a debugger cannot connect.
+//!
+//! To make the device reliably enter debug mode we drive both pins high and let
+//! the BootROM's "TMS device reset" mechanism trigger a reset (holding TMS and
+//! SWDCLK high for more than 200 MCLK cycles triggers a device reset). With the
+//! pins still held high while the BootROM executes, the device latches into
+//! debug mode and the regular SWD connection sequence can proceed.
+//!
+//! References (sections "Debug mode" / "Debug mode entry" /
+//! "Device reset during debug mode"):
+//! - MOTIX™ TLE987x user manual, "Booting scheme"
+//! - MOTIX™ TLE988x/TLE989x user manual
+
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use crate::architecture::arm::{
+    ArmError, Pins,
+    communication_interface::DapProbe,
+    dp::DpAddress,
+    sequences::{ArmDebugSequence, DefaultArmSequence},
+};
+
+/// Debug sequence for Infineon MOTIX™ TLE98xx / TLE99xx MCUs.
+#[derive(Debug)]
+pub struct InfineonTle;
+
+impl InfineonTle {
+    /// Create the debug sequencer for an Infineon TLE motor-control MCU.
+    pub fn create() -> Arc<dyn ArmDebugSequence> {
+        Arc::new(Self)
+    }
+
+    /// Reset the device while holding TMS (SWDIO) and SWDCLK high so that the
+    /// BootROM latches the device into debug mode.
+    ///
+    /// The device only starts up in debug mode if the BootROM samples both TMS
+    /// and SWDCLK high right after a reset. Holding the pins high on their own
+    /// is not enough: the "TMS device reset" mechanism is disabled until the
+    /// next cold/warm reset, so we have to trigger a fresh reset ourselves.
+    /// We do that with the nRESET line (wired to the device reset pin on the
+    /// debug connector) while keeping TMS and SWDCLK high across the reset and
+    /// the subsequent BootROM execution.
+    fn enter_debug_mode(&self, interface: &mut dyn DapProbe) -> Result<(), ArmError> {
+        // The pins we drive: nRESET, TMS (SWDIO) and SWDCLK.
+        let mut select = Pins(0);
+        select.set_nreset(true);
+        select.set_swdio_tms(true);
+        select.set_swclk_tck(true);
+        let select = select.0 as u32;
+
+        // TMS and SWDCLK high, nRESET asserted (driven low).
+        let mut reset_asserted = Pins(0);
+        reset_asserted.set_swdio_tms(true);
+        reset_asserted.set_swclk_tck(true);
+        let reset_asserted = reset_asserted.0 as u32;
+
+        // TMS and SWDCLK high, nRESET released (driven high).
+        let mut reset_released = Pins(0);
+        reset_released.set_swdio_tms(true);
+        reset_released.set_swclk_tck(true);
+        reset_released.set_nreset(true);
+        let reset_released = reset_released.0 as u32;
+
+        tracing::debug!("Infineon TLE: resetting with TMS/SWDCLK high to enter debug mode");
+
+        // Assert nRESET while holding TMS and SWDCLK high.
+        let _ = interface.swj_pins(reset_asserted, select, 0)?;
+        thread::sleep(Duration::from_millis(10));
+
+        // Release nRESET while keeping TMS and SWDCLK high, so that the BootROM
+        // samples them high after the reset and starts up in debug mode instead
+        // of user mode. The hold time has to cover oscillator settling and
+        // BootROM execution; a few milliseconds is ample.
+        let _ = interface.swj_pins(reset_released, select, 0)?;
+        thread::sleep(Duration::from_millis(10));
+
+        Ok(())
+    }
+}
+
+impl ArmDebugSequence for InfineonTle {
+    fn debug_port_setup(
+        &self,
+        interface: &mut dyn DapProbe,
+        dp: DpAddress,
+    ) -> Result<(), ArmError> {
+        // Make the BootROM bring the device up in debug mode before attempting
+        // the regular SWD connection sequence.
+        self.enter_debug_mode(interface)?;
+
+        // Run the standard debug port setup (SWJ switch + line reset + connect).
+        DefaultArmSequence(()).debug_port_setup(interface, dp)
+    }
+
+    fn reset_hardware_assert(&self, interface: &mut dyn DapProbe) -> Result<(), ArmError> {
+        // A device reset has to keep TMS and SWDCLK high so that the BootROM
+        // re-enters (preserves) debug mode after the reset, per the "Device
+        // reset during debug mode" procedure in the user manuals.
+        let mut select = Pins(0);
+        select.set_nreset(true);
+        select.set_swdio_tms(true);
+        select.set_swclk_tck(true);
+
+        // nRESET low (asserted) while TMS and SWDCLK are held high.
+        let mut output = Pins(0);
+        output.set_swdio_tms(true);
+        output.set_swclk_tck(true);
+
+        let _ = interface.swj_pins(output.0 as u32, select.0 as u32, 0)?;
+
+        Ok(())
+    }
+}

--- a/probe-rs/targets/TLE987x_Series.yaml
+++ b/probe-rs/targets/TLE987x_Series.yaml
@@ -1,5 +1,5 @@
-name: TLE98xx Series
-generated_from_pack: true
+name: TLE987x Series
+generated_from_pack: false
 pack_file_release: 1.6.2
 variants:
 - name: TLE9871QXA20
@@ -44,8 +44,6 @@ variants:
       end: 0x18000c00
     cores:
     - main
-    access:
-      execute: false
   flash_algorithms:
   - tle9871
   - tle9871_eep
@@ -91,8 +89,6 @@ variants:
       end: 0x18002000
     cores:
     - main
-    access:
-      execute: false
   flash_algorithms:
   - tle9872
   - tle9872_eep
@@ -138,8 +134,6 @@ variants:
       end: 0x18002000
     cores:
     - main
-    access:
-      execute: false
   flash_algorithms:
   - tle9872
   - tle9872_eep
@@ -185,8 +179,6 @@ variants:
       end: 0x18002000
     cores:
     - main
-    access:
-      execute: false
   flash_algorithms:
   - tle9872
   - tle9872_eep
@@ -232,8 +224,6 @@ variants:
       end: 0x18000c00
     cores:
     - main
-    access:
-      execute: false
   flash_algorithms:
   - tle9873
   - tle9873_eep
@@ -279,8 +269,6 @@ variants:
       end: 0x18001800
     cores:
     - main
-    access:
-      execute: false
   flash_algorithms:
   - tle9877
   - tle9877_eep
@@ -326,8 +314,6 @@ variants:
       end: 0x18001800
     cores:
     - main
-    access:
-      execute: false
   flash_algorithms:
   - tle9877
   - tle9877_eep
@@ -373,8 +359,6 @@ variants:
       end: 0x18001800
     cores:
     - main
-    access:
-      execute: false
   flash_algorithms:
   - tle9877
   - tle9877_eep
@@ -420,8 +404,6 @@ variants:
       end: 0x18001800
     cores:
     - main
-    access:
-      execute: false
   flash_algorithms:
   - tle9879
   - tle9879_eep
@@ -467,8 +449,6 @@ variants:
       end: 0x18001800
     cores:
     - main
-    access:
-      execute: false
   flash_algorithms:
   - tle9879
   - tle9879_eep
@@ -514,8 +494,6 @@ variants:
       end: 0x18001800
     cores:
     - main
-    access:
-      execute: false
   flash_algorithms:
   - tle9879
   - tle9879_eep
@@ -561,8 +539,6 @@ variants:
       end: 0x18001800
     cores:
     - main
-    access:
-      execute: false
   flash_algorithms:
   - tle9879
   - tle9879_eep

--- a/probe-rs/targets/TLE987x_Series.yaml
+++ b/probe-rs/targets/TLE987x_Series.yaml
@@ -13,7 +13,7 @@ variants:
     name: IROM1
     range:
       start: 0x11000000
-      end: 0x11007ffc
+      end: 0x11008000
     cores:
     - main
     access:
@@ -22,7 +22,7 @@ variants:
   - !Nvm
     name: IROM2
     range:
-      start: 0x11007ffc
+      start: 0x11008000
       end: 0x11009000
     cores:
     - main
@@ -58,7 +58,7 @@ variants:
     name: IROM1
     range:
       start: 0x11000000
-      end: 0x1103effc
+      end: 0x1103f000
     cores:
     - main
     access:
@@ -67,7 +67,7 @@ variants:
   - !Nvm
     name: IROM2
     range:
-      start: 0x1103effc
+      start: 0x1103f000
       end: 0x11040000
     cores:
     - main
@@ -103,7 +103,7 @@ variants:
     name: IROM1
     range:
       start: 0x11000000
-      end: 0x1103effc
+      end: 0x1103f000
     cores:
     - main
     access:
@@ -112,7 +112,7 @@ variants:
   - !Nvm
     name: IROM2
     range:
-      start: 0x1103effc
+      start: 0x1103f000
       end: 0x11040000
     cores:
     - main
@@ -148,7 +148,7 @@ variants:
     name: IROM1
     range:
       start: 0x11000000
-      end: 0x1103effc
+      end: 0x1103f000
     cores:
     - main
     access:
@@ -157,7 +157,7 @@ variants:
   - !Nvm
     name: IROM2
     range:
-      start: 0x1103effc
+      start: 0x1103f000
       end: 0x11040000
     cores:
     - main
@@ -193,7 +193,7 @@ variants:
     name: IROM1
     range:
       start: 0x11000000
-      end: 0x1100affc
+      end: 0x1100b000
     cores:
     - main
     access:
@@ -202,7 +202,7 @@ variants:
   - !Nvm
     name: IROM2
     range:
-      start: 0x1100affc
+      start: 0x1100b000
       end: 0x1100c000
     cores:
     - main
@@ -238,7 +238,7 @@ variants:
     name: IROM1
     range:
       start: 0x11000000
-      end: 0x1100effc
+      end: 0x1100f000
     cores:
     - main
     access:
@@ -247,7 +247,7 @@ variants:
   - !Nvm
     name: IROM2
     range:
-      start: 0x1100effc
+      start: 0x1100f000
       end: 0x11010000
     cores:
     - main
@@ -283,7 +283,7 @@ variants:
     name: IROM1
     range:
       start: 0x11000000
-      end: 0x1100effc
+      end: 0x1100f000
     cores:
     - main
     access:
@@ -292,7 +292,7 @@ variants:
   - !Nvm
     name: IROM2
     range:
-      start: 0x1100effc
+      start: 0x1100f000
       end: 0x11010000
     cores:
     - main
@@ -328,7 +328,7 @@ variants:
     name: IROM1
     range:
       start: 0x11000000
-      end: 0x1100effc
+      end: 0x1100f000
     cores:
     - main
     access:
@@ -337,7 +337,7 @@ variants:
   - !Nvm
     name: IROM2
     range:
-      start: 0x1100effc
+      start: 0x1100f000
       end: 0x11010000
     cores:
     - main
@@ -373,7 +373,7 @@ variants:
     name: IROM1
     range:
       start: 0x11000000
-      end: 0x1101effc
+      end: 0x1101f000
     cores:
     - main
     access:
@@ -382,7 +382,7 @@ variants:
   - !Nvm
     name: IROM2
     range:
-      start: 0x1101effc
+      start: 0x1101f000
       end: 0x11020000
     cores:
     - main
@@ -418,7 +418,7 @@ variants:
     name: IROM1
     range:
       start: 0x11000000
-      end: 0x1101effc
+      end: 0x1101f000
     cores:
     - main
     access:
@@ -427,7 +427,7 @@ variants:
   - !Nvm
     name: IROM2
     range:
-      start: 0x1101effc
+      start: 0x1101f000
       end: 0x11020000
     cores:
     - main
@@ -463,7 +463,7 @@ variants:
     name: IROM1
     range:
       start: 0x11000000
-      end: 0x1101effc
+      end: 0x1101f000
     cores:
     - main
     access:
@@ -472,7 +472,7 @@ variants:
   - !Nvm
     name: IROM2
     range:
-      start: 0x1101effc
+      start: 0x1101f000
       end: 0x11020000
     cores:
     - main
@@ -508,7 +508,7 @@ variants:
     name: IROM1
     range:
       start: 0x11000000
-      end: 0x1101effc
+      end: 0x1101f000
     cores:
     - main
     access:
@@ -517,7 +517,7 @@ variants:
   - !Nvm
     name: IROM2
     range:
-      start: 0x1101effc
+      start: 0x1101f000
       end: 0x11020000
     cores:
     - main

--- a/probe-rs/targets/TLE988x_9x_Series.yaml
+++ b/probe-rs/targets/TLE988x_9x_Series.yaml
@@ -1,5 +1,5 @@
-name: TLE98xx Series
-generated_from_pack: true
+name: TLE988x_9x Series
+generated_from_pack: false
 pack_file_release: 1.3.0
 variants:
 - name: TLE9881_2QTW60

--- a/probe-rs/targets/TLE98xx_Series.yaml
+++ b/probe-rs/targets/TLE98xx_Series.yaml
@@ -1,0 +1,621 @@
+name: TLE98xx Series
+generated_from_pack: true
+pack_file_release: 1.3.0
+variants:
+- name: TLE9881_2QTW60
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: Flash0
+    range:
+      start: 0x11000000
+      end: 0x11006000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: Flash1
+    range:
+      start: 0x12002000
+      end: 0x12020000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: PSRAM
+    range:
+      start: 0x18000000
+      end: 0x18002000
+    cores:
+    - main
+  - !Ram
+    name: DSRAM
+    range:
+      start: 0x18002000
+      end: 0x18004000
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9881_flash0_ubsl
+  - tle9881_flash0_dataflash
+  - tle9883_flash1
+- name: TLE9883QTA62
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: Flash0
+    range:
+      start: 0x11000000
+      end: 0x11006000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: Flash1
+    range:
+      start: 0x12002000
+      end: 0x12040000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: PSRAM
+    range:
+      start: 0x18000000
+      end: 0x18002000
+    cores:
+    - main
+  - !Ram
+    name: DSRAM
+    range:
+      start: 0x18002000
+      end: 0x18007c00
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9881_flash0_ubsl
+  - tle9881_flash0_dataflash
+  - tle9883_flash1
+- name: TLE9883_2QTW62S
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: Flash0
+    range:
+      start: 0x11000000
+      end: 0x11006000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: Flash1
+    range:
+      start: 0x12002000
+      end: 0x12040000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: PSRAM
+    range:
+      start: 0x18000000
+      end: 0x18002000
+    cores:
+    - main
+  - !Ram
+    name: DSRAM
+    range:
+      start: 0x18002000
+      end: 0x18007c00
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9881_flash0_ubsl
+  - tle9881_flash0_dataflash
+  - tle9883_flash1
+- name: TLE9891QTA61
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: Flash0
+    range:
+      start: 0x11000000
+      end: 0x11006000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: Flash1
+    range:
+      start: 0x12002000
+      end: 0x12020000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: PSRAM
+    range:
+      start: 0x18000000
+      end: 0x18002000
+    cores:
+    - main
+  - !Ram
+    name: DSRAM
+    range:
+      start: 0x18002000
+      end: 0x18004000
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9881_flash0_ubsl
+  - tle9881_flash0_dataflash
+  - tle9891_flash1
+- name: TLE9891_2QTW60
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: Flash0
+    range:
+      start: 0x11000000
+      end: 0x11006000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: Flash1
+    range:
+      start: 0x12002000
+      end: 0x12020000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: PSRAM
+    range:
+      start: 0x18000000
+      end: 0x18002000
+    cores:
+    - main
+  - !Ram
+    name: DSRAM
+    range:
+      start: 0x18002000
+      end: 0x18004000
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9881_flash0_ubsl
+  - tle9881_flash0_dataflash
+  - tle9891_flash1
+- name: TLE9891_2QTW61
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: Flash0
+    range:
+      start: 0x11000000
+      end: 0x11006000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: Flash1
+    range:
+      start: 0x12002000
+      end: 0x12020000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: PSRAM
+    range:
+      start: 0x18000000
+      end: 0x18002000
+    cores:
+    - main
+  - !Ram
+    name: DSRAM
+    range:
+      start: 0x18002000
+      end: 0x18004000
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9881_flash0_ubsl
+  - tle9881_flash0_dataflash
+  - tle9891_flash1
+- name: TLE9893QKW62S
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: Flash0
+    range:
+      start: 0x11000000
+      end: 0x11006000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: Flash1
+    range:
+      start: 0x12002000
+      end: 0x12040000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: PSRAM
+    range:
+      start: 0x18000000
+      end: 0x18002000
+    cores:
+    - main
+  - !Ram
+    name: DSRAM
+    range:
+      start: 0x18002000
+      end: 0x18007c00
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9881_flash0_ubsl
+  - tle9893_flash0_dataflash
+  - tle9883_flash1
+- name: TLE9893_2QKW62S
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: Flash0
+    range:
+      start: 0x11000000
+      end: 0x11006000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: Flash1
+    range:
+      start: 0x12002000
+      end: 0x12040000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: PSRAM
+    range:
+      start: 0x18000000
+      end: 0x18002000
+    cores:
+    - main
+  - !Ram
+    name: DSRAM
+    range:
+      start: 0x18002000
+      end: 0x18007c00
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9881_flash0_ubsl
+  - tle9893_flash0_dataflash
+  - tle9883_flash1
+- name: TLE9893_2QTA62
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: Flash0
+    range:
+      start: 0x11000000
+      end: 0x11006000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: Flash1
+    range:
+      start: 0x12002000
+      end: 0x12040000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: PSRAM
+    range:
+      start: 0x18000000
+      end: 0x18002000
+    cores:
+    - main
+  - !Ram
+    name: DSRAM
+    range:
+      start: 0x18002000
+      end: 0x18007c00
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9881_flash0_ubsl
+  - tle9893_flash0_dataflash
+  - tle9883_flash1
+- name: TLE9893_2QTA62S
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: Flash0
+    range:
+      start: 0x11000000
+      end: 0x11006000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: Flash1
+    range:
+      start: 0x12002000
+      end: 0x12040000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: PSRAM
+    range:
+      start: 0x18000000
+      end: 0x18002000
+    cores:
+    - main
+  - !Ram
+    name: DSRAM
+    range:
+      start: 0x18002000
+      end: 0x18007c00
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9881_flash0_ubsl
+  - tle9893_flash0_dataflash
+  - tle9883_flash1
+- name: TLE9893_2QTW62S
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: Flash0
+    range:
+      start: 0x11000000
+      end: 0x11006000
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: Flash1
+    range:
+      start: 0x12002000
+      end: 0x12040000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: PSRAM
+    range:
+      start: 0x18000000
+      end: 0x18002000
+    cores:
+    - main
+  - !Ram
+    name: DSRAM
+    range:
+      start: 0x18002000
+      end: 0x18007c00
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9881_flash0_ubsl
+  - tle9893_flash0_dataflash
+  - tle9883_flash1
+flash_algorithms:
+- name: tle9881_flash0_ubsl
+  description: Infineon TLE988x/TLE989x Flash0 UBSL, V0.7.1
+  default: true
+  instructions: QLpwR8C6cEdP6jAAcEcAAAAgQWg2SKH1uEJIRBE6CND5IQFgQPIBEUFgCR2BYAAgcEdA8hURAWBA8iERQWCJHfTnACBwRwAgcEf+tf/34P/IuSdOAqpORAGpcGgwYTNoaEbzYJhHBUYAJE/wiFcG4DJpB+sEMAEhkEcFQ2QcAJiEQvXTBbEBJShG/r0QtQNG//e+/0C5FkgBIUhEQmgCYRhGkEcAKADQASAQvf61FUYORgdG//es/2C5DUwDIExEaUajaGNhAJXN6QFgOEaYRwAoANABIP69BeAQ+AE7k0IB0AEgcEdJHvfSACBwRwAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  pc_init: 0x43
+  pc_uninit: 0x47
+  pc_program_page: 0xad
+  pc_erase_sector: 0x8d
+  pc_erase_all: 0x4b
+  pc_blank_check: 0xd9
+  data_section_offset: 0xf4
+  flash_properties:
+    address_range:
+      start: 0x11000000
+      end: 0x11006000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: tle9881_flash0_dataflash
+  description: Infineon TLE988x/TLE989x Flash0 Dataflash, V0.7.1
+  default: true
+  instructions: QLpwR8C6cEdP6jAAcEcAAAAgQWg1SKH1uEJIRBE6CND5IQFgQPIBEUFgCR2BYAAgcEdA8hURAWBA8iERQWCJHfTnACBwRwAgcEf+tf/34P/AuSZOakZORAKpcGgwYTNoAajzYJhHBUYAJCFPBuAyaQfrBDABIZBHBUNkHACYhEL10wWxASUoRv69ELUDRv/3v/9AuRVIASFIREJoAmEYRpBHACgA0AEgEL3+tRVGDkYHRv/3rf9guQxMAyBMRGlGo2hjYQCVzekBYDhGmEcAKADQASD+vQXgEPgBO5NCAdABIHBHSR730gAgcEcEAAAAAGAAEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  pc_init: 0x43
+  pc_uninit: 0x47
+  pc_program_page: 0xab
+  pc_erase_sector: 0x8b
+  pc_erase_all: 0x4b
+  pc_blank_check: 0xd7
+  data_section_offset: 0xf4
+  flash_properties:
+    address_range:
+      start: 0x11006000
+      end: 0x11008000
+    page_size: 0x80
+    erased_byte_value: 0x0
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: tle9883_flash1
+  description: Infineon TLE988x/TLE989x Flash1, 248K, V0.7.1
+  default: true
+  instructions: QLpwR8C6cEdP6jAAcEcAAAAgQWg1SKH1uEJIRBE6CND5IQFgQPIBEUFgCR2BYAAgcEdA8hURAWBA8iERQWCJHfTnACBwRwAgcEf+tf/34P/AuSZOAqpORGlGcGgwYTNoAajzYJhHBUYAJCFPBuAyaQfrBDABIZBHBUNkHACYhEL10wWxASUoRv69ELUDRv/3v/9AuRVIASFIREJoAmEYRpBHACgA0AEgEL3+tRVGDkYHRv/3rf9guQxMAyBMRGlGo2hjYQCVzekBYDhGmEcAKADQASD+vQXgEPgBO5NCAdABIHBHSR730gAgcEcEAAAAACAAEgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  pc_init: 0x43
+  pc_uninit: 0x47
+  pc_program_page: 0xab
+  pc_erase_sector: 0x8b
+  pc_erase_all: 0x4b
+  pc_blank_check: 0xd7
+  data_section_offset: 0xf4
+  flash_properties:
+    address_range:
+      start: 0x12002000
+      end: 0x12040000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: tle9891_flash1
+  description: Infineon TLE988x/TLE989x Flash1, 120K, V0.7.1
+  default: true
+  instructions: QLpwR8C6cEdP6jAAcEcAAAAgQWg1SKH1uEJIRBE6CND5IQFgQPIBEUFgCR2BYAAgcEdA8hURAWBA8iERQWCJHfTnACBwRwAgcEf+tf/34P/AuSZOakZORAKpcGgwYTNoAajzYJhHBUYAJCFPBuAyaQfrBDABIZBHBUNkHACYhEL10wWxASUoRv69ELUDRv/3v/9AuRVIASFIREJoAmEYRpBHACgA0AEgEL3+tRVGDkYHRv/3rf9guQxMAyBMRGlGo2hjYQCVzekBYDhGmEcAKADQASD+vQXgEPgBO5NCAdABIHBHSR730gAgcEcEAAAAAGAAEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  pc_init: 0x43
+  pc_uninit: 0x47
+  pc_program_page: 0xab
+  pc_erase_sector: 0x8b
+  pc_erase_all: 0x4b
+  pc_blank_check: 0xd7
+  data_section_offset: 0xf4
+  flash_properties:
+    address_range:
+      start: 0x12002000
+      end: 0x12020000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: tle9893_flash0_dataflash
+  description: Infineon TLE988x/TLE989x Flash0 Dataflash, V0.7.1
+  default: true
+  instructions: QLpwR8C6cEdP6jAAcEcAAAAgQWg2SKH1uEJIRBE6CND5IQFgQPIBEUFgCR2BYAAgcEdA8hURAWBA8iERQWCJHfTnACBwRwAgcEf+tf/34P/IuSdOAqpORAGpcGgwYTNoaEbzYJhHBUYAJE/wiFcG4DJpB+sEMAEhkEcFQ2QcAJiEQvXTBbEBJShG/r0QtQNG//e+/0C5FkgBIUhEQmgCYRhGkEcAKADQASAQvf61FUYORgdG//es/2C5DUwDIExEaUajaGNhAJXN6QFgOEaYRwAoANABIP69BeAQ+AE7k0IB0AEgcEdJHvfSACBwRwAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  pc_init: 0x43
+  pc_uninit: 0x47
+  pc_program_page: 0xad
+  pc_erase_sector: 0x8d
+  pc_erase_all: 0x4b
+  pc_blank_check: 0xd9
+  data_section_offset: 0xf4
+  flash_properties:
+    address_range:
+      start: 0x11006000
+      end: 0x11008000
+    page_size: 0x80
+    erased_byte_value: 0x0
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0

--- a/probe-rs/targets/TLE98xx_Series.yaml
+++ b/probe-rs/targets/TLE98xx_Series.yaml
@@ -1,0 +1,789 @@
+name: TLE98xx Series
+generated_from_pack: true
+pack_file_release: 1.6.2
+variants:
+- name: TLE9871QXA20
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x11000000
+      end: 0x11007ffc
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM2
+    range:
+      start: 0x11007ffc
+      end: 0x11009000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x18000000
+      end: 0x18000010
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x18000018
+      end: 0x18000c00
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9871
+  - tle9871_eep
+- name: TLE9872-2QXA40
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x11000000
+      end: 0x1103effc
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM2
+    range:
+      start: 0x1103effc
+      end: 0x11040000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x18000000
+      end: 0x18000014
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x18000018
+      end: 0x18002000
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9872
+  - tle9872_eep
+- name: TLE9872QTW40
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x11000000
+      end: 0x1103effc
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM2
+    range:
+      start: 0x1103effc
+      end: 0x11040000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x18000000
+      end: 0x18000014
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x18000018
+      end: 0x18002000
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9872
+  - tle9872_eep
+- name: TLE9872QXA40
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x11000000
+      end: 0x1103effc
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM2
+    range:
+      start: 0x1103effc
+      end: 0x11040000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x18000000
+      end: 0x18000014
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x18000018
+      end: 0x18002000
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9872
+  - tle9872_eep
+- name: TLE9873QXW40
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x11000000
+      end: 0x1100affc
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM2
+    range:
+      start: 0x1100affc
+      end: 0x1100c000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x18000000
+      end: 0x18000014
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x18000018
+      end: 0x18000c00
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9873
+  - tle9873_eep
+- name: TLE9877QTW40
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x11000000
+      end: 0x1100effc
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM2
+    range:
+      start: 0x1100effc
+      end: 0x11010000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x18000000
+      end: 0x18000010
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x18000018
+      end: 0x18001800
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9877
+  - tle9877_eep
+- name: TLE9877QXA40
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x11000000
+      end: 0x1100effc
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM2
+    range:
+      start: 0x1100effc
+      end: 0x11010000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x18000000
+      end: 0x18000010
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x18000018
+      end: 0x18001800
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9877
+  - tle9877_eep
+- name: TLE9877QXW40
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x11000000
+      end: 0x1100effc
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM2
+    range:
+      start: 0x1100effc
+      end: 0x11010000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x18000000
+      end: 0x18000014
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x18000018
+      end: 0x18001800
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9877
+  - tle9877_eep
+- name: TLE9879-2QXA40
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x11000000
+      end: 0x1101effc
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM2
+    range:
+      start: 0x1101effc
+      end: 0x11020000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x18000000
+      end: 0x18000014
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x18000018
+      end: 0x18001800
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9879
+  - tle9879_eep
+- name: TLE9879QTW40
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x11000000
+      end: 0x1101effc
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM2
+    range:
+      start: 0x1101effc
+      end: 0x11020000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x18000000
+      end: 0x18000014
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x18000018
+      end: 0x18001800
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9879
+  - tle9879_eep
+- name: TLE9879QXA40
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x11000000
+      end: 0x1101effc
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM2
+    range:
+      start: 0x1101effc
+      end: 0x11020000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x18000000
+      end: 0x18000010
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x18000018
+      end: 0x18001800
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9879
+  - tle9879_eep
+- name: TLE9879QXW40
+  cores:
+  - name: main
+    type: armv7m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x11000000
+      end: 0x1101effc
+    cores:
+    - main
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM2
+    range:
+      start: 0x1101effc
+      end: 0x11020000
+    cores:
+    - main
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x18000000
+      end: 0x18000014
+    cores:
+    - main
+    access:
+      execute: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x18000018
+      end: 0x18001800
+    cores:
+    - main
+    access:
+      execute: false
+  flash_algorithms:
+  - tle9879
+  - tle9879_eep
+flash_algorithms:
+- name: tle9871
+  description: Infineon TLE9871, 32kB Flash
+  default: true
+  instructions: ACBwRwAgcEdwtR9NQ/ZlAE1EACRP8IhWaGBpaAbrBDCIR2QcCCz403C9F0pD9mUBSkRRYAhHLenwQRNPFUZPREP21QIORvpgQ/blATlgQ/bdAgRGumCIRwAgAuApXCFUQBywQvrTuWi96PBBAiAIRwXgEPgBO5NCAdABIHBHSR730gAgcEcAAAQAAAAdOQAADTkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  pc_init: 0x1
+  pc_uninit: 0x5
+  pc_program_page: 0x37
+  pc_erase_sector: 0x2b
+  pc_erase_all: 0x9
+  pc_blank_check: 0x71
+  data_section_offset: 0x94
+  flash_properties:
+    address_range:
+      start: 0x11000000
+      end: 0x11008000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: tle9871_eep
+  description: Infineon TLE9871, 4kB EEPROM
+  default: true
+  instructions: ACBwRwAgcEcaSEP2ZQFIREFgGUgIRxdKQ/ZlAUpEUWAIRy3p8EETTxVGT0RD9tUCDkb6YEP25QE5YEP23QIERrpgiEcAIALgKVwhVEAcsEL607lovejwQQIgCEcF4BD4ATuTQgHQASBwR0ke99IAIHBHAAAEAAAAAIAAER05AAANOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x5
+  pc_program_page: 0x23
+  pc_erase_sector: 0x17
+  pc_erase_all: 0x9
+  pc_blank_check: 0x5d
+  data_section_offset: 0x84
+  flash_properties:
+    address_range:
+      start: 0x11008000
+      end: 0x11009000
+    page_size: 0x80
+    erased_byte_value: 0x0
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: tle9872
+  description: Infineon TLE9872, 252kB Flash
+  default: true
+  instructions: ACBwRwAgcEdwtR9NQ/ZlAE1EACRP8IhWaGBpaAbrBDCIR2QcPyz403C9F0pD9mUBSkRRYAhHLenwQRNPFUZPREP21QIORvpgQ/blATlgQ/bdAgRGumCIRwAgAuApXCFUQBywQvrTuWi96PBBAiAIRwXgEPgBO5NCAdABIHBHSR730gAgcEcAAAQAAAAdOQAADTkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  pc_init: 0x1
+  pc_uninit: 0x5
+  pc_program_page: 0x37
+  pc_erase_sector: 0x2b
+  pc_erase_all: 0x9
+  pc_blank_check: 0x71
+  data_section_offset: 0x94
+  flash_properties:
+    address_range:
+      start: 0x11000000
+      end: 0x1103f000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: tle9872_eep
+  description: Infineon TLE9872, 4kB EEPROM
+  default: true
+  instructions: ACBwRwAgcEcaSEP2ZQFIREFgGUgIRxdKQ/ZlAUpEUWAIRy3p8EETTxVGT0RD9tUCDkb6YEP25QE5YEP23QIERrpgiEcAIALgKVwhVEAcsEL607lovejwQQIgCEcF4BD4ATuTQgHQASBwR0ke99IAIHBHAAAEAAAAAPADER05AAANOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x5
+  pc_program_page: 0x23
+  pc_erase_sector: 0x17
+  pc_erase_all: 0x9
+  pc_blank_check: 0x5d
+  data_section_offset: 0x84
+  flash_properties:
+    address_range:
+      start: 0x1103f000
+      end: 0x11040000
+    page_size: 0x80
+    erased_byte_value: 0x0
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: tle9873
+  description: Infineon TLE9873, 44kB Flash
+  default: true
+  instructions: ACBwRwAgcEdwtR9NQ/ZlAE1EACRP8IhWaGBpaAbrBDCIR2QcCyz403C9F0pD9mUBSkRRYAhHLenwQRNPFUZPREP21QIORvpgQ/blATlgQ/bdAgRGumCIRwAgAuApXCFUQBywQvrTuWi96PBBAiAIRwXgEPgBO5NCAdABIHBHSR730gAgcEcAAAQAAAAdOQAADTkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  pc_init: 0x1
+  pc_uninit: 0x5
+  pc_program_page: 0x37
+  pc_erase_sector: 0x2b
+  pc_erase_all: 0x9
+  pc_blank_check: 0x71
+  data_section_offset: 0x94
+  flash_properties:
+    address_range:
+      start: 0x11000000
+      end: 0x1100b000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: tle9873_eep
+  description: Infineon TLE9873, 4kB EEPROM
+  default: true
+  instructions: ACBwRwAgcEcaSEP2ZQFIREFgGUgIRxdKQ/ZlAUpEUWAIRy3p8EETTxVGT0RD9tUCDkb6YEP25QE5YEP23QIERrpgiEcAIALgKVwhVEAcsEL607lovejwQQIgCEcF4BD4ATuTQgHQASBwR0ke99IAIHBHAAAEAAAAALAAER05AAANOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x5
+  pc_program_page: 0x23
+  pc_erase_sector: 0x17
+  pc_erase_all: 0x9
+  pc_blank_check: 0x5d
+  data_section_offset: 0x84
+  flash_properties:
+    address_range:
+      start: 0x1100b000
+      end: 0x1100c000
+    page_size: 0x80
+    erased_byte_value: 0x0
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: tle9877
+  description: Infineon TLE9877, 60kB Flash
+  default: true
+  instructions: ACBwRwAgcEdwtR9NQ/ZlAE1EACRP8IhWaGBpaAbrBDCIR2QcDyz403C9F0pD9mUBSkRRYAhHLenwQRNPFUZPREP21QIORvpgQ/blATlgQ/bdAgRGumCIRwAgAuApXCFUQBywQvrTuWi96PBBAiAIRwXgEPgBO5NCAdABIHBHSR730gAgcEcAAAQAAAAdOQAADTkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  pc_init: 0x1
+  pc_uninit: 0x5
+  pc_program_page: 0x37
+  pc_erase_sector: 0x2b
+  pc_erase_all: 0x9
+  pc_blank_check: 0x71
+  data_section_offset: 0x94
+  flash_properties:
+    address_range:
+      start: 0x11000000
+      end: 0x1100f000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: tle9877_eep
+  description: Infineon TLE9877, 4kB EEPROM
+  default: true
+  instructions: ACBwRwAgcEcaSEP2ZQFIREFgGUgIRxdKQ/ZlAUpEUWAIRy3p8EETTxVGT0RD9tUCDkb6YEP25QE5YEP23QIERrpgiEcAIALgKVwhVEAcsEL607lovejwQQIgCEcF4BD4ATuTQgHQASBwR0ke99IAIHBHAAAEAAAAAOAAER05AAANOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x5
+  pc_program_page: 0x23
+  pc_erase_sector: 0x17
+  pc_erase_all: 0x9
+  pc_blank_check: 0x5d
+  data_section_offset: 0x84
+  flash_properties:
+    address_range:
+      start: 0x1100f000
+      end: 0x11010000
+    page_size: 0x80
+    erased_byte_value: 0x0
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: tle9879
+  description: Infineon TLE9879, 124kB Flash
+  default: true
+  instructions: ACBwRwAgcEdwtR9NQ/ZlAE1EACRP8IhWaGBpaAbrBDCIR2QcHyz403C9F0pD9mUBSkRRYAhHLenwQRNPFUZPREP21QIORvpgQ/blATlgQ/bdAgRGumCIRwAgAuApXCFUQBywQvrTuWi96PBBAiAIRwXgEPgBO5NCAdABIHBHSR730gAgcEcAAAQAAAAdOQAADTkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  pc_init: 0x1
+  pc_uninit: 0x5
+  pc_program_page: 0x37
+  pc_erase_sector: 0x2b
+  pc_erase_all: 0x9
+  pc_blank_check: 0x71
+  data_section_offset: 0x94
+  flash_properties:
+    address_range:
+      start: 0x11000000
+      end: 0x1101f000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: tle9879_eep
+  description: Infineon TLE9879, 4kB EEPROM
+  default: true
+  instructions: ACBwRwAgcEcaSEP2ZQFIREFgGUgIRxdKQ/ZlAUpEUWAIRy3p8EETTxVGT0RD9tUCDkb6YEP25QE5YEP23QIERrpgiEcAIALgKVwhVEAcsEL607lovejwQQIgCEcF4BD4ATuTQgHQASBwR0ke99IAIHBHAAAEAAAAAPABER05AAANOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x5
+  pc_program_page: 0x23
+  pc_erase_sector: 0x17
+  pc_erase_all: 0x9
+  pc_blank_check: 0x5d
+  data_section_offset: 0x84
+  flash_properties:
+    address_range:
+      start: 0x1101f000
+      end: 0x11020000
+    page_size: 0x80
+    erased_byte_value: 0x0
+    program_page_timeout: 1000
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x1000
+      address: 0x0

--- a/probe-rs/tests/flash_dry_run.rs
+++ b/probe-rs/tests/flash_dry_run.rs
@@ -48,3 +48,35 @@ fn flash_dry_run_mimxrt1010() {
         .commit(&mut session, flash_options)
         .expect("Failed to flash in dry run mode.");
 }
+
+/// TLE987x: the Bootstrap Loader NAC/NAD word lives in the last 4 bytes of code
+/// flash (0x11007ffc). Regression test for the IROM1/IROM2 boundary, which used
+/// to sit at 0x11007ffc and so straddled the code-flash (`tle9871`) and EEPROM
+/// (`tle9871_eep`) algorithm ranges, leaving no single algorithm able to cover
+/// the region (`NoFlashLoaderAlgorithmAttached`).
+#[test]
+fn flash_dry_run_tle9871_nac_nad() {
+    let probe = Probe::from_specific_probe(Box::new(FakeProbe::with_mocked_core()));
+
+    let mut session = probe
+        .attach("TLE9871QXA20", Permissions::default())
+        .expect("Failed to attach with 'fake' probe.");
+
+    let mut flasher = session.target().flash_loader();
+
+    // Vector table at flash origin + the NAC/NAD word at the very top of code flash.
+    flasher
+        .add_data(0x11000000, &[0x1, 0x2, 0x3, 0x4])
+        .expect("Failed to add flash");
+    flasher
+        .add_data(0x11007ffc, &[0x1, 0xfe, 0x7f, 0x80])
+        .expect("Failed to add flash");
+
+    let mut flash_options = DownloadOptions::new();
+
+    flash_options.dry_run = true;
+
+    flasher
+        .commit(&mut session, flash_options)
+        .expect("Failed to flash in dry run mode.");
+}


### PR DESCRIPTION
This PR adds support for Infineons TLE987x and TLE988x/9x device families.

The debug sequence is also applicable for other TLE devices, but those cmsis_pack files are not yet publicly available.

These boards come with an onboard XMC-Link which is basically a SEGGER JLink-lite. 

This PR also includes the necessary adaptions in the JLink debug probe to manually toggle the `TMS` and `TCK` pins which are required to enter the debug mode on TLE devices.
