### PR TITLE
fix(cmsisdap): don't unwrap a read that came back empty

### DIFF
--- a/changelog/fixed-cmsisdap-read-unwrap-panic.md
+++ b/changelog/fixed-cmsisdap-read-unwrap-panic.md
@@ -1,0 +1,1 @@
+cmsisdap: a read that comes back without data now returns an error instead of panicking, which could happen during session cleanup.

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -1098,9 +1098,12 @@ impl RawDapAccess for CmsisDap {
     fn raw_read_register(&mut self, address: RegisterAddress) -> Result<u32, ArmError> {
         let res = self.batch_add(BatchCommand::Read(address))?;
 
-        // NOTE(unwrap): batch_add will always return Some if the last command is a read
-        // and running the batch was successful.
-        Ok(res.unwrap())
+        // batch_add processes the batch immediately for a read, so a successful call
+        // returns the read value. A None here means the probe returned a response that
+        // didn't contain the read data - report it instead of panicking.
+        res.ok_or_else(|| {
+            DebugProbeError::Other("CMSIS-DAP read did not return any data".to_string()).into()
+        })
     }
 
     /// Writes a value to the DAP register on the specified port and address.


### PR DESCRIPTION
`raw_read_register` unwraps the value from `batch_add`, on the assumption that a read always comes back with data. If the probe returns a response without the read data, that unwrap panics — a couple of people have hit it during session teardown (see #3448).

Return a `DebugProbeError` in that case instead so the session can unwind cleanly. The happy path is unchanged.

Closes #3294
Closes #3448