### PR TITLE
feat: hint that a failed `probe-rs info` isn't necessarily fatal

### DIFF
--- a/changelog/changed-info-not-fatal-hint.md
+++ b/changelog/changed-info-not-fatal-hint.md
@@ -1,0 +1,1 @@
+`probe-rs info` now prints a hint that a failed or incomplete result does not necessarily mean the chip or wiring is broken, since flashing and debugging may still work.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -72,6 +72,8 @@ impl Cmd {
 
             let probe = select_probe(&client, self.common.probe.map(Into::into)).await?;
 
+            let mut any_success = false;
+
             for protocol in protocols {
                 let msg = format!("Probing target via {protocol}");
                 println!("{msg}");
@@ -119,10 +121,20 @@ impl Cmd {
                         println!("{message}");
                     }
                 } else {
+                    any_success = true;
                     for message in successes {
                         println!("{message}");
                     }
                 }
+            }
+
+            if !any_success {
+                println!();
+                println!(
+                    "Note: `info` only tries to identify the debug port and its components. \
+                     A failed or incomplete result does not necessarily mean the chip or your \
+                     wiring is broken - flashing and debugging may still work fine."
+                );
             }
         } else {
             match crate::cmd::common::info::basic_info(&client, self.common).await {
@@ -135,6 +147,9 @@ impl Cmd {
                 Err(e) => {
                     eprintln!(
                         "Could not attach to target. Try running with --verbose for more information about the target."
+                    );
+                    eprintln!(
+                        "A failed `info` command does not necessarily mean the chip or your wiring is broken - flashing and debugging may still work fine."
                     );
                     return Err(e);
                 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -148,9 +148,6 @@ impl Cmd {
                     eprintln!(
                         "Could not attach to target. Try running with --verbose for more information about the target."
                     );
-                    eprintln!(
-                        "A failed `info` command does not necessarily mean the chip or your wiring is broken - flashing and debugging may still work fine."
-                    );
                     return Err(e);
                 }
             };


### PR DESCRIPTION
We repeatedly get people asking why their chip "isn't working" when in reality it's just `probe-rs info` failing to identify the debug port/components - flashing and debugging work fine for them.

This adds a short note in the failure and empty-result paths of `probe-rs info` (both verbose and non-verbose) explaining that a failed or incomplete `info` result does not necessarily mean the chip or wiring is broken.

Closes #3378