### PR TITLE
fix rt1015 flash fault issue

### DIFF
--- a/changelog/fixed-imxrt10xx-flash-fault.md
+++ b/changelog/fixed-imxrt10xx-flash-fault.md
@@ -1,0 +1,1 @@
+Fixed MIMXRT1015 flashing: disable the MPU left enabled by the boot ROM after reset catch.

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -371,6 +371,50 @@ impl MemoryMappedRegister<u32> for Demcr {
 }
 
 bitfield! {
+    /// MPU Control Register, MPU_CTRL (see armv7-M Architecture Reference Manual B3.5.3)
+    #[derive(Copy, Clone)]
+    pub struct MpuCtrl(u32);
+    impl Debug;
+    /// When the ENABLE bit is set to `1`, controls whether privileged software
+    /// access to the default memory map is enabled:
+    ///
+    /// `0`: Disabled. Any privileged access to an address not covered by an
+    /// enabled MPU region generates a fault.\
+    /// `1`: Enabled. Privileged accesses to addresses not covered by an
+    /// enabled MPU region use the default memory map.
+    pub privdefena, set_privdefena: 2;
+    /// Controls whether handlers executing with priority less than 0 access
+    /// memory with the MPU enabled or disabled (HardFault, NMI, and
+    /// FAULTMASK escalated handlers):
+    ///
+    /// `0`: MPU disabled for these handlers.\
+    /// `1`: MPU enabled for these handlers.
+    pub hfnmiena, set_hfnmiena: 1;
+    /// Enables the MPU:
+    ///
+    /// `0`: MPU disabled.\
+    /// `1`: MPU enabled.
+    pub enable, set_enable: 0;
+}
+
+impl From<u32> for MpuCtrl {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<MpuCtrl> for u32 {
+    fn from(value: MpuCtrl) -> Self {
+        value.0
+    }
+}
+
+impl MemoryMappedRegister<u32> for MpuCtrl {
+    const ADDRESS_OFFSET: u64 = 0xE000_ED94;
+    const NAME: &'static str = "MPU_CTRL";
+}
+
+bitfield! {
     /// Flash Patch Control Register, FP_CTRL (see armv7-M Architecture Reference Manual C1.11.3)
     #[derive(Copy,Clone)]
     pub struct FpCtrl(u32);

--- a/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
+++ b/probe-rs/src/vendor/nxp/sequences/nxp_armv7m.rs
@@ -14,7 +14,7 @@ use probe_rs_target::Chip;
 use crate::{
     architecture::arm::{
         ArmDebugInterface, ArmError, FullyQualifiedApAddress, Pins,
-        armv7m::{Demcr, FpCtrl, FpRev2CompX},
+        armv7m::{Demcr, FpCtrl, FpRev2CompX, MpuCtrl},
         communication_interface::DapProbe,
         core::{
             armv7m::{Aircr, Dhcsr},
@@ -184,6 +184,19 @@ impl ArmDebugSequence for MIMXRT10xx {
         // Wait for that watchpoint to hit.
         tracing::debug!("Waiting for watchpoint to hit");
         self.wait_for_halt(interface, true)?;
+
+        // The boot ROM enables the MPU while it runs, and we catch it before
+        // it gets a chance to clean that up. The debug port is not subject to
+        // the MPU, so downloading code to FlexRAM works fine, but the core
+        // faults as soon as it touches memory the ROM's MPU setup does not
+        // allow (e.g. the flash algorithm pushing to its stack). Disable the
+        // MPU while the core is halted so downloaded code can run.
+        let mpu_ctrl = MpuCtrl(interface.read_word_32(MpuCtrl::get_mmio_address())?);
+        tracing::debug!("MPU_CTRL at boot ROM catch: {mpu_ctrl:?}");
+        if mpu_ctrl.enable() {
+            interface.write_word_32(MpuCtrl::get_mmio_address(), MpuCtrl(0).into())?;
+            interface.flush()?;
+        }
 
         // Clean up after ourselves.
         tracing::debug!("Cleaning up watchpoints");

--- a/probe-rs/targets/MIMXRT1015.yaml
+++ b/probe-rs/targets/MIMXRT1015.yaml
@@ -11,6 +11,20 @@ variants:
       ap: !v1 0
   memory_map:
   - !Ram
+    name: ITCM
+    range:
+      start: 0x0
+      end: 0x20000
+    cores:
+    - main
+  - !Ram
+    name: DTCM
+    range:
+      start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Ram
     name: OCRAM
     range:
       start: 0x20200000


### PR DESCRIPTION
## Problem

Flashing a MIMXRT1015 always failed.

```bash
probe-rs download hello.elf --chip MIMXRT1015 --probe 0d28:0204:02260000060aa42900000000000000000000000097969905 --binary-format elf --disable-double-buffering
Erasing ✔ 0% [--------------------] 0 B @ 0 B/s (ETA 0s) WARN probe_rs::session: Could not clear all hardware breakpoints: An ARM specific error occurred.

Caused by:
0: An error occurred in the communication with an access port or debug port.
1: Target device responded with a FAULT response to the request.
WARN probe_rs::session: Failed to deconfigure device during shutdown: Arm(Dap(FaultResponse))
Error: An error with the flashing procedure has occurred.

Caused by:
0: The initialization of the flash algorithm failed.
1: Failed to read the core status.
2: An ARM specific error occurred.
3: Error using access port FullyQualifiedApAddress { dp: Default, ap: V1(0) }.
4: Failed to read register DRW at address 0xd0c
5: An error occurred in the communication with an access port or debug port.
6: Target device did not respond to request.
```

## Root cause

The MIMXRT10xx reset sequence catches the boot ROM early (watchpoint on the SRC_SBMR1 read). On the RT1015, the ROM has already enabled the MPU at that point. Debug port accesses bypass the MPU,
so downloading the algorithm worked — but the core faulted on its very first stack push, fell into the ROM's fault handler, and rebooted the chip. Other RT10xx parts don't hit this because
their ROMs haven't armed the MPU yet at the same catch point.



## Test
verified on rt1052 and rt1050, works well.

```bash
probe-rs download hello.elf --chip MIMXRT1015 --probe 0d28:0204:02260000060aa42900000000000000000000000097969905 --binary-format elf --log-file log.txt
      Erasing ✔ 100% [####################]  16.00 KiB @   6.48 KiB/s (took 2s)                                           
Programming ✔ 100% [####################]   8.50 KiB @   2.49 KiB/s (took 3s)                                              
Finished in 6.00s
```

