### PR TITLE
cmsisdap: persistent endpoints for v2 probes

### DIFF
--- a/changelog/changed-cmsisdap2-usb-endpoint.md
+++ b/changelog/changed-cmsisdap2-usb-endpoint.md
@@ -1,0 +1,1 @@
+Updated the CMSIS-DAP v2 USB endpoint handling to retain a persistent endpoint handle.

--- a/probe-rs/src/probe/cmsisdap/commands/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/mod.rs
@@ -6,8 +6,12 @@ pub mod swo;
 pub mod transfer;
 
 use crate::probe::cmsisdap::commands::general::info::PacketSizeCommand;
-use crate::probe::usb_util::InterfaceExt;
+use crate::probe::usb_util::{read_bulk_endpoint, write_bulk_endpoint};
 use crate::probe::{ProbeError, WireProtocol};
+use nusb::{
+    Endpoint,
+    transfer::{Bulk, In, Out},
+};
 use std::io::ErrorKind;
 use std::str::Utf8Error;
 use std::time::Duration;
@@ -168,14 +172,20 @@ pub enum CmsisDapDevice {
     },
 
     /// CMSIS-DAP v2 over WinUSB/Bulk.
-    /// Stores an usb device handle, out/in EP addresses, maximum DAP packet size,
-    /// and an optional SWO streaming EP address and SWO maximum packet size.
+    /// Stores the usb interface handle, persistent bulk out/in endpoints, the
+    /// maximum DAP packet size, and an optional persistent SWO streaming
+    /// endpoint.
+    ///
+    /// The endpoints are claimed once when the device is opened and reused for
+    /// every transfer, rather than being re-claimed per transfer. This both
+    /// removes per-transfer setup/teardown cost and provides a stable place to
+    /// keep multiple transfers in flight (see FAST_USB.md).
     V2 {
         handle: nusb::Interface,
-        out_ep: u8,
-        in_ep: u8,
+        out_ep: Endpoint<Bulk, Out>,
+        in_ep: Endpoint<Bulk, In>,
         max_packet_size: usize,
-        swo_ep: Option<(u8, usize)>,
+        swo_ep: Option<Endpoint<Bulk, In>>,
         usb_timeout: Duration,
     },
 }
@@ -198,30 +208,38 @@ impl CmsisDapDevice {
     }
 
     /// Read from the probe into `buf`, returning the number of bytes read on success.
-    fn read(&self, buf: &mut [u8]) -> Result<usize, SendError> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, SendError> {
         match self {
             #[cfg(feature = "cmsisdap_v1")]
-            CmsisDapDevice::V1 { handle, .. } => {
-                match handle.read_timeout(buf, self.usb_timeout().as_millis() as i32)? {
+            CmsisDapDevice::V1 {
+                handle,
+                usb_timeout,
+                ..
+            } => {
+                match handle.read_timeout(buf, usb_timeout.as_millis() as i32)? {
                     // Timeout is not indicated by error, but by returning 0 read bytes
                     0 => Err(SendError::Timeout),
                     n => Ok(n),
                 }
             }
-            CmsisDapDevice::V2 { handle, in_ep, .. } => {
-                Ok(handle.read_bulk(*in_ep, buf, self.usb_timeout())?)
-            }
+            CmsisDapDevice::V2 {
+                in_ep, usb_timeout, ..
+            } => Ok(read_bulk_endpoint(in_ep, buf, *usb_timeout)?),
         }
     }
 
     /// Write `buf` to the probe, returning the number of bytes written on success.
-    fn write(&self, buf: &[u8]) -> Result<usize, SendError> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, SendError> {
         match self {
             #[cfg(feature = "cmsisdap_v1")]
             CmsisDapDevice::V1 { handle, .. } => Ok(handle.write(buf)?),
-            CmsisDapDevice::V2 { handle, out_ep, .. } => {
+            CmsisDapDevice::V2 {
+                out_ep,
+                usb_timeout,
+                ..
+            } => {
                 // Skip first byte as it's set to 0 for HID transfers
-                Ok(handle.write_bulk(*out_ep, &buf[1..], self.usb_timeout())?)
+                Ok(write_bulk_endpoint(out_ep, &buf[1..], *usb_timeout)?)
             }
         }
     }
@@ -229,7 +247,7 @@ impl CmsisDapDevice {
     /// Drain any pending data from the probe, ensuring future responses are
     /// synchronised to requests. Swallows any errors, which are expected if
     /// there is no pending data to read.
-    pub(super) fn drain(&self) {
+    pub(super) fn drain(&mut self) {
         tracing::debug!("Draining probe of any pending data.");
 
         match self {
@@ -239,7 +257,7 @@ impl CmsisDapDevice {
                 report_size,
                 ..
             } => loop {
-                let mut discard = vec![0u8; report_size + 1];
+                let mut discard = vec![0u8; *report_size + 1];
                 match handle.read_timeout(&mut discard, 1) {
                     Ok(n) if n != 0 => continue,
                     _ => break,
@@ -247,7 +265,6 @@ impl CmsisDapDevice {
             },
 
             CmsisDapDevice::V2 {
-                handle,
                 in_ep,
                 max_packet_size,
                 ..
@@ -255,7 +272,7 @@ impl CmsisDapDevice {
                 let timeout = Duration::from_millis(1);
                 let mut discard = vec![0u8; *max_packet_size];
                 loop {
-                    match handle.read_bulk(*in_ep, &mut discard, timeout) {
+                    match read_bulk_endpoint(in_ep, &mut discard, timeout) {
                         Ok(n) if n != 0 => continue,
                         _ => break,
                     }
@@ -335,14 +352,14 @@ impl CmsisDapDevice {
     /// Returns SWOModeNotAvailable if this device does not support SWO streaming.
     ///
     /// On timeout, returns a zero-length buffer.
-    pub(super) fn read_swo_stream(&self, timeout: Duration) -> Result<Vec<u8>, CmsisDapError> {
+    pub(super) fn read_swo_stream(&mut self, timeout: Duration) -> Result<Vec<u8>, CmsisDapError> {
         match self {
             #[cfg(feature = "cmsisdap_v1")]
             CmsisDapDevice::V1 { .. } => Err(CmsisDapError::SwoModeNotAvailable),
-            CmsisDapDevice::V2 { handle, swo_ep, .. } => match swo_ep {
-                Some((ep, len)) => {
-                    let mut buf = vec![0u8; *len];
-                    match handle.read_bulk(*ep, &mut buf, timeout) {
+            CmsisDapDevice::V2 { swo_ep, .. } => match swo_ep {
+                Some(ep) => {
+                    let mut buf = vec![0u8; ep.max_packet_size()];
+                    match read_bulk_endpoint(ep, &mut buf, timeout) {
                         Ok(n) => {
                             buf.truncate(n);
                             Ok(buf)

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -5,7 +5,12 @@ use crate::probe::{
 };
 #[cfg(feature = "cmsisdap_v1")]
 use hidapi::HidApi;
-use nusb::{DeviceInfo, MaybeFuture, descriptors::TransferType, transfer::Direction};
+use nusb::{
+    DeviceInfo, MaybeFuture,
+    descriptors::TransferType,
+    transfer::{Bulk, Direction, In, Out},
+};
+use std::io;
 
 const USB_CLASS_HID: u8 = 0x03;
 const USB_CMSIS_DAP_CLASS: u8 = 0xFF;
@@ -276,14 +281,19 @@ pub fn open_v2_device(
             }
 
             // Detect a third bulk EP which will be for SWO streaming
-            let mut swo_ep = None;
+            let mut swo_ep_addr = None;
 
             if eps.len() > 2
                 && eps[2].transfer_type() == TransferType::Bulk
                 && eps[2].direction() == Direction::In
             {
-                swo_ep = Some((eps[2].address(), eps[2].max_packet_size()));
+                swo_ep_addr = Some(eps[2].address());
             }
+
+            let out_ep_addr = eps[0].address();
+            let in_ep_addr = eps[1].address();
+            let max_packet_size = eps[1].max_packet_size();
+
             // Attempt to claim this interface
             match device.claim_interface(interface.interface_number()).wait() {
                 Ok(handle) => {
@@ -293,12 +303,31 @@ pub fn open_v2_device(
                         device_info.product_id(),
                         device_info.device_version(),
                     )?;
+
+                    // Claim the bulk endpoints once and keep them for the
+                    // lifetime of the device, so transfers don't pay the
+                    // per-call endpoint setup/teardown cost.
+                    let out_ep = handle
+                        .endpoint::<Bulk, Out>(out_ep_addr)
+                        .map_err(|e| ProbeCreationError::Usb(io::Error::from(e)))?;
+                    let in_ep = handle
+                        .endpoint::<Bulk, In>(in_ep_addr)
+                        .map_err(|e| ProbeCreationError::Usb(io::Error::from(e)))?;
+                    let swo_ep = match swo_ep_addr {
+                        Some(addr) => Some(
+                            handle
+                                .endpoint::<Bulk, In>(addr)
+                                .map_err(|e| ProbeCreationError::Usb(io::Error::from(e)))?,
+                        ),
+                        None => None,
+                    };
+
                     return Ok(Some(CmsisDapDevice::V2 {
                         handle,
-                        out_ep: eps[0].address(),
-                        in_ep: eps[1].address(),
+                        out_ep,
+                        in_ep,
                         swo_ep,
-                        max_packet_size: eps[1].max_packet_size(),
+                        max_packet_size,
                         usb_timeout: DEFAULT_USB_TIMEOUT,
                     }));
                 }

--- a/probe-rs/src/probe/usb_util.rs
+++ b/probe-rs/src/probe/usb_util.rs
@@ -1,7 +1,7 @@
 //! USB bulk transfer utilities.
 
 use nusb::{
-    Interface,
+    Endpoint, Interface,
     transfer::{Buffer, Bulk, In, Out},
 };
 use std::fmt::Write;
@@ -15,7 +15,97 @@ pub(crate) fn to_hex(s: &str) -> String {
     })
 }
 
+/// Submit a single buffer to a bulk OUT endpoint and wait for it to complete.
+///
+/// On timeout, the pending transfer is cancelled and drained so the endpoint is
+/// left with no outstanding transfers, and a `TimedOut` error is returned.
+pub fn write_bulk_endpoint(
+    endpoint: &mut Endpoint<Bulk, Out>,
+    buf: &[u8],
+    timeout: Duration,
+) -> io::Result<usize> {
+    let mut transfer_buffer = Buffer::new(buf.len());
+    transfer_buffer.extend_from_slice(buf);
+
+    endpoint.submit(transfer_buffer);
+
+    let Some(completion) = endpoint.wait_next_complete(timeout) else {
+        // Request cancellation...
+        endpoint.cancel_all();
+
+        // ...and then immediately drain the completion. Whether the the response is the
+        // result of the original write, the cancellation, or a timeout of the cancellation, we
+        // drop it and return a timeout.
+        let _ = endpoint.wait_next_complete(Duration::from_millis(100));
+
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "bulk write timed out",
+        ));
+    };
+
+    completion.status.map_err(io::Error::from)?;
+
+    Ok(completion.actual_len)
+}
+
+/// Submit a read to a bulk IN endpoint and wait for it to complete, copying the
+/// received bytes into `buf`.
+///
+/// On timeout, the pending transfer is cancelled and drained so the endpoint is
+/// left with no outstanding transfers, and a `TimedOut` error is returned.
+pub fn read_bulk_endpoint(
+    endpoint: &mut Endpoint<Bulk, In>,
+    buf: &mut [u8],
+    timeout: Duration,
+) -> io::Result<usize> {
+    let max_packet_size = endpoint.max_packet_size().max(1);
+    let requested_len = buf.len().div_ceil(max_packet_size) * max_packet_size;
+
+    let transfer_buffer = Buffer::new(requested_len);
+    endpoint.submit(transfer_buffer);
+
+    let Some(completion) = endpoint.wait_next_complete(timeout) else {
+        // Request cancellation...
+        endpoint.cancel_all();
+
+        // ...and then immediately drain the completion. Whether the the response is the
+        // result of the original read, the cancellation, or a timeout of the cancellation, we
+        // drop it and return a timeout.
+        let _ = endpoint.wait_next_complete(Duration::from_millis(100));
+
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "bulk read timed out",
+        ));
+    };
+
+    completion.status.map_err(io::Error::from)?;
+
+    let actual_len = completion.actual_len;
+    let data = completion.buffer;
+
+    if actual_len > buf.len() || data.len() > buf.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "device returned {actual_len} bytes, buffer length is {}",
+                buf.len()
+            ),
+        ));
+    }
+
+    buf[..actual_len].copy_from_slice(&data[..actual_len]);
+
+    Ok(actual_len)
+}
+
 /// USB bulk transfer utility functions.
+///
+/// These claim a fresh endpoint for every transfer. For hot paths where the
+/// same endpoint is used repeatedly, claim an [`Endpoint`] once and use
+/// [`write_bulk_endpoint`] / [`read_bulk_endpoint`] instead to avoid the
+/// per-transfer endpoint setup/teardown cost.
 pub trait InterfaceExt {
     /// Reads data from the given bulk endpoint into the provided buffer.
     fn read_bulk(&self, endpoint: u8, buf: &mut [u8], timeout: Duration) -> io::Result<usize>;
@@ -30,29 +120,7 @@ impl InterfaceExt for Interface {
             .endpoint::<Bulk, Out>(endpoint)
             .map_err(io::Error::from)?;
 
-        let mut transfer_buffer = Buffer::new(buf.len());
-        transfer_buffer.extend_from_slice(buf);
-
-        endpoint.submit(transfer_buffer);
-
-        let Some(completion) = endpoint.wait_next_complete(timeout) else {
-            // Request cancellation...
-            endpoint.cancel_all();
-
-            // ...and then immediately drain the completion. Whether the the response is the
-            // result of the original write, the cancellation, or a timeout of the cancellation, we
-            // drop it and return a timeout.
-            let _ = endpoint.wait_next_complete(Duration::from_millis(100));
-
-            return Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                "bulk write timed out",
-            ));
-        };
-
-        completion.status.map_err(io::Error::from)?;
-
-        Ok(completion.actual_len)
+        write_bulk_endpoint(&mut endpoint, buf, timeout)
     }
 
     fn read_bulk(&self, endpoint: u8, buf: &mut [u8], timeout: Duration) -> io::Result<usize> {
@@ -60,44 +128,6 @@ impl InterfaceExt for Interface {
             .endpoint::<Bulk, In>(endpoint)
             .map_err(io::Error::from)?;
 
-        let max_packet_size = endpoint.max_packet_size().max(1);
-        let requested_len = buf.len().div_ceil(max_packet_size) * max_packet_size;
-
-        let transfer_buffer = Buffer::new(requested_len);
-        endpoint.submit(transfer_buffer);
-
-        let Some(completion) = endpoint.wait_next_complete(timeout) else {
-            // Request cancellation...
-            endpoint.cancel_all();
-
-            // ...and then immediately drain the completion. Whether the the response is the
-            // result of the original read, the cancellation, or a timeout of the cancellation, we
-            // drop it and return a timeout.
-            let _ = endpoint.wait_next_complete(Duration::from_millis(100));
-
-            return Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                "bulk read timed out",
-            ));
-        };
-
-        completion.status.map_err(io::Error::from)?;
-
-        let actual_len = completion.actual_len;
-        let data = completion.buffer;
-
-        if actual_len > buf.len() || data.len() > buf.len() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "device returned {actual_len} bytes, buffer length is {}",
-                    buf.len()
-                ),
-            ));
-        }
-
-        buf[..actual_len].copy_from_slice(&data[..actual_len]);
-
-        Ok(actual_len)
+        read_bulk_endpoint(&mut endpoint, buf, timeout)
     }
 }


### PR DESCRIPTION
CMSIS-DAP v2 (WinUSB/bulk) transfers previously claimed and dropped a
fresh nusb Endpoint on every read and write (in InterfaceExt::read_bulk /
write_bulk), paying per-transfer endpoint setup/teardown and making it
impossible to keep multiple transfers in flight.

Claim the bulk OUT/IN endpoints (and the optional SWO IN endpoint) once
when the device is opened and reuse them for the lifetime of the probe.

  - usb_util: factor the submit/wait logic into write_bulk_endpoint and
    read_bulk_endpoint, which operate on a persistent &mut Endpoint. The
    existing InterfaceExt impl (still used by stlink, jlink, ftdi, ch347
    and wlink) now delegates to these, so its behavior is unchanged.
  - CmsisDapDevice::V2 stores Endpoint<Bulk, Out>, Endpoint<Bulk, In> and
    an optional SWO Endpoint<Bulk, In> instead of raw endpoint addresses;
    read/write/drain/read_swo_stream take &mut self and reuse them.
  - tools: claim the endpoints in open_v2_device.

The v1/HID path is unchanged.

Signed-off-by: Tom Burdick <thomas.burdick@infineon.com>

picked from #4055 

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo fmt` was run.
- [ ] Add a changelog fragment describing your changes in `changelogs/`. See https://github.com/probe-rs/probe-rs/blob/master/CONTRIBUTING.md#changelog-entries. 

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs (in code, rustdoc and README.md) for your newly added features and code.