### PR TITLE
Add support for XVC (Xilinx Virtual Cable) JTAG over TCP

### DIFF
--- a/changelog/added-xvc-jtag.md
+++ b/changelog/added-xvc-jtag.md
@@ -1,0 +1,1 @@
+Added support for XVC (Xilinx Virtual Cable) JTAG over TCP. Select an XVC server with `--probe 0000:0000:<host>:<port>`.

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -15,6 +15,7 @@ mod selector;
 pub mod sifliuart;
 pub mod stlink;
 pub mod wlink;
+pub mod xvc;
 
 use crate::architecture::arm::sequences::{ArmDebugSequence, DefaultArmSequence};
 use crate::architecture::arm::{ArmDebugInterface, ArmError};
@@ -55,6 +56,7 @@ static DRIVERS: LazyLock<RwLock<Vec<&'static dyn ProbeFactory>>> = LazyLock::new
         &sifliuart::SifliUartFactory,
         &glasgow::GlasgowFactory,
         &ch347usbjtag::Ch347UsbJtagFactory,
+        &xvc::XvcFactory,
     ];
 
     RwLock::new(probes)

--- a/probe-rs/src/probe/xvc/mod.rs
+++ b/probe-rs/src/probe/xvc/mod.rs
@@ -1,0 +1,253 @@
+//! XVC (Xilinx Virtual Cable) JTAG probe support.
+//!
+//! XVC tunnels JTAG over TCP, allowing probe-rs to drive a TAP exposed by a
+//! remote XVC server (for example an FPGA-based bridge or `hw_server`).
+//!
+//! Because XVC is a network protocol with no USB identity, the probe cannot be
+//! auto-discovered. Select it explicitly by passing the placeholder USB id
+//! `0000:0000` together with the server address as the "serial number", e.g.
+//!
+//! ```text
+//! probe-rs ... --probe 0000:0000:192.168.1.123:2542
+//! ```
+//!
+//! The port defaults to 2542 when omitted (`--probe 0:0:192.168.1.123`).
+
+mod protocol;
+
+use std::sync::Arc;
+
+use protocol::XvcDevice;
+
+use crate::{
+    architecture::{
+        arm::{
+            ArmCommunicationInterface, ArmDebugInterface, ArmError,
+            communication_interface::DapProbe, sequences::ArmDebugSequence,
+        },
+        riscv::{
+            communication_interface::{RiscvError, RiscvInterfaceBuilder},
+            dtm::jtag_dtm::JtagDtmBuilder,
+        },
+        xtensa::communication_interface::{
+            XtensaCommunicationInterface, XtensaDebugInterfaceState, XtensaError,
+        },
+    },
+    probe::{
+        AutoImplementJtagAccess, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
+        IoSequenceItem, JtagAccess, JtagDriverState, ProbeFactory, RawJtagIo, RawSwdIo,
+        SwdSettings, WireProtocol,
+    },
+};
+
+/// Placeholder USB vendor id used to select an XVC probe.
+///
+/// XVC has no USB identity; this value only serves to route a
+/// [`DebugProbeSelector`] to the XVC driver.
+pub(crate) const XVC_VID: u16 = 0x0000;
+
+/// Placeholder USB product id used to select an XVC probe.
+pub(crate) const XVC_PID: u16 = 0x0000;
+
+/// A factory for creating [`XvcProbe`] instances.
+#[derive(Debug)]
+pub struct XvcFactory;
+
+impl std::fmt::Display for XvcFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("XVC")
+    }
+}
+
+impl ProbeFactory for XvcFactory {
+    fn open(&self, selector: &DebugProbeSelector) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
+        let device = XvcDevice::new_from_selector(selector)?;
+
+        Ok(Box::new(XvcProbe {
+            device,
+            jtag_state: JtagDriverState::default(),
+            swd_settings: SwdSettings::default(),
+        }))
+    }
+
+    fn list_probes(&self) -> Vec<DebugProbeInfo> {
+        // XVC servers are reached over the network and cannot be enumerated.
+        Vec::new()
+    }
+
+    fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+        // Surface exactly the requested probe when the selector explicitly
+        // targets an XVC endpoint (placeholder VID/PID plus a server address).
+        if let Some(selector) = selector
+            && selector.vendor_id == XVC_VID
+            && selector.product_id == XVC_PID
+            && let Some(address) = selector.serial_number.clone()
+            && !address.is_empty()
+        {
+            return vec![DebugProbeInfo {
+                identifier: "XVC".to_string(),
+                vendor_id: XVC_VID,
+                product_id: XVC_PID,
+                serial_number: Some(address),
+                probe_factory: &Self,
+                is_hid_interface: false,
+                interface: None,
+            }];
+        }
+
+        Vec::new()
+    }
+}
+
+/// An XVC (Xilinx Virtual Cable) debug probe.
+#[derive(Debug)]
+pub struct XvcProbe {
+    device: XvcDevice,
+    jtag_state: JtagDriverState,
+    swd_settings: SwdSettings,
+}
+
+impl DebugProbe for XvcProbe {
+    fn get_name(&self) -> &str {
+        "XVC"
+    }
+
+    fn speed_khz(&self) -> u32 {
+        self.device.speed_khz()
+    }
+
+    fn set_speed(&mut self, speed_khz: u32) -> Result<u32, DebugProbeError> {
+        Ok(self.device.set_speed_khz(speed_khz))
+    }
+
+    fn attach(&mut self) -> Result<(), DebugProbeError> {
+        // The TCP connection is established when the probe is opened, so there
+        // is nothing to initialize here.
+        Ok(())
+    }
+
+    fn detach(&mut self) -> Result<(), crate::Error> {
+        Ok(())
+    }
+
+    fn target_reset(&mut self) -> Result<(), DebugProbeError> {
+        Err(DebugProbeError::NotImplemented {
+            function_name: "target_reset",
+        })
+    }
+
+    fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
+        Err(DebugProbeError::NotImplemented {
+            function_name: "target_reset_assert",
+        })
+    }
+
+    fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {
+        Err(DebugProbeError::NotImplemented {
+            function_name: "target_reset_deassert",
+        })
+    }
+
+    fn select_protocol(&mut self, protocol: WireProtocol) -> Result<(), DebugProbeError> {
+        if protocol != WireProtocol::Jtag {
+            Err(DebugProbeError::UnsupportedProtocol(protocol))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn active_protocol(&self) -> Option<WireProtocol> {
+        // XVC only carries JTAG.
+        Some(WireProtocol::Jtag)
+    }
+
+    fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
+    }
+
+    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JtagAccess> {
+        Some(self)
+    }
+
+    fn has_arm_interface(&self) -> bool {
+        true
+    }
+
+    fn try_get_arm_debug_interface<'probe>(
+        self: Box<Self>,
+        sequence: Arc<dyn ArmDebugSequence>,
+    ) -> Result<Box<dyn ArmDebugInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
+        Ok(ArmCommunicationInterface::create(self, sequence, true))
+    }
+
+    fn has_riscv_interface(&self) -> bool {
+        true
+    }
+
+    fn try_get_riscv_interface_builder<'probe>(
+        &'probe mut self,
+    ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, RiscvError> {
+        Ok(Box::new(JtagDtmBuilder::new(self)))
+    }
+
+    fn has_xtensa_interface(&self) -> bool {
+        true
+    }
+
+    fn try_get_xtensa_interface<'probe>(
+        &'probe mut self,
+        state: &'probe mut XtensaDebugInterfaceState,
+    ) -> Result<XtensaCommunicationInterface<'probe>, XtensaError> {
+        Ok(XtensaCommunicationInterface::new(self, state))
+    }
+}
+
+impl AutoImplementJtagAccess for XvcProbe {}
+impl DapProbe for XvcProbe {}
+
+impl RawJtagIo for XvcProbe {
+    fn shift_bit(&mut self, tms: bool, tdi: bool, capture: bool) -> Result<(), DebugProbeError> {
+        self.jtag_state.state.update(tms);
+        self.device.shift_bit(tms, tdi, capture)?;
+        Ok(())
+    }
+
+    fn read_captured_bits(&mut self) -> Result<bitvec::prelude::BitVec, DebugProbeError> {
+        self.device.read_captured_bits()
+    }
+
+    fn state_mut(&mut self) -> &mut JtagDriverState {
+        &mut self.jtag_state
+    }
+
+    fn state(&self) -> &JtagDriverState {
+        &self.jtag_state
+    }
+}
+
+impl RawSwdIo for XvcProbe {
+    fn swd_io<S>(&mut self, _swdio: S) -> Result<Vec<bool>, DebugProbeError>
+    where
+        S: IntoIterator<Item = IoSequenceItem>,
+    {
+        // XVC is a JTAG-only transport.
+        Err(DebugProbeError::NotImplemented {
+            function_name: "swd_io",
+        })
+    }
+
+    fn swj_pins(
+        &mut self,
+        _pin_out: u32,
+        _pin_select: u32,
+        _pin_wait: u32,
+    ) -> Result<u32, DebugProbeError> {
+        Err(DebugProbeError::CommandNotSupportedByProbe {
+            command_name: "swj_pins",
+        })
+    }
+
+    fn swd_settings(&self) -> &SwdSettings {
+        &self.swd_settings
+    }
+}

--- a/probe-rs/src/probe/xvc/mod.rs
+++ b/probe-rs/src/probe/xvc/mod.rs
@@ -1,0 +1,253 @@
+//! XVC (Xilinx Virtual Cable) JTAG probe support.
+//!
+//! XVC tunnels JTAG over TCP, allowing probe-rs to drive a TAP exposed by a
+//! remote XVC server (for example an FPGA-based bridge or `hw_server`).
+//!
+//! Because XVC is a network protocol with no USB identity, the probe cannot be
+//! auto-discovered. Select it explicitly by passing the placeholder USB id
+//! `0000:0000` together with the server address as the "serial number", e.g.
+//!
+//! ```text
+//! probe-rs ... --probe 0000:0000:192.168.1.123:2542
+//! ```
+//!
+//! The port defaults to 2542 when omitted (`--probe 0:0:192.168.1.123`).
+
+mod protocol;
+
+use std::sync::Arc;
+
+use protocol::XvcDevice;
+
+use crate::{
+    architecture::{
+        arm::{
+            ArmCommunicationInterface, ArmDebugInterface, ArmError,
+            communication_interface::DapProbe, sequences::ArmDebugSequence,
+        },
+        riscv::{
+            communication_interface::{RiscvError, RiscvInterfaceBuilder},
+            dtm::jtag_dtm::JtagDtmBuilder,
+        },
+        xtensa::communication_interface::{
+            XtensaCommunicationInterface, XtensaDebugInterfaceState, XtensaError,
+        },
+    },
+    probe::{
+        AutoImplementJtagAccess, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
+        IoSequenceItem, JtagAccess, JtagDriverState, ProbeFactory, RawJtagIo, RawSwdIo,
+        SwdSettings, WireProtocol, list::ProbeListItem,
+    },
+};
+
+/// Placeholder USB vendor id used to select an XVC probe.
+///
+/// XVC has no USB identity; this value only serves to route a
+/// [`DebugProbeSelector`] to the XVC driver.
+pub(crate) const XVC_VID: u16 = 0x0000;
+
+/// Placeholder USB product id used to select an XVC probe.
+pub(crate) const XVC_PID: u16 = 0x0000;
+
+/// A factory for creating [`XvcProbe`] instances.
+#[derive(Debug)]
+pub struct XvcFactory;
+
+impl std::fmt::Display for XvcFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("XVC")
+    }
+}
+
+impl ProbeFactory for XvcFactory {
+    fn open(&self, selector: &DebugProbeSelector) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
+        let device = XvcDevice::new_from_selector(selector)?;
+
+        Ok(Box::new(XvcProbe {
+            device,
+            jtag_state: JtagDriverState::default(),
+            swd_settings: SwdSettings::default(),
+        }))
+    }
+
+    fn list_probes(&self) -> Vec<ProbeListItem> {
+        // XVC servers are reached over the network and cannot be enumerated.
+        Vec::new()
+    }
+
+    fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<ProbeListItem> {
+        // Surface exactly the requested probe when the selector explicitly
+        // targets an XVC endpoint (placeholder VID/PID plus a server address).
+        if let Some(selector) = selector
+            && selector.vendor_id == XVC_VID
+            && selector.product_id == XVC_PID
+            && let Some(address) = selector.serial_number.clone()
+            && !address.is_empty()
+        {
+            return vec![ProbeListItem::accessible(DebugProbeInfo {
+                identifier: "XVC".to_string(),
+                vendor_id: XVC_VID,
+                product_id: XVC_PID,
+                serial_number: Some(address),
+                probe_factory: &Self,
+                is_hid_interface: false,
+                interface: None,
+            })];
+        }
+
+        Vec::new()
+    }
+}
+
+/// An XVC (Xilinx Virtual Cable) debug probe.
+#[derive(Debug)]
+pub struct XvcProbe {
+    device: XvcDevice,
+    jtag_state: JtagDriverState,
+    swd_settings: SwdSettings,
+}
+
+impl DebugProbe for XvcProbe {
+    fn get_name(&self) -> &str {
+        "XVC"
+    }
+
+    fn speed_khz(&self) -> u32 {
+        self.device.speed_khz()
+    }
+
+    fn set_speed(&mut self, speed_khz: u32) -> Result<u32, DebugProbeError> {
+        Ok(self.device.set_speed_khz(speed_khz))
+    }
+
+    fn attach(&mut self) -> Result<(), DebugProbeError> {
+        // The TCP connection is established when the probe is opened, so there
+        // is nothing to initialize here.
+        Ok(())
+    }
+
+    fn detach(&mut self) -> Result<(), crate::Error> {
+        Ok(())
+    }
+
+    fn target_reset(&mut self) -> Result<(), DebugProbeError> {
+        Err(DebugProbeError::NotImplemented {
+            function_name: "target_reset",
+        })
+    }
+
+    fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
+        Err(DebugProbeError::NotImplemented {
+            function_name: "target_reset_assert",
+        })
+    }
+
+    fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {
+        Err(DebugProbeError::NotImplemented {
+            function_name: "target_reset_deassert",
+        })
+    }
+
+    fn select_protocol(&mut self, protocol: WireProtocol) -> Result<(), DebugProbeError> {
+        if protocol != WireProtocol::Jtag {
+            Err(DebugProbeError::UnsupportedProtocol(protocol))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn active_protocol(&self) -> Option<WireProtocol> {
+        // XVC only carries JTAG.
+        Some(WireProtocol::Jtag)
+    }
+
+    fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
+    }
+
+    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn JtagAccess> {
+        Some(self)
+    }
+
+    fn has_arm_interface(&self) -> bool {
+        true
+    }
+
+    fn try_get_arm_debug_interface<'probe>(
+        self: Box<Self>,
+        sequence: Arc<dyn ArmDebugSequence>,
+    ) -> Result<Box<dyn ArmDebugInterface + 'probe>, (Box<dyn DebugProbe>, ArmError)> {
+        Ok(ArmCommunicationInterface::create(self, sequence, true))
+    }
+
+    fn has_riscv_interface(&self) -> bool {
+        true
+    }
+
+    fn try_get_riscv_interface_builder<'probe>(
+        &'probe mut self,
+    ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, RiscvError> {
+        Ok(Box::new(JtagDtmBuilder::new(self)))
+    }
+
+    fn has_xtensa_interface(&self) -> bool {
+        true
+    }
+
+    fn try_get_xtensa_interface<'probe>(
+        &'probe mut self,
+        state: &'probe mut XtensaDebugInterfaceState,
+    ) -> Result<XtensaCommunicationInterface<'probe>, XtensaError> {
+        Ok(XtensaCommunicationInterface::new(self, state))
+    }
+}
+
+impl AutoImplementJtagAccess for XvcProbe {}
+impl DapProbe for XvcProbe {}
+
+impl RawJtagIo for XvcProbe {
+    fn shift_bit(&mut self, tms: bool, tdi: bool, capture: bool) -> Result<(), DebugProbeError> {
+        self.jtag_state.state.update(tms);
+        self.device.shift_bit(tms, tdi, capture)?;
+        Ok(())
+    }
+
+    fn read_captured_bits(&mut self) -> Result<bitvec::prelude::BitVec, DebugProbeError> {
+        self.device.read_captured_bits()
+    }
+
+    fn state_mut(&mut self) -> &mut JtagDriverState {
+        &mut self.jtag_state
+    }
+
+    fn state(&self) -> &JtagDriverState {
+        &self.jtag_state
+    }
+}
+
+impl RawSwdIo for XvcProbe {
+    fn swd_io<S>(&mut self, _swdio: S) -> Result<Vec<bool>, DebugProbeError>
+    where
+        S: IntoIterator<Item = IoSequenceItem>,
+    {
+        // XVC is a JTAG-only transport.
+        Err(DebugProbeError::NotImplemented {
+            function_name: "swd_io",
+        })
+    }
+
+    fn swj_pins(
+        &mut self,
+        _pin_out: u32,
+        _pin_select: u32,
+        _pin_wait: u32,
+    ) -> Result<u32, DebugProbeError> {
+        Err(DebugProbeError::CommandNotSupportedByProbe {
+            command_name: "swj_pins",
+        })
+    }
+
+    fn swd_settings(&self) -> &SwdSettings {
+        &self.swd_settings
+    }
+}

--- a/probe-rs/src/probe/xvc/protocol.rs
+++ b/probe-rs/src/probe/xvc/protocol.rs
@@ -1,0 +1,266 @@
+//! XVC (Xilinx Virtual Cable) wire protocol.
+//!
+//! XVC is a small TCP-based protocol that tunnels JTAG over a network
+//! connection. It only defines three commands:
+//!
+//! - `getinfo:` returns the server version and the maximum vector length
+//!   (in bytes) that can be shifted in a single operation.
+//! - `settck:<period>` sets the TCK period in nanoseconds.
+//! - `shift:<num_bits><tms><tdi>` clocks `num_bits` bits through the TAP and
+//!   returns the sampled TDO bits.
+//!
+//! For each command the bit vectors are LSB-first, packed into
+//! `ceil(num_bits / 8)` bytes. This module buffers individual bits and flushes
+//! them to the server in batches using a single `shift:` command.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+use bitvec::prelude::*;
+
+use crate::probe::{DebugProbeError, DebugProbeSelector, ProbeCreationError, ProbeError};
+
+use super::{XVC_PID, XVC_VID};
+
+/// Default TCP port used by XVC servers.
+const DEFAULT_PORT: u16 = 2542;
+
+/// Lower bound applied to the buffer size reported by `getinfo:`.
+const MIN_SHIFT_BITS: usize = 64;
+
+/// Upper bound applied to the buffer size reported by `getinfo:`, to guard
+/// against pathological allocations.
+const MAX_SHIFT_BITS: usize = 64 * 1024 * 8;
+
+/// How long to wait for the server's reply to the `getinfo:` handshake before
+/// concluding that the peer is not an XVC server.
+const GETINFO_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Errors specific to the XVC probe.
+#[derive(Debug, thiserror::Error)]
+pub enum XvcError {
+    /// The server address could not be parsed.
+    #[error("Invalid XVC server address {0:?}. Expected \"<host>\" or \"<host>:<port>\".")]
+    InvalidAddress(String),
+
+    /// Communication with the XVC server failed.
+    #[error("Failed to communicate with the XVC server: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The server sent a response that could not be understood.
+    #[error("Unexpected response from the XVC server: {0}")]
+    Protocol(String),
+}
+
+impl ProbeError for XvcError {}
+
+/// A connection to an XVC server.
+pub struct XvcDevice {
+    stream: TcpStream,
+    address: String,
+
+    /// Maximum number of bits that can be shifted in a single `shift:` command.
+    max_shift_bits: usize,
+    speed_khz: u32,
+
+    /// Pending TMS bits, packed for direct transmission.
+    tms: BitVec<u8, Lsb0>,
+    /// Pending TDI bits, packed for direct transmission.
+    tdi: BitVec<u8, Lsb0>,
+    /// For each pending bit, whether its TDO output should be captured.
+    capture: BitVec<u8, Lsb0>,
+    /// Captured TDO bits, waiting to be read out.
+    response: BitVec,
+}
+
+impl std::fmt::Debug for XvcDevice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("XvcDevice")
+            .field("address", &self.address)
+            .field("max_shift_bits", &self.max_shift_bits)
+            .field("speed_khz", &self.speed_khz)
+            .finish()
+    }
+}
+
+impl XvcDevice {
+    pub(crate) fn new_from_selector(
+        selector: &DebugProbeSelector,
+    ) -> Result<Self, ProbeCreationError> {
+        // Only handle selectors that explicitly target an XVC endpoint, so that
+        // we never try to open a TCP connection for unrelated probes.
+        if selector.vendor_id != XVC_VID || selector.product_id != XVC_PID {
+            return Err(ProbeCreationError::NotFound);
+        }
+
+        let Some(serial) = selector.serial_number.as_deref() else {
+            return Err(ProbeCreationError::NotFound);
+        };
+
+        let address = normalize_address(serial)?;
+
+        let mut stream = TcpStream::connect(&address).map_err(XvcError::from)?;
+        // Disable Nagle's algorithm: XVC is a strict request/response protocol,
+        // so batching writes only adds latency.
+        stream.set_nodelay(true).map_err(XvcError::from)?;
+
+        tracing::info!("Connected to {address}");
+
+        // Validate that the peer is actually an XVC server (and learn its shift
+        // buffer size) before sending any `shift:` commands.
+        let max_shift_bits = handshake(&mut stream)?;
+        tracing::debug!("XVC server at {address} reports a {max_shift_bits}-bit shift buffer");
+
+        Ok(Self {
+            stream,
+            address,
+            max_shift_bits,
+            speed_khz: 1000,
+            tms: BitVec::new(),
+            tdi: BitVec::new(),
+            capture: BitVec::new(),
+            response: BitVec::new(),
+        })
+    }
+
+    pub(crate) fn speed_khz(&self) -> u32 {
+        self.speed_khz
+    }
+
+    pub(crate) fn set_speed_khz(&mut self, speed_khz: u32) -> u32 {
+        // XVC defines a `settck:` command, but many minimal servers ignore it or
+        // do not implement it at all, so we only record the requested speed.
+        self.speed_khz = speed_khz;
+        self.speed_khz
+    }
+
+    /// Buffers a single bit, flushing first if the buffer is full.
+    pub(crate) fn shift_bit(
+        &mut self,
+        tms: bool,
+        tdi: bool,
+        capture: bool,
+    ) -> Result<(), DebugProbeError> {
+        if self.tms.len() >= self.max_shift_bits {
+            self.flush()?;
+        }
+
+        self.tms.push(tms);
+        self.tdi.push(tdi);
+        self.capture.push(capture);
+
+        Ok(())
+    }
+
+    /// Flushes any pending bits and returns the captured TDO bits.
+    pub(crate) fn read_captured_bits(&mut self) -> Result<BitVec, DebugProbeError> {
+        self.flush()?;
+        Ok(std::mem::take(&mut self.response))
+    }
+
+    /// Sends all pending bits to the server with a single `shift:` command and
+    /// collects the requested TDO bits.
+    fn flush(&mut self) -> Result<(), DebugProbeError> {
+        let num_bits = self.tms.len();
+        if num_bits == 0 {
+            return Ok(());
+        }
+
+        // Zero the unused bits of the final byte so we transmit clean padding.
+        self.tms.set_uninitialized(false);
+        self.tdi.set_uninitialized(false);
+
+        let byte_len = num_bits.div_ceil(8);
+
+        let mut request = Vec::with_capacity(b"shift:".len() + 4 + byte_len * 2);
+        request.extend_from_slice(b"shift:");
+        request.extend_from_slice(&(num_bits as u32).to_le_bytes());
+        request.extend_from_slice(self.tms.as_raw_slice());
+        request.extend_from_slice(self.tdi.as_raw_slice());
+
+        self.stream
+            .write_all(&request)
+            .map_err(|e| DebugProbeError::from(XvcError::from(e)))?;
+
+        let mut tdo = vec![0u8; byte_len];
+        self.stream
+            .read_exact(&mut tdo)
+            .map_err(|e| DebugProbeError::from(XvcError::from(e)))?;
+
+        let tdo_bits = tdo.view_bits::<Lsb0>();
+        for index in 0..num_bits {
+            if self.capture[index] {
+                self.response.push(tdo_bits[index]);
+            }
+        }
+
+        self.tms.clear();
+        self.tdi.clear();
+        self.capture.clear();
+
+        Ok(())
+    }
+}
+
+/// Normalizes a user-supplied address into a `host:port` pair, applying the
+/// default XVC port when none is given.
+fn normalize_address(serial: &str) -> Result<String, XvcError> {
+    let serial = serial.trim();
+    if serial.is_empty() {
+        return Err(XvcError::InvalidAddress(serial.to_string()));
+    }
+
+    // A colon means the port (or an IPv6 literal such as `[::1]:2542`) is
+    // already present, so use the address verbatim. Otherwise append the
+    // default port.
+    if serial.contains(':') {
+        Ok(serial.to_string())
+    } else {
+        Ok(format!("{serial}:{DEFAULT_PORT}"))
+    }
+}
+
+/// Performs the XVC `getinfo:` handshake.
+///
+/// This both validates that the peer is an XVC server and returns the maximum
+/// number of bits that can be shifted in a single command. A missing or
+/// non-XVC reply is treated as a hard error, since it most likely means we
+/// connected to something that is not an XVC server at all.
+fn handshake(stream: &mut TcpStream) -> Result<usize, XvcError> {
+    // Bound the reply by a read timeout so a peer that never answers cannot make
+    // us hang. On any error below the connection is dropped, so we only need to
+    // restore blocking reads (for the shift operations) on the success path.
+    stream.set_read_timeout(Some(GETINFO_TIMEOUT))?;
+
+    stream.write_all(b"getinfo:")?;
+
+    // The reply has the form `xvcServer_v<version>:<max-bytes>\n`.
+    let mut buffer = [0u8; 64];
+    let read = stream.read(&mut buffer)?;
+    let response = String::from_utf8_lossy(&buffer[..read]);
+    let response = response.trim();
+
+    if !response.starts_with("xvcServer") {
+        return Err(XvcError::Protocol(format!(
+            "unexpected reply to `getinfo:` ({response:?}); is this an XVC server?"
+        )));
+    }
+
+    // The peer is confirmed to be an XVC server; parse its maximum shift length.
+    let max_bytes = response
+        .rsplit(':')
+        .next()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .ok_or_else(|| {
+            XvcError::Protocol(format!(
+                "could not parse the buffer size from the `getinfo:` reply ({response:?})"
+            ))
+        })?;
+
+    stream.set_read_timeout(None)?;
+
+    Ok(max_bytes
+        .saturating_mul(8)
+        .clamp(MIN_SHIFT_BITS, MAX_SHIFT_BITS))
+}


### PR DESCRIPTION
https://github.com/Xilinx/XilinxVirtualCable

There are many open-source and commercial probes that allow remote JTAG connection using XVC.
This is a client that allows connecting to such probes.

The protocol is very simple, just shifting TMS and TDI bits in order followed by TDO bits in reply,
it should be compatible with any target.

To select the probe pass the server address and port as a serial number:
```
probe-rs ... --probe 0000:0000:192.168.1.123:2542
```