### PR TITLE
fix(arm): don't panic on AP type / DP mismatch

### DIFF
--- a/changelog/fixed-wrong-chip-apv2-panic.md
+++ b/changelog/fixed-wrong-chip-apv2-panic.md
@@ -1,0 +1,1 @@
+Selecting a chip that uses APv2 addresses (e.g. RP2350) while a different, DPv1-only target is connected now returns a proper error instead of panicking with "entered unreachable code".

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -487,9 +487,11 @@ impl ArmCommunicationInterface {
                     "DPv3 targets require APv2 addresses in target descriptions; got legacy AP index {port}. Use `ap: !v2 0x...`."
                 )));
             }
-            _ => unreachable!(
-                "Did not expect to be called with {ap:x?}. This is a bug, please report it."
-            ),
+            (ApAddress::V2(_), SelectCache::DPv1(_)) => {
+                return Err(ArmError::Other(format!(
+                    "The selected target uses an APv2 address ({ap:x?}), but the connected debug port only supports the ADIv5 SELECT register. This usually means the wrong chip was selected for the attached target."
+                )));
+            }
         }
 
         if previous_select != dp_state.current_select {


### PR DESCRIPTION
Picking a chip that uses APv2 addresses (RP2350 for me) while a DPv1-only target is actually connected panics with `internal error: entered unreachable code`. Same thing happens with `probe-rs reset`/`info` when you don't pass `--chip` and it tries a few APs against whatever's plugged in.

`select_ap_and_ap_bank` only had arms for the combinations it expected and left everything else to `unreachable!`, but `(APv2 address, DPv1 select)` is very much reachable when the wrong chip is selected. Handle that pair explicitly and return an `ArmError` hinting at the likely cause instead of tearing the process down.

Closes #3872
Closes #3257