### PR TITLE
fix(arm): report correct width when APB4/APB5 rejects a transfer

### DIFF
--- a/changelog/fixed-apb45-transfer-width-error.md
+++ b/changelog/fixed-apb45-transfer-width-error.md
@@ -1,0 +1,1 @@
+Fixed the reported transfer width when an APB4/APB5 memory AP rejects a non-32-bit access: it used the `DataSize` discriminant instead of the byte count, so e.g. a 64-bit access was reported as "24 bits" instead of 64.

--- a/probe-rs/src/architecture/arm/ap/memory_ap/amba_apb4_apb5.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/amba_apb4_apb5.rs
@@ -55,7 +55,9 @@ impl super::MemoryApType for AmbaApb4Apb5 {
     ) -> Result<(), ArmError> {
         match data_size {
             DataSize::U32 => Ok(()),
-            _ => Err(ArmError::UnsupportedTransferWidth(data_size as usize * 8)),
+            _ => Err(ArmError::UnsupportedTransferWidth(
+                data_size.to_byte_count() * 8,
+            )),
         }
     }
 


### PR DESCRIPTION
`AmbaApb4Apb5::try_set_datasize` only supports 32-bit accesses and rejects everything else with `UnsupportedTransferWidth`. It built that error from the `DataSize` discriminant (`data_size as usize * 8`) rather than the byte count, so the reported width was wrong — e.g. a rejected 64-bit access reported 24 bits instead of 64.

Use `data_size.to_byte_count() * 8`, matching the other memory AP implementations.

Only affects the error message; no behavioural change to what's accepted.