### PR TITLE
docs: fix broken CHANGELOG link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ As of version 0.27.0 this library can:
 - Download ELF, BIN and IHEX binaries using standard CMSIS-Pack flash algorithms.
 - Debug a target via the CLI, VSCode (MS-DAP) and GDB.
 
-To see what new functionality gets added every release, have a look at the [CHANGELOG](https://github.com/probe-rs/probe-rs/blob/master/CHANGELOG.md)
+To see what new functionality gets added every release, have a look at the [CHANGELOG](https://github.com/probe-rs/probe-rs/blob/master/CHANGELOG.md). Changes that haven't been released yet live as individual fragments in the [`changelog/`](https://github.com/probe-rs/probe-rs/tree/master/changelog) directory.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ As of version 0.27.0 this library can:
 - Download ELF, BIN and IHEX binaries using standard CMSIS-Pack flash algorithms.
 - Debug a target via the CLI, VSCode (MS-DAP) and GDB.
 
-To see what new functionality gets added every release, have a look at the [CHANGELOG](CHANGELOG.md)
+To see what new functionality gets added every release, have a look at the [CHANGELOG](https://github.com/probe-rs/probe-rs/blob/master/CHANGELOG.md)
 
 ## Support
 


### PR DESCRIPTION
The root README is published as the crate readme for `probe-rs` and `probe-rs-tools`, so the relative `CHANGELOG.md` link renders as a dead link on crates.io and docs.rs (it only resolves on GitHub). This is what people hit when following the link from the crate page.

Point it at the file on GitHub so it works everywhere.

Closes #3912