### PR TITLE
debug: fix bogus inline frame locations for cross-CU inlines

### DIFF
--- a/changelog/fixed-cross-cu-inline-call-location.md
+++ b/changelog/fixed-cross-cu-inline-call-location.md
@@ -1,0 +1,1 @@
+Fixed bogus source locations and `<unknown function>` names in backtraces for inlined functions whose abstract origin lives in another compilation unit. The `DW_AT_specification` of such a cross-unit abstract origin was resolved against the wrong unit, landing on an unrelated DIE and producing nonsensical line/column numbers.

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -965,11 +965,29 @@ impl DebugInfo {
     where
         'unit_info: 'debug_info,
     {
+        self.resolve_die_reference_with_unit_info(attribute, die, unit_info)
+            .map(|(_, die)| die)
+    }
+
+    /// Look up the DIE reference for the given attribute, returning both the resolved DIE
+    /// and the compilation unit it belongs to.
+    ///
+    /// The resolved unit can differ from `unit_info` when the reference crosses a compilation
+    /// unit boundary (`DW_FORM_ref_addr`). Callers that subsequently follow *unit-relative*
+    /// references (e.g. `DW_AT_specification`) from the resolved DIE must use the returned unit,
+    /// not the unit the reference originated from.
+    pub(crate) fn resolve_die_reference_with_unit_info<'debug_info, 'unit_info>(
+        &'debug_info self,
+        attribute: gimli::DwAt,
+        die: &Die,
+        unit_info: &'unit_info UnitInfo,
+    ) -> Option<(&'debug_info UnitInfo, Die)>
+    where
+        'unit_info: 'debug_info,
+    {
         let attr = die.attr(attribute)?;
 
-        self.resolve_die_reference_with_unit(attr, unit_info)
-            .ok()
-            .map(|(_, die)| die)
+        self.resolve_die_reference_with_unit(attr, unit_info).ok()
     }
 
     /// The program binary's (and core's) endianness.

--- a/probe-rs-debug/src/function_die.rs
+++ b/probe-rs-debug/src/function_die.rs
@@ -17,17 +17,23 @@ pub(crate) struct FunctionDie<'data> {
     pub(crate) unit_info: &'data UnitInfo,
     /// The DIE (Debugging Information Entry) for the function.
     pub(crate) function_die: Die,
-    /// The optional specification DIE for the function, if it has one.
+    /// The optional specification DIE for the function, if it has one, paired with the
+    /// compilation unit it belongs to.
     /// - For regular functions, this applies to the `function_die`.
     /// - For inlined functions, this applies to the `abstract_die`.
     ///
     /// The specification DIE will contain separately declared attributes,
     /// e.g. for the function name.
     /// See DWARF spec, 2.13.2.
-    pub(crate) specification_die: Option<Die>,
+    ///
+    /// The unit can differ from `unit_info`, because the abstract origin of an inlined
+    /// function may live in another compilation unit (cross-unit `DW_FORM_ref_addr`).
+    pub(crate) specification_die: Option<(&'data UnitInfo, Die)>,
     /// Only present for inlined functions, where this is a reference
-    /// to the declaration of the function.
-    pub(crate) abstract_die: Option<Die>,
+    /// to the declaration of the function, paired with the compilation unit it belongs to.
+    ///
+    /// The unit can differ from `unit_info` (cross-unit `DW_FORM_ref_addr`).
+    pub(crate) abstract_die: Option<(&'data UnitInfo, Die)>,
     /// The address ranges for which this function is valid.
     pub(crate) ranges: Vec<Range<u64>>,
 }
@@ -90,22 +96,29 @@ impl<'a> FunctionDie<'a> {
 
         // For inlined functions, we also need to find the abstract origin.
         let abstract_die = if is_inlined_function {
-            let Some(abstract_die) = debug_info.resolve_die_reference(
-                gimli::DW_AT_abstract_origin,
-                &function_die,
-                unit_info,
-            ) else {
+            let Some((abstract_unit, abstract_die)) = debug_info
+                .resolve_die_reference_with_unit_info(
+                    gimli::DW_AT_abstract_origin,
+                    &function_die,
+                    unit_info,
+                )
+            else {
                 tracing::debug!("No abstract origin found for inlined function");
                 return Ok(None);
             };
-            specification_die = debug_info.resolve_die_reference(
+            // The abstract origin may reside in a different compilation unit, referenced via a
+            // cross-unit `DW_FORM_ref_addr`. Its `DW_AT_specification`, however, is a
+            // *unit-relative* reference, so it must be resolved against the abstract origin's
+            // own unit. Resolving it against the concrete unit (`unit_info`) lands on an
+            // unrelated DIE and yields garbage attributes (e.g. nonsensical inline call_line).
+            specification_die = debug_info.resolve_die_reference_with_unit_info(
                 gimli::DW_AT_specification,
                 &abstract_die,
-                unit_info,
+                abstract_unit,
             );
-            Some(abstract_die)
+            Some((abstract_unit, abstract_die))
         } else {
-            specification_die = debug_info.resolve_die_reference(
+            specification_die = debug_info.resolve_die_reference_with_unit_info(
                 gimli::DW_AT_specification,
                 &function_die,
                 unit_info,
@@ -216,7 +229,7 @@ impl<'a> FunctionDie<'a> {
     ) -> Option<debug_info::GimliAttribute> {
         let attribute = collapsed_attribute(
             &self.function_die,
-            self.specification_die.as_ref(),
+            self.specification_die.as_ref().map(|(_, die)| die),
             attribute_name,
         );
 
@@ -226,11 +239,11 @@ impl<'a> FunctionDie<'a> {
 
         // For inlined function, the *abstract instance* has to be checked if we cannot find the
         // attribute on the *concrete instance*. The abstract instance my also be a reference to a specification.
-        if let Some(abstract_die) = &self.abstract_die {
+        if let Some((abstract_unit, abstract_die)) = &self.abstract_die {
             let inlined_specification_die = debug_info.resolve_die_reference(
                 gimli::DW_AT_specification,
                 abstract_die,
-                self.unit_info,
+                abstract_unit,
             );
             let inline_attribute = collapsed_attribute(
                 abstract_die,
@@ -268,15 +281,17 @@ impl<'a> FunctionDie<'a> {
         }
     }
 
-    pub(crate) fn parent_offset(&self) -> Option<UnitOffset> {
-        self.unit_info.parent_offset(self.spec_offset())
-    }
-
-    pub(crate) fn spec_offset(&self) -> UnitOffset {
-        self.specification_die
-            .as_ref()
-            .map(|d| d.offset())
-            .unwrap_or(self.function_die.offset())
+    /// Returns the parent DIE offset of the function's declaration, together with the unit
+    /// that offset is relative to.
+    ///
+    /// The declaration is the specification DIE if present (which may live in a different
+    /// compilation unit than `unit_info`), otherwise the concrete function DIE.
+    pub(crate) fn parent_offset(&self) -> Option<(&'a UnitInfo, UnitOffset)> {
+        let (unit, offset) = match &self.specification_die {
+            Some((unit, die)) => (*unit, die.offset()),
+            None => (self.unit_info, self.function_die.offset()),
+        };
+        unit.parent_offset(offset).map(|parent| (unit, parent))
     }
 }
 

--- a/probe-rs-debug/src/language/rust.rs
+++ b/probe-rs-debug/src/language/rust.rs
@@ -225,10 +225,10 @@ impl ProgrammingLanguage for Rust {
         debug_info: &super::DebugInfo,
     ) -> String {
         let parent = function_die.parent_offset();
-        if let Some(parent_offset) = parent
-            && let Ok(die) = function_die.unit_info.unit.entry(parent_offset)
+        if let Some((parent_unit, parent_offset)) = parent
+            && let Ok(die) = parent_unit.unit.entry(parent_offset)
             && is_datatype(&die)
-            && let Ok(Some(typename)) = function_die.unit_info.extract_type_name(debug_info, &die)
+            && let Ok(Some(typename)) = parent_unit.extract_type_name(debug_info, &die)
         {
             // TODO: apply better heuristics to clean up the final function name
             if let Some((_, type_generic)) = typename.split_once('<')


### PR DESCRIPTION
When a function is inlined from another crate, its abstract origin lives
in a different compilation unit. The abstract origin's DW_AT_specification
is a unit-relative reference, but we resolved it against the concrete
unit, landing on an unrelated DIE and producing garbage call_file/line/
column (and unknown function names). Resolve it against the abstract
origin's own unit instead.

Warning: Bug found with Claude. I'm not a DWARF expert.

Backtrace before:

```
Firmware exited unexpectedly: Exception
Core 0
    Frame 0: <unknown function @ 0x00064f2c> @ 0x64f2c
    Frame 1: HardFault <Cause: Escalated UsageFault (Undefined instruction)> @ 0x42372
    Frame 2: __cortex_m_rt_WDT31 @ 0x42372 inline
        /home/dirbaio/akiles/workspace/firmware/ak-application/src/mcu_nrf54.rs:364:5
    Frame 3: __cortex_m_rt_WDT31_trampoline @ 0x4236c
        /home/dirbaio/akiles/workspace/firmware/ak-application/src/mcu_nrf54.rs:361:1
    Frame 4: External interrupt #265 @ 0x42372
    Frame 5: __cortex_m_rt_WDT31 @ 0x42372 inline
        /home/dirbaio/akiles/workspace/firmware/ak-application/src/mcu_nrf54.rs:364:5
    Frame 6: __cortex_m_rt_WDT31_trampoline @ 0x4236c
        /home/dirbaio/akiles/workspace/firmware/ak-application/src/mcu_nrf54.rs:361:1
    Frame 7: Sqspi::csb @ 0x47b6c inline
        /home/dirbaio/.cargo/git/checkouts/embassy-4561af411798bcdf/d569644/embassy-nrf/src/sqspi/mod.rs:480:14
    Frame 8: Sqspi::start @ 0x47b5e
        /home/dirbaio/.cargo/git/checkouts/embassy-4561af411798bcdf/d569644/embassy-nrf/src/sqspi/mod.rs:537:14
    Frame 9: <unknown function @ 0x00042a90> @ 0x42a90 inline
        /home/dirbaio/.cargo/git/checkouts/embassy-4561af411798bcdf/d569644/embassy-nrf/src/sqspi/mod.rs:617:18
    Frame 10: <unknown function @ 0x00042a90> @ 0x42a78 inline
        /home/dirbaio/akiles/workspace/firmware/ak-application/src/mcu_nrf54.rs:30208:116
    Frame 11: Activated::wait_idle @ 0x42a24
        /home/dirbaio/akiles/workspace/firmware/ak-application/src/hw/drivers/sqspi_flash.rs:271:19
    Frame 12: {async_fn#0} @ 0x249a6
        /home/dirbaio/akiles/workspace/firmware/ak-application/src/hw/drivers/sqspi_flash.rs:252:19
```

Backtrace after:

```
Firmware exited unexpectedly: Exception
Core 0
    Frame 0: <unknown function @ 0x00064f2c> @ 0x64f2c
    Frame 1: HardFault <Cause: Escalated UsageFault (Undefined instruction)> @ 0x42372
    Frame 2: __cortex_m_rt_WDT31 @ 0x42372 inline
        /home/dirbaio/akiles/workspace/firmware/ak-application/src/mcu_nrf54.rs:364:5
    Frame 3: __cortex_m_rt_WDT31_trampoline @ 0x4236c
        /home/dirbaio/akiles/workspace/firmware/ak-application/src/mcu_nrf54.rs:361:1
    Frame 4: External interrupt #265 @ 0x42372
    Frame 5: __cortex_m_rt_WDT31 @ 0x42372 inline
        /home/dirbaio/akiles/workspace/firmware/ak-application/src/mcu_nrf54.rs:364:5
    Frame 6: __cortex_m_rt_WDT31_trampoline @ 0x4236c
        /home/dirbaio/akiles/workspace/firmware/ak-application/src/mcu_nrf54.rs:361:1
    Frame 7: Sqspi::csb @ 0x47b6c inline
        /home/dirbaio/.cargo/git/checkouts/embassy-4561af411798bcdf/d569644/embassy-nrf/src/sqspi/mod.rs:480:14
    Frame 8: Sqspi::start @ 0x47b5e
        /home/dirbaio/.cargo/git/checkouts/embassy-4561af411798bcdf/d569644/embassy-nrf/src/sqspi/mod.rs:537:14
    Frame 9: Sqspi::blocking_wait_wip @ 0x42a90 inline
        /home/dirbaio/.cargo/git/checkouts/embassy-4561af411798bcdf/d569644/embassy-nrf/src/sqspi/mod.rs:617:18
    Frame 10: Sqspi::blocking_custom_instruction @ 0x42a78 inline
        /home/dirbaio/.cargo/git/checkouts/embassy-4561af411798bcdf/d569644/embassy-nrf/src/sqspi/mod.rs:669:14
    Frame 11: Activated::wait_idle @ 0x42a24
        /home/dirbaio/akiles/workspace/firmware/ak-application/src/hw/drivers/sqspi_flash.rs:271:19
    Frame 12: {async_fn#0} @ 0x249a6
        /home/dirbaio/akiles/workspace/firmware/ak-application/src/hw/drivers/sqspi_flash.rs:252:19
```

Note frames 9, 10 are garbage before, fixed after.
