### PR TITLE
Cache memory AP base addresses

### DIFF
--- a/changelog/changed-cache-memory-ap-base-address.md
+++ b/changelog/changed-cache-memory-ap-base-address.md
@@ -1,0 +1,1 @@
+The ARM debug interface now caches memory AP base addresses instead of re-reading them from the target on every access, since they never change.

--- a/probe-rs/src/architecture/arm/ap/v2/root_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/ap/v2/root_memory_interface.rs
@@ -88,6 +88,10 @@ impl<ADI: ArmDebugInterface> ArmMemoryInterface for RootMemoryInterface<'_, ADI>
     }
 
     fn base_address(&mut self) -> Result<u64, ArmError> {
+        let fqa = self.fully_qualified_address();
+        if let Some(base) = self.iface.cached_base_address(&fqa) {
+            return Ok(base);
+        }
         let base_ptr0: BASEPTR0 = self.iface.read_dp_register(self.dp)?;
         let base_ptr1: BASEPTR1 = self.iface.read_dp_register(self.dp)?;
         let base = base_ptr0
@@ -95,6 +99,7 @@ impl<ADI: ArmDebugInterface> ArmMemoryInterface for RootMemoryInterface<'_, ADI>
             .then(|| u64::from(base_ptr1.ptr()) | u64::from(base_ptr0.ptr() << 12))
             .ok_or_else(|| ArmError::Other("DP has no valid base address defined.".into()))?;
 
+        self.iface.cache_base_address(fqa, base);
         Ok(base)
     }
 

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -86,6 +86,20 @@ pub trait ArmDebugInterface: DapAccess + SwdSequence + SwoAccess + Send {
         &mut self,
         access_port: &FullyQualifiedApAddress,
     ) -> Result<Box<dyn ArmMemoryInterface + '_>, ArmError>;
+
+    /// Returns the cached base address of a memory AP, if it has already been read.
+    ///
+    /// A memory AP's base address never changes, so it only needs to be read from the
+    /// target once. Implementations that persist across memory accesses can cache it;
+    /// the default implementation caches nothing.
+    fn cached_base_address(&self, _ap: &FullyQualifiedApAddress) -> Option<u64> {
+        None
+    }
+
+    /// Stores the base address of a memory AP for later reuse by [`cached_base_address`].
+    ///
+    /// [`cached_base_address`]: ArmDebugInterface::cached_base_address
+    fn cache_base_address(&mut self, _ap: FullyQualifiedApAddress, _base_address: u64) {}
 }
 
 /// Read chip information from the ROM tables
@@ -175,6 +189,8 @@ pub struct ArmCommunicationInterface {
     /// If this is None, the interface is in an uninitialized state.
     current_dp: Option<DpAddress>,
     dps: HashMap<DpAddress, DpState>,
+    /// Base addresses of memory APs, which never change and so are only read once.
+    base_addresses: HashMap<FullyQualifiedApAddress, u64>,
     use_overrun_detect: bool,
     sequence: Arc<dyn ArmDebugSequence>,
 }
@@ -273,6 +289,14 @@ impl ArmDebugInterface for ArmCommunicationInterface {
         self.current_dp
     }
 
+    fn cached_base_address(&self, ap: &FullyQualifiedApAddress) -> Option<u64> {
+        self.base_addresses.get(ap).copied()
+    }
+
+    fn cache_base_address(&mut self, ap: FullyQualifiedApAddress, base_address: u64) {
+        self.base_addresses.insert(ap, base_address);
+    }
+
     fn close(self: Box<Self>) -> Probe {
         ArmCommunicationInterface::close(*self)
     }
@@ -325,6 +349,7 @@ impl ArmCommunicationInterface {
             probe: Some(probe),
             current_dp: None,
             dps: Default::default(),
+            base_addresses: Default::default(),
             use_overrun_detect,
             sequence,
         };

--- a/probe-rs/src/architecture/arm/memory/adi_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_memory_interface.rs
@@ -486,7 +486,13 @@ where
     APA: ApAccess + ArmDebugInterface,
 {
     fn base_address(&mut self) -> Result<u64, ArmError> {
-        self.memory_ap.base_address(self.interface)
+        let ap = self.memory_ap.ap_address().clone();
+        if let Some(base_address) = self.interface.cached_base_address(&ap) {
+            return Ok(base_address);
+        }
+        let base_address = self.memory_ap.base_address(self.interface)?;
+        self.interface.cache_base_address(ap, base_address);
+        Ok(base_address)
     }
 
     fn fully_qualified_address(&self) -> FullyQualifiedApAddress {


### PR DESCRIPTION
Closes #2929.

A memory AP's base address never changes, but we re-read it from the target every time we build a memory interface and ask for its base address (ROM table / component enumeration). Caching it on the memory AP struct itself doesn't help since the AP and its `ADIMemoryInterface` are rebuilt on every `memory_interface()` call, so the cache lives on the long-lived `ArmCommunicationInterface`, keyed by AP address.

Two small `ArmDebugInterface` methods (`cached_base_address` / `cache_base_address`) with default no-op impls carry it, so probe-specific interfaces (ST-Link, Black Magic, …) are unaffected. Both the ADIv5 (`ADIMemoryInterface`) and ADIv6 root memory interface consult the cache.

Not tested on hardware yet.