### PR TITLE
Fix a few spelling typos in comments and messages

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -1066,7 +1066,7 @@ mod test {
             self
         }
 
-        fn and_succesful_response(self) -> ResponseBuilder<'r> {
+        fn and_successful_response(self) -> ResponseBuilder<'r> {
             let req = self.adapter.requests.back_mut().unwrap();
 
             let response = Response {
@@ -1162,7 +1162,7 @@ mod test {
         fn expect_response(&mut self, response: Response) -> ResponseBuilder<'_> {
             assert!(
                 response.success,
-                "success field must be true for succesful response"
+                "success field must be true for successful response"
             );
             self.expected_responses.push(response);
             ResponseBuilder { adapter: self }
@@ -1277,7 +1277,7 @@ mod test {
         protocol_adapter
             .add_request("initialize")
             .with_arguments(default_initialize_args())
-            .and_succesful_response()
+            .and_successful_response()
             .with_body(expected_capabilities());
 
         protocol_adapter.expect_output_event("probe-rs-debug: Log output for \"probe_rs=warn\" will be written to the Debug Console.\n");
@@ -1311,7 +1311,7 @@ mod test {
         protocol_adapter
             .add_request("launch")
             .with_arguments(launch_args)
-            .and_succesful_response();
+            .and_successful_response();
 
         protocol_adapter.expect_event("initialized", None::<u32>);
 
@@ -1326,7 +1326,7 @@ mod test {
                 suspend_debuggee: Some(false),
                 terminate_debuggee: Some(false),
             })
-            .and_succesful_response();
+            .and_successful_response();
     }
 
     fn fake_probe() -> (DebugProbeInfo, FakeProbe) {
@@ -1431,7 +1431,7 @@ mod test {
         protocol_adapter
             .add_request("attach")
             .with_arguments(attach_args)
-            .and_succesful_response();
+            .and_successful_response();
 
         protocol_adapter.expect_event("initialized", None::<u32>);
 
@@ -1471,7 +1471,7 @@ mod test {
 
         protocol_adapter
             .add_request("configurationDone")
-            .and_succesful_response();
+            .and_successful_response();
 
         protocol_adapter.expect_event(
             "continued",
@@ -1497,7 +1497,7 @@ mod test {
 
         protocol_adapter
             .add_request("threads")
-            .and_succesful_response()
+            .and_successful_response()
             .with_body(ThreadsResponseBody {
                 threads: vec![Thread {
                     id: 0,
@@ -1581,7 +1581,7 @@ mod test {
 
         protocol_adapter
             .add_request("configurationDone")
-            .and_succesful_response();
+            .and_successful_response();
 
         protocol_adapter.expect_event(
             "continued",
@@ -1641,7 +1641,7 @@ mod test {
                 instruction_count: *inst_cnt,
                 resolve_symbols: None,
             })
-            .and_succesful_response()
+            .and_successful_response()
             .with_body(DisassembleResponseBody {
                 instructions: test_instrs
                     .iter()

--- a/probe-rs/examples/ram_download.rs
+++ b/probe-rs/examples/ram_download.rs
@@ -143,7 +143,7 @@ fn main() -> Result<()> {
         );
         eprintln!("Verification failed!");
     } else {
-        println!("Verification succesful.");
+        println!("Verification successful.");
     }
 
     Ok(())

--- a/probe-rs/src/architecture/arm/memory/adi_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_memory_interface.rs
@@ -178,7 +178,7 @@ where
             self.memory_ap.read_data(self.interface, &mut values)?;
 
             // The required shifting logic here is described in C2.2.6 Byte lanes of the ADI v5.2 specification.
-            // All bytes are transfered in their lane, so when we do an access at an address that is not divisible by 4,
+            // All bytes are transferred in their lane, so when we do an access at an address that is not divisible by 4,
             // we have to shift the word (one or two bytes) to it's correct position.
             for (target, (i, source)) in
                 data[..chunk_size].iter_mut().zip(values.iter().enumerate())
@@ -228,7 +228,7 @@ where
             self.memory_ap.read_data(self.interface, &mut values)?;
 
             // The required shifting logic here is described in C2.2.6 Byte lanes of the ADI v5.2 specification.
-            // All bytes are transfered in their lane, so when we do an access at an address that is not divisible by 4,
+            // All bytes are transferred in their lane, so when we do an access at an address that is not divisible by 4,
             // we have to shift the word (one or two bytes) to it's correct position.
             for (target, (i, source)) in
                 data[..chunk_size].iter_mut().zip(values.iter().enumerate())

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1345,7 +1345,7 @@ impl DapAccess for StlinkArmDebug {
 
         tracing::Span::current().record("value", result);
 
-        tracing::debug!("Read succesful");
+        tracing::debug!("Read successful");
 
         Ok(result)
     }


### PR DESCRIPTION
Small no-op cleanup: fixes "transfered" -> "transferred" and "succesful" -> "successful" in a handful of comments, log/error messages and one private helper name. No behaviour change.