### PR TITLE
debug: ensure register values are consistent U32/U64 depending on target bitness.

### DIFF
--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -349,7 +349,7 @@ impl DebugInfo {
             function_name: fn_name,
             source_location: None,
             registers: unwind_registers.clone(),
-            pc: RegisterValue::from(address),
+            pc: unwind_registers.address_to_register_value(address),
             frame_base: None,
             is_inlined: false,
             local_variables: None,
@@ -429,8 +429,9 @@ impl DebugInfo {
                 continue;
             }
 
-            // The first instruction of the inlined function is used as the call site
-            let inlined_call_site = RegisterValue::from(next_function_low_pc);
+            // The first instruction of the inlined function is used as the call site.
+            let inlined_call_site =
+                unwind_registers.address_to_register_value(next_function_low_pc);
 
             tracing::debug!(
                 "UNWIND: Callsite for inlined function {:?}",
@@ -494,11 +495,7 @@ impl DebugInfo {
             function_name,
             source_location: function_location,
             registers: unwind_registers.clone(),
-            pc: match unwind_registers.get_address_size_bytes() {
-                4 => RegisterValue::U32(address as u32),
-                8 => RegisterValue::U64(address),
-                _ => RegisterValue::from(address),
-            },
+            pc: unwind_registers.address_to_register_value(address),
             frame_base,
             is_inlined: last_function.is_inline(),
             local_variables,

--- a/probe-rs-debug/src/registers.rs
+++ b/probe-rs-debug/src/registers.rs
@@ -146,6 +146,17 @@ impl DebugRegisters {
             .unwrap_or(0)
     }
 
+    /// Wraps a program address in a [`RegisterValue`] of the target's address size, so that its
+    /// printed width is consistent across all stack frames. A plain `RegisterValue::from(u64)`
+    /// would always yield a `U64`, printing 16 hex digits on 32-bit targets.
+    pub fn address_to_register_value(&self, address: u64) -> RegisterValue {
+        match self.get_address_size_bytes() {
+            4 => RegisterValue::U32(address as u32),
+            8 => RegisterValue::U64(address),
+            _ => RegisterValue::from(address),
+        }
+    }
+
     /// Get the canonical frame address, as specified in the [DWARF](https://dwarfstd.org) specification, section 6.4.
     /// [DWARF](https://dwarfstd.org)
     ///

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_svcall.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_svcall.snap
@@ -417,7 +417,7 @@ expression: stack_frames
       value:
         U32: 0
   pc:
-    U64: 268437116
+    U32: 268437116
   frame_base: 536886912
   is_inlined: false
   local_variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_systick.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__RP2040_systick.snap
@@ -417,7 +417,7 @@ expression: stack_frames
       value:
         U32: 0
   pc:
-    U64: 268436678
+    U32: 268436678
   frame_base: 536886872
   is_inlined: false
   local_variables:
@@ -1255,7 +1255,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 268437342
+    U32: 268437342
   frame_base: 536886936
   is_inlined: false
   local_variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32c6_coredump_elf.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32c6_coredump_elf.snap
@@ -2221,7 +2221,7 @@ expression: stack_frames
       value:
         U32: 1107296770
   pc:
-    U64: 1107296602
+    U32: 1107296602
   frame_base: 1082582304
   is_inlined: false
   local_variables:
@@ -3105,7 +3105,7 @@ expression: stack_frames
       value:
         U32: 1107296770
   pc:
-    U64: 1107296602
+    U32: 1107296602
   frame_base: 1082582432
   is_inlined: false
   local_variables:
@@ -3879,7 +3879,7 @@ expression: stack_frames
       value:
         U32: 1107317484
   pc:
-    U64: 1107317484
+    U32: 1107317484
   frame_base: 1082582448
   is_inlined: true
   local_variables:
@@ -4222,7 +4222,7 @@ expression: stack_frames
       value:
         U32: 1107317484
   pc:
-    U64: 1107317482
+    U32: 1107317482
   frame_base: 1082582448
   is_inlined: true
   local_variables:
@@ -4590,7 +4590,7 @@ expression: stack_frames
       value:
         U32: 1107317484
   pc:
-    U64: 1107317464
+    U32: 1107317464
   frame_base: 1082582448
   is_inlined: true
   local_variables:
@@ -4924,7 +4924,7 @@ expression: stack_frames
       value:
         U32: 1107317484
   pc:
-    U64: 1107317464
+    U32: 1107317464
   frame_base: 1082582448
   is_inlined: false
   local_variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32s3_coredump_elf.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32s3_coredump_elf.snap
@@ -1768,7 +1768,7 @@ expression: stack_frames
       value:
         U32: 396576
   pc:
-    U64: 1107299479
+    U32: 1107299479
   frame_base: 1070450064
   is_inlined: false
   local_variables:
@@ -2652,7 +2652,7 @@ expression: stack_frames
       value:
         U32: 396576
   pc:
-    U64: 1107315785
+    U32: 1107315785
   frame_base: 1070450240
   is_inlined: true
   local_variables:
@@ -2984,7 +2984,7 @@ expression: stack_frames
       value:
         U32: 396576
   pc:
-    U64: 1107315720
+    U32: 1107315720
   frame_base: 1070450240
   is_inlined: true
   local_variables:
@@ -3259,7 +3259,7 @@ expression: stack_frames
       value:
         U32: 396576
   pc:
-    U64: 1107315720
+    U32: 1107315720
   frame_base: 1070450240
   is_inlined: false
   local_variables:
@@ -4199,7 +4199,7 @@ expression: stack_frames
       value:
         U32: 396576
   pc:
-    U64: 1107300213
+    U32: 1107300213
   frame_base: 1070450352
   is_inlined: false
   local_variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32s3_esp_hal_panic.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__esp32s3_esp_hal_panic.snap
@@ -3443,7 +3443,7 @@ expression: stack_frames
       dwarf_id: 17
       value: ~
   pc:
-    U64: 1107300547
+    U32: 1107300547
   frame_base: 1070450064
   is_inlined: false
   local_variables:
@@ -5004,7 +5004,7 @@ expression: stack_frames
       dwarf_id: 17
       value: ~
   pc:
-    U64: 1107323449
+    U32: 1107323449
   frame_base: 1070450240
   is_inlined: true
   local_variables:
@@ -5540,7 +5540,7 @@ expression: stack_frames
       dwarf_id: 17
       value: ~
   pc:
-    U64: 1107323384
+    U32: 1107323384
   frame_base: 1070450240
   is_inlined: true
   local_variables:
@@ -5814,7 +5814,7 @@ expression: stack_frames
       dwarf_id: 17
       value: ~
   pc:
-    U64: 1107323384
+    U32: 1107323384
   frame_base: 1070450240
   is_inlined: false
   local_variables:
@@ -6751,7 +6751,7 @@ expression: stack_frames
       dwarf_id: 17
       value: ~
   pc:
-    U64: 1107301845
+    U32: 1107301845
   frame_base: 1070450352
   is_inlined: false
   local_variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_from_busfault.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_from_busfault.snap
@@ -417,7 +417,7 @@ expression: stack_frames
       value:
         U32: 0
   pc:
-    U64: 24810
+    U32: 24810
   frame_base: 536887064
   is_inlined: false
   local_variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_from_usagefault.snap
@@ -417,7 +417,7 @@ expression: stack_frames
       value:
         U32: 0
   pc:
-    U64: 24798
+    U32: 24798
   frame_base: 536887088
   is_inlined: false
   local_variables:
@@ -1038,7 +1038,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 1586
+    U32: 1586
   frame_base: 536887128
   is_inlined: false
   local_variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_hardfault_in_systick.snap
@@ -417,7 +417,7 @@ expression: stack_frames
       value:
         U32: 0
   pc:
-    U64: 25298
+    U32: 25298
   frame_base: 536886968
   is_inlined: false
   local_variables:
@@ -2106,7 +2106,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 1212
+    U32: 1212
   frame_base: 536887104
   is_inlined: false
   local_variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_svcall.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_svcall.snap
@@ -417,7 +417,7 @@ expression: stack_frames
       value:
         U32: 0
   pc:
-    U64: 1242
+    U32: 1242
   frame_base: 536887080
   is_inlined: false
   local_variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_systick.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__nRF52833_xxAA_systick.snap
@@ -417,7 +417,7 @@ expression: stack_frames
       value:
         U32: 0
   pc:
-    U64: 1266
+    U32: 1266
   frame_base: 536887040
   is_inlined: false
   local_variables:
@@ -1265,7 +1265,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 1370
+    U32: 1370
   frame_base: 536887104
   is_inlined: false
   local_variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__stm32u585_exception_no_debuginfo.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__stm32u585_exception_no_debuginfo.snap
@@ -833,7 +833,7 @@ expression: stack_frames
       value:
         U32: 0
   pc:
-    U64: 134219912
+    U32: 134219912
   frame_base: 537657312
   is_inlined: false
   local_variables:

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__stm32u585_hardfault_fp.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__stm32u585_hardfault_fp.snap
@@ -417,7 +417,7 @@ expression: stack_frames
       value:
         U32: 0
   pc:
-    U64: 134219964
+    U32: 134219964
   frame_base: 537657272
   is_inlined: true
   local_variables:
@@ -629,7 +629,7 @@ expression: stack_frames
       value:
         U32: 0
   pc:
-    U64: 134219964
+    U32: 134219964
   frame_base: 537657272
   is_inlined: false
   local_variables:
@@ -1287,7 +1287,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 134219906
+    U32: 134219906
   frame_base: 537657312
   is_inlined: false
   local_variables:
@@ -2106,7 +2106,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 134219834
+    U32: 134219834
   frame_base: ~
   is_inlined: false
   local_variables: ~

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__stm32u585_nested_exceptions.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__stm32u585_nested_exceptions.snap
@@ -416,7 +416,7 @@ expression: stack_frames
       value:
         U32: 0
   pc:
-    U64: 134219996
+    U32: 134219996
   frame_base: 537657216
   is_inlined: false
   local_variables:
@@ -828,7 +828,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 134219894
+    U32: 134219894
   frame_base: 537657216
   is_inlined: false
   local_variables:
@@ -1250,7 +1250,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 134220040
+    U32: 134220040
   frame_base: 537657224
   is_inlined: false
   local_variables:
@@ -1908,7 +1908,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 134219982
+    U32: 134219982
   frame_base: 537657264
   is_inlined: false
   local_variables:
@@ -2539,7 +2539,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 134219944
+    U32: 134219944
   frame_base: 537657304
   is_inlined: false
   local_variables:
@@ -3564,7 +3564,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 134219834
+    U32: 134219834
   frame_base: ~
   is_inlined: false
   local_variables: ~

--- a/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__stm32u585_psp_exception.snap
+++ b/probe-rs-debug/src/snapshots/probe_rs_debug__debug_info__test__stm32u585_psp_exception.snap
@@ -416,7 +416,7 @@ expression: stack_frames
       value:
         U32: 0
   pc:
-    U64: 134219974
+    U32: 134219974
   frame_base: 537657312
   is_inlined: false
   local_variables:
@@ -828,7 +828,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 134219968
+    U32: 134219968
   frame_base: 537657312
   is_inlined: false
   local_variables:
@@ -1240,7 +1240,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 134219868
+    U32: 134219868
   frame_base: 537657320
   is_inlined: false
   local_variables:
@@ -1871,7 +1871,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 134219950
+    U32: 134219950
   frame_base: 536872944
   is_inlined: false
   local_variables:
@@ -2690,7 +2690,7 @@ expression: stack_frames
       dwarf_id: 19
       value: ~
   pc:
-    U64: 134219834
+    U32: 134219834
   frame_base: ~
   is_inlined: false
   local_variables: ~


### PR DESCRIPTION
Without this some frames have U32 and some U64 on 32bit targets, which triggers my OCD.
