### PR TITLE
docs: explain when to use probe-rs vs cargo-flash vs cargo-embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ If you think probe-rs makes your embedded journey more enjoyable or even earns y
 
 In addition to being a library, probe-rs also includes a suite of tools which can be used for flashing and debugging.
 
+### Which tool should I use?
+
+The tools share a lot of functionality (flashing, running, RTT, ...) but target different workflows:
+
+- **`probe-rs`** is the standalone CLI. It works with any ELF/BIN/IHEX binary regardless of language or build system, and exposes lower-level operations (`info`, `read`, `write`, `erase`, ...). Reach for it when you are not building a Cargo project, or when you need fine-grained control.
+- **`cargo-flash`** is a cargo subcommand that builds your Rust project and flashes the resulting binary in one step. Use it when you just want to flash a Cargo project.
+- **`cargo-embed`** builds and flashes like `cargo-flash`, but additionally offers a richer, config-file-driven experience with RTT, GDB and multiple views. Use it when you want a more complete debugging session for a Cargo project.
+
+If in doubt, start with `cargo-embed` for Rust projects and `probe-rs` for everything else.
+
 ### Installation
 
 The recommended way to install the tools is to download a precompiled version, using one of the methods below.

--- a/README.md
+++ b/README.md
@@ -33,13 +33,20 @@ In addition to being a library, probe-rs also includes a suite of tools which ca
 
 ### Which tool should I use?
 
-The tools share a lot of functionality (flashing, running, RTT, ...) but target different workflows:
+For most projects, **`probe-rs run`** is what you want. It flashes your firmware, resets the target and streams RTT/`defmt` output and panics back to your console, so it works as a Cargo runner. Point Cargo at it once:
 
-- **`probe-rs`** is the standalone CLI. It works with any ELF/BIN/IHEX binary regardless of language or build system, and exposes lower-level operations (`info`, `read`, `write`, `erase`, ...). Reach for it when you are not building a Cargo project, or when you need fine-grained control.
-- **`cargo-flash`** is a cargo subcommand that builds your Rust project and flashes the resulting binary in one step. Use it when you just want to flash a Cargo project.
-- **`cargo-embed`** builds and flashes like `cargo-flash`, but additionally offers a richer, config-file-driven experience with RTT, GDB and multiple views. Use it when you want a more complete debugging session for a Cargo project.
+```toml
+# .cargo/config.toml
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "probe-rs run --chip nRF52840_xxAA"
+```
 
-If in doubt, start with `cargo-embed` for Rust projects and `probe-rs` for everything else.
+and then `cargo run` flashes and runs your firmware.
+
+The other two tools cover narrower needs:
+
+- **`cargo-embed`** offers similar functionality with an interactive RTT terminal on top. It is expected to be phased out in the future, so prefer `probe-rs run` for new setups.
+- **`cargo-flash`** just flashes a binary onto the target without any further faff, for when you only need to program the chip.
 
 ### Installation
 


### PR DESCRIPTION
The CLI, `cargo-flash` and `cargo-embed` share a lot of functionality, and it isn't obvious from the docs why there are three of them or which one to reach for. This adds a short "Which tool should I use?" section to the README describing the workflow each one targets.

Closes #3498