### PR TITLE
Report probes that can't be accessed on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,6 +3152,7 @@ dependencies = [
  "itertools 0.15.0",
  "itm",
  "jep106",
+ "nix 0.31.3",
  "nusb",
  "object 0.39.1",
  "parking_lot",

--- a/changelog/added-report-inaccessible-probes.md
+++ b/changelog/added-report-inaccessible-probes.md
@@ -1,0 +1,1 @@
+On Linux, probes that are detected but can't be opened due to missing permissions (e.g. no udev rule) are now listed and flagged as inaccessible instead of silently disappearing, and the setup hint only fires when it's actually relevant.

--- a/probe-rs-espressif/src/espusbjtag/mod.rs
+++ b/probe-rs-espressif/src/espusbjtag/mod.rs
@@ -13,8 +13,8 @@ use probe_rs::{
         },
     },
     probe::{
-        AutoImplementJtagAccess, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
-        JtagAccess, JtagDriverState, ProbeFactory, RawJtagIo, WireProtocol,
+        AutoImplementJtagAccess, DebugProbe, DebugProbeError, DebugProbeSelector, JtagAccess,
+        JtagDriverState, ProbeFactory, RawJtagIo, WireProtocol, list::ProbeListItem,
     },
 };
 
@@ -40,7 +40,7 @@ impl ProbeFactory for EspUsbJtagFactory {
         }))
     }
 
-    fn list_probes(&self) -> Vec<DebugProbeInfo> {
+    fn list_probes(&self) -> Vec<ProbeListItem> {
         protocol::list_espjtag_devices()
     }
 }

--- a/probe-rs-espressif/src/espusbjtag/protocol.rs
+++ b/probe-rs-espressif/src/espusbjtag/protocol.rs
@@ -7,6 +7,7 @@ use std::{
 
 use probe_rs::probe::{
     DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeCreationError, ProbeError,
+    list::{ProbeListItem, usb_probe_accessibility},
     usb_util::InterfaceExt,
 };
 
@@ -564,12 +565,13 @@ pub(super) fn is_espjtag_device(device: &DeviceInfo) -> bool {
 }
 
 #[tracing::instrument(skip_all)]
-pub(super) fn list_espjtag_devices() -> Vec<DebugProbeInfo> {
+pub(super) fn list_espjtag_devices() -> Vec<ProbeListItem> {
     match nusb::list_devices().wait() {
         Ok(devices) => devices
             .filter(is_espjtag_device)
-            .map(|device| {
-                DebugProbeInfo::new(
+            .map(|device| ProbeListItem {
+                accessibility: usb_probe_accessibility(&device),
+                info: DebugProbeInfo::new(
                     "ESP JTAG".to_string(),
                     device.vendor_id(),
                     device.product_id(),
@@ -577,7 +579,7 @@ pub(super) fn list_espjtag_devices() -> Vec<DebugProbeInfo> {
                     &EspUsbJtagFactory,
                     None,
                     false,
-                )
+                ),
             })
             .collect(),
         Err(e) => {

--- a/probe-rs-linux/src/linuxgpiod/mod.rs
+++ b/probe-rs-linux/src/linuxgpiod/mod.rs
@@ -17,7 +17,7 @@ use probe_rs::architecture::arm::{
 use probe_rs::probe::{
     AutoImplementJtagAccess, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
     IoSequenceItem, JtagDriverState, ProbeCreationError, ProbeFactory, RawJtagIo, RawSwdIo,
-    SwdSettings, WireProtocol,
+    SwdSettings, WireProtocol, list::ProbeListItem,
 };
 
 use self::error::LinuxGpiodError;
@@ -244,12 +244,12 @@ impl ProbeFactory for LinuxGpiodFactory {
         Ok(Box::new(probe))
     }
 
-    fn list_probes(&self) -> Vec<DebugProbeInfo> {
+    fn list_probes(&self) -> Vec<ProbeListItem> {
         // Pin assignments are board-specific; auto-discovery is not meaningful.
         Vec::new()
     }
 
-    fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+    fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<ProbeListItem> {
         // Synthesise an entry for any well-formed gpiod selector — the CLI
         // resolves `--probe` via this method before calling open().
         let Some(selector) = selector else {
@@ -264,7 +264,7 @@ impl ProbeFactory for LinuxGpiodFactory {
         if serial.parse::<PinMap>().is_err() {
             return Vec::new();
         }
-        vec![DebugProbeInfo::new(
+        vec![ProbeListItem::accessible(DebugProbeInfo::new(
             format!("Linux GPIO bit-bang SWD ({serial})"),
             0,
             0,
@@ -272,7 +272,7 @@ impl ProbeFactory for LinuxGpiodFactory {
             &LinuxGpiodFactory,
             None,
             false,
-        )]
+        ))]
     }
 }
 
@@ -319,8 +319,8 @@ mod tests {
         let s = sel(&format!("0:0:{serial}"));
         let entries = LinuxGpiodFactory.list_probes_filtered(Some(&s));
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].vendor_id, 0);
-        assert_eq!(entries[0].product_id, 0);
-        assert_eq!(entries[0].serial_number.as_deref(), Some(serial));
+        assert_eq!(entries[0].info.vendor_id, 0);
+        assert_eq!(entries[0].info.product_id, 0);
+        assert_eq!(entries[0].info.serial_number.as_deref(), Some(serial));
     }
 }

--- a/probe-rs-linux/src/linuxspidevswd/mod.rs
+++ b/probe-rs-linux/src/linuxspidevswd/mod.rs
@@ -45,7 +45,7 @@ use probe_rs::{
     },
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeCreationError,
-        ProbeError, ProbeFactory, SwdSettings, WireProtocol,
+        ProbeError, ProbeFactory, SwdSettings, WireProtocol, list::ProbeListItem,
     },
 };
 use spidev::{SpiModeFlags, SpidevOptions, SpidevTransfer};
@@ -87,14 +87,14 @@ impl ProbeFactory for LinuxSpidevSwdFactory {
         Ok(Box::new(LinuxSpidevSwdProbe::new(spidev)))
     }
 
-    fn list_probes(&self) -> Vec<DebugProbeInfo> {
+    fn list_probes(&self) -> Vec<ProbeListItem> {
         list_spidev_links()
             .into_iter()
-            .map(|path| probe_info_for_path(&path))
+            .map(|path| ProbeListItem::accessible(probe_info_for_path(&path)))
             .collect()
     }
 
-    fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+    fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<ProbeListItem> {
         let Some(selector) = selector else {
             return self.list_probes();
         };
@@ -104,14 +104,14 @@ impl ProbeFactory for LinuxSpidevSwdFactory {
             .as_deref()
             .is_some_and(|serial| is_valid_spidev_path(Path::new(serial)))
         {
-            return vec![probe_info_for_path(Path::new(
+            return vec![ProbeListItem::accessible(probe_info_for_path(Path::new(
                 selector.serial_number.as_deref().unwrap(),
-            ))];
+            )))];
         }
 
         self.list_probes()
             .into_iter()
-            .filter(|probe| selector.matches_probe(probe))
+            .filter(|probe| selector.matches_probe(&probe.info))
             .collect()
     }
 }
@@ -699,7 +699,10 @@ mod tests {
         let probes = LinuxSpidevSwdFactory.list_probes_filtered(Some(&selector));
 
         assert_eq!(probes.len(), 1);
-        assert_eq!(probes[0].serial_number.as_deref(), Some("/dev/spidev0.0"));
+        assert_eq!(
+            probes[0].info.serial_number.as_deref(),
+            Some("/dev/spidev0.0")
+        );
     }
 
     #[test]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -984,7 +984,7 @@ mod test {
             todo!()
         }
 
-        fn list_probes(&self) -> Vec<DebugProbeInfo> {
+        fn list_probes(&self) -> Vec<probe_rs::probe::list::ProbeListItem> {
             todo!()
         }
     }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/test.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/test.rs
@@ -2,7 +2,10 @@ use std::cell::RefCell;
 
 use probe_rs::{
     integration::{FakeProbe, ProbeLister},
-    probe::{DebugProbeError, DebugProbeInfo, DebugProbeSelector, Probe, ProbeCreationError},
+    probe::{
+        DebugProbeError, DebugProbeInfo, DebugProbeSelector, Probe, ProbeCreationError,
+        list::ProbeListItem,
+    },
 };
 
 #[derive(Debug)]
@@ -37,7 +40,7 @@ impl ProbeLister for TestLister {
         }
     }
 
-    fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+    fn list_with_access(&self, selector: Option<&DebugProbeSelector>) -> Vec<ProbeListItem> {
         self.probes
             .borrow()
             .iter()
@@ -46,7 +49,7 @@ impl ProbeLister for TestLister {
                     .as_ref()
                     .is_none_or(|selector| selector.matches_probe(info))
                 {
-                    Some(info.clone())
+                    Some(ProbeListItem::accessible(info.clone()))
                 } else {
                     None
                 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/list.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/list.rs
@@ -10,11 +10,22 @@ impl Cmd {
         if !probes.is_empty() {
             println!("The following debug probes were found:");
             for (num, link) in probes.iter().enumerate() {
-                println!("[{num}]: {link}");
+                let marker = if link.inaccessible {
+                    " (inaccessible)"
+                } else {
+                    ""
+                };
+                println!("[{num}]: {link}{marker}");
             }
         } else {
             println!("No debug probes were found.");
         }
+
+        // Nudge the user about their setup if we found nothing, or found a probe we can't access.
+        if probes.is_empty() || probes.iter().any(|probe| probe.inaccessible) {
+            crate::util::setup_hints::print_setup_hints();
+        }
+
         Ok(())
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
@@ -50,10 +50,8 @@ use postcard_rpc::{Topic, TopicDirection, endpoints, host_client, server, topics
 use postcard_schema::Schema;
 use probe_rs::config::Registry;
 use probe_rs::integration::ProbeLister;
-use probe_rs::probe::list::AllProbesLister;
-use probe_rs::probe::{
-    DebugProbeError, DebugProbeInfo, DebugProbeSelector, Probe, ProbeCreationError,
-};
+use probe_rs::probe::list::{AllProbesLister, ProbeListItem};
+use probe_rs::probe::{DebugProbeError, DebugProbeSelector, Probe, ProbeCreationError};
 use probe_rs::{Session, probe::list::Lister};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{Receiver, Sender, channel};
@@ -302,11 +300,11 @@ impl ProbeLister for LimitedLister {
         self.all_probes.open(selector)
     }
 
-    fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+    fn list_with_access(&self, selector: Option<&DebugProbeSelector>) -> Vec<ProbeListItem> {
         self.all_probes
-            .list(selector)
+            .list_with_access(selector)
             .into_iter()
-            .filter(|info| self.is_allowed(&DebugProbeSelector::from(info)))
+            .filter(|item| self.is_allowed(&DebugProbeSelector::from(&item.info)))
             .collect()
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/probe.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/probe.rs
@@ -1,6 +1,9 @@
 use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;
-use probe_rs::{Session, probe::DebugProbeInfo};
+use probe_rs::{
+    Session,
+    probe::list::{Accessibility, ProbeListItem},
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -28,6 +31,10 @@ pub struct DebugProbeEntry {
     pub serial_number: String,
 
     pub probe_type: String,
+
+    /// The probe was found but the current user cannot access its device
+    /// (e.g. a missing udev rule on Linux).
+    pub inaccessible: bool,
 }
 
 impl Display for DebugProbeEntry {
@@ -42,14 +49,19 @@ impl Display for DebugProbeEntry {
             write!(f, "-{}", interface)?;
         }
 
-        write!(f, ":{} ({})", self.serial_number, self.probe_type)
+        write!(f, ":{} ({})", self.serial_number, self.probe_type)?;
+
+        Ok(())
     }
 }
 
-impl From<DebugProbeInfo> for DebugProbeEntry {
-    fn from(probe: DebugProbeInfo) -> DebugProbeEntry {
+impl From<ProbeListItem> for DebugProbeEntry {
+    fn from(item: ProbeListItem) -> DebugProbeEntry {
+        let inaccessible = item.accessibility == Accessibility::PermissionDenied;
+        let probe = item.info;
         DebugProbeEntry {
             probe_type: probe.probe_type(),
+            inaccessible,
             identifier: probe.identifier,
             vendor_id: probe.vendor_id,
             product_id: probe.product_id,
@@ -95,7 +107,7 @@ pub fn list_probes(
     _request: ListProbesRequest,
 ) -> ListProbesResponse {
     let lister = ctx.lister();
-    let probes = lister.list_all();
+    let probes = lister.list_all_with_access();
 
     Ok(probes
         .into_iter()
@@ -131,7 +143,7 @@ pub async fn select_probe(
     // attach() call opens the correct channel.
     let requested_interface = request.probe.as_ref().and_then(|s| s.interface);
 
-    let mut list = lister.list(request.probe.map(|sel| sel.into()).as_ref());
+    let mut list = lister.list_with_access(request.probe.map(|sel| sel.into()).as_ref());
 
     // If the probe entry does not carry an interface (common for FTDI probes)
     // but the caller requested one, copy it from the original selector.

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -89,7 +89,13 @@ pub async fn attach_probe(
         client.load_chip_family(file).await?;
     }
 
-    let probe = select_probe(client, probe_options.probe.map(Into::into)).await?;
+    let probe = match select_probe(client, probe_options.probe.map(Into::into)).await {
+        Ok(probe) => probe,
+        Err(error) => {
+            print_setup_hints_if_relevant(client).await;
+            return Err(error);
+        }
+    };
 
     if probe_options.cycle_power {
         power_reset(probe.selector().into(), Duration::from_secs(1)).await?;
@@ -110,9 +116,32 @@ pub async fn attach_probe(
 
     match result {
         AttachResult::Success(session) => Ok(SessionInterface::new(client.clone(), session)),
-        AttachResult::ProbeNotFound => anyhow::bail!("Probe not found"),
-        AttachResult::FailedToOpenProbe(error) => anyhow::bail!("Failed to open probe: {error}"),
+        AttachResult::ProbeNotFound => {
+            print_setup_hints_if_relevant(client).await;
+            anyhow::bail!("Probe not found")
+        }
+        AttachResult::FailedToOpenProbe(error) => {
+            print_setup_hints_if_relevant(client).await;
+            anyhow::bail!("Failed to open probe: {error}")
+        }
+        // A busy probe is accessible, so no setup hint here.
         AttachResult::ProbeInUse => anyhow::bail!("Probe is already in use"),
+    }
+}
+
+/// Nudge the user about probe setup after a failed attach over the RPC client.
+///
+/// Mirrors the direct-attach path: we key off the accessibility reported by
+/// listing, not the specific error, so a probe that is present but blocked (or a
+/// missing probe) prints the hint, while a busy-but-accessible probe does not.
+async fn print_setup_hints_if_relevant(client: &RpcClient) {
+    let relevant = match client.list_probes().await {
+        Ok(probes) => probes.is_empty() || probes.iter().any(|probe| probe.inaccessible),
+        // If we can't even list, something setup-related is plausible.
+        Err(_) => true,
+    };
+    if relevant {
+        crate::util::setup_hints::print_setup_hints();
     }
 }
 

--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -8,7 +8,8 @@ use probe_rs::{
     flashing::{FileDownloadError, FlashError},
     integration::FakeProbe,
     probe::{
-        DebugProbeError, DebugProbeInfo, DebugProbeSelector, Probe, WireProtocol, list::Lister,
+        DebugProbeError, DebugProbeInfo, DebugProbeSelector, Probe, WireProtocol,
+        list::{Accessibility, Lister},
     },
 };
 use serde::{Deserialize, Serialize};
@@ -280,9 +281,18 @@ impl<'r> LoadedProbeOptions<'r> {
         } else {
             // If we got a probe selector as an argument, open the probe
             // matching the selector if possible.
-            match &self.0.probe {
-                Some(selector) => lister.open(selector.clone())?,
-                None => Self::select_probe(lister, self.0.non_interactive)?,
+            let result = match &self.0.probe {
+                Some(selector) => lister.open(selector.clone()).map_err(OperationError::from),
+                None => Self::select_probe(lister, self.0.non_interactive),
+            };
+            match result {
+                Ok(probe) => probe,
+                Err(error) => {
+                    if setup_hint_warranted(&error, lister) {
+                        crate::util::setup_hints::print_setup_hints();
+                    }
+                    return Err(error);
+                }
             }
         };
 
@@ -567,6 +577,21 @@ pub enum OperationError {
 
     #[error(transparent)]
     Anyhow(#[from] anyhow::Error),
+}
+
+/// Whether to nudge the user about probe setup after a failed attach.
+///
+/// We key this off the accessibility signal from listing, not the open error: a
+/// permission problem can surface as several different error variants (or get
+/// swallowed into "no probe found"), while a busy device (EBUSY) is fully
+/// accessible and shouldn't trigger it. So we show the hint when no probe was
+/// found at all, or when the lister reports a probe the current user can't access.
+fn setup_hint_warranted(error: &OperationError, lister: &Lister) -> bool {
+    matches!(error, OperationError::NoProbesFound)
+        || lister
+            .list_all_with_access()
+            .iter()
+            .any(|probe| probe.accessibility != Accessibility::Accessible)
 }
 
 /// Used in errors it can print a list of items.

--- a/probe-rs-tools/src/bin/probe-rs/util/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/mod.rs
@@ -6,6 +6,7 @@ pub mod logging;
 pub mod meta;
 pub mod pwr;
 pub mod rtt;
+pub mod setup_hints;
 pub mod visualizer;
 
 use std::num::ParseIntError;

--- a/probe-rs-tools/src/bin/probe-rs/util/setup_hints.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/setup_hints.rs
@@ -1,0 +1,36 @@
+//! Hints shown to the user when a probe can't be found or accessed.
+//!
+//! These are a CLI concern: the library only reports what it found, and the CLI decides
+//! whether to nudge the user about their setup.
+
+/// Prints a setup hint when a probe is missing or can't be accessed.
+///
+/// Only does anything on Linux, and never when `PROBE_RS_DISABLE_SETUP_HINTS` is set.
+pub fn print_setup_hints() {
+    #[cfg(target_os = "linux")]
+    linux::print_setup_hints();
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    const SETUP_URL: &str = "https://probe.rs/docs/getting-started/probe-setup/";
+
+    pub(super) fn print_setup_hints() {
+        if std::env::var("PROBE_RS_DISABLE_SETUP_HINTS").is_ok() {
+            return;
+        }
+
+        // We deliberately don't try to guess the cause (missing udev rule, wrong group,
+        // ...): that guessing is wrong on NixOS, Alpine, serial probes, etc. Whatever the
+        // cause, the fix is documented, so point there.
+        tracing::warn!(
+            "If your probe is plugged in but not listed, or shown as inaccessible, it is most likely a permissions problem."
+        );
+        tracing::warn!(
+            "Your user needs read and write access to the probe's device node: a USB node under /dev/bus/usb, or a serial port such as /dev/ttyACM0."
+        );
+        tracing::warn!(
+            "See {SETUP_URL} for how to set up the required udev rules and group membership."
+        );
+    }
+}

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -82,6 +82,10 @@ hexdump = { version = "0.1", optional = true }
 rmp-serde = { version = "1", optional = true }
 dunce = { version = "1.0.5", optional = true }
 
+# Used to check whether a probe's device node is accessible to the current user (access(2)).
+[target.'cfg(target_os = "linux")'.dependencies]
+nix = { version = "0.31", features = ["fs"] }
+
 [build-dependencies]
 probe-rs-target = { workspace = true, optional = true, features = ["bincode"] }
 

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -639,18 +639,26 @@ pub trait ProbeFactory: std::any::Any + std::fmt::Display + std::fmt::Debug + Sy
     /// When opening, it will open the first probe which succeeds during this call.
     fn open(&self, selector: &DebugProbeSelector) -> Result<Box<dyn DebugProbe>, DebugProbeError>;
 
-    /// Returns a list of all available debug probes of the current type.
-    fn list_probes(&self) -> Vec<DebugProbeInfo>;
+    /// Returns a list of all available debug probes of the current type, each annotated with
+    /// whether the current process can access it.
+    fn list_probes(&self) -> Vec<list::ProbeListItem>;
 
     /// Returns a list of probes that match the optional selector.
     ///
     /// If the selector is `None`, all available probes are returned.
-    fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+    fn list_probes_filtered(
+        &self,
+        selector: Option<&DebugProbeSelector>,
+    ) -> Vec<list::ProbeListItem> {
         // The default implementation falls back to listing all probes so that drivers don't need
         // to deal with the common filtering logic.
         self.list_probes()
             .into_iter()
-            .filter(|probe| selector.as_ref().is_none_or(|s| s.matches_probe(probe)))
+            .filter(|probe| {
+                selector
+                    .as_ref()
+                    .is_none_or(|s| s.matches_probe(&probe.info))
+            })
             .collect()
     }
 }

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -25,6 +25,7 @@ use crate::{
         AutoImplementJtagAccess, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
         IoSequenceItem, JtagAccess, JtagDriverState, ProbeCreationError, ProbeError, ProbeFactory,
         RawJtagIo, RawSwdIo, SwdSettings, WireProtocol, blackmagic::arm::BlackMagicProbeArmDebug,
+        list::ProbeListItem,
     },
 };
 use bitfield::bitfield;
@@ -1578,7 +1579,7 @@ impl ProbeFactory for BlackMagicProbeFactory {
         ))
     }
 
-    fn list_probes(&self) -> Vec<super::DebugProbeInfo> {
+    fn list_probes(&self) -> Vec<ProbeListItem> {
         let mut probes = vec![];
         let ports = match available_ports() {
             Ok(ports) => ports,
@@ -1592,12 +1593,17 @@ impl ProbeFactory for BlackMagicProbeFactory {
             let Some(info) = black_magic_debug_port_info(port.port_type, &port.port_name) else {
                 continue;
             };
-            probes.push(info);
+            // Black Magic probes are accessed over a serial port; check that node, not usbfs.
+            let accessibility = crate::probe::list::device_node_accessibility(&port.port_name);
+            probes.push(ProbeListItem {
+                info,
+                accessibility,
+            });
         }
         probes
     }
 
-    fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+    fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<ProbeListItem> {
         // No selector - list probes as usual
         let Some(selector) = selector else {
             return self.list_probes();
@@ -1624,7 +1630,7 @@ impl ProbeFactory for BlackMagicProbeFactory {
             return self
                 .list_probes()
                 .into_iter()
-                .filter(|probe| selector.matches_probe(probe))
+                .filter(|probe| selector.matches_probe(&probe.info))
                 .collect();
         };
 
@@ -1634,7 +1640,7 @@ impl ProbeFactory for BlackMagicProbeFactory {
         }
 
         // Filter is a valid probe, and VID:PID is either a BMP or the "not specified" convention.
-        vec![DebugProbeInfo {
+        vec![ProbeListItem::accessible(DebugProbeInfo {
             identifier: format!("{}:{}", ip_port.ip(), ip_port.port()),
             vendor_id: BLACK_MAGIC_PROBE_VID,
             product_id: BLACK_MAGIC_PROBE_PID,
@@ -1642,6 +1648,6 @@ impl ProbeFactory for BlackMagicProbeFactory {
             probe_factory: &BlackMagicProbeFactory,
             interface: None,
             is_hid_interface: false,
-        }]
+        })]
     }
 }

--- a/probe-rs/src/probe/ch347usbjtag/mod.rs
+++ b/probe-rs/src/probe/ch347usbjtag/mod.rs
@@ -50,7 +50,7 @@ impl ProbeFactory for Ch347UsbJtagFactory {
         }))
     }
 
-    fn list_probes(&self) -> Vec<super::DebugProbeInfo> {
+    fn list_probes(&self) -> Vec<super::list::ProbeListItem> {
         protocol::list_ch347usbjtag_devices()
     }
 }

--- a/probe-rs/src/probe/ch347usbjtag/protocol.rs
+++ b/probe-rs/src/probe/ch347usbjtag/protocol.rs
@@ -5,6 +5,7 @@ use nusb::{DeviceInfo, Interface, MaybeFuture};
 
 use crate::probe::{
     self, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeCreationError,
+    list::{ProbeListItem, usb_probe_accessibility},
     usb_util::InterfaceExt,
 };
 
@@ -286,12 +287,12 @@ impl Ch347UsbJtagDevice {
     }
 }
 
-pub(super) fn list_ch347usbjtag_devices() -> Vec<DebugProbeInfo> {
+pub(super) fn list_ch347usbjtag_devices() -> Vec<ProbeListItem> {
     match nusb::list_devices().wait() {
         Ok(devices) => devices
             .filter(is_ch34x_device)
             .map(|device| {
-                DebugProbeInfo::new(
+                let info = DebugProbeInfo::new(
                     "CH347 USB Jtag".to_string(),
                     device.vendor_id(),
                     device.product_id(),
@@ -299,7 +300,11 @@ pub(super) fn list_ch347usbjtag_devices() -> Vec<DebugProbeInfo> {
                     &Ch347UsbJtagFactory,
                     None,
                     false,
-                )
+                );
+                ProbeListItem {
+                    info,
+                    accessibility: usb_probe_accessibility(&device),
+                }
             })
             .collect(),
         Err(e) => {

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -22,8 +22,8 @@ use crate::{
         },
     },
     probe::{
-        AutoImplementJtagAccess, BatchCommand, DebugProbe, DebugProbeError, DebugProbeInfo,
-        DebugProbeSelector, JtagAccess, JtagDriverState, ProbeFactory, WireProtocol,
+        AutoImplementJtagAccess, BatchCommand, DebugProbe, DebugProbeError, DebugProbeSelector,
+        JtagAccess, JtagDriverState, ProbeFactory, WireProtocol,
         cmsisdap::commands::{
             CmsisDapError, RequestError,
             general::info::{CapabilitiesCommand, PacketCountCommand, SWOTraceBufferSizeCommand},
@@ -85,7 +85,7 @@ impl ProbeFactory for CmsisDapFactory {
             .map(DebugProbe::into_probe)
     }
 
-    fn list_probes(&self) -> Vec<DebugProbeInfo> {
+    fn list_probes(&self) -> Vec<crate::probe::list::ProbeListItem> {
         tools::list_cmsisdap_devices()
     }
 }

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -2,6 +2,7 @@ use super::CmsisDapDevice;
 use crate::probe::{
     BoxedProbeError, DebugProbeInfo, DebugProbeSelector, ProbeCreationError,
     cmsisdap::{CmsisDapFactory, commands::CmsisDapError, commands::DEFAULT_USB_TIMEOUT},
+    list::{ProbeListItem, usb_probe_accessibility},
 };
 #[cfg(feature = "cmsisdap_v1")]
 use hidapi::HidApi;
@@ -17,13 +18,23 @@ const USB_CMSIS_DAP_SUBCLASS: u8 = 0;
 /// to permission or driver errors, so it falls back to listing only
 /// HID devices if it does not find any suitable devices.
 #[tracing::instrument(skip_all)]
-pub fn list_cmsisdap_devices() -> Vec<DebugProbeInfo> {
+pub fn list_cmsisdap_devices() -> Vec<ProbeListItem> {
     tracing::debug!("Searching for CMSIS-DAP probes using nusb");
 
     #[cfg_attr(not(feature = "cmsisdap_v1"), expect(unused_mut))]
-    let mut probes = match nusb::list_devices().wait() {
+    let mut probes: Vec<ProbeListItem> = match nusb::list_devices().wait() {
         Ok(devices) => devices
-            .flat_map(|device| get_cmsisdap_info(&device, false))
+            .flat_map(|device| {
+                // A single USB device can yield multiple entries (v1/v2 interfaces); give each
+                // entry the same accessibility for that device.
+                let accessibility = usb_probe_accessibility(&device);
+                get_cmsisdap_info(&device, false)
+                    .into_iter()
+                    .map(move |info| ProbeListItem {
+                        info,
+                        accessibility,
+                    })
+            })
             .collect(),
         Err(e) => {
             tracing::warn!("error listing devices with nusb: {e}");
@@ -42,13 +53,14 @@ pub fn list_cmsisdap_devices() -> Vec<DebugProbeInfo> {
         for device in api.device_list() {
             if let Some(info) = get_cmsisdap_hid_info(device) {
                 if !probes.iter().any(|p| {
-                    p.vendor_id == info.vendor_id
-                        && p.product_id == info.product_id
-                        && p.serial_number.as_deref().unwrap_or("")
+                    p.info.vendor_id == info.vendor_id
+                        && p.info.product_id == info.product_id
+                        && p.info.serial_number.as_deref().unwrap_or("")
                             == info.serial_number.as_deref().unwrap_or("")
                 }) {
                     tracing::trace!("Adding new HID-only probe {:?}", info);
-                    probes.push(info)
+                    // HID-only probes are not opened over usbfs, so the access check doesn't apply.
+                    probes.push(ProbeListItem::accessible(info))
                 } else {
                     tracing::trace!("Ignoring duplicate {:?}", info);
                 }

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -17,6 +17,7 @@ use crate::{
         AutoImplementJtagAccess, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
         IoSequenceItem, JtagAccess, JtagDriverState, ProbeCreationError, ProbeFactory, RawJtagIo,
         RawSwdIo, SwdSettings, WireProtocol,
+        list::{ProbeListItem, usb_probe_accessibility},
     },
 };
 use bitvec::prelude::*;
@@ -334,11 +335,11 @@ impl ProbeFactory for FtdiProbeFactory {
         Ok(Box::new(probe))
     }
 
-    fn list_probes(&self) -> Vec<DebugProbeInfo> {
+    fn list_probes(&self) -> Vec<ProbeListItem> {
         list_ftdi_devices()
     }
 
-    fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+    fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<ProbeListItem> {
         // FTDI probes are enumerated as one entry per USB device. The interface/channel
         // (A/B/C/D) is not stored in DebugProbeInfo; it is a runtime selection passed
         // through to open(). The default list_probes_filtered() filters by interface,
@@ -351,10 +352,10 @@ impl ProbeFactory for FtdiProbeFactory {
             .into_iter()
             .filter(|probe| {
                 selector.as_ref().is_none_or(|s| {
-                    probe.vendor_id == s.vendor_id
-                        && probe.product_id == s.product_id
+                    probe.info.vendor_id == s.vendor_id
+                        && probe.info.product_id == s.product_id
                         && s.serial_number.as_ref().is_none_or(|sn| {
-                            if let Some(probe_sn) = &probe.serial_number {
+                            if let Some(probe_sn) = &probe.info.serial_number {
                                 probe_sn == sn
                             } else {
                                 sn.is_empty()
@@ -647,22 +648,25 @@ static FTDI_COMPAT_DEVICES: &[FtdiDevice] = &[
     },
 ];
 
-fn get_device_info(device: &DeviceInfo) -> Option<DebugProbeInfo> {
+fn get_device_info(device: &DeviceInfo) -> Option<ProbeListItem> {
     FTDI_COMPAT_DEVICES.iter().find_map(|ftdi| {
-        ftdi.matches(device).then(|| DebugProbeInfo {
-            identifier: device.product_string().unwrap_or("FTDI").to_string(),
-            vendor_id: device.vendor_id(),
-            product_id: device.product_id(),
-            serial_number: device.serial_number().map(|s| s.to_string()),
-            probe_factory: &FtdiProbeFactory,
-            is_hid_interface: false,
-            interface: None,
+        ftdi.matches(device).then(|| ProbeListItem {
+            info: DebugProbeInfo {
+                identifier: device.product_string().unwrap_or("FTDI").to_string(),
+                vendor_id: device.vendor_id(),
+                product_id: device.product_id(),
+                serial_number: device.serial_number().map(|s| s.to_string()),
+                probe_factory: &FtdiProbeFactory,
+                is_hid_interface: false,
+                interface: None,
+            },
+            accessibility: usb_probe_accessibility(device),
         })
     })
 }
 
 #[tracing::instrument(skip_all)]
-fn list_ftdi_devices() -> Vec<DebugProbeInfo> {
+fn list_ftdi_devices() -> Vec<ProbeListItem> {
     match nusb::list_devices().wait() {
         Ok(devices) => devices
             .filter_map(|device| get_device_info(&device))

--- a/probe-rs/src/probe/glasgow/mod.rs
+++ b/probe-rs/src/probe/glasgow/mod.rs
@@ -15,6 +15,7 @@ use crate::architecture::arm::{
 
 use super::{
     DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeFactory, WireProtocol,
+    list::ProbeListItem,
 };
 
 mod mux;
@@ -43,14 +44,14 @@ impl ProbeFactory for GlasgowFactory {
             .map(DebugProbe::into_probe)
     }
 
-    fn list_probes(&self) -> Vec<DebugProbeInfo> {
+    fn list_probes(&self) -> Vec<ProbeListItem> {
         // Don't return anything; we don't know whether any given device is running a compatible
         // bitstream, and there is no way for us to know which interfaces are bound to the probe-rs
         // applet. These parameters must be specified by the user.
         Vec::new()
     }
 
-    fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+    fn list_probes_filtered(&self, selector: Option<&DebugProbeSelector>) -> Vec<ProbeListItem> {
         // Return exactly the specified probe, if it has the option string (which is referred to
         // here as the serial number).
         if let Some(DebugProbeSelector {
@@ -62,7 +63,9 @@ impl ProbeFactory for GlasgowFactory {
             && *vendor_id == usb::VID_QIHW
             && *product_id == usb::PID_GLASGOW
         {
-            return vec![DebugProbeInfo {
+            // The probe is built from the selector, so there is no enumerated device to check
+            // accessibility against here.
+            return vec![ProbeListItem::accessible(DebugProbeInfo {
                 identifier: "Glasgow".to_owned(),
                 vendor_id: *vendor_id,
                 product_id: *product_id,
@@ -70,7 +73,7 @@ impl ProbeFactory for GlasgowFactory {
                 is_hid_interface: false,
                 probe_factory: &Self,
                 interface: *interface,
-            }];
+            })];
         }
 
         vec![]

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -45,6 +45,7 @@ use crate::{
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, IoSequenceItem,
         JtagDriverState, ProbeFactory, RawJtagIo, RawSwdIo, SwdSettings, WireProtocol,
+        list::{ProbeListItem, usb_probe_accessibility},
     },
 };
 
@@ -273,7 +274,7 @@ impl ProbeFactory for JLinkFactory {
         Ok(Box::new(this))
     }
 
-    fn list_probes(&self) -> Vec<DebugProbeInfo> {
+    fn list_probes(&self) -> Vec<ProbeListItem> {
         list_jlink_devices()
     }
 }
@@ -1309,7 +1310,7 @@ impl SwoAccess for JLink {
 }
 
 #[tracing::instrument]
-fn list_jlink_devices() -> Vec<DebugProbeInfo> {
+fn list_jlink_devices() -> Vec<ProbeListItem> {
     let devices = match nusb::list_devices().wait() {
         Ok(devices) => devices,
         Err(e) => {
@@ -1321,7 +1322,7 @@ fn list_jlink_devices() -> Vec<DebugProbeInfo> {
     devices
         .filter(is_jlink)
         .map(|info| {
-            DebugProbeInfo::new(
+            let debug_probe_info = DebugProbeInfo::new(
                 info.product_string().unwrap_or("J-Link").to_string(),
                 info.vendor_id(),
                 info.product_id(),
@@ -1329,7 +1330,11 @@ fn list_jlink_devices() -> Vec<DebugProbeInfo> {
                 &JLinkFactory,
                 None,
                 false,
-            )
+            );
+            ProbeListItem {
+                info: debug_probe_info,
+                accessibility: usb_probe_accessibility(&info),
+            }
         })
         .collect()
 }

--- a/probe-rs/src/probe/list.rs
+++ b/probe-rs/src/probe/list.rs
@@ -6,6 +6,67 @@ use crate::probe::{
 
 use super::DRIVERS;
 
+/// Whether the current process can access a listed probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Accessibility {
+    /// The probe can be accessed.
+    #[default]
+    Accessible,
+    /// The probe was found but the current user is not allowed to access it.
+    PermissionDenied,
+}
+
+/// A probe found during listing, together with whether it can be accessed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProbeListItem {
+    /// The probe that was found.
+    pub info: DebugProbeInfo,
+    /// Whether the current process can access the probe's underlying device.
+    pub accessibility: Accessibility,
+}
+
+impl ProbeListItem {
+    /// Creates a list item for a probe that is accessible.
+    pub fn accessible(info: DebugProbeInfo) -> Self {
+        Self {
+            info,
+            accessibility: Accessibility::Accessible,
+        }
+    }
+}
+
+/// Returns whether the current process can access the USB probe backed by the given device.
+///
+/// On platforms other than Linux this always returns [`Accessibility::Accessible`].
+pub fn usb_probe_accessibility(device: &nusb::DeviceInfo) -> Accessibility {
+    #[cfg(target_os = "linux")]
+    let accessibility = {
+        let path = linux::usbfs_node_path(device.busnum(), device.device_address());
+        device_node_accessibility(&path)
+    };
+    #[cfg(not(target_os = "linux"))]
+    let accessibility = {
+        let _ = device;
+        Accessibility::Accessible
+    };
+    accessibility
+}
+
+/// Returns whether the current process can access the probe reached through the given device node.
+///
+/// Use this for probes opened through a filesystem path, such as a serial port.
+/// On platforms other than Linux this always returns [`Accessibility::Accessible`].
+pub fn device_node_accessibility(path: &str) -> Accessibility {
+    #[cfg(target_os = "linux")]
+    {
+        if !linux::can_access(path) {
+            return Accessibility::PermissionDenied;
+        }
+    }
+    let _ = path;
+    Accessibility::Accessible
+}
+
 /// Struct to list all attached debug probes
 #[derive(Debug)]
 pub struct Lister {
@@ -32,12 +93,25 @@ impl Lister {
 
     /// List all available debug probes
     pub fn list_all(&self) -> Vec<DebugProbeInfo> {
-        self.lister.list_all()
+        self.list(None)
     }
 
     /// List probes found by the lister, with optional filtering.
     pub fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
         self.lister.list(selector)
+    }
+
+    /// List all available debug probes, annotating each with whether it can be accessed.
+    pub fn list_all_with_access(&self) -> Vec<ProbeListItem> {
+        self.list_with_access(None)
+    }
+
+    /// List probes with optional filtering, annotating each with whether it can be accessed.
+    ///
+    /// Probes that cannot be accessed are still included, marked
+    /// [`Accessibility::PermissionDenied`].
+    pub fn list_with_access(&self, selector: Option<&DebugProbeSelector>) -> Vec<ProbeListItem> {
+        self.lister.list_with_access(selector)
     }
 }
 
@@ -54,13 +128,21 @@ pub trait ProbeLister: std::fmt::Debug {
     /// Try to open a probe using the given selector
     fn open(&self, selector: &DebugProbeSelector) -> Result<Probe, DebugProbeError>;
 
+    /// List probes found by the lister, annotating each with whether it can be accessed.
+    fn list_with_access(&self, selector: Option<&DebugProbeSelector>) -> Vec<ProbeListItem>;
+
+    /// List probes found by the lister, with optional filtering.
+    fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+        self.list_with_access(selector)
+            .into_iter()
+            .map(|item| item.info)
+            .collect()
+    }
+
     /// List all probes found by the lister.
     fn list_all(&self) -> Vec<DebugProbeInfo> {
         self.list(None)
     }
-
-    /// List probes found by the lister, with optional filtering.
-    fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo>;
 }
 
 /// Default lister implementation that includes all built-in probe drivers.
@@ -83,24 +165,14 @@ impl ProbeLister for AllProbesLister {
             };
         }
 
-        #[cfg(target_os = "linux")]
-        if matches!(fallback_error, ProbeCreationError::CouldNotOpen) {
-            linux::help_linux();
-        }
-
         Err(open_error.unwrap_or(DebugProbeError::ProbeCouldNotBeCreated(fallback_error)))
     }
 
-    fn list(&self, selector: Option<&DebugProbeSelector>) -> Vec<DebugProbeInfo> {
+    fn list_with_access(&self, selector: Option<&DebugProbeSelector>) -> Vec<ProbeListItem> {
         let mut list = vec![];
 
         for driver in DRIVERS.read().iter() {
             list.extend(driver.list_probes_filtered(selector));
-        }
-
-        #[cfg(target_os = "linux")]
-        if list.is_empty() {
-            linux::help_linux();
         }
 
         list
@@ -122,163 +194,29 @@ impl AllProbesLister {
 
 #[cfg(target_os = "linux")]
 mod linux {
-    use std::process::Command;
+    /// Builds the usbfs device node path for a bus/device number pair.
+    pub(super) fn usbfs_node_path(busnum: u8, device_address: u8) -> String {
+        format!("/dev/bus/usb/{busnum:03}/{device_address:03}")
+    }
 
-    const UDEV_GROUP: &str = "plugdev";
-    const SYSTEMD_STRICT_SYSTEM_GROUP_VERSION: usize = 258;
-    const UDEV_RULES_PATH: &str = "/etc/udev/rules.d";
-
-    /// Gives the user a hint if they are on Linux.
+    /// Returns whether the current process can read and write the given device node.
     ///
-    /// Best is to call this only if no probes were found.
-    pub(super) fn help_linux() {
-        if std::env::var("PROBE_RS_DISABLE_SETUP_HINTS").is_ok() {
-            return;
-        }
-
-        help_systemd();
-        help_udev_rules();
+    /// This reflects the permissions and ACLs actually applied to the node, so it is
+    /// agnostic to how they got there (udev rule, group mode, `uaccess`, ...).
+    pub(super) fn can_access(path: &str) -> bool {
+        use nix::unistd::{AccessFlags, access};
+        // access(2) with R_OK|W_OK checks the real uid/gid against the node's perms and ACLs.
+        access(path, AccessFlags::R_OK | AccessFlags::W_OK).is_ok()
     }
 
-    /// Prints a helptext if udev rules seem to be missing.
-    fn help_udev_rules() {
-        if !udev_rule_present() {
-            tracing::warn!("There seems no probe-rs rule to be installed.");
-            tracing::warn!("Read more under https://probe.rs/docs/getting-started/probe-setup/");
-            tracing::warn!(
-                "If you manage your rules differently, put an empty rule file with 'probe-rs' in the name in {UDEV_RULES_PATH}."
-            );
+    #[cfg(test)]
+    mod tests {
+        use super::usbfs_node_path;
+
+        #[test]
+        fn node_path_is_zero_padded() {
+            assert_eq!(usbfs_node_path(1, 5), "/dev/bus/usb/001/005");
+            assert_eq!(usbfs_node_path(12, 127), "/dev/bus/usb/012/127");
         }
-    }
-
-    /// Prints a helptext if udev user groups seem to be missing or wrong.
-    fn help_systemd() {
-        let groups = user_groups();
-        let systemd_version = systemd_version();
-        let udev_group_id = udev_group_id();
-
-        let systemd_version_requires_system_group =
-            systemd_version.unwrap_or_default() >= SYSTEMD_STRICT_SYSTEM_GROUP_VERSION;
-
-        match udev_group_id {
-            None => {
-                tracing::warn!("The '{UDEV_GROUP}' group does not exist.");
-                tracing::warn!(
-                    "On how to create it, read more under https://probe.rs/docs/getting-started/probe-setup/"
-                );
-                return;
-            }
-            Some(id) if id >= 1000 && systemd_version_requires_system_group => {
-                tracing::warn!("The '{UDEV_GROUP}' group is not a system group.");
-                tracing::warn!(
-                    "Read more under https://probe.rs/docs/getting-started/probe-setup/"
-                );
-
-                return;
-            }
-            _ => {
-                // We do not have to print a message as the group exists and is a system group (id < 1000).
-            }
-        }
-
-        // Warn if the user does not belong to the right udev group.
-        if !groups.iter().any(|g| g == UDEV_GROUP) {
-            tracing::warn!("The user does not belong to the group '{UDEV_GROUP}'.");
-            tracing::warn!("Read more under https://probe.rs/docs/getting-started/probe-setup/");
-        } else {
-            tracing::warn!("Make sure you have reloaded udev rules after setting everything up");
-            tracing::warn!("Read more under https://probe.rs/docs/getting-started/probe-setup/");
-        }
-    }
-
-    /// Returns the groups assigned to the current user.
-    fn user_groups() -> Vec<String> {
-        let username = match std::env::var("USER") {
-            Err(error) => {
-                tracing::debug!("Gathering information about user failed: {error}");
-                return Vec::new();
-            }
-            Ok(username) => username,
-        };
-        let output = match Command::new("id").arg("-Gn").arg(&username).output() {
-            Err(error) => {
-                tracing::debug!("Gathering information about relevant user groups failed: {error}");
-                return Vec::new();
-            }
-            Ok(child) => child,
-        };
-        if !output.status.success() {
-            tracing::debug!(
-                "Gathering information about relevant user groups failed: {:?}",
-                output.status.code()
-            );
-            return Vec::new();
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        stdout
-            .split_ascii_whitespace()
-            .map(|g| g.to_owned())
-            .collect()
-    }
-
-    /// Returns the systemd version of the current system.
-    fn systemd_version() -> Option<usize> {
-        let output = match Command::new("systemctl").arg("--version").output() {
-            Err(error) => {
-                tracing::debug!("Gathering information about relevant user groups failed: {error}");
-                return None;
-            }
-            Ok(child) => child,
-        };
-        if !output.status.success() {
-            tracing::debug!(
-                "Gathering information about relevant user groups failed: {:?}",
-                output.status.code()
-            );
-            return None;
-        }
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        // First line looks like: "systemd 256 (256.6-1-arch)"
-        stdout
-            .lines()
-            .next()
-            .and_then(|l| l.split_whitespace().nth(1))
-            .and_then(|version| version.parse().ok())
-    }
-
-    /// Returns the group id of the group required to list udev devices.
-    fn udev_group_id() -> Option<usize> {
-        let output = match Command::new("getent").arg("group").arg(UDEV_GROUP).output() {
-            Err(error) => {
-                tracing::debug!("Finding the entry for the {UDEV_GROUP} failed: {error}");
-                return None;
-            }
-            Ok(child) => child,
-        };
-
-        if !output.status.success() {
-            tracing::debug!(
-                "Finding the entry for the {UDEV_GROUP} failed: {:?}",
-                output.status.code()
-            );
-            return None;
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        stdout.split(':').nth(2).and_then(|id| id.parse().ok())
-    }
-
-    /// Returns true if there is a probe-rs resembling udev rule file.
-    fn udev_rule_present() -> bool {
-        let mut files = match std::fs::read_dir(UDEV_RULES_PATH) {
-            Err(error) => {
-                tracing::debug!("Listing udev rule files at {UDEV_RULES_PATH} failed: {error}");
-                return false;
-            }
-            Ok(files) => files,
-        };
-
-        files.any(|p| p.unwrap().path().display().to_string().contains("probe-rs"))
     }
 }

--- a/probe-rs/src/probe/sifliuart/mod.rs
+++ b/probe-rs/src/probe/sifliuart/mod.rs
@@ -9,7 +9,7 @@ use crate::architecture::arm::{ArmDebugInterface, ArmError};
 use crate::probe::sifliuart::arm::SifliUartArmDebug;
 use crate::probe::{
     DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeCreationError,
-    ProbeFactory, WireProtocol,
+    ProbeFactory, WireProtocol, list::ProbeListItem,
 };
 use serialport::{SerialPort, SerialPortType, available_ports};
 use std::io::{BufReader, BufWriter, Read, Write};
@@ -469,7 +469,7 @@ impl ProbeFactory for SifliUartFactory {
         ))
     }
 
-    fn list_probes(&self) -> Vec<DebugProbeInfo> {
+    fn list_probes(&self) -> Vec<ProbeListItem> {
         let mut probes = vec![];
         let Ok(ports) = available_ports() else {
             return probes;
@@ -479,7 +479,12 @@ impl ProbeFactory for SifliUartFactory {
             else {
                 continue;
             };
-            probes.push(info);
+            // The SiFli probe is accessed over a serial port; check that node, not usbfs.
+            let accessibility = crate::probe::list::device_node_accessibility(&port.port_name);
+            probes.push(ProbeListItem {
+                info,
+                accessibility,
+            });
         }
         probes
     }

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -20,8 +20,8 @@ use crate::{
         valid_32bit_arm_address,
     },
     probe::{
-        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, Probe, ProbeError,
-        ProbeFactory, WireProtocol,
+        DebugProbe, DebugProbeError, DebugProbeSelector, Probe, ProbeError, ProbeFactory,
+        WireProtocol,
     },
 };
 
@@ -79,7 +79,7 @@ impl ProbeFactory for StLinkFactory {
         Ok(Box::new(stlink))
     }
 
-    fn list_probes(&self) -> Vec<DebugProbeInfo> {
+    fn list_probes(&self) -> Vec<crate::probe::list::ProbeListItem> {
         tools::list_stlink_devices()
     }
 }

--- a/probe-rs/src/probe/stlink/tools.rs
+++ b/probe-rs/src/probe/stlink/tools.rs
@@ -1,4 +1,5 @@
 use crate::probe::DebugProbeInfo;
+use crate::probe::list::{ProbeListItem, usb_probe_accessibility};
 use crate::probe::stlink::StLinkFactory;
 use crate::probe::usb_util::to_hex;
 use nusb::MaybeFuture;
@@ -12,7 +13,7 @@ pub(super) fn is_stlink_device(device: &nusb::DeviceInfo) -> bool {
 }
 
 #[tracing::instrument(skip_all)]
-pub(super) fn list_stlink_devices() -> Vec<DebugProbeInfo> {
+pub(super) fn list_stlink_devices() -> Vec<ProbeListItem> {
     let devices = match nusb::list_devices().wait() {
         Ok(d) => d,
         Err(e) => {
@@ -24,7 +25,7 @@ pub(super) fn list_stlink_devices() -> Vec<DebugProbeInfo> {
     devices
         .filter(is_stlink_device)
         .map(|device| {
-            DebugProbeInfo::new(
+            let info = DebugProbeInfo::new(
                 format!(
                     "STLink {}",
                     USB_PID_EP_MAP[&device.product_id()].version_name
@@ -35,7 +36,11 @@ pub(super) fn list_stlink_devices() -> Vec<DebugProbeInfo> {
                 &StLinkFactory,
                 None,
                 false,
-            )
+            );
+            ProbeListItem {
+                info,
+                accessibility: usb_probe_accessibility(&device),
+            }
         })
         .collect()
 }

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -20,6 +20,7 @@ use crate::{
     probe::{
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JtagSequence, ProbeError,
         ProbeFactory, WireProtocol,
+        list::{ProbeListItem, usb_probe_accessibility},
     },
 };
 
@@ -197,7 +198,7 @@ impl ProbeFactory for WchLinkFactory {
         Ok(Box::new(wlink))
     }
 
-    fn list_probes(&self) -> Vec<DebugProbeInfo> {
+    fn list_probes(&self) -> Vec<ProbeListItem> {
         list_wlink_devices()
     }
 }
@@ -553,9 +554,9 @@ impl JtagAccess for WchLink {
     }
 }
 
-fn get_wlink_info(device: &DeviceInfo) -> Option<DebugProbeInfo> {
+fn get_wlink_info(device: &DeviceInfo) -> Option<ProbeListItem> {
     if matches!(device.product_string(), Some("WCH-Link") | Some("WCH_Link")) {
-        Some(DebugProbeInfo::new(
+        let info = DebugProbeInfo::new(
             "WCH-Link",
             VENDOR_ID,
             PRODUCT_ID,
@@ -563,14 +564,18 @@ fn get_wlink_info(device: &DeviceInfo) -> Option<DebugProbeInfo> {
             &WchLinkFactory,
             None,
             false,
-        ))
+        );
+        Some(ProbeListItem {
+            info,
+            accessibility: usb_probe_accessibility(device),
+        })
     } else {
         None
     }
 }
 
 #[tracing::instrument(skip_all)]
-fn list_wlink_devices() -> Vec<DebugProbeInfo> {
+fn list_wlink_devices() -> Vec<ProbeListItem> {
     tracing::debug!("Searching for WCH-Link(RV) probes");
     let devices = match nusb::list_devices().wait() {
         Ok(devices) => devices,

--- a/smoke-tester/src/dut_definition.rs
+++ b/smoke-tester/src/dut_definition.rs
@@ -8,7 +8,10 @@ use probe_rs::config::Registry;
 use probe_rs::probe::WireProtocol;
 use probe_rs::{
     Target,
-    probe::{DebugProbeSelector, Probe, list::Lister},
+    probe::{
+        DebugProbeSelector, Probe,
+        list::{Accessibility, Lister},
+    },
 };
 use serde::Deserialize;
 use std::{
@@ -118,6 +121,37 @@ impl DutDefinition {
         let raw_definition = RawDutDefinition::from_file(file)?;
 
         DutDefinition::from_raw_definition(raw_definition, file)
+    }
+
+    /// Check that the configured probe shows up when listing probes, and that the
+    /// current user is allowed to access it.
+    pub fn assert_listed(&self) -> Result<()> {
+        let lister = Lister::new();
+        let probes = lister.list_all_with_access();
+
+        let listed = match &self.probe_selector {
+            Some(selector) => probes
+                .iter()
+                .find(|probe| selector.matches_probe(&probe.info))
+                .with_context(|| {
+                    format!("Probe with selector {selector} did not show up when listing probes")
+                })?,
+            None => {
+                anyhow::ensure!(
+                    !probes.is_empty(),
+                    "No probes detected when listing probes!"
+                );
+                &probes[0]
+            }
+        };
+
+        anyhow::ensure!(
+            listed.accessibility == Accessibility::Accessible,
+            "Probe was listed but reported as not accessible: {}",
+            listed.info
+        );
+
+        Ok(())
     }
 
     pub fn open_probe(&self) -> Result<Probe> {

--- a/smoke-tester/src/main.rs
+++ b/smoke-tester/src/main.rs
@@ -70,6 +70,18 @@ fn run_test(mut args: Arguments, definitions: &[DutDefinition]) -> Result<ExitCo
 
         let chip_name = definition.chip.name.clone();
 
+        // Verify the probe shows up when listing, and is reported as accessible.
+        {
+            let definition = definition.clone();
+            let trial = Trial::test("List probe", move || {
+                definition.assert_listed()?;
+                Ok(())
+            })
+            .with_kind(&chip_name);
+
+            trials.push(trial);
+        }
+
         for test in SESSION_TESTS {
             let session_definition = definition.clone();
 


### PR DESCRIPTION
Closes #357.
Closes #4025.
Closes #3566.
Closes #3622.
Closes #3683.
Closes #3924.

A USB probe you don't have access to used to just vanish from `list`, and the "no probe found" path leaned on a pile of distro guesswork to decide whether to print a udev hint — scanning `/etc/udev/rules.d` for a probe-rs rule, looking for a `plugdev` group, poking at the systemd version. That guessing is wrong on openSUSE, which uses `dialout` (#4025), and on NixOS and Alpine; it fired on completely unrelated failures like a busy device (#3622); and it kept nagging people whose rules were actually fine (#3924).

So accessibility becomes a real, checked property instead of something inferred. Listing returns `ProbeListItem { info, access }`; on Linux each probe's device node gets an `access(2)` check — read+write, no open, no side effects — on the usbfs node for USB probes and on the tty for serial ones like the Black Magic and SiFli probes. `access(2)` reflects the permissions and ACLs actually applied to the node, so it doesn't matter whether they came from a group, a `uaccess` rule, or anything else, and it gives the same answer on every distro. `probe-rs list` now shows a blocked probe with an "insufficient permissions" note instead of hiding it.

The library no longer prints anything, it just reports the data. The CLI decides whether to nudge, and keys that off the accessibility signal rather than the error variant: show the hint when nothing was found at all, or when a listed probe is genuinely inaccessible. A busy device (EBUSY) is accessible, so it no longer triggers the udev spiel (#3622); a real permission problem does, whichever error a given driver happens to surface (#3683). `PROBE_RS_DISABLE_SETUP_HINTS` still silences it.

The distro-specific detail that used to be baked (wrongly) into the binary now lives in the setup guide instead — dialout vs plugdev, NixOS and Alpine, and the systemd 258 change that started ignoring non-system groups. See probe-rs/webpage#273, which covers #3566.

On the hardware side the smoke-tester gains a per-DUT "List probe" trial that asserts the configured probe shows up in `list` and is reported accessible, so the listing path runs against real probes in CI.

`access(2)` goes through `nix`, which is already in the tree, so there's no new dependency and no `unsafe`.

#3567 is probably the same permission story, but there isn't enough in the report to be sure; worth a re-test against this once it lands.
