### PR TITLE
feat(nrf53): add application-only nRF5340 target

### DIFF
--- a/changelog/added-nrf5340-app-only-target.md
+++ b/changelog/added-nrf5340-app-only-target.md
@@ -1,0 +1,1 @@
+Added an `nRF5340_xxAA_APPONLY` target for application-core-only workflows that must not access or erase the network core.

--- a/probe-rs/src/vendor/nordicsemi/mod.rs
+++ b/probe-rs/src/vendor/nordicsemi/mod.rs
@@ -32,7 +32,7 @@ const JEP_NORDICSEMI: JEP106Code = JEP106Code::new(0x2, 0x44);
 impl Vendor for NordicSemi {
     fn try_create_debug_sequence(&self, chip: &Chip) -> Option<DebugSequence> {
         let sequence = if chip.name.starts_with("nRF5340") {
-            DebugSequence::Arm(Nrf5340::create())
+            DebugSequence::Arm(Nrf5340::create_for_chip(chip))
         } else if chip.name.starts_with("nRF52") {
             DebugSequence::Arm(Nrf52::create())
         } else if chip.name.starts_with("nRF9160") {

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
@@ -116,6 +116,13 @@ impl<T: Nrf> ArmDebugSequence for T {
     ) -> Result<(), ArmError> {
         let aps = self.core_aps(&default_ap.dp());
 
+        if aps.is_empty() {
+            return Err(ArmDebugSequenceError::custom(
+                "Target does not declare a supported Nordic core access port",
+            )
+            .into());
+        }
+
         // TODO: Eraseprotect is not considered. If enabled, the debugger must set up the same keys as the firmware does
         // TODO: Approtect and Secure Approtect are not considered. If enabled, the debugger must set up the same keys as the firmware does
         // These keys should be queried from the user if required and once that mechanism is implemented

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
@@ -7,15 +7,58 @@ use crate::architecture::arm::{
     ArmDebugInterface, ArmError, FullyQualifiedApAddress, ap::CSW, dp::DpAddress,
     sequences::ArmDebugSequence,
 };
+use probe_rs_target::{ApAddress, Chip, CoreAccessOptions};
 
 /// The sequence handle for the nRF5340.
 #[derive(Debug)]
-pub struct Nrf5340(());
+pub struct Nrf5340 {
+    core_aps: Vec<(u8, u8)>,
+}
 
 impl Nrf5340 {
     /// Create a new sequence handle for the nRF5340.
     pub fn create() -> Arc<dyn ArmDebugSequence> {
-        Arc::new(Self(()))
+        Arc::new(Self {
+            core_aps: vec![(0, 2), (1, 3)],
+        })
+    }
+
+    pub(crate) fn create_for_chip(chip: &Chip) -> Arc<dyn ArmDebugSequence> {
+        Arc::new(Self::from_chip(chip))
+    }
+
+    fn from_chip(chip: &Chip) -> Self {
+        let mut core_aps = Vec::with_capacity(chip.cores.len());
+
+        for core in &chip.cores {
+            let CoreAccessOptions::Arm(options) = &core.core_access_options else {
+                tracing::error!("Unsupported non-Arm core {} in nRF5340 target", core.name);
+                return Self {
+                    core_aps: Vec::new(),
+                };
+            };
+
+            let ap_pair = match options.ap {
+                ApAddress::V1(0) => (0, 2),
+                ApAddress::V1(1) => (1, 3),
+                ref ap => {
+                    tracing::error!(
+                        "Unsupported nRF5340 core access port {ap:?} for core {}",
+                        core.name
+                    );
+                    return Self {
+                        core_aps: Vec::new(),
+                    };
+                }
+            };
+
+            if !core_aps.contains(&ap_pair) {
+                core_aps.push(ap_pair);
+            }
+        }
+
+        core_aps.sort_unstable();
+        Self { core_aps }
     }
 }
 
@@ -24,10 +67,9 @@ impl Nrf for Nrf5340 {
         &self,
         dp_address: &DpAddress,
     ) -> Vec<(FullyQualifiedApAddress, FullyQualifiedApAddress)> {
-        let core_aps = [(0, 2), (1, 3)];
-
-        core_aps
-            .into_iter()
+        self.core_aps
+            .iter()
+            .copied()
             .map(|(core_ahb_ap, core_ctrl_ap)| {
                 (
                     FullyQualifiedApAddress::v1_with_dp(*dp_address, core_ahb_ap),
@@ -50,6 +92,114 @@ impl Nrf for Nrf5340 {
     }
 
     fn has_network_core(&self) -> bool {
-        true
+        self.core_aps.iter().any(|&(ahb_ap, _)| ahb_ap == 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use probe_rs_target::{ApAddress, CoreAccessOptions, CoreType};
+
+    use super::*;
+
+    #[cfg(feature = "builtin-targets")]
+    use crate::config::Registry;
+
+    #[test]
+    fn application_only_target_only_selects_application_access_ports() {
+        let chip = Chip::generic_arm("nRF5340_xxAA_APPONLY", CoreType::Armv8m);
+        let sequence = Nrf5340::from_chip(&chip);
+
+        assert_eq!(sequence.core_aps, vec![(0, 2)]);
+        assert!(!sequence.has_network_core());
+    }
+
+    #[test]
+    fn dual_core_target_selects_both_access_port_pairs() {
+        let mut chip = Chip::generic_arm("nRF5340_xxAA", CoreType::Armv8m);
+        let mut network_core = chip.cores[0].clone();
+        network_core.name = "network".to_string();
+        let CoreAccessOptions::Arm(options) = &mut network_core.core_access_options else {
+            unreachable!();
+        };
+        options.ap = ApAddress::V1(1);
+        chip.cores.push(network_core);
+
+        let sequence = Nrf5340::from_chip(&chip);
+
+        assert_eq!(sequence.core_aps, vec![(0, 2), (1, 3)]);
+        assert!(sequence.has_network_core());
+    }
+
+    #[test]
+    fn unsupported_target_does_not_fall_back_to_all_access_ports() {
+        let mut chip = Chip::generic_arm("nRF5340_INVALID", CoreType::Armv8m);
+        let CoreAccessOptions::Arm(options) = &mut chip.cores[0].core_access_options else {
+            unreachable!();
+        };
+        options.ap = ApAddress::V1(7);
+
+        let sequence = Nrf5340::from_chip(&chip);
+
+        assert!(sequence.core_aps.is_empty());
+        assert!(!sequence.has_network_core());
+    }
+
+    #[test]
+    fn mixed_supported_and_unsupported_target_is_rejected() {
+        let mut chip = Chip::generic_arm("nRF5340_INVALID", CoreType::Armv8m);
+        let mut unsupported_core = chip.cores[0].clone();
+        unsupported_core.name = "unsupported".to_string();
+        let CoreAccessOptions::Arm(options) = &mut unsupported_core.core_access_options else {
+            unreachable!();
+        };
+        options.ap = ApAddress::V1(7);
+        chip.cores.push(unsupported_core);
+
+        let sequence = Nrf5340::from_chip(&chip);
+
+        assert!(sequence.core_aps.is_empty());
+        assert!(!sequence.has_network_core());
+    }
+
+    #[cfg(feature = "builtin-targets")]
+    #[test]
+    fn builtin_targets_select_the_expected_scope() {
+        let registry = Registry::from_builtin_families();
+        let family = registry
+            .families()
+            .iter()
+            .find(|family| family.name == "nRF53 Series")
+            .expect("nRF53 family is built in");
+
+        let stock = family
+            .variants
+            .iter()
+            .find(|chip| chip.name == "nRF5340_xxAA")
+            .expect("stock nRF5340 target is built in");
+        let stock_sequence = Nrf5340::from_chip(stock);
+        assert_eq!(stock_sequence.core_aps, vec![(0, 2), (1, 3)]);
+        assert!(stock_sequence.has_network_core());
+
+        let app_only = family
+            .variants
+            .iter()
+            .find(|chip| chip.name == "nRF5340_xxAA_APPONLY")
+            .expect("application-only nRF5340 target is built in");
+        let app_only_sequence = Nrf5340::from_chip(app_only);
+        assert_eq!(app_only_sequence.core_aps, vec![(0, 2)]);
+        assert!(!app_only_sequence.has_network_core());
+        assert_eq!(app_only.cores.len(), 1);
+        assert_eq!(app_only.cores[0].name, "application");
+        assert_eq!(
+            app_only.flash_algorithms,
+            ["nrf53xx_application", "nrf53xx_application_uicr"]
+        );
+        assert!(
+            app_only
+                .memory_map
+                .iter()
+                .all(|region| region.cores() == ["application"])
+        );
     }
 }

--- a/probe-rs/targets/nRF53_Series.yaml
+++ b/probe-rs/targets/nRF53_Series.yaml
@@ -61,6 +61,36 @@ variants:
   - nrf53xx_application_uicr
   - nrf53xx_network
   - nrf53xx_network_uicr
+- name: nRF5340_xxAA_APPONLY
+  cores:
+  - name: application
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v1 0
+  memory_map:
+  - !Nvm
+    range:
+      start: 0x0
+      end: 0x100000
+    cores:
+    - application
+    access:
+      boot: true
+  - !Ram
+    range:
+      start: 0x20000000
+      end: 0x20040000
+    cores:
+    - application
+  - !Ram
+    range:
+      start: 0x20040000
+      end: 0x20080000
+    cores:
+    - application
+  flash_algorithms:
+  - nrf53xx_application
+  - nrf53xx_application_uicr
 flash_algorithms:
 - name: nrf53xx_application
   description: nRF53xxx_app


### PR DESCRIPTION

## Summary

Add an explicitly selected `nRF5340_xxAA_APPONLY` operational target containing
only the application core, application memory map, and application flash
algorithms. Derive the nRF5340 sequence's AHB-AP/CTRL-AP scope from the cores
declared by the selected target.

The existing `nRF5340_xxAA` target remains dual-core and continues to select
AP0/CTRL-AP2 plus AP1/CTRL-AP3. Automatic chip detection continues to resolve
to that full physical target. The new profile is opt-in.

## Motivation

The current nRF5340 sequence hard-codes both cores for every session. An
application-only product therefore still reads AP1, releases the unused network
domain, and can request explicitly authorized recovery through CTRL-AP3.

This profile provides strict AP0/AP2-only scope. It remains useful independently
of repairs to the stock dual-core connection flow, because those repairs must
intentionally access and activate the network domain.

The missing per-core scope was identified when nRF53 support was introduced in
[PR #918](https://github.com/probe-rs/probe-rs/pull/918) and is related to the
generic selective-core request in
[#2446](https://github.com/probe-rs/probe-rs/issues/2446). Generic lazy per-core
session initialization would be more general, but changes session attach,
unlock permissions, breakpoint cleanup, under-reset behavior, flashing, and
shutdown. `RP2040_SELFDEBUG` provides precedent for an explicitly selected
single-core operational profile of a multicore device.

## Safety properties

- The app-only profile produces only the AP0/CTRL-AP2 pair.
- Its target contains no network core, network memory, or network flash
  algorithm.
- Unsupported or mixed-invalid nRF5340 core descriptions fail closed during
  session unlock instead of silently broadening or truncating recovery scope.
- The stock target retains both existing AP pairs.
- Automatic detection remains mapped to the stock target.

## Validation

- Tests load the actual built-in stock and app-only targets and assert their
  AP pairs, core count, memory ownership, and flash algorithms.
- Synthetic tests cover application-only, dual-core, wholly unsupported, and
  mixed supported/unsupported core descriptions.
- Built-in target-registry validation passes.
- The generated CLI lists `nRF5340_xxAA_APPONLY`.
- A hardware AP0 read passed with a CMSIS-DAP Raspberry Pi Debug Probe at
  100 kHz. The trace selected only `[(0, 2)]` and contained no AP1/AP3 markers.

No erase-all permission or network-core access was used for the hardware test.

This profile duplicates the per-variant target description, as operational
profiles such as `RP2040_SELFDEBUG` do. Maintainer feedback on whether
`APPONLY`, `APPLICATION`, or a future generic selected-core mechanism is the
preferred long-term naming/API is explicitly requested.

## Checklist

- [x] The code compiles without errors or warnings.
- [x] Tests pass and new tests are included.
- [x] `cargo fmt` was run.
- [x] A changelog fragment is included.
- [x] Both shipped target profiles are covered by registry-backed tests.