### PR TITLE
docs: drop stale version reference from README feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Additionally the project offers a variety of tools to be used directly for flash
 
 ## Functionality
 
-As of version 0.27.0 this library can:
+This library can:
 
 - Connect to a DAPLink, STLink, JLink, FTDI probes, ESP32 devices with USB JTAG, WLink and the Blackmagic probe.
 - Talk to ARM, Risc-V and Xtensa cores via SWD or JTAG.


### PR DESCRIPTION
The "Functionality" list in the README opens with "As of version 0.27.0 this library can:". That version pin has been stale for many releases and misleadingly suggests the listed capabilities are specific to 0.27.0. Drop the version so the list simply describes what the library does.