### PR TITLE
smoke-tester: reset target on test failure

### DIFF
--- a/changelog/fixed-smoke-tester-panic-reset.md
+++ b/changelog/fixed-smoke-tester-panic-reset.md
@@ -1,0 +1,1 @@
+Fixed smoke-tester not resetting target as normal on panic

--- a/smoke-tester/src/main.rs
+++ b/smoke-tester/src/main.rs
@@ -1,4 +1,9 @@
-use std::{path::PathBuf, process::ExitCode, time::Duration};
+use std::{
+    panic::{AssertUnwindSafe, catch_unwind},
+    path::PathBuf,
+    process::ExitCode,
+    time::Duration,
+};
 
 use crate::dut_definition::DutDefinition;
 
@@ -142,15 +147,31 @@ fn run_test(mut args: Arguments, definitions: &[DutDefinition]) -> Result<ExitCo
 
                     core.reset_and_halt(Duration::from_millis(500))?;
 
-                    let result = (test_struct.test_fn)(&definition, &mut core);
+                    // Catch panics early so we can reset the core before libtest reports the failure.
+                    // Otherwise a panic during a test can leave the target in a different state than on success.
+                    let test_outcome = catch_unwind(AssertUnwindSafe(|| {
+                        (test_struct.test_fn)(&definition, &mut core)
+                    }));
 
                     // Ensure core is not running anymore.
-                    core.reset_and_halt(Duration::from_millis(200))
+                    let reset_result = core
+                        .reset_and_halt(Duration::from_millis(200))
                         .with_context(|| {
                             format!("Failed to reset core with index {core_index} after test")
-                        })?;
+                        });
 
-                    result
+                    match test_outcome {
+                        Ok(test_result) => {
+                            reset_result?;
+                            test_result
+                        }
+                        Err(payload) => {
+                            if let Err(err) = &reset_result {
+                                eprintln!("Failed to reset core with index {core_index} after panic: {err:#}");
+                            }
+                            std::panic::resume_unwind(payload)
+                        }
+                    }
                 })
                 .with_kind(&chip_name);
 


### PR DESCRIPTION
I noticed that when breaking one test in the smoke tester, others started failing.
If the test results in a panic we were no longer resetting the target afterwards.
This PR catches the panic, resets the target as per normal, then resumes panicking.

We do need better target recovery mechanisms, but this should at least improve feedback on which tests are actually broken.