### PR TITLE
probe-rs-debug: remove hardcoded 32-register DWARF ID limit

### DIFF
--- a/changelog/fixed-dwarf-register-limit.md
+++ b/changelog/fixed-dwarf-register-limit.md
@@ -1,0 +1,1 @@
+Fixed the hardcoded limit of 32 DWARF registers in debug unwinding.

--- a/probe-rs-debug/src/registers.rs
+++ b/probe-rs-debug/src/registers.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 pub struct DebugRegister {
     /// To lookup platform specific details of core register definitions.
     pub core_register: &'static CoreRegister,
-    /// [DWARF](https://dwarfstd.org) specification, section 2.6.1.1.3.1 "... operations encode the names of up to 32 registers, numbered from 0 through 31, inclusive ..."
+    /// The DWARF register ID, which maps to the register number in DWARF debugging information.
     pub dwarf_id: Option<u16>,
     /// The value of the register is read from the target memory and updated as needed.
     pub value: Option<RegisterValue>,
@@ -121,12 +121,7 @@ impl DebugRegisters {
             {
                 debug_registers.push(DebugRegister {
                     core_register,
-                    // The DWARF register ID is only valid for the first 32 registers.
-                    dwarf_id: if dwarf_id < 32 {
-                        Some(dwarf_id as u16)
-                    } else {
-                        None
-                    },
+                    dwarf_id: Some(dwarf_id as u16),
                     value: reg_value(&core_register.id()),
                 });
             } else {
@@ -208,8 +203,7 @@ impl DebugRegisters {
             .find(|debug_register| debug_register.core_register.id == register_id)
     }
 
-    /// Get the register value using the positional index into core registers.
-    /// [DWARF](https://dwarfstd.org) specification, section 2.6.1.1.3.1 "... operations encode the names of up to 32 registers, numbered from 0 through 31, inclusive ..."
+    /// Get the register value using the DWARF register ID.
     pub fn get_register_by_dwarf_id(&self, dwarf_id: u16) -> Option<&DebugRegister> {
         self.0
             .iter()

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32c3_full_unwind.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32c3_full_unwind.snap
@@ -1,6 +1,5 @@
 ---
 source: probe-rs-debug/src/debug_info.rs
-assertion_line: 1999
 expression: stack_frames
 ---
 - function_name: test_deep_stack
@@ -341,7 +340,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107350494
   pc:
@@ -684,7 +683,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107350506
   pc:
@@ -1027,7 +1026,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107350506
   pc:
@@ -1370,7 +1369,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107350506
   pc:
@@ -1713,7 +1712,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107350506
   pc:
@@ -2056,7 +2055,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107350506
   pc:
@@ -2399,7 +2398,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107350302
   pc:
@@ -5660,7 +5659,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107297626
   pc:
@@ -6593,7 +6592,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107304766
   pc:
@@ -6962,7 +6961,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107296514
   pc:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32c6_coredump_elf.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32c6_coredump_elf.snap
@@ -339,7 +339,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107300942
   pc:
@@ -819,7 +819,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107318002
   pc:
@@ -1143,7 +1143,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107318002
   pc:
@@ -1467,7 +1467,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107318002
   pc:
@@ -1791,7 +1791,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107296770
   pc:
@@ -2217,7 +2217,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107296770
   pc:
@@ -2657,7 +2657,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107296770
   pc:
@@ -3101,7 +3101,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107296770
   pc:
@@ -3541,7 +3541,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107317484
   pc:
@@ -3875,7 +3875,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107317484
   pc:
@@ -4218,7 +4218,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107317484
   pc:
@@ -4586,7 +4586,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107317484
   pc:
@@ -4920,7 +4920,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107317484
   pc:
@@ -5254,7 +5254,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107296836
   pc:
@@ -5673,7 +5673,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107297552
   pc:
@@ -6116,7 +6116,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107313548
   pc:
@@ -6482,7 +6482,7 @@ expression: stack_frames
           - ProgramCounter
         data_type:
           UnsignedInteger: 32
-      dwarf_id: ~
+      dwarf_id: 32
       value:
         U32: 1107296562
   pc:


### PR DESCRIPTION
### Description
Part of the plan discussed in #3835. This is Phase 1 only — a behavior-preserving change that removes the hardcoded assumption that DWARF register IDs only go up to 32. Phases 2 (RISC-V CSR DWARF definitions) and 3 (CSR read API) are separate follow-up work, not included here.

### Problem
`registers.rs` previously discarded any `dwarf_id >= 32`, based on a misreading of DWARF spec section 2.6.1.1.3.1 — that section describes the basic register operations (`DW_OP_reg0` to `DW_OP_reg31`), not a hard ceiling; `DW_OP_regx` supports arbitrary register numbers via LEB128. RISC-V relies on this: its `pc` register is index 32 in `RISCV_COMMON_REGS_SET`, so it was silently assigned `dwarf_id: None`, breaking `.cfi_register`-based unwind rules that reference it or higher-indexed CSRs.

### Changes
* Removed the `if dwarf_id < 32` cutoff in the register-mapping loop; `dwarf_id` is now always populated.
* Updated stale comments referencing the incorrect 32-register limit.

### Verification
* **Crate Tests:** Ran `cargo test -p probe-rs-debug` (unfiltered) — all 33 + 5 tests passed.
* **Workspace Tests:** Ran `cargo test --workspace` — all library and unit tests passed. *(Note: `smoke_tester` reports as a failure under this runner because it's a CLI binary requiring a `<DIRECTORY>` argument, not a real test. This is pre-existing and unrelated to this change.)*
* **Snapshot Analysis:** Ran with `INSTA_UPDATE=always` to surface any snapshot changes. Only two RISC-V snapshots changed (`esp32c3_full_unwind.snap` and `esp32c6_coredump_elf.snap`), both now correctly showing `dwarf_id: 32` for `pc` instead of `~`. ARM snapshots (e.g., `RP2040_full_unwind.snap`) are byte-identical — confirming zero behavioral change for ARM, as expected since ARM register sets are under 32 registers wide.