### PR TITLE
fix(arm): clearer error when no target is connected

### DIFF
--- a/changelog/fixed-no-target-error-message.md
+++ b/changelog/fixed-no-target-error-message.md
@@ -1,0 +1,1 @@
+Reading the debug port when no target is connected (or the target is unpowered) now returns a clear "no target responded" error that points at connection/power/wiring, instead of a cryptic SWD protocol error.

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -61,6 +61,12 @@ pub enum ArmError {
     /// The current target device is not an ARM device.
     NoArmTarget,
 
+    /// No target responded to the debug port. Check that the target is connected and powered, and that the SWD/JTAG wiring is correct.
+    NoTargetResponse {
+        /// The underlying communication error from the failed debug port read.
+        source: Box<ArmError>,
+    },
+
     /// Error using access port {address:?}.
     AccessPort {
         /// Address of the access port

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -1009,7 +1009,11 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
                 Err(z) => {
                     if guard.elapsed() > RESET_RECOVERY_TIMEOUT {
                         tracing::debug!("DPIDR didn't become readable within guard time");
-                        return Err(z);
+                        // The debug port never acknowledged the initial read, which usually
+                        // means nothing is listening on the wire.
+                        return Err(ArmError::NoTargetResponse {
+                            source: Box::new(z),
+                        });
                     }
                 }
             }


### PR DESCRIPTION
Fixes #496.

When no target is connected or the target is unpowered, connecting gave a cryptic error ("A protocol error occurred in the SWD communication between probe and device" / "Target device did not respond"), with no hint that the target might just be unplugged or off.

The first real transaction with the target is the DPIDR read in `debug_port_connect`. When nothing is on the wire it keeps NAKing, the retry loop hits its guard timeout, and the raw SWD error was returned as-is. This wraps that timeout case in a new `ArmError::NoTargetDetected` whose message points at connection/power/wiring, while keeping the underlying error as the `source` so nothing is lost.

Draft because I haven't verified it on hardware yet (disconnect a probe's target and confirm the message shows up on the CLI). Only touches the SWD path via `debug_port_connect`; JTAG first-contact goes through a different path and isn't covered here.