### PR TITLE
fix(deps): update addr2line to 0.27 and gimli to 0.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,13 +14,13 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+checksum = "efe1709241908a54ef1925c6018f41d3f523d0cfe174719761eb39e7b7bf086a"
 dependencies = [
  "cpp_demangle",
  "fallible-iterator",
- "gimli 0.33.0",
+ "gimli 0.34.0",
  "memmap2",
  "object 0.39.1",
  "rustc-demangle",
@@ -1632,12 +1632,12 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+checksum = "1033caf0b349c518623b5396bfb2cf0bddf44f0306d543a250e5743297aafd10"
 dependencies = [
  "fnv",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap",
  "stable_deref_trait",
 ]
@@ -3177,7 +3177,7 @@ version = "0.31.0"
 dependencies = [
  "addr2line",
  "bitfield",
- "gimli 0.33.0",
+ "gimli 0.34.0",
  "insta",
  "itertools 0.15.0",
  "object 0.39.1",

--- a/probe-rs-debug/Cargo.toml
+++ b/probe-rs-debug/Cargo.toml
@@ -14,9 +14,9 @@ description = "Debugging functionality built on top of the probe-rs crate"
 exclude = ["tests/debug-unwind-tests"]
 
 [dependencies]
-addr2line = "0.26"
+addr2line = "0.27"
 bitfield = "0.19.0"
-gimli = "0.33.0"
+gimli = "0.34.0"
 itertools = "0.15.0"
 object = "0.39"
 parse_int = "0.9.0"

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -36,7 +36,7 @@ espflash = { version = "4.5", default-features = false }
 itertools = "0.15"
 
 # CLI-only
-addr2line = "0.26"
+addr2line = "0.27"
 bytesize = "2"
 capstone = "0.14"
 cargo_metadata = "0.23"


### PR DESCRIPTION
Combines #4079 (addr2line 0.26 → 0.27) and #4092 (gimli 0.33 → 0.34).

These can't go in separately: addr2line 0.27 depends on gimli 0.34, so whichever one lands first leaves the tree with two incompatible gimli versions and the build breaks. Bumping both in one go keeps everything on the same gimli.

Builds and clippy pass on `probe-rs-debug` and `probe-rs-tools`; no source changes were needed for the gimli 0.34 API.

Supersedes #4079 and #4092.