### PR TITLE
fix(arm): don't warn when the multidrop DP switch falls back to full setup

### DIFF
--- a/changelog/fixed-multidrop-switch-warning.md
+++ b/changelog/fixed-multidrop-switch-warning.md
@@ -1,0 +1,1 @@
+Stopped logging a spurious "Failed to switch to DP" warning on multidrop targets (e.g. RP2040) when the quick DP connect fails but the full setup sequence succeeds. The failed quick connect is now logged at debug level, and a genuine failure is still surfaced as an error.

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -354,11 +354,17 @@ impl ArmCommunicationInterface {
             if self.current_dp.is_none() {
                 sequence.debug_port_setup(&mut *self.probe_mut(), dp)?;
             } else {
-                // Try to switch to the new DP.
+                // Try the quick switch to the new DP first. This is expected to fail for
+                // some targets (e.g. RP2040 multidrop, which needs the dormant-state
+                // transition), so only fall back to the full setup here - if that also
+                // fails, the `?` below surfaces the real error.
                 if let Err(e) = sequence.debug_port_connect(&mut *self.probe_mut(), dp) {
-                    tracing::warn!("Failed to switch to DP {:x?}: {}", dp, e);
+                    tracing::debug!(
+                        "Quick connect to DP {:x?} failed ({e}), running full setup",
+                        dp
+                    );
 
-                    // Try the more involved debug_port_setup sequence, which also handles dormant mode.
+                    // The more involved debug_port_setup sequence also handles dormant mode.
                     sequence.debug_port_setup(&mut *self.probe_mut(), dp)?;
                 }
             }


### PR DESCRIPTION
On multidrop targets (RP2040, RP2350) the quick `debug_port_connect` can't select the DP on its own — those need the dormant-state transition that only the fuller `debug_port_setup` performs. We already fall back to `debug_port_setup` in that case, so the `Failed to switch to DP ...` warning fires on essentially every connect even though nothing is wrong.

It's especially visible on Ctrl+C teardown, where `Session::drop` re-selects core 1's DP to clear breakpoints — that's the `Failed to switch to DP Multidrop(...)` message people keep reporting.

This demotes the failed quick-connect to `debug!`. If the fallback `debug_port_setup` also fails, the `?` still surfaces that as a real error, so we don't lose genuine failures.

Only tested by building locally; I don't have an RP2040 in front of me right now, so leaving as draft for a hardware smoke test.

Closes #3316