### PR TITLE
fix(jlink): use legacy JTAG command for ARM Lite

### DIFF
--- a/changelog/fixed-jlink-arm-lite-v8-jtag.md
+++ b/changelog/fixed-jlink-arm-lite-v8-jtag.md
@@ -1,0 +1,1 @@
+Use the legacy JTAG command for J-Link ARM Lite probes to keep JTAG scans working.

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -192,6 +192,7 @@ impl ProbeFactory for JLinkFactory {
             speed_khz: 0, // default is unknown
             swd_settings: SwdSettings::default(),
             jtag_state: JtagDriverState::default(),
+            force_legacy_jtag_command: selector.product_id == 0x0101,
 
             jtag_tms_bits: vec![],
             jtag_tdi_bits: vec![],
@@ -388,6 +389,7 @@ pub struct JLink {
     jtag_capture_tdo: Vec<bool>,
     jtag_response: BitVec,
     jtag_state: JtagDriverState,
+    force_legacy_jtag_command: bool,
 
     /// max number of bits in a transfer chunk, when using JTAG
     jtag_chunk_size: usize,
@@ -741,7 +743,10 @@ impl JLink {
         // version 5 and above, which adds the 3rd command. Unfortunately we cannot reliably use the
         // HW version to determine this since some embedded J-Link probes have a HW version of
         // 1.0.0, but still support SWD, so we use the `SELECT_IF` capability instead.
-        let cmd = if self.caps.contains(Capability::SelectIf) {
+        // J-Link ARM Lite V8 (USB PID 0x0101) reports SELECT_IF, but returns an
+        // all-low TDO stream for HW_JTAG3 on macOS. HW_JTAG2 scans the same target
+        // chain correctly, matching SEGGER J-Link Commander/GDB Server.
+        let cmd = if self.caps.contains(Capability::SelectIf) && !self.force_legacy_jtag_command {
             // Use the new JTAG3 command, make sure to select the JTAG interface mode
             has_status_byte = true;
             Command::HwJtag3


### PR DESCRIPTION
## Summary

Use the legacy `HW_JTAG2` transfer command for J-Link ARM Lite devices with USB PID `0x0101` instead of selecting `HW_JTAG3` solely from the `SELECT_IF` capability.

## Problem

On macOS, a J-Link ARM Lite V8 reports `SELECT_IF`, so probe-rs currently chooses `HW_JTAG3` for JTAG bit transfers. With this probe, the `HW_JTAG3` path returns an all-low/empty TDO stream during JTAG scan-chain detection. That makes probe-rs detect zero TAPs and later fail while trying to scan IR length.

Observed probe and target:

- J-Link ARM Lite V8
- USB VID:PID `1366:0101`
- Firmware: `J-Link ARM Lite V8 compiled Mar 14 2018 16:03:26`
- Target: generic Cortex-M3 over JTAG
- macOS host

probe-rs failure before this change:

```text
Invalid data length. IR bits: 0, expected: 0
```

SEGGER tools on the same host, probe, target, wiring, and speed can scan the chain correctly:

```text
J-Link found 1 JTAG device, Total IRLen = 4
JTAG ID: 0x4BA00477 (Cortex-M3)
```

## Fix

The J-Link backend already treats PID `0x0101` specially for JTAG transfer sizing. This change also marks that PID to use the legacy JTAG transfer command. With `HW_JTAG2`, the same probe scans the target chain correctly:

```text
J-Link JTAG scan chain: 1 device(s)
J-Link JTAG TAP #0 idcode=0x4BA00477 (ARM Ltd) ir_len=4
```

## Validation

Ran locally:

```text
cargo fmt --check -p probe-rs
cargo check -p probe-rs --no-default-features
cargo test -p probe-rs jlink --lib
```

Hardware validation was done through a downstream probe-rs consumer using this patch on the same macOS/J-Link ARM Lite V8 setup.
