### PR TITLE
fix(debug): allow breakpoints in C++ by extending the prologue heuristic

### DIFF
--- a/changelog/fixed-cpp-prologue-breakpoints.md
+++ b/changelog/fixed-cpp-prologue-breakpoints.md
@@ -1,0 +1,1 @@
+Fixed breakpoints and stepping in C++ source files. The GDB-style prologue-end heuristic (used because GNU compilers do not emit `DW_LNS_set_prologue_end`) was gated to C only, so for C++ no line was ever classified as a valid breakpoint location.

--- a/probe-rs-debug/src/source_instructions.rs
+++ b/probe-rs-debug/src/source_instructions.rs
@@ -445,13 +445,22 @@ impl<'debug_info> InstructionSequence<'debug_info> {
                 prologue_completed = true;
             }
 
-            // For GNU C, it is known that the `DW_LNS_set_prologue_end` is not set, so we employ the same heuristic as GDB to determine when the prologue is complete.
-            // For other C compilers in the C99/11/17 standard, they will either set the `DW_LNS_set_prologue_end` or they will trigger this heuristic also.
+            // For GNU C/C++, it is known that `DW_LNS_set_prologue_end` is not emitted, so we employ the same heuristic as GDB to determine when the prologue is complete.
+            // For other C/C++ compilers, they will either set the `DW_LNS_set_prologue_end` or they will trigger this heuristic also.
+            // C++ must be included here: g++ omits prologue_end just like gcc, and without this every instruction is classified as Prologue, so no line ever becomes a valid breakpoint (HaltLocation) location.
             // See https://gcc.gnu.org/legacy-ml/gcc-patches/2011-03/msg02106.html
             if !prologue_completed
                 && matches!(
                     program_language,
-                    gimli::DW_LANG_C99 | gimli::DW_LANG_C11 | gimli::DW_LANG_C17
+                    gimli::DW_LANG_C99
+                        | gimli::DW_LANG_C11
+                        | gimli::DW_LANG_C17
+                        | gimli::DW_LANG_C_plus_plus
+                        | gimli::DW_LANG_C_plus_plus_03
+                        | gimli::DW_LANG_C_plus_plus_11
+                        | gimli::DW_LANG_C_plus_plus_14
+                        | gimli::DW_LANG_C_plus_plus_17
+                        | gimli::DW_LANG_C_plus_plus_20
                 )
                 && let Some(prev_row) = previous_row
                 && (row.end_sequence()


### PR DESCRIPTION
GNU compilers don't emit DW_LNS_set_prologue_end, so probe-rs falls back to a GDB-style heuristic to detect the prologue end -- but it was gated to C99/C11/C17. g++ omits prologue_end just like gcc, so for C++ units prologue_completed never flipped, every instruction was classified Prologue, no line ever became a HaltLocation, and breakpoints/stepping failed on all C++ files. Include the C++ language variants in the heuristic.

AI disclosure: Claude Code was used to generate this PR.