### PR TITLE
fix(release): give probe-rs-mi its own tag name

### DIFF
--- a/probe-rs-mi/Cargo.toml
+++ b/probe-rs-mi/Cargo.toml
@@ -17,3 +17,9 @@ serde = { version = "1", features = ["derive"] }
 
 [lints]
 workspace = true
+
+# probe-rs-mi is versioned independently, so it needs its own tag name.
+# Without this, it inherits the workspace tag-name ("v{{version}}") and
+# produces ambiguous tags like `v0.1.0` (see #3116).
+[package.metadata.release]
+tag-name = "probe-rs-mi-v{{version}}"


### PR DESCRIPTION
`probe-rs-mi` is versioned and tagged separately from the rest of the workspace, but it was inheriting the workspace `tag-name = "v{{version}}"`, so it ended up tagged `v0.1.0` — which clashes with the old main-crate series (`v0.2.0`, `v0.3.0`, …). This gives it its own `tag-name` so future releases tag as `probe-rs-mi-v*`.

Already renamed the existing `v0.1.0` tag to `probe-rs-mi-v0.1.0` on the remote.

Fixes #3116