### PR TITLE
fix(silabs): raise EFM32PG1B flash page_size to 8K for faster flashing

### DIFF
--- a/changelog/changed-efm32pg1b-page-size.md
+++ b/changelog/changed-efm32pg1b-page-size.md
@@ -1,0 +1,1 @@
+Changed EFM32PG1B Series flash algorithm page size to 8192 bytes to speed up flashing.

--- a/probe-rs/targets/EFM32PG1B_Series.yaml
+++ b/probe-rs/targets/EFM32PG1B_Series.yaml
@@ -1,3 +1,6 @@
+# This file has been changed compared to the version as generated from the cmsispack.
+# * changed flash algorithm page_size to 8K to speed up flashing.
+
 name: EFM32PG1B Series
 manufacturer:
   id: 0x21
@@ -296,7 +299,7 @@ flash_algorithms:
     address_range:
       start: 0x0
       end: 0x40000
-    page_size: 0x400
+    page_size: 0x2000 # Changed to 8K from 1K to speed up flashing (J-Link/SWD, ~120kB download+verify: 14.6s -> 9.5s, -35%)
     erased_byte_value: 0xff
     program_page_timeout: 260
     erase_sector_timeout: 200


### PR DESCRIPTION
The cmsispack-generated page_size is 0x400 (1K). Raising it to 0x2000 (8K) reduces probe round trips during programming. Measured on J-Link over SWD with a ~120kB download+verify image: 14.6s -> 9.5s (-35%). 0x2000 is the knee of the curve; 0x4000 gives no further gain. Verified correct via read-back at every size up to 0x4000.

Mirrors the cmsispack-deviation style of the MIMXRT685S PR (#3409).