### PR TITLE
Fix for PSE84: various PSOC Edge E84 bugfixes

### DIFF
--- a/changelog/changed-gdbserver-multicore.md
+++ b/changelog/changed-gdbserver-multicore.md
@@ -1,0 +1,1 @@
+The GDB server now tolerates cores that firmware has not enabled yet (e.g. a secondary core still held in reset): such cores are skipped when halting and reporting stop reasons, and accesses to them return `EIO` instead of aborting the session, so debugging the remaining cores keeps working.

--- a/changelog/changed-pse84-support.md
+++ b/changelog/changed-pse84-support.md
@@ -1,1 +1,1 @@
-Improved the PSOC Edge E84 debug sequence reliability, extended list of supported targets and thair memory map layout.
+Improved the PSOC Edge E84 debug sequence reliability, extended list of supported targets and their memory map layout.

--- a/changelog/changed-pse84-support.md
+++ b/changelog/changed-pse84-support.md
@@ -1,0 +1,1 @@
+Improved the PSOC Edge E84 debug sequence reliability, extended list of supported targets and thair memory map layout.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/mod.rs
@@ -146,7 +146,15 @@ impl<'a> RuntimeTarget<'a> {
         let mut session = self.session.lock();
 
         for i in &self.cores {
-            let mut core = session.core(*i)?;
+            let mut core = match session.core(*i) {
+                Ok(core) => core,
+                // A core that is not enabled yet (e.g. a secondary core still
+                // held in reset by firmware) cannot be halted. Skip it rather
+                // than failing the whole session; it will be picked up on a
+                // later access once firmware has enabled it.
+                Err(Error::CoreDisabled(_)) => continue,
+                Err(e) => return Err(e),
+            };
             if !core.core_halted()? {
                 core.halt(Duration::from_millis(100))?;
             }
@@ -197,7 +205,12 @@ impl<'a> RuntimeTarget<'a> {
             let mut session = self.session.lock();
 
             for i in &self.cores {
-                let mut core = session.core(*i)?;
+                let mut core = match session.core(*i) {
+                    Ok(core) => core,
+                    // A core that is not enabled yet has no status to report.
+                    Err(Error::CoreDisabled(_)) => continue,
+                    Err(e) => return Err(e.into()),
+                };
                 let CoreStatus::Halted(reason) = core.status()? else {
                     continue;
                 };

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/traits.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/traits.rs
@@ -13,6 +13,14 @@ impl<T> GdbErrorExt<T> for Result<T, Error> {
     fn into_target_result(self) -> TargetResult<T, RuntimeTarget<'static>> {
         match self {
             Ok(v) => Ok(v),
+            // A core that is not enabled yet (e.g. a secondary core still held in
+            // reset by firmware) is not a fatal protocol error: report EIO so GDB
+            // can keep the session alive and access to other cores keeps working.
+            Err(Error::CoreDisabled(index)) => {
+                tracing::debug!("Core {index} is not enabled");
+                // EIO
+                Err(TargetError::Errno(122))
+            }
             Err(e) => Err(TargetError::Fatal(e.into())),
         }
     }

--- a/probe-rs/src/vendor/infineon/sequences/psoc_edge.rs
+++ b/probe-rs/src/vendor/infineon/sequences/psoc_edge.rs
@@ -1,15 +1,25 @@
 //! Debug sequences for PSOC Edge devices.
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicU32, Ordering},
+};
 
 use bitfield::bitfield;
 use probe_rs_target::{Chip, CoreType};
 
 use crate::{
     architecture::arm::{
-        ArmDebugInterface, ArmError, FullyQualifiedApAddress,
-        sequences::{ArmDebugSequence, DefaultArmSequence},
+        ApV2Address, ArmDebugInterface, ArmError, FullyQualifiedApAddress,
+        armv8m::Dhcsr,
+        core::cortex_m,
+        dp::{Abort, DpAddress, DpRegister},
+        memory::ArmMemoryInterface,
+        sequences::{
+            ArmDebugSequence, DefaultArmSequence, cortex_m_reset_system, cortex_m_wait_for_reset,
+        },
     },
     config::CoreExt,
+    core::memory_mapped_registers::MemoryMappedRegister,
 };
 
 bitfield! {
@@ -23,7 +33,26 @@ bitfield! {
     pub cm55_wait, set_cm55_wait: 4;
 }
 impl MxCm55Ctl {
-    const ADDRESS: u64 = 0x44160000;
+    /// Secure alias address (`APPSS->APPCPUSS->MXCM55->CM55_CTL`)
+    /// The CM33 AP accesses this register with a secure transaction by default,
+    /// so the non-secure alias (`0x44160000`) could return a stale/incorrect value.
+    const ADDRESS: u64 = 0x54160000;
+}
+
+bitfield! {
+    /// CM55 local command register (APPSS->APPCPUSS->MXCM55->CM55_CMD).
+    ///
+    /// Writing the reset value triggers a local CM55 reset without affecting CM33
+    /// or the rest of the system. The 0xA5FA key must be included in the write.
+    #[derive(Clone, Copy)]
+    struct MxCm55Cmd(u32);
+    impl Debug;
+}
+impl MxCm55Cmd {
+    /// Secure alias address for the CM55_CMD register.
+    const ADDRESS: u64 = 0x54160004;
+    /// Write this value to trigger a local CM55 reset (key=0xA5FA, RESET=1).
+    const RESET: u32 = 0x05FA_0001;
 }
 
 bitfield! {
@@ -35,7 +64,7 @@ bitfield! {
     /// Enables the CM55 debug access port.
     pub cm55_enable, set_cm55_enable: 0;
 
-    /// Enables invasive debug access to the CM55 (halting, stepping, breakpooints).
+    /// Enables invasive debug access to the CM55 (halting, stepping, breakpoints).
     pub cm55_dbg_enable, set_cm55_dbg_enable: 4;
 
     /// Enables non-invasive debug access to the CM55 (tracing and memory access).
@@ -45,6 +74,75 @@ impl AppCpussApCtl {
     const ADDRESS: u64 = 0x441C1000;
 }
 
+bitfield! {
+    /// CM55 power domain sense register (PWRMODE->PD6->PD_SENSE).
+    ///
+    /// Controls whether the CM55 power domain is turned on. After a reset the CM55
+    /// domain is off; the debugger must enable it before accessing any CM55 registers.
+    #[derive(Clone, Copy)]
+    struct PwrmodePd6PdSense(u32);
+    impl Debug;
+
+    /// Powers on the CM55 core power domain.
+    pub pd_on_cm55, set_pd_on_cm55: 4;
+}
+impl PwrmodePd6PdSense {
+    const ADDRESS: u64 = 0x42410060;
+}
+
+/// Safe RAM address for the CM55 pre-initialization endless-loop instruction.
+///
+/// Located in the CM55's low internal memory (ITCM/DTCM window), which is one of
+/// the few regions the CM55 AP is allowed to access immediately after reset.
+const CM55_ENDLESS_LOOP_ADDR: u64 = 0x0003_FF00;
+
+/// `b .` (branch-to-self, `0xE7FE`) packed into a 32-bit word.
+const CM55_ENDLESS_LOOP_INSTR: u32 = 0xE7FE_E7FE;
+
+/// Safe initial stack pointer value used when pre-initializing the CM55.
+const CM55_SAFE_SP: u32 = 0x0000_0100;
+
+/// DCRSR register selectors (ARMv8-M Architecture Reference Manual, `DCRSR.REGSEL`),
+/// passed to `cortex_m::{read,write}_core_reg` as [`crate::RegisterId`]s.
+const REGSEL_SP: u16 = 13;
+const REGSEL_LR: u16 = 14;
+const REGSEL_PC: u16 = 15;
+const REGSEL_MSP: u16 = 17;
+
+/// ADIv6 base address of the system (SYS) access port (`__apid=0`).
+///
+/// The bus-access portal used to acquire the device before the CM33/CM55 APs are open,
+/// so it is addressed directly
+const SYS_AP_BASE: u64 = 0xF000_0000;
+
+// ADIv6 memory-AP register offsets (same layout for all APv2 memory APs).
+const AP_CSW: u64 = 0xD00;
+const AP_TAR: u64 = 0xD04;
+const AP_DRW: u64 = 0xD0C;
+
+/// SYS AP CSW for 32-bit secure word accesses with single auto-increment
+/// (DbgSwEnable | MasterType | Cacheable | Privileged | Data | Size=Word).
+const SYS_AP_CSW_WORD: u32 = 0xAB00_0002;
+
+/// Test Mode Control Register (`SRSS->TST_MODE`).
+const TST_MODE_ADDRESS: u32 = 0x5240_0400;
+
+/// `TST_MODE.TEST_MODE` (bit 31): request the boot ROM to stay in its Listen Window.
+const TEST_MODE_MSK: u32 = 0x8000_0000;
+
+/// Extended boot status word, mirrored at the base of secure SRAM (`SRAM_S_BASE`).
+const EXT_BOOT_STATUS_ADDRESS: u32 = 0x3400_0000;
+
+/// Value of [`EXT_BOOT_STATUS_ADDRESS`] once the boot ROM has reached its idle
+/// Listen Window (i.e. the device is acquired in Test Mode).
+const EXT_BOOT_STATUS_IDLE: u32 = 0xAA00_B5F8;
+
+/// Maximum time to wait for the boot ROM to reach its idle Listen Window.
+const TIMEOUT_BOOT_COMPLETE_MS: u64 = 5000;
+
+/// Settle time after a reset before further debug access (DFP `__Reset_Finish_Delay`).
+const RESET_FINISH_DELAY_MS: u64 = 50;
+
 /// PSOC Edge debug sequences.
 #[derive(Debug)]
 pub struct PsocEdge {
@@ -53,6 +151,16 @@ pub struct PsocEdge {
 
     // The access port for the application CPU (CM55).
     cm55_ap: FullyQualifiedApAddress,
+
+    // Whether the CM55 debug interface was successfully enabled. Used to decide
+    // whether to re-enable it after a system reset.
+    cm55_enabled: AtomicBool,
+
+    // Saved DEMCR values for exact reset-catch restore semantics per core.
+    cm33_demcr_saved: AtomicU32,
+    cm55_demcr_saved: AtomicU32,
+    cm33_demcr_valid: AtomicBool,
+    cm55_demcr_valid: AtomicBool,
 }
 
 impl PsocEdge {
@@ -66,7 +174,15 @@ impl PsocEdge {
                 .expect("PSOC Edge core must have a memory AP")
         });
 
-        Arc::new(PsocEdge { cm33_ap, cm55_ap })
+        Arc::new(PsocEdge {
+            cm33_ap,
+            cm55_ap,
+            cm55_enabled: AtomicBool::new(false),
+            cm33_demcr_saved: AtomicU32::new(0),
+            cm55_demcr_saved: AtomicU32::new(0),
+            cm33_demcr_valid: AtomicBool::new(false),
+            cm55_demcr_valid: AtomicBool::new(false),
+        })
     }
 }
 
@@ -78,24 +194,606 @@ impl ArmDebugSequence for PsocEdge {
         core_type: CoreType,
     ) -> Result<(), ArmError> {
         if core_ap == &self.cm55_ap {
-            // In order to debug the CM55, we may need to first power it up using the CM33.
-            let mut cm33_ap = interface.memory_interface(&self.cm33_ap)?;
+            let dp = self.cm33_ap.dp();
 
-            // Check if the CM55 is enabled.
-            let ctl = MxCm55Ctl(cm33_ap.read_word_32(MxCm55Ctl::ADDRESS)?);
-            if ctl.cm55_wait() {
-                return Err(ArmError::CoreDisabled);
+            // If the CM55 has already been enabled, do NOT re-run the full power-up /
+            // CPU_WAIT-release sequence on every attach. `session.core(1)` calls this
+            // on each access (connect, `info threads`, register reads), and re-driving
+            // that sequence re-writes DHCSR and can resume a core the debugger had
+            // already halted, which then makes register reads fail. Instead just
+            // confirm the debug interface is still live and (re-)halt the core.
+            if self.cm55_enabled.load(Ordering::Relaxed) {
+                match self.ensure_cm55_halted(interface) {
+                    Ok(()) => {
+                        return DefaultArmSequence(()).on_attach(interface, core_ap, core_type);
+                    }
+                    Err(e) => {
+                        // Interface no longer responding — fall back to a full re-enable.
+                        tracing::debug!("CM55 re-attach halt check failed: {:?}", e);
+                        Self::recover_dp(interface, dp);
+                        self.cm55_enabled.store(false, Ordering::Relaxed);
+                    }
+                }
             }
 
-            // Enable the CM55 AP.
-            let mut ap_ctl = AppCpussApCtl(cm33_ap.read_word_32(AppCpussApCtl::ADDRESS)?);
+            // Enable the CM55 via the CM33 AP. If this fails with a hardware error
+            // (e.g. AHB stall accessing an unclocked register), clear DP sticky error
+            // flags so subsequent CM33 operations are not affected.
+            match self.try_enable_cm55(interface) {
+                Ok(()) => {}
+                Err(ArmError::CoreDisabled) => {
+                    return Err(ArmError::CoreDisabled);
+                }
+                Err(e) => {
+                    // Non-CoreDisabled failure while enabling the CM55 (e.g. firmware has
+                    // locked the secure APPSS space): recover the DP and report the core as
+                    // disabled so the caller/GDB stub can treat it as not-yet-debuggable.
+                    tracing::debug!("CM55 enable failed during attach: {:?}", e);
+                    Self::recover_dp(interface, dp);
+                    return Err(ArmError::CoreDisabled);
+                }
+            }
+        }
+
+        DefaultArmSequence(()).on_attach(interface, core_ap, core_type)
+    }
+
+    fn debug_device_unlock(
+        &self,
+        interface: &mut dyn ArmDebugInterface,
+        default_ap: &FullyQualifiedApAddress,
+        _permissions: &crate::Permissions,
+    ) -> Result<(), ArmError> {
+        // Best-effort Test Mode acquisition: request that the boot ROM remain in its
+        // Listen Window and wait until it reports idle. This lets the debugger attach
+        // before user firmware runs. Failures here are non-fatal — a device already
+        // running firmware simply will not reach the idle state — so any hardware
+        // error is logged, the DP sticky flags are cleared, and attach proceeds.
+        let dp = default_ap.dp();
+        let sys_ap = Self::sys_ap(dp);
+        if let Err(e) = self.acquire_test_mode(interface, &sys_ap) {
+            tracing::debug!("PSoC Edge: Test Mode acquisition skipped: {:?}", e);
+            Self::recover_dp(interface, dp);
+        }
+        Ok(())
+    }
+
+    fn reset_system(
+        &self,
+        interface: &mut dyn ArmMemoryInterface,
+        _core_type: CoreType,
+        _debug_base: Option<u64>,
+    ) -> Result<(), ArmError> {
+        let ap = interface.fully_qualified_address();
+
+        if ap == self.cm55_ap {
+            // Local CM55 reset: write CM55_CMD reset value via the CM33 AP so that only
+            // the CM55 is reset, leaving CM33 and the rest of the system untouched.
+            // The CMD register lives in the APPSS secure address space; CM55 AHB can
+            // also reach it but the CM33 AP is the safer path since CM55 may be halted.
+            tracing::debug!("PSoC Edge: local CM55 reset via CM33 AP");
+
+            let local_reset_result = (|| -> Result<(), ArmError> {
+                {
+                    let arm = interface
+                        .get_arm_debug_interface()
+                        .map_err(ArmError::Probe)?;
+                    let mut cm33_ap = arm.memory_interface(&self.cm33_ap)?;
+                    cm33_ap.write_word_32(MxCm55Cmd::ADDRESS, MxCm55Cmd::RESET)?;
+                }
+
+                // Wait for CM55 to come back up by polling DHCSR via the CM55 AP.
+                cortex_m_wait_for_reset(interface)?;
+                Ok(())
+            })();
+
+            if let Err(e) = local_reset_result {
+                tracing::warn!(
+                    "PSoC Edge: local CM55 reset failed ({:?}), falling back to SYSRESETREQ",
+                    e
+                );
+                let dp = self.cm33_ap.dp();
+                match interface.get_arm_debug_interface() {
+                    Ok(arm) => Self::recover_dp(arm, dp),
+                    Err(err) => tracing::warn!(
+                        "PSoC Edge: could not obtain ARM debug interface to recover DP: {:?}",
+                        err
+                    ),
+                }
+                cortex_m_reset_system(interface)?;
+            }
+
+            // Re-enable CM55 debug AP access (local reset and system reset both clear AppCpussApCtl).
+            self.cm55_enabled.store(false, Ordering::Relaxed);
+            let enable_result = {
+                let arm = interface
+                    .get_arm_debug_interface()
+                    .map_err(ArmError::Probe)?;
+                self.try_enable_cm55(arm)
+            };
+            match enable_result {
+                Ok(()) => {}
+                Err(ArmError::CoreDisabled) => {
+                    tracing::debug!("PSoC Edge: CM55 not ready after reset");
+                }
+                Err(e) => {
+                    let dp = self.cm33_ap.dp();
+                    match interface.get_arm_debug_interface() {
+                        Ok(arm) => Self::recover_dp(arm, dp),
+                        Err(err) => tracing::warn!(
+                            "PSoC Edge: could not obtain ARM debug interface to recover DP: {:?}",
+                            err
+                        ),
+                    }
+                    return Err(e);
+                }
+            }
+            return Ok(());
+        }
+
+        // CM33 (system) reset path: issue AIRCR.SYSRESETREQ, then re-enable CM55
+        // debug access if it was active before the reset.
+        tracing::debug!("PSoC Edge: system reset via AIRCR.SYSRESETREQ");
+        cortex_m_reset_system(interface)?;
+
+        // Give secure boot time to re-run before touching CM55 debug registers.
+        std::thread::sleep(std::time::Duration::from_millis(RESET_FINISH_DELAY_MS));
+
+        if self.cm55_enabled.load(Ordering::Relaxed) {
+            tracing::debug!("PSoC Edge: re-enabling CM55 debug access after system reset");
+            self.cm55_enabled.store(false, Ordering::Relaxed);
+            let enable_result = {
+                let arm = interface
+                    .get_arm_debug_interface()
+                    .map_err(ArmError::Probe)?;
+                self.try_enable_cm55(arm)
+            };
+            match enable_result {
+                Ok(()) => {}
+                Err(ArmError::CoreDisabled) => {
+                    // CM55 not yet started by firmware — not an error; it will be
+                    // re-enabled on the next on_attach call when firmware starts it.
+                    tracing::debug!(
+                        "PSoC Edge: CM55 not ready after system reset (firmware may not have started it yet)"
+                    );
+                }
+                Err(e) => {
+                    // The re-enable may fault if secure boot has re-locked the CM55's
+                    // secure space; recover the DP and continue — the CM55 will be
+                    // re-enabled on the next on_attach once firmware releases it.
+                    let dp = self.cm33_ap.dp();
+                    match interface.get_arm_debug_interface() {
+                        Ok(arm) => Self::recover_dp(arm, dp),
+                        Err(err) => tracing::warn!(
+                            "PSoC Edge: could not obtain ARM debug interface to recover DP: {:?}",
+                            err
+                        ),
+                    }
+                    tracing::debug!(
+                        "PSoC Edge: failed to re-enable CM55 after system reset: {:?}",
+                        e
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn debug_core_start(
+        &self,
+        interface: &mut dyn ArmDebugInterface,
+        core_ap: &FullyQualifiedApAddress,
+        core_type: CoreType,
+        debug_base: Option<u64>,
+        cti_base: Option<u64>,
+    ) -> Result<(), ArmError> {
+        if core_ap == &self.cm55_ap {
+            // CM55 enablement is deferred to on_attach() which has proper error recovery
+            // for the AHB stall that can occur when accessing CM55 registers in boot ROM state.
+            return Ok(());
+        }
+        DefaultArmSequence(()).debug_core_start(interface, core_ap, core_type, debug_base, cti_base)
+    }
+
+    fn reset_catch_set(
+        &self,
+        core: &mut dyn ArmMemoryInterface,
+        _core_type: CoreType,
+        _debug_base: Option<u64>,
+    ) -> Result<(), ArmError> {
+        use crate::architecture::arm::armv8m::Demcr;
+
+        let ap = core.fully_qualified_address();
+        let current_demcr = core.read_word_32(Demcr::get_mmio_address())?;
+
+        if ap == self.cm33_ap {
+            self.cm33_demcr_saved
+                .store(current_demcr, Ordering::Relaxed);
+            self.cm33_demcr_valid.store(true, Ordering::Relaxed);
+        } else if ap == self.cm55_ap {
+            self.cm55_demcr_saved
+                .store(current_demcr, Ordering::Relaxed);
+            self.cm55_demcr_valid.store(true, Ordering::Relaxed);
+        }
+
+        let mut demcr = Demcr(current_demcr);
+        demcr.set_vc_corereset(true);
+        core.write_word_32(Demcr::get_mmio_address(), demcr.into())?;
+
+        // Clear S_RESET_ST side effects on write by reading DHCSR.
+        let _ = core.read_word_32(Dhcsr::get_mmio_address())?;
+
+        Ok(())
+    }
+
+    fn reset_catch_clear(
+        &self,
+        core: &mut dyn ArmMemoryInterface,
+        _core_type: CoreType,
+        _debug_base: Option<u64>,
+    ) -> Result<(), ArmError> {
+        use crate::architecture::arm::armv8m::Demcr;
+
+        let ap = core.fully_qualified_address();
+        let restored = if ap == self.cm33_ap && self.cm33_demcr_valid.load(Ordering::Relaxed) {
+            self.cm33_demcr_valid.store(false, Ordering::Relaxed);
+            Some(self.cm33_demcr_saved.load(Ordering::Relaxed))
+        } else if ap == self.cm55_ap && self.cm55_demcr_valid.load(Ordering::Relaxed) {
+            self.cm55_demcr_valid.store(false, Ordering::Relaxed);
+            Some(self.cm55_demcr_saved.load(Ordering::Relaxed))
+        } else {
+            None
+        };
+
+        if let Some(previous_demcr) = restored {
+            core.write_word_32(Demcr::get_mmio_address(), previous_demcr)?;
+            return Ok(());
+        }
+
+        // Fallback: no saved state for this core, so clear reset-catch bit only.
+        let mut demcr = Demcr(core.read_word_32(Demcr::get_mmio_address())?);
+        demcr.set_vc_corereset(false);
+        core.write_word_32(Demcr::get_mmio_address(), demcr.into())?;
+        Ok(())
+    }
+}
+
+impl PsocEdge {
+    /// Build the fully-qualified address of the system (SYS) access port.
+    fn sys_ap(dp: DpAddress) -> FullyQualifiedApAddress {
+        FullyQualifiedApAddress::v2_with_dp(dp, ApV2Address(Some(SYS_AP_BASE)))
+    }
+
+    /// Write one 32-bit word to `addr` through the SYS AP using raw TAR/DRW writes.
+    ///
+    /// `memory_interface()` is not used for the SYS AP: it would initialise a generic
+    /// AMBA memory-AP adapter and reset CSW to a default that clears `DbgSwEnable`,
+    /// breaking subsequent transfers. The SYS AP is a proprietary bus-access portal.
+    fn write_sys_ap32(
+        interface: &mut dyn ArmDebugInterface,
+        sys_ap: &FullyQualifiedApAddress,
+        addr: u32,
+        value: u32,
+    ) -> Result<(), ArmError> {
+        interface.write_raw_ap_register(sys_ap, AP_TAR, addr)?;
+        interface.write_raw_ap_register(sys_ap, AP_DRW, value)?;
+        Ok(())
+    }
+
+    /// Read one 32-bit word from `addr` through the SYS AP using raw TAR/DRW accesses.
+    fn read_sys_ap32(
+        interface: &mut dyn ArmDebugInterface,
+        sys_ap: &FullyQualifiedApAddress,
+        addr: u32,
+    ) -> Result<u32, ArmError> {
+        interface.write_raw_ap_register(sys_ap, AP_TAR, addr)?;
+        interface.read_raw_ap_register(sys_ap, AP_DRW)
+    }
+
+    /// Acquire the device in Test Mode via the SYS AP.
+    ///
+    /// Sets `TST_MODE.TEST_MODE` so the boot ROM stays in its Listen Window, then polls
+    /// the extended boot status until it reports idle or the boot-complete timeout
+    /// elapses. Returns `Ok(())` on success or timeout (non-fatal); returns an error
+    /// only on a debug transport fault, which the caller recovers from.
+    fn acquire_test_mode(
+        &self,
+        interface: &mut dyn ArmDebugInterface,
+        sys_ap: &FullyQualifiedApAddress,
+    ) -> Result<(), ArmError> {
+        // Configure the SYS AP for 32-bit secure word accesses before using TAR/DRW.
+        interface.write_raw_ap_register(sys_ap, AP_CSW, SYS_AP_CSW_WORD)?;
+
+        // Request Test Mode so the boot ROM does not hand control to user firmware.
+        Self::write_sys_ap32(interface, sys_ap, TST_MODE_ADDRESS, TEST_MODE_MSK)?;
+
+        let deadline =
+            std::time::Instant::now() + std::time::Duration::from_millis(TIMEOUT_BOOT_COMPLETE_MS);
+        loop {
+            let status = Self::read_sys_ap32(interface, sys_ap, EXT_BOOT_STATUS_ADDRESS)?;
+            if status == EXT_BOOT_STATUS_IDLE {
+                tracing::debug!("PSoC Edge: acquired in Test Mode (boot status idle)");
+                return Ok(());
+            }
+            if std::time::Instant::now() >= deadline {
+                tracing::debug!(
+                    "PSoC Edge: boot status did not reach idle (last=0x{:08X}); \
+                     continuing without Test Mode",
+                    status
+                );
+                return Ok(());
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+    }
+
+    /// Enable the CM55 debug interface via the CM33 memory AP.
+    ///
+    /// This powers up the CM55 domain, opens the CM55 AP, and enables debug. If the
+    /// CM55 is still held in its post-reset wait state (boot firmware has not started
+    /// it yet), it is released from wait and pre-initialized to a safe state so the
+    /// debugger can attach to it directly
+    ///
+    /// Returns `Err(ArmError::CoreDisabled)` if the CM55 debug interface cannot be
+    /// enabled. Returns other errors on hardware faults (e.g. AHB bus stall).
+    fn try_enable_cm55(&self, interface: &mut dyn ArmDebugInterface) -> Result<(), ArmError> {
+        // Power up the CM55 domain and open its AP + debug features via the CM33 AP.
+        // Without this the CM55 AP and its peripheral registers are inaccessible. The
+        // PWRMODE and APPCPUSS registers are reachable from CM33 at any time.
+        {
+            let mut cm33_ap = interface.memory_interface(&self.cm33_ap)?;
+
+            let pd_sense_val = cm33_ap.read_word_32(PwrmodePd6PdSense::ADDRESS)?;
+            let mut pd_sense = PwrmodePd6PdSense(pd_sense_val);
+            if !pd_sense.pd_on_cm55() {
+                tracing::debug!("Powering on CM55 domain");
+                pd_sense.set_pd_on_cm55(true);
+                cm33_ap.write_word_32(PwrmodePd6PdSense::ADDRESS, pd_sense.0)?;
+            }
+
+            // Enable the CM55 AP bits via CM33's system control register. This must
+            // happen before any access through the CM55 AP.
+            let ap_ctl_val = cm33_ap.read_word_32(AppCpussApCtl::ADDRESS)?;
+            let mut ap_ctl = AppCpussApCtl(ap_ctl_val);
             ap_ctl.set_cm55_enable(true);
             ap_ctl.set_cm55_dbg_enable(true);
             ap_ctl.set_cm55_nid_enable(true);
             cm33_ap.write_word_32(AppCpussApCtl::ADDRESS, ap_ctl.0)?;
         }
 
-        DefaultArmSequence(()).on_attach(interface, core_ap, core_type)
+        // Write C_DEBUGEN to DHCSR via the CM55 AP and verify it sticks.
+        // DHCSR is in the CoreSight PPB space and is safe to access
+        // even when CM55 is not running — unlike peripheral registers like MxCm55Ctl.
+        // C_HALT is set alongside C_DEBUGEN so that attaching halts the core (proper
+        // debugger-attach semantics): if firmware has already released the CM55 it is
+        // stopped for the debugger, and a subsequent attach will not resume it.
+        {
+            let mut cm55_ap = interface.memory_interface(&self.cm55_ap)?;
+            let mut dhcsr = Dhcsr(0);
+            dhcsr.enable_write();
+            dhcsr.set_c_debugen(true);
+            dhcsr.set_c_halt(true);
+            cm55_ap.write_word_32(Dhcsr::get_mmio_address(), dhcsr.into())?;
+
+            // Verify the write was accepted by polling DHCSR.C_DEBUGEN.
+            // The write may not take effect immediately, so retry a few times.
+            const MAX_RETRIES: usize = 10;
+            let mut enabled = false;
+            for attempt in 1..=MAX_RETRIES {
+                let dhcsr = Dhcsr(cm55_ap.read_word_32(Dhcsr::get_mmio_address())?);
+                if dhcsr.c_debugen() {
+                    tracing::debug!(
+                        "CM55 debug interface enabled (attempt {}/{})",
+                        attempt,
+                        MAX_RETRIES
+                    );
+                    enabled = true;
+                    break;
+                }
+                if attempt < MAX_RETRIES {
+                    // Give the debug interface a moment to process the write
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                }
+            }
+            if !enabled {
+                tracing::warn!(
+                    "CM55 debug interface did not respond to DHCSR.C_DEBUGEN write after {} attempts",
+                    MAX_RETRIES
+                );
+                return Err(ArmError::CoreDisabled);
+            }
+        }
+
+        // If the CM55 is still held in wait (boot firmware has not started it), release
+        // it and set a safe initial state so the debugger can attach directly.
+        //
+        // MxCm55Ctl lives in the secure APPSS space. Once user firmware is running it
+        // typically locks that space down, so the read faults with a DAP FaultResponse.
+        // That fault is expected and simply means firmware has already taken the CM55
+        // out of wait — so we treat it as "not waiting", clear the resulting DP sticky
+        // error flags, and skip the release step (the core was already halted above via
+        // DHCSR.C_HALT).
+        let mut wait_read_faulted = false;
+        let cpu_wait = {
+            let mut cm33_ap = interface.memory_interface(&self.cm33_ap)?;
+            match cm33_ap.read_word_32(MxCm55Ctl::ADDRESS) {
+                Ok(val) => MxCm55Ctl(val).cm55_wait(),
+                Err(e) => {
+                    tracing::debug!(
+                        "CM55 wait-state register not readable ({:?}); assuming firmware manages the CM55",
+                        e
+                    );
+                    wait_read_faulted = true;
+                    false
+                }
+            }
+        };
+        if wait_read_faulted {
+            Self::recover_dp(interface, self.cm33_ap.dp());
+        }
+        if cpu_wait {
+            tracing::debug!("CM55 held in CPU_WAIT; releasing and pre-initializing");
+            self.release_cm55_from_wait(interface)?;
+        }
+
+        self.cm55_enabled.store(true, Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// Lightweight re-attach path for an already-enabled CM55.
+    ///
+    /// Instead of re-running the full power-up / CPU_WAIT-release sequence (which
+    /// re-writes DHCSR and can resume a core the debugger had already halted), this
+    /// just confirms the CM55 debug interface is still responding and (re-)halts the
+    /// core for the debugger.
+    ///
+    /// Returns `Err(ArmError::CoreDisabled)` if the CM55 debug interface is no longer
+    /// accessible, so the caller can fall back to a full re-enable.
+    fn ensure_cm55_halted(&self, interface: &mut dyn ArmDebugInterface) -> Result<(), ArmError> {
+        let mut cm55_ap = interface.memory_interface(&self.cm55_ap)?;
+
+        let dhcsr = Dhcsr(cm55_ap.read_word_32(Dhcsr::get_mmio_address())?);
+        if !dhcsr.c_debugen() {
+            return Err(ArmError::CoreDisabled);
+        }
+        if dhcsr.s_halt() {
+            // Already halted — nothing to do.
+            return Ok(());
+        }
+
+        // Core is running (e.g. firmware released it after the previous attach); halt
+        // it so the debugger can read its state.
+        let mut halt = Dhcsr(0);
+        halt.enable_write();
+        halt.set_c_debugen(true);
+        halt.set_c_halt(true);
+        cm55_ap.write_word_32(Dhcsr::get_mmio_address(), halt.into())?;
+
+        for _ in 0..100 {
+            if Dhcsr(cm55_ap.read_word_32(Dhcsr::get_mmio_address())?).s_halt() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        Ok(())
+    }
+
+    /// Release the CM55 from its post-reset wait state.
+    ///
+    /// Sets vector-catch-on-reset so the core halts the instant it is released, clears
+    /// the `CPU_WAIT` bit via the CM33 AP, halts the core, restores the caller's
+    /// original `DEMCR`, then pre-initializes the core to a safe state.
+    fn release_cm55_from_wait(
+        &self,
+        interface: &mut dyn ArmDebugInterface,
+    ) -> Result<(), ArmError> {
+        use crate::architecture::arm::armv8m::Demcr;
+
+        // Enable vector-catch-on-reset so the CM55 halts immediately once released.
+        let saved_demcr = {
+            let mut cm55_ap = interface.memory_interface(&self.cm55_ap)?;
+            let saved = cm55_ap.read_word_32(Demcr::get_mmio_address())?;
+            let mut demcr = Demcr(saved);
+            demcr.set_vc_corereset(true);
+            cm55_ap.write_word_32(Demcr::get_mmio_address(), demcr.into())?;
+            saved
+        };
+
+        // Clear CPU_WAIT via the CM33 AP so the CM55 leaves its wait state.
+        {
+            let mut cm33_ap = interface.memory_interface(&self.cm33_ap)?;
+            let mut ctl = MxCm55Ctl(cm33_ap.read_word_32(MxCm55Ctl::ADDRESS)?);
+            ctl.set_cm55_wait(false);
+            cm33_ap.write_word_32(MxCm55Ctl::ADDRESS, ctl.0)?;
+        }
+
+        // Halt the CM55 and wait until it reports being in debug state.
+        let halted = {
+            let mut cm55_ap = interface.memory_interface(&self.cm55_ap)?;
+            let mut dhcsr = Dhcsr(0);
+            dhcsr.enable_write();
+            dhcsr.set_c_debugen(true);
+            dhcsr.set_c_halt(true);
+            cm55_ap.write_word_32(Dhcsr::get_mmio_address(), dhcsr.into())?;
+
+            let mut halted = false;
+            for _ in 0..100 {
+                if Dhcsr(cm55_ap.read_word_32(Dhcsr::get_mmio_address())?).s_halt() {
+                    halted = true;
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            halted
+        };
+
+        // Restore the original DEMCR (removes the temporary vector-catch).
+        {
+            let mut cm55_ap = interface.memory_interface(&self.cm55_ap)?;
+            cm55_ap.write_word_32(Demcr::get_mmio_address(), saved_demcr)?;
+        }
+
+        if !halted {
+            tracing::warn!(
+                "CM55 did not halt after clearing CPU_WAIT; skipping pre-initialization"
+            );
+            return Ok(());
+        }
+
+        self.preinit_cm55(interface)
+    }
+
+    /// Pre-initialize a freshly-released CM55 to a safe, well-defined state.
+    ///
+    /// When the CM55 has not been set up by firmware its `PC`/`SP` hold boot-time
+    /// garbage, which makes the debugger fault on the first step or resume. A link
+    /// register with the top nibble set (`0xF...`, an `EXC_RETURN` pattern) indicates
+    /// this uninitialized state. In that case the core is pointed at an endless-loop
+    /// instruction in safe internal memory with sane stack pointers.
+    fn preinit_cm55(&self, interface: &mut dyn ArmDebugInterface) -> Result<(), ArmError> {
+        let mut cm55_ap = interface.memory_interface(&self.cm55_ap)?;
+
+        let lr = cortex_m::read_core_reg(&mut *cm55_ap, crate::RegisterId(REGSEL_LR))?;
+        if lr & 0xF000_0000 != 0xF000_0000 {
+            // Core already holds a plausible state; leave it untouched.
+            return Ok(());
+        }
+
+        tracing::debug!(
+            "Pre-initializing CM55: pc=0x{:X}, sp=0x{:X}",
+            CM55_ENDLESS_LOOP_ADDR | 1,
+            CM55_SAFE_SP
+        );
+        cm55_ap.write_word_32(CM55_ENDLESS_LOOP_ADDR, CM55_ENDLESS_LOOP_INSTR)?;
+        cortex_m::write_core_reg(
+            &mut *cm55_ap,
+            crate::RegisterId(REGSEL_PC),
+            (CM55_ENDLESS_LOOP_ADDR as u32) | 1,
+        )?;
+        cortex_m::write_core_reg(&mut *cm55_ap, crate::RegisterId(REGSEL_SP), CM55_SAFE_SP)?;
+        cortex_m::write_core_reg(&mut *cm55_ap, crate::RegisterId(REGSEL_MSP), CM55_SAFE_SP)?;
+        Ok(())
+    }
+
+    /// Clear all DP sticky error flags via the ABORT register.
+    ///
+    /// Called after a failed AHB access that may have set STICKYERR/STICKYORUN.
+    fn recover_dp(interface: &mut dyn ArmDebugInterface, dp: DpAddress) {
+        let mut abort = Abort(0);
+        abort.set_dapabort(true);
+        abort.set_orunerrclr(true);
+        abort.set_wderrclr(true);
+        abort.set_stkerrclr(true);
+        abort.set_stkcmpclr(true);
+        // Attempt to clear sticky error flags
+        match interface.write_raw_dp_register(dp, Abort::ADDRESS, abort.0) {
+            Ok(()) => tracing::debug!("Cleared DP sticky error flags"),
+            Err(e) => tracing::warn!(
+                "Failed to clear DP sticky error flags: {:?} (potential debug transport issue)",
+                e
+            ),
+        }
     }
 }
 

--- a/probe-rs/targets/PSOC_E84.yaml
+++ b/probe-rs/targets/PSOC_E84.yaml
@@ -63,7 +63,7 @@ chip_detection:
     0xf186: PSE845GPS2DFMC4
     0xf187: PSE846GPS2DBZQ3
     0xf188: PSE833GOS2DBZC4
-    0xf189: PSE813GOS4DBZC4
+    0xf189: PSE813GOS4DBZC4A
 generated_from_pack: true
 pack_file_release: 1.1.0
 variants:
@@ -92,12 +92,13 @@ variants:
     name: IRAM1
     range:
       start: 0x24000000
-      end: 0x24080000
+      end: 0x24100000
     cores:
     - cortex-m33
     - cortex-m55
   - !Nvm
     name: IROM2
+    is_alias: true
     range:
       start: 0x32011000
       end: 0x32040000
@@ -107,11 +108,23 @@ variants:
     access:
       write: false
       boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
   - !Ram
     name: IRAM2
+    is_alias: true
     range:
       start: 0x34000000
-      end: 0x34080000
+      end: 0x34100000
     cores:
     - cortex-m33
     - cortex-m55
@@ -119,17 +132,7 @@ variants:
     name: IROM3
     range:
       start: 0x60000000
-      end: 0x64000000
-    cores:
-    - cortex-m33
-    - cortex-m55
-    access:
-      write: false
-  - !Nvm
-    name: IROM5
-    range:
-      start: 0x64000000
-      end: 0x68000000
+      end: 0x61000000
     cores:
     - cortex-m33
     - cortex-m55
@@ -137,19 +140,21 @@ variants:
       write: false
   - !Nvm
     name: IROM4
+    is_alias: true
     range:
       start: 0x70000000
-      end: 0x74000000
+      end: 0x71000000
     cores:
     - cortex-m33
     - cortex-m55
     access:
       write: false
   - !Nvm
-    name: IROM6
+    name: IROM3_XIP
+    is_alias: true
     range:
-      start: 0x74000000
-      end: 0x78000000
+      start: 0x08000000
+      end: 0x09000000
     cores:
     - cortex-m33
     - cortex-m55
@@ -170,6 +175,10 @@ variants:
     type: armv8m
     core_access_options: !Arm
       ap: !v2 0xf0006000
+  jtag:
+    scan_chain:
+    - name: chain
+      ir_len: 8
   memory_map:
   - !Nvm
     name: IROM1
@@ -185,12 +194,13 @@ variants:
     name: IRAM1
     range:
       start: 0x24000000
-      end: 0x24080000
+      end: 0x24100000
     cores:
     - cortex-m33
     - cortex-m55
   - !Nvm
     name: IROM2
+    is_alias: true
     range:
       start: 0x32011000
       end: 0x3206a000
@@ -200,11 +210,23 @@ variants:
     access:
       write: false
       boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
   - !Ram
     name: IRAM2
+    is_alias: true
     range:
       start: 0x34000000
-      end: 0x34080000
+      end: 0x34100000
     cores:
     - cortex-m33
     - cortex-m55
@@ -212,17 +234,7 @@ variants:
     name: IROM3
     range:
       start: 0x60000000
-      end: 0x64000000
-    cores:
-    - cortex-m33
-    - cortex-m55
-    access:
-      write: false
-  - !Nvm
-    name: IROM5
-    range:
-      start: 0x64000000
-      end: 0x68000000
+      end: 0x61000000
     cores:
     - cortex-m33
     - cortex-m55
@@ -230,19 +242,21 @@ variants:
       write: false
   - !Nvm
     name: IROM4
+    is_alias: true
     range:
       start: 0x70000000
-      end: 0x74000000
+      end: 0x71000000
     cores:
     - cortex-m33
     - cortex-m55
     access:
       write: false
   - !Nvm
-    name: IROM6
+    name: IROM3_XIP
+    is_alias: true
     range:
-      start: 0x74000000
-      end: 0x78000000
+      start: 0x08000000
+      end: 0x09000000
     cores:
     - cortex-m33
     - cortex-m55
@@ -278,12 +292,13 @@ variants:
     name: IRAM1
     range:
       start: 0x24000000
-      end: 0x24080000
+      end: 0x24100000
     cores:
     - cortex-m33
     - cortex-m55
   - !Nvm
     name: IROM2
+    is_alias: true
     range:
       start: 0x32011000
       end: 0x3206a000
@@ -293,11 +308,23 @@ variants:
     access:
       write: false
       boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
   - !Ram
     name: IRAM2
+    is_alias: true
     range:
       start: 0x34000000
-      end: 0x34080000
+      end: 0x34100000
     cores:
     - cortex-m33
     - cortex-m55
@@ -305,17 +332,7 @@ variants:
     name: IROM3
     range:
       start: 0x60000000
-      end: 0x64000000
-    cores:
-    - cortex-m33
-    - cortex-m55
-    access:
-      write: false
-  - !Nvm
-    name: IROM5
-    range:
-      start: 0x64000000
-      end: 0x68000000
+      end: 0x61000000
     cores:
     - cortex-m33
     - cortex-m55
@@ -323,19 +340,21 @@ variants:
       write: false
   - !Nvm
     name: IROM4
+    is_alias: true
     range:
       start: 0x70000000
-      end: 0x74000000
+      end: 0x71000000
     cores:
     - cortex-m33
     - cortex-m55
     access:
       write: false
   - !Nvm
-    name: IROM6
+    name: IROM3_XIP
+    is_alias: true
     range:
-      start: 0x74000000
-      end: 0x78000000
+      start: 0x08000000
+      end: 0x09000000
     cores:
     - cortex-m33
     - cortex-m55
@@ -371,12 +390,13 @@ variants:
     name: IRAM1
     range:
       start: 0x24000000
-      end: 0x24080000
+      end: 0x24100000
     cores:
     - cortex-m33
     - cortex-m55
   - !Nvm
     name: IROM2
+    is_alias: true
     range:
       start: 0x32011000
       end: 0x3206a000
@@ -386,11 +406,23 @@ variants:
     access:
       write: false
       boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
   - !Ram
     name: IRAM2
+    is_alias: true
     range:
       start: 0x34000000
-      end: 0x34080000
+      end: 0x34100000
     cores:
     - cortex-m33
     - cortex-m55
@@ -398,17 +430,7 @@ variants:
     name: IROM3
     range:
       start: 0x60000000
-      end: 0x64000000
-    cores:
-    - cortex-m33
-    - cortex-m55
-    access:
-      write: false
-  - !Nvm
-    name: IROM5
-    range:
-      start: 0x64000000
-      end: 0x68000000
+      end: 0x61000000
     cores:
     - cortex-m33
     - cortex-m55
@@ -416,19 +438,21 @@ variants:
       write: false
   - !Nvm
     name: IROM4
+    is_alias: true
     range:
       start: 0x70000000
-      end: 0x74000000
+      end: 0x71000000
     cores:
     - cortex-m33
     - cortex-m55
     access:
       write: false
   - !Nvm
-    name: IROM6
+    name: IROM3_XIP
+    is_alias: true
     range:
-      start: 0x74000000
-      end: 0x78000000
+      start: 0x08000000
+      end: 0x09000000
     cores:
     - cortex-m33
     - cortex-m55
@@ -464,12 +488,13 @@ variants:
     name: IRAM1
     range:
       start: 0x24000000
-      end: 0x24080000
+      end: 0x24100000
     cores:
     - cortex-m33
     - cortex-m55
   - !Nvm
     name: IROM2
+    is_alias: true
     range:
       start: 0x32011000
       end: 0x3206a000
@@ -479,11 +504,23 @@ variants:
     access:
       write: false
       boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
   - !Ram
     name: IRAM2
+    is_alias: true
     range:
       start: 0x34000000
-      end: 0x34080000
+      end: 0x34100000
     cores:
     - cortex-m33
     - cortex-m55
@@ -491,17 +528,7 @@ variants:
     name: IROM3
     range:
       start: 0x60000000
-      end: 0x64000000
-    cores:
-    - cortex-m33
-    - cortex-m55
-    access:
-      write: false
-  - !Nvm
-    name: IROM5
-    range:
-      start: 0x64000000
-      end: 0x68000000
+      end: 0x61000000
     cores:
     - cortex-m33
     - cortex-m55
@@ -509,19 +536,21 @@ variants:
       write: false
   - !Nvm
     name: IROM4
+    is_alias: true
     range:
       start: 0x70000000
-      end: 0x74000000
+      end: 0x71000000
     cores:
     - cortex-m33
     - cortex-m55
     access:
       write: false
   - !Nvm
-    name: IROM6
+    name: IROM3_XIP
+    is_alias: true
     range:
-      start: 0x74000000
-      end: 0x78000000
+      start: 0x08000000
+      end: 0x09000000
     cores:
     - cortex-m33
     - cortex-m55
@@ -557,12 +586,13 @@ variants:
     name: IRAM1
     range:
       start: 0x24000000
-      end: 0x24080000
+      end: 0x24100000
     cores:
     - cortex-m33
     - cortex-m55
   - !Nvm
     name: IROM2
+    is_alias: true
     range:
       start: 0x32011000
       end: 0x3206a000
@@ -572,11 +602,23 @@ variants:
     access:
       write: false
       boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
   - !Ram
     name: IRAM2
+    is_alias: true
     range:
       start: 0x34000000
-      end: 0x34080000
+      end: 0x34100000
     cores:
     - cortex-m33
     - cortex-m55
@@ -584,17 +626,7 @@ variants:
     name: IROM3
     range:
       start: 0x60000000
-      end: 0x64000000
-    cores:
-    - cortex-m33
-    - cortex-m55
-    access:
-      write: false
-  - !Nvm
-    name: IROM5
-    range:
-      start: 0x64000000
-      end: 0x68000000
+      end: 0x61000000
     cores:
     - cortex-m33
     - cortex-m55
@@ -602,19 +634,21 @@ variants:
       write: false
   - !Nvm
     name: IROM4
+    is_alias: true
     range:
       start: 0x70000000
-      end: 0x74000000
+      end: 0x71000000
     cores:
     - cortex-m33
     - cortex-m55
     access:
       write: false
   - !Nvm
-    name: IROM6
+    name: IROM3_XIP
+    is_alias: true
     range:
-      start: 0x74000000
-      end: 0x78000000
+      start: 0x08000000
+      end: 0x09000000
     cores:
     - cortex-m33
     - cortex-m55
@@ -650,12 +684,13 @@ variants:
     name: IRAM1
     range:
       start: 0x24000000
-      end: 0x24080000
+      end: 0x24100000
     cores:
     - cortex-m33
     - cortex-m55
   - !Nvm
     name: IROM2
+    is_alias: true
     range:
       start: 0x32011000
       end: 0x32040000
@@ -665,11 +700,23 @@ variants:
     access:
       write: false
       boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
   - !Ram
     name: IRAM2
+    is_alias: true
     range:
       start: 0x34000000
-      end: 0x34080000
+      end: 0x34100000
     cores:
     - cortex-m33
     - cortex-m55
@@ -677,17 +724,7 @@ variants:
     name: IROM3
     range:
       start: 0x60000000
-      end: 0x64000000
-    cores:
-    - cortex-m33
-    - cortex-m55
-    access:
-      write: false
-  - !Nvm
-    name: IROM5
-    range:
-      start: 0x64000000
-      end: 0x68000000
+      end: 0x61000000
     cores:
     - cortex-m33
     - cortex-m55
@@ -695,19 +732,4921 @@ variants:
       write: false
   - !Nvm
     name: IROM4
+    is_alias: true
     range:
       start: 0x70000000
-      end: 0x74000000
+      end: 0x71000000
     cores:
     - cortex-m33
     - cortex-m55
     access:
       write: false
   - !Nvm
-    name: IROM6
+    name: IROM3_XIP
+    is_alias: true
     range:
-      start: 0x74000000
-      end: 0x78000000
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE812GMS2DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE812GMS4DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE812GOS2DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE812GOS4DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE813GMS2DBZC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE813GMS2DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE813GMS4DBZC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE813GMS4DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE813GOS2DBZC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE813GOS2DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE813GOS4DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE822GMS2DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE822GMS4DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE822GOS2DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE822GOS4DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE823GMS2DBZC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE823GMS2DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE823GMS4DBZC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE823GMS4DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE823GOS2DBZC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE823GOS2DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE823GOS4DBZC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE823GOS4DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE832GMS2DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE832GMS4DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE832GOS2DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE832GOS4DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE833GMS2DBZC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE833GMS2DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE833GMS4DBZC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE833GMS4DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE833GOS2DBZC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE833GOS2DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE833GOS4DBZC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE833GOS4DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE845GOS2DFMC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE845GOS2DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE845GOS4DFMC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE845GOS4DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE845GPS2DFMC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE845GPS2DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE845GPS4DFMC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE845GPS4DFNC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE846GOS2DBZC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE846GOS2DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE846GOS4DBZC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE846GOS4DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE846GPS2DBZC4
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE846GPS2DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x2206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x3206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x1206a000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  flash_algorithms:
+  - pse84_rram_nvm
+  - pse84_rram_nvm_s
+  - pse84_smif
+  - pse84_smif_s
+- name: PSE846GPS4DBZQ3
+  cores:
+  - name: cortex-m33
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0002000
+  - name: cortex-m55
+    type: armv8m
+    core_access_options: !Arm
+      ap: !v2 0xf0006000
+  memory_map:
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x22011000
+      end: 0x22040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x24000000
+      end: 0x24100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM2
+    is_alias: true
+    range:
+      start: 0x32011000
+      end: 0x32040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+      boot: true
+  - !Nvm
+    name: IROM_S_CBUS
+    is_alias: true
+    range:
+      start: 0x12011000
+      end: 0x12040000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Ram
+    name: IRAM2
+    is_alias: true
+    range:
+      start: 0x34000000
+      end: 0x34100000
+    cores:
+    - cortex-m33
+    - cortex-m55
+  - !Nvm
+    name: IROM3
+    range:
+      start: 0x60000000
+      end: 0x61000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM4
+    is_alias: true
+    range:
+      start: 0x70000000
+      end: 0x71000000
+    cores:
+    - cortex-m33
+    - cortex-m55
+    access:
+      write: false
+  - !Nvm
+    name: IROM3_XIP
+    is_alias: true
+    range:
+      start: 0x08000000
+      end: 0x09000000
     cores:
     - cortex-m33
     - cortex-m55
@@ -722,18 +5661,18 @@ flash_algorithms:
 - name: pse84_rram_nvm
   description: PSE84_RRAM_NVM
   default: true
-  instructions: gLUA8Fn+gL2AHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEdDQ1FDMLVcGAEMEwwNRpKyXUOAslFDLBkFRlVDCgwJBE0ZYkFYQwEMAARAGVFBML3+tQRGEEYNRhhDc9CmRoxGACCkGgFGnUFn02ZGACcBJD1GthqdQQLTE0Y6RiEkZUZ2Ri8ENgw+Qy0MthqdQQTTFQwbBCtDEgQQNGVGdkYvBjYKPkMtCrYanUEE0xUOGwIrQxICCDRlRnZGLwc2CT5DLQm2Gp1BBNMVDxsBK0MSASQdZUZ2Rq8Htgg+Q60IthqdQQTTlQ+bACtDkgCkHGVGdkbvB3YIPkNtCLYanUEa05IYW0FkHBbgABh2RmVGSUG3Gp1BAZEAkAnTYEaxGphBjkaERgCYAZkAJUAcaUHdB1IIKkNbCGQe5tVyRmNGA7Dwvf/nIEYoQwfQACDAQwFGwEbARiJGK0bx5wAgAUb35wHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAAAAiAwmLQizTAwqLQhHTACOcRk7gA0YLQzzUACJDCItCMdMDCYtCHNMDCotCAdOURj/gwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJBQwiLQgHTSwDAGlJBQRoA0gFGUkEQRnBHXeDKDwDQSUIDEADTQEJTQJxGACIDCYtCLdMDCotCEtOJAfwiEroDCotCDNOJAZIRi0II04kBkhGLQgTTiQE60JIRAOCJCcMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQdnSQwiLQgHTSwDAGlJBQRoA0gFGUkEQRmNGWxAB00BCACsA1UlCcEdjRlsQANNAQgG1BUkAKALcSRwIQADgCEbARsBGAr0Av////3+AtQDwrfyAvcJpACoB1ANIcEeJskFgACBwR8BGAQCKAAABAklBWA8gCEBwRwRQKUIAAQJJQVgPIAhAcEcEUBxU+LUGRiFIeEQFaP/3W/4ERihsACUAKATUIEb/91f+KEb4vRZIMVgWT3ocCkMyUDYYAPAq/UCIYyFJAYhCDtARSYhCCdAQSYhCEdETIP/30P8AKAbRBiAE4AAgAOAHIP/3v/8xaA8iCkCCQgHQ1OcwaDBouELQ2QElzufARiAAAQD////vIQ0AACINAADKCgAA8LUAIwNgQ2ABJjIHDEaUQ28lbQZlGW0LVS0E0hEjXQZVI1sDHuADJS0GrEIX0BslbQWsQhbQEU8PQLMEjyWtBa9CDtAHJe0Fr0IL0H8lbQZlGW0LNS0K0nUGNSPh5yVGAOA9RhFAQ2ANQwVg8L0PJa0Fr0L20AAhJUb15wAA/O8BRgEgAgeRQ0IGACCRQh/QE0qRQh/QGyJSBZFCFtAHItIFkUIS0A8ikgWRQg7QESJSBpFCDNCPIIAFgUIG0AlIgUIG0AMgAAaBQgfRNSBAAnBHBUhwRysggAJwR1Ug9ucAQCBCAIgQQICDAAAAKwfQACgF0AApA9AAKgHQmkIB0gAgcEcBIHBH8LWLsB1GA5IHRgmoAZH/93P/CpwJngKXOEYxRiJGAJUrRgOd//fe/xJPAC0f0AAoHdAEqAEhAYIHlAaWAZgFkAKcBJR/HAxIeEQAaMBtACgN1CBG//cI/wAoCNAEqClGAJoA8B/4B0YgRgDwB/g4Rguw8L0BADYB8AgAAIC1B0lCWA8jGweaQ0JQBUh4RABoQDAAIf/3zP6AvcBGIAABAKwIAAD+tQ5GBEZAaKFo42gbGlkYkUIB0ilI/r0CkiFoKE1KWQ8nukNKUUpZASMTQw4ik0NLUTlGAkY6QAAnACoBkRTQiENgYBAggBoCnahCANMoRgCQIEYxRgCbAPA0+GFoEDFhYACZdhhtGgHgOEYCnSlGKQkCkQAoD9ECmY9CDNIAIhAjIEYxRgDwHfhhaBAxYWB/HBA2ED3t5wAoB9EALQXQACIgRjFGK0YA8Az4IWgES8pYAZyiQ8pQ/r3ARgEANgEEMAEA8LWJsB1GApIORkdoBJCAaDkaDAn/9/z+JBg6RnNIOBhACgEnCygG0wsgQAJwSVEYgUIA07DgBJsBlwOSGGhwSQCURFBvTBMhDwPBWckHCNAALAbQMiD/9638BJtkHBho8edpSQAsGNDAGQBoAAMW1AKYACgDnAjRASAPLQFGANgAIQGaUEABQh3RACAQKBrQIVgFqhFQAB345whGpOBYfAAoA5wH0QDwk/sEmwAoAtBVSMAcmOAAIBAoBNAFqQAiClAAHfjnAZgAKAzQBagCmUAYAC0S0DF4AngKQwJwQBxtHnYc9ecFqAKZQBgALQXQMXgBcEAcbR52HPfnGGhDTUAZQWgAmpFCQ9EZfAApPklQ0MgcAyGJAwKRACYDLmPQACADmhAoBNAFqQlYEVAAHfjnGGhBWQKaEUNBUTFMwVnJBwjQACwG0DIg//cz/GQcBJgAaPPnACw70MAZAGjABkQPACACLD/TAi4B0QIsO9AA8C77ACgE0GAfAygEmwTSK+AgHwQoBJsq0x9IgB12HMTnHUhAHCfgUAsWSYhCBJsA0UnnFEiCQgLTFEiCQhLTACdB5wAhECkE0AWqUlhiUAkd+OcDIYkDAmgKQwJgACAK4A1ICOABJy7nC0iAHQPgwLKAAAqhCFgJsPC9AMDfvQDA362AgAIAAAAQQAAgEEAIMAEAgMf+/wMANgEEMAEAAAAAAAAAAAAJADYBCQA2ARC1gAAHSUJYEgUUD0FYDyAIQADwCfhhHEoIEBj/94r8EL3ARkASQFIQtQRGAPAq+AIsCdgCLAPQYQEGSokYAOAFSQloACkA1BC9IEYA8J75EL3ARgAWQFIAGEBSgQAHSApYByAQQAcoBtEFSAhYHyEBQAEgAAIIGHBHwEYAEkBSAAFAUoC1//fp/wMoDtkRIQkBiEIh0P8hCkYSMpBCDdAUMYhCINETSIBoGOB4RAB5QACHRAEbCRcPSIC9ASDBAwxIwGpAAwbgCkgAaAtJSkZRWIAHwBcIQIC9BkiAacAPwAOAvQdIgL0AIIC9BEhJRghYgL1oE0BSgPD6AhQAAAAQAAAAABJ6APi1DEYFRkhoNCH/9wz8qQE4SotYYGgDcNwPBHGcAKQPxHBcBGQPhHBbBVsPQ3CJGEpoMUsTQINgEwEbD0NzEgJSDwJzi2gBIpwAE0CDc+MPw3PMaB8jAJMlRh1ABXRlAC0PhXVlAS0PRXVlAm0PBXUlAy0PxXSlBG0PhXSkBeQORHQNaU5pjGnnAv8PJCPHVMZh6wTbD0N2qwXbDgN2AJsdQMV1FUsjQANi4wHcDwNGJDNccMxpIkCacOIC0g9aceID0g8acaIH0g/acAlqyg9ac4oA0g8ac8oA0gzChcgGwA8YcggHwA/YcQcgCECYcQAg+L0AGEBS//8fAP//BwDwtZGwBUYErjQhMEb/94v7A5YAJAKUAqkoRv/3cf+oARhJQFgAKCrV8HgCKCfQsHhAHAGQcHhEHDB4RhwGn6gc//cc/wJGAC8R0HAFACXAGSlGaUErRv/3qPoBmlRDIkYrRv/3uvrJAkANRBgH4FZDAZhEQzBGIUb/91j7BEYgRhGw8L0AGEBSsLUMRgVGCGhgIf/3SPtpARdKi1ggaANwnACkDwRxHAHkD8Rw3ALkDoRw2wTbDkNwiRhKaNMPQ3P/IxsGFEacQ4RgiWjLD8N1y7IDYQcjGwcTQFoek0EDc8oA0g+CdcoB0g9CdUkDSQ8BdQAgsL3ARgAWQFLwtZuwBEYDr2AhOEb/9w37ACUClQGXAakgRv/3t/9gARhJQFgAKCrVOHkCKCfQfngALiTQv3gALyHQA6gFeAWYAJAgRv/3nP4CRigGACQAmUAYIUZhQSNG//cp+gVGAJE4RiFGMkYjRv/3IfoCRgtGKEYAmf/3M/oJAgAORRgoRhuw8L0AFkBSgLUBKALY//e3/4C9gB7/9zX/gL2AtQNJSkZRWEhD//fz+YC9OAAAAIC1APAv+IC9C0gAaAEOQSkB0AAgAeCAsgAJCElKRlEYSIAHSUAYQUJBQQEgAAd6RgJAEA8IQ3BHAO0A4AYAAACg8///gLUA8EX4gL0AKQfQQxxJHgB4kEIYRvfQASBwRwAgcEd/tQVGACQDlAKUAZQAlCZGsAoI0agZaUYQIgDwPfgQNgAo9dABJCBGBLBwvby1BEYNTUhGQF0AKATRAPBN+EhGASFBVWhGIUb/94b7B0hJRgCaClAIGAGZQWBLQktBUEJQQRhDvL3ARgQAAABAAAAAgLULRhFGGkYA8A74gL2wtQAjmUIG0NRcxVysQgHRWxz35xlGCBiwvfi1FEYNRgZGZCcALw3QCUgxRipGI0b/99f7B0mIQgbRBkj/92X/fx7v5wEg+L1BHohB+L0AACBSAgA2ARAnAAD4tQAkG019RCBGqEcPT05G8FEPSXBQCiCoRw5JcFD3WQ1IN1ANSDgYDUn/9wv6DUlwUA1IOBh9IckA//cD+gtJcFAgRqhHCklwUPi9IAAAACgAAAAsAAAAMAAAAD9CDwBAQg8AOAAAAOcDAAA0AAAAJAAAAAf7//9wtQxMSEYAXQAoENEKSABoAQ5BKQHQACAB4ICyAAlNRi4ZcID/9xb/ASEpVXBwSEYAGXC9BgAAAADtAOAAIHBHgLX/93T/gL0AIHBHAAAqUgAAHVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIDw+gKA8PoCgPD6AoDw+gKA8PoCUMMAADIAAAAAAAAAAAAAIgAACAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  instructions: gLUA8Pv9gL2AHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEdDQ1FDMLVcGAEMEwwNRpKyXUOAslFDLBkFRlVDCgwJBE0ZYkFYQwEMAARAGVFBML3+tQRGEEYNRhhDc9CmRoxGACCkGgFGnUFn02ZGACcBJD1GthqdQQLTE0Y6RiEkZUZ2Ri8ENgw+Qy0MthqdQQTTFQwbBCtDEgQQNGVGdkYvBjYKPkMtCrYanUEE0xUOGwIrQxICCDRlRnZGLwc2CT5DLQm2Gp1BBNMVDxsBK0MSASQdZUZ2Rq8Htgg+Q60IthqdQQTTlQ+bACtDkgCkHGVGdkbvB3YIPkNtCLYanUEa05IYW0FkHBbgABh2RmVGSUG3Gp1BAZEAkAnTYEaxGphBjkaERgCYAZkAJUAcaUHdB1IIKkNbCGQe5tVyRmNGA7Dwvf/nIEYoQwfQACDAQwFGwEbARiJGK0bx5wAgAUb35wHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAAAAiAwmLQizTAwqLQhHTACOcRk7gA0YLQzzUACJDCItCMdMDCYtCHNMDCotCAdOURj/gwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJBQwiLQgHTSwDAGlJBQRoA0gFGUkEQRnBHXeDKDwDQSUIDEADTQEJTQJxGACIDCYtCLdMDCotCEtOJAfwiEroDCotCDNOJAZIRi0II04kBkhGLQgTTiQE60JIRAOCJCcMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQdnSQwiLQgHTSwDAGlJBQRoA0gFGUkEQRmNGWxAB00BCACsA1UlCcEdjRlsQANNAQgG1BUkAKALcSRwIQADgCEbARsBGAr0Av////3+AtQDwT/yAvcJpACoB1ANIcEeJskFgACBwR8BGAQCKAHC1BUYRSHhEBGj/92v+IWwAJAApENUKSqtYCklOHB5DrlAJSxtorlheQDMHBNGqGBJoikIA2QEk//dY/iBGcL0gAAEA////7wRQKULaCQAAcLUAIwNgQ2ABJSoHGU4OQBEkZAamQgHR6wQT4A5GlkMDJCQGpkIM0BskZAWmQgnQEUvzGFwLCyNbAwssB9IPTADgNEYRQENgDEMEYHC9fyRkBjQZZAs1LAPSbAY1I1sD8OcHTDQZnEIB0gZM6ucAITRG6ecAAPjvAGA93ACgwiMAYD38AKDCAwEhCgeQQw1KkEIU0BsiUgWQQgrQESJSBpBCCNAISpBCA9ADIhIGkEID0TUgBOAAIHBHyANwR0EgQAJwRwBAIEIAoMIjACsH0AAoBdAAKQPQACoB0JpCAdIAIHBHASBwR/C1i7AdRgOSB0YJqAGR//eD/wqcCZ4ClzhGMUYiRgCVK0YDnf/33v8STwAtH9AAKB3QBKgBIQGCB5QGlgGYBZACnASUfxwMSHhEAGjAbQAoDdQgRv/3OP8AKAjQBKgpRgCaAPAf+AdGIEYA8Af4OEYLsPC9AQA2AWAIAACAtQdJQlgPIxsHmkNCUAVIeEQAaEAwACH/9wz/gL3ARiAAAQAcCAAA/rUORgRGQGihaONoGxpZGJFCAdIpSP69ApIhaChNSlkPJ7pDSlFKWQEjE0MOIpNDS1E5RgJGOkAAJwAqAZEU0IhDYGAQIIAaAp2oQgDTKEYAkCBGMUYAmwDwNPhhaBAxYWAAmXYYbRoB4DhGAp0pRikJApEAKA/RApmPQgzSACIQIyBGMUYA8B34YWgQMWFgfxwQNhA97ecAKAfRAC0F0AAiIEYxRitGAPAM+CFoBEvKWAGcokPKUP69wEYBADYBBDABAPC1ibAdRgKSDkZHaASQgGg5GgwJ//cQ/yQYOkZzSDgYQAoBJwsoBtMLIEACcElRGIFCANOw4ASbAZcDkhhocEkAlERQb0wTIQ8DwVnJBwjQACwG0DIg//ft/ASbZBwYaPHnaUkALBjQwBkAaAADFtQCmAAoA5wI0QEgDy0BRgDYACEBmlBAAUId0QAgECga0CFYBaoRUAAd+OcIRqTgWHwAKAOcB9EA8Ev7BJsAKALQVUjAHJjgACAQKATQBakAIgpQAB345wGYACgM0AWoAplAGAAtEtAxeAJ4CkMCcEAcbR52HPXnBagCmUAYAC0F0DF4AXBAHG0edhz35xhoQ01AGUFoAJqRQkPRGXwAKT5JUNDIHAMhiQMCkQAmAy5j0AAgA5oQKATQBakJWBFQAB345xhoQVkCmhFDQVExTMFZyQcI0AAsBtAyIP/3c/xkHASYAGjz5wAsO9DAGQBowAZEDwAgAiw/0wIuAdECLDvQAPDm+gAoBNBgHwMoBJsE0ivgIB8EKASbKtMfSIAddhzE5x1IQBwn4FALFkmIQgSbANFJ5xRIgkIC0xRIgkIS0wAnQecAIRApBNAFqlJYYlAJHfjnAyGJAwJoCkMCYAAgCuANSAjgAScu5wtIgB0D4MCygAAKoQhYCbDwvQDA370AwN+tgIACAAAAEEAAIBBACDABAIDH/v8DADYBBDABAAAAAAAAAAAACQA2AQkANgEQtYAAB0lCWBIFFA9BWA8gCEAA8An4YRxKCBAY//fK/BC9wEZAEkBSELUERgDwKvgCLAnYAiwD0GEBBkqJGADgBUkJaAApANQQvSBGAPCe+RC9wEYAFkBSABhAUoEAB0gKWAcgEEAHKAbRBUgIWB8hAUABIAACCBhwR8BGABJAUgABQFKAtf/36f8DKA7ZESEJAYhCIdD/IQpGEjKQQg3QFDGIQhfRE0iAaBjgeEQAeUAAh0QBGQoXD0iAvQEgwQMMSMBqQAMIQIC9CkgAaAMhAUADKQrQACCAvQZIgGnAD8ADgL0HSIC9BUgA4ANISUYIWIC9aBNAUoDw+gIQAAAADAAAAAASegD4tQxGBUZIaDQh//dM/KkBOEqLWGBoA3DcDwRxnACkD8RwXARkD4RwWwVbD0NwiRhKaDFLE0CDYBMBGw9DcxICUg8Cc4toASKcABNAg3PjD8NzzGgfIwCTJUYdQAV0ZQAtD4V1ZQEtD0V1ZQJtDwV1JQMtD8V0pQRtD4V0pAXkDkR0DWlOaYxp5wL/DyQjx1TGYesE2w9DdqsF2w4DdgCbHUDFdRVLI0ADYuMB3A8DRiQzXHDMaSJAmnDiAtIPWnHiA9IPGnGiB9IP2nAJasoPWnOKANIPGnPKANIMwoXIBsAPGHIIB8AP2HEHIAhAmHEAIPi9ABhAUv//HwD//wcA8LWRsAVGBK40ITBG//fL+wOWACQClAKpKEb/93H/qAEYSUBYACgq1fB4Aign0LB4QBwBkHB4RBwweEYcBp+oHP/3HP8CRgAvEdBwBQAlwBkpRmlBK0b/9+j6AZpUQyJGK0b/9/r6yQJADUQYB+BWQwGYREMwRiFG//eY+wRGIEYRsPC9ABhAUrC1DEYFRghoYCH/94j7aQEXSotYIGgDcJwApA8EcRwB5A/EcNwC5A6EcNsE2w5DcIkYSmjTD0Nz/yMbBhRGnEOEYIloyw/DdcuyA2EHIxsHE0BaHpNBA3PKANIPgnXKAdIPQnVJA0kPAXUAILC9wEYAFkBS8LWbsARGA69gIThG//dN+wAlApUBlwGpIEb/97f/YAEYSUBYACgq1Th5Aign0H54AC4k0L94AC8h0AOoBXgFmACQIEb/95z+AkYoBgAkAJlAGCFGYUEjRv/3afoFRgCROEYhRjJGI0b/92H6AkYLRihGAJn/93P6CQIADkUYKEYbsPC9ABZAUoC1ASgC2P/3t/+AvYAe//c1/4C9gLUDSUpGUVhIQ//3M/qAvSwAAACAtQDwEfiAvYC1APBF+IC9ACkH0EMcSR4AeJBCGEb30AEgcEcAIHBHf7UFRgAkA5QClAGUAJQmRrAKCNGoGWlGECIA8D34EDYAKPXQASQgRgSwcL28tQRGDU1IRkBdACgE0QDwTfhIRgEhQVVoRiFG//e0+wdISUYAmgpQCBgBmUFgS0JLQVBCUEEYQ7y9wEYEAAAAMAAAAIC1C0YRRhpGAPAO+IC9sLUAI5lCBtDUXMVcrEIB0Vsc9+cZRggYsL34tRRGDUYGRmQnAC8N0AlIMUYqRiNG//f1+wdJiEIG0QZI//eD/38e7+cBIPi9QR6IQfi9AAAgUgIANgEQJwAAcLUAJCBG//eh/QVGDEhORjVQDEg1UAxIKBgMSf/3cPoLSXBQC0goGH0hyQD/92j6CUlwUCBG//eJ/QhJcFBwvRwAAAAkAAAAP0IPAEBCDwAsAAAA5wMAACgAAAAgAAAAACBwR4C1//ee/4C9ACBwRwAAKlIAAB1UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIDw+gKA8PoCgPD6AlDDAAAyAAAAAAAAIgCgBgABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
   load_address: 0x34008108
   pc_init: 0x1
-  pc_uninit: 0xe19
-  pc_program_page: 0xc6d
-  pc_erase_sector: 0xc29
-  pc_verify: 0xe1d
+  pc_uninit: 0xd09
+  pc_program_page: 0xbb1
+  pc_erase_sector: 0xba9
+  pc_verify: 0xd0d
   pc_blank_check: 0x315
-  data_section_offset: 0xe30
+  data_section_offset: 0xd20
   flash_properties:
     address_range:
-      start: 0x22011000
+      start: 0x22000000
       end: 0x2206a000
     page_size: 0x400
     erased_byte_value: 0x0
@@ -745,18 +5684,18 @@ flash_algorithms:
   stack_size: 4096
 - name: pse84_rram_nvm_s
   description: PSE84_RRAM_NVM
-  default: true
-  instructions: gLUA8Fn+gL2AHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEdDQ1FDMLVcGAEMEwwNRpKyXUOAslFDLBkFRlVDCgwJBE0ZYkFYQwEMAARAGVFBML3+tQRGEEYNRhhDc9CmRoxGACCkGgFGnUFn02ZGACcBJD1GthqdQQLTE0Y6RiEkZUZ2Ri8ENgw+Qy0MthqdQQTTFQwbBCtDEgQQNGVGdkYvBjYKPkMtCrYanUEE0xUOGwIrQxICCDRlRnZGLwc2CT5DLQm2Gp1BBNMVDxsBK0MSASQdZUZ2Rq8Htgg+Q60IthqdQQTTlQ+bACtDkgCkHGVGdkbvB3YIPkNtCLYanUEa05IYW0FkHBbgABh2RmVGSUG3Gp1BAZEAkAnTYEaxGphBjkaERgCYAZkAJUAcaUHdB1IIKkNbCGQe5tVyRmNGA7Dwvf/nIEYoQwfQACDAQwFGwEbARiJGK0bx5wAgAUb35wHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAAAAiAwmLQizTAwqLQhHTACOcRk7gA0YLQzzUACJDCItCMdMDCYtCHNMDCotCAdOURj/gwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJBQwiLQgHTSwDAGlJBQRoA0gFGUkEQRnBHXeDKDwDQSUIDEADTQEJTQJxGACIDCYtCLdMDCotCEtOJAfwiEroDCotCDNOJAZIRi0II04kBkhGLQgTTiQE60JIRAOCJCcMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQdnSQwiLQgHTSwDAGlJBQRoA0gFGUkEQRmNGWxAB00BCACsA1UlCcEdjRlsQANNAQgG1BUkAKALcSRwIQADgCEbARsBGAr0Av////3+AtQDwrfyAvcJpACoB1ANIcEeJskFgACBwR8BGAQCKAAABAklBWA8gCEBwRwRQKUIAAQJJQVgPIAhAcEcEUBxU+LUGRiFIeEQFaP/3W/4ERihsACUAKATUIEb/91f+KEb4vRZIMVgWT3ocCkMyUDYYAPAq/UCIYyFJAYhCDtARSYhCCdAQSYhCEdETIP/30P8AKAbRBiAE4AAgAOAHIP/3v/8xaA8iCkCCQgHQ1OcwaDBouELQ2QElzufARiAAAQD////vIQ0AACINAADKCgAA8LUAIwNgQ2ABJjIHDEaUQ28lbQZlGW0LVS0E0hEjXQZVI1sDHuADJS0GrEIX0BslbQWsQhbQEU8PQLMEjyWtBa9CDtAHJe0Fr0IL0H8lbQZlGW0LNS0K0nUGNSPh5yVGAOA9RhFAQ2ANQwVg8L0PJa0Fr0L20AAhJUb15wAA/O8BRgEgAgeRQ0IGACCRQh/QE0qRQh/QGyJSBZFCFtAHItIFkUIS0A8ikgWRQg7QESJSBpFCDNCPIIAFgUIG0AlIgUIG0AMgAAaBQgfRNSBAAnBHBUhwRysggAJwR1Ug9ucAQCBCAIgQQICDAAAAKwfQACgF0AApA9AAKgHQmkIB0gAgcEcBIHBH8LWLsB1GA5IHRgmoAZH/93P/CpwJngKXOEYxRiJGAJUrRgOd//fe/xJPAC0f0AAoHdAEqAEhAYIHlAaWAZgFkAKcBJR/HAxIeEQAaMBtACgN1CBG//cI/wAoCNAEqClGAJoA8B/4B0YgRgDwB/g4Rguw8L0BADYB8AgAAIC1B0lCWA8jGweaQ0JQBUh4RABoQDAAIf/3zP6AvcBGIAABAKwIAAD+tQ5GBEZAaKFo42gbGlkYkUIB0ilI/r0CkiFoKE1KWQ8nukNKUUpZASMTQw4ik0NLUTlGAkY6QAAnACoBkRTQiENgYBAggBoCnahCANMoRgCQIEYxRgCbAPA0+GFoEDFhYACZdhhtGgHgOEYCnSlGKQkCkQAoD9ECmY9CDNIAIhAjIEYxRgDwHfhhaBAxYWB/HBA2ED3t5wAoB9EALQXQACIgRjFGK0YA8Az4IWgES8pYAZyiQ8pQ/r3ARgEANgEEMAEA8LWJsB1GApIORkdoBJCAaDkaDAn/9/z+JBg6RnNIOBhACgEnCygG0wsgQAJwSVEYgUIA07DgBJsBlwOSGGhwSQCURFBvTBMhDwPBWckHCNAALAbQMiD/9638BJtkHBho8edpSQAsGNDAGQBoAAMW1AKYACgDnAjRASAPLQFGANgAIQGaUEABQh3RACAQKBrQIVgFqhFQAB345whGpOBYfAAoA5wH0QDwk/sEmwAoAtBVSMAcmOAAIBAoBNAFqQAiClAAHfjnAZgAKAzQBagCmUAYAC0S0DF4AngKQwJwQBxtHnYc9ecFqAKZQBgALQXQMXgBcEAcbR52HPfnGGhDTUAZQWgAmpFCQ9EZfAApPklQ0MgcAyGJAwKRACYDLmPQACADmhAoBNAFqQlYEVAAHfjnGGhBWQKaEUNBUTFMwVnJBwjQACwG0DIg//cz/GQcBJgAaPPnACw70MAZAGjABkQPACACLD/TAi4B0QIsO9AA8C77ACgE0GAfAygEmwTSK+AgHwQoBJsq0x9IgB12HMTnHUhAHCfgUAsWSYhCBJsA0UnnFEiCQgLTFEiCQhLTACdB5wAhECkE0AWqUlhiUAkd+OcDIYkDAmgKQwJgACAK4A1ICOABJy7nC0iAHQPgwLKAAAqhCFgJsPC9AMDfvQDA362AgAIAAAAQQAAgEEAIMAEAgMf+/wMANgEEMAEAAAAAAAAAAAAJADYBCQA2ARC1gAAHSUJYEgUUD0FYDyAIQADwCfhhHEoIEBj/94r8EL3ARkASQFIQtQRGAPAq+AIsCdgCLAPQYQEGSokYAOAFSQloACkA1BC9IEYA8J75EL3ARgAWQFIAGEBSgQAHSApYByAQQAcoBtEFSAhYHyEBQAEgAAIIGHBHwEYAEkBSAAFAUoC1//fp/wMoDtkRIQkBiEIh0P8hCkYSMpBCDdAUMYhCINETSIBoGOB4RAB5QACHRAEbCRcPSIC9ASDBAwxIwGpAAwbgCkgAaAtJSkZRWIAHwBcIQIC9BkiAacAPwAOAvQdIgL0AIIC9BEhJRghYgL1oE0BSgPD6AhQAAAAQAAAAABJ6APi1DEYFRkhoNCH/9wz8qQE4SotYYGgDcNwPBHGcAKQPxHBcBGQPhHBbBVsPQ3CJGEpoMUsTQINgEwEbD0NzEgJSDwJzi2gBIpwAE0CDc+MPw3PMaB8jAJMlRh1ABXRlAC0PhXVlAS0PRXVlAm0PBXUlAy0PxXSlBG0PhXSkBeQORHQNaU5pjGnnAv8PJCPHVMZh6wTbD0N2qwXbDgN2AJsdQMV1FUsjQANi4wHcDwNGJDNccMxpIkCacOIC0g9aceID0g8acaIH0g/acAlqyg9ac4oA0g8ac8oA0gzChcgGwA8YcggHwA/YcQcgCECYcQAg+L0AGEBS//8fAP//BwDwtZGwBUYErjQhMEb/94v7A5YAJAKUAqkoRv/3cf+oARhJQFgAKCrV8HgCKCfQsHhAHAGQcHhEHDB4RhwGn6gc//cc/wJGAC8R0HAFACXAGSlGaUErRv/3qPoBmlRDIkYrRv/3uvrJAkANRBgH4FZDAZhEQzBGIUb/91j7BEYgRhGw8L0AGEBSsLUMRgVGCGhgIf/3SPtpARdKi1ggaANwnACkDwRxHAHkD8Rw3ALkDoRw2wTbDkNwiRhKaNMPQ3P/IxsGFEacQ4RgiWjLD8N1y7IDYQcjGwcTQFoek0EDc8oA0g+CdcoB0g9CdUkDSQ8BdQAgsL3ARgAWQFLwtZuwBEYDr2AhOEb/9w37ACUClQGXAakgRv/3t/9gARhJQFgAKCrVOHkCKCfQfngALiTQv3gALyHQA6gFeAWYAJAgRv/3nP4CRigGACQAmUAYIUZhQSNG//cp+gVGAJE4RiFGMkYjRv/3IfoCRgtGKEYAmf/3M/oJAgAORRgoRhuw8L0AFkBSgLUBKALY//e3/4C9gB7/9zX/gL2AtQNJSkZRWEhD//fz+YC9OAAAAIC1APAv+IC9C0gAaAEOQSkB0AAgAeCAsgAJCElKRlEYSIAHSUAYQUJBQQEgAAd6RgJAEA8IQ3BHAO0A4AYAAACg8///gLUA8EX4gL0AKQfQQxxJHgB4kEIYRvfQASBwRwAgcEd/tQVGACQDlAKUAZQAlCZGsAoI0agZaUYQIgDwPfgQNgAo9dABJCBGBLBwvby1BEYNTUhGQF0AKATRAPBN+EhGASFBVWhGIUb/94b7B0hJRgCaClAIGAGZQWBLQktBUEJQQRhDvL3ARgQAAABAAAAAgLULRhFGGkYA8A74gL2wtQAjmUIG0NRcxVysQgHRWxz35xlGCBiwvfi1FEYNRgZGZCcALw3QCUgxRipGI0b/99f7B0mIQgbRBkj/92X/fx7v5wEg+L1BHohB+L0AACBSAgA2ARAnAAD4tQAkG019RCBGqEcPT05G8FEPSXBQCiCoRw5JcFD3WQ1IN1ANSDgYDUn/9wv6DUlwUA1IOBh9IckA//cD+gtJcFAgRqhHCklwUPi9IAAAACgAAAAsAAAAMAAAAD9CDwBAQg8AOAAAAOcDAAA0AAAAJAAAAAf7//9wtQxMSEYAXQAoENEKSABoAQ5BKQHQACAB4ICyAAlNRi4ZcID/9xb/ASEpVXBwSEYAGXC9BgAAAADtAOAAIHBHgLX/93T/gL0AIHBHAAAqUgAAHVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIDw+gKA8PoCgPD6AoDw+gKA8PoCUMMAADIAAAAAAAAAAAAAIgAACAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  default: false
+  instructions: gLUA8Pv9gL2AHIAIA9BAHIAe/NEAv3BH7/MQgHK2cEeA8xCIcEdDQ1FDMLVcGAEMEwwNRpKyXUOAslFDLBkFRlVDCgwJBE0ZYkFYQwEMAARAGVFBML3+tQRGEEYNRhhDc9CmRoxGACCkGgFGnUFn02ZGACcBJD1GthqdQQLTE0Y6RiEkZUZ2Ri8ENgw+Qy0MthqdQQTTFQwbBCtDEgQQNGVGdkYvBjYKPkMtCrYanUEE0xUOGwIrQxICCDRlRnZGLwc2CT5DLQm2Gp1BBNMVDxsBK0MSASQdZUZ2Rq8Htgg+Q60IthqdQQTTlQ+bACtDkgCkHGVGdkbvB3YIPkNtCLYanUEa05IYW0FkHBbgABh2RmVGSUG3Gp1BAZEAkAnTYEaxGphBjkaERgCYAZkAJUAcaUHdB1IIKkNbCGQe5tVyRmNGA7Dwvf/nIEYoQwfQACDAQwFGwEbARiJGK0bx5wAgAUb35wHgBMAJHwQp+9KLBwHVAoCAHMkHANACcHBHACkL0MMHAtACcEAcSR4CKQTTgwcC1QKAgByJHuPnACLu5wAi3+cAAAAiAwmLQizTAwqLQhHTACOcRk7gA0YLQzzUACJDCItCMdMDCYtCHNMDCotCAdOURj/gwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJBQwiLQgHTSwDAGlJBQRoA0gFGUkEQRnBHXeDKDwDQSUIDEADTQEJTQJxGACIDCYtCLdMDCotCEtOJAfwiEroDCotCDNOJAZIRi0II04kBkhGLQgTTiQE60JIRAOCJCcMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQdnSQwiLQgHTSwDAGlJBQRoA0gFGUkEQRmNGWxAB00BCACsA1UlCcEdjRlsQANNAQgG1BUkAKALcSRwIQADgCEbARsBGAr0Av////3+AtQDwT/yAvcJpACoB1ANIcEeJskFgACBwR8BGAQCKAHC1BUYRSHhEBGj/92v+IWwAJAApENUKSqtYCklOHB5DrlAJSxtorlheQDMHBNGqGBJoikIA2QEk//dY/iBGcL0gAAEA////7wRQKULaCQAAcLUAIwNgQ2ABJSoHGU4OQBEkZAamQgHR6wQT4A5GlkMDJCQGpkIM0BskZAWmQgnQEUvzGFwLCyNbAwssB9IPTADgNEYRQENgDEMEYHC9fyRkBjQZZAs1LAPSbAY1I1sD8OcHTDQZnEIB0gZM6ucAITRG6ecAAPjvAGA93ACgwiMAYD38AKDCAwEhCgeQQw1KkEIU0BsiUgWQQgrQESJSBpBCCNAISpBCA9ADIhIGkEID0TUgBOAAIHBHyANwR0EgQAJwRwBAIEIAoMIjACsH0AAoBdAAKQPQACoB0JpCAdIAIHBHASBwR/C1i7AdRgOSB0YJqAGR//eD/wqcCZ4ClzhGMUYiRgCVK0YDnf/33v8STwAtH9AAKB3QBKgBIQGCB5QGlgGYBZACnASUfxwMSHhEAGjAbQAoDdQgRv/3OP8AKAjQBKgpRgCaAPAf+AdGIEYA8Af4OEYLsPC9AQA2AWAIAACAtQdJQlgPIxsHmkNCUAVIeEQAaEAwACH/9wz/gL3ARiAAAQAcCAAA/rUORgRGQGihaONoGxpZGJFCAdIpSP69ApIhaChNSlkPJ7pDSlFKWQEjE0MOIpNDS1E5RgJGOkAAJwAqAZEU0IhDYGAQIIAaAp2oQgDTKEYAkCBGMUYAmwDwNPhhaBAxYWAAmXYYbRoB4DhGAp0pRikJApEAKA/RApmPQgzSACIQIyBGMUYA8B34YWgQMWFgfxwQNhA97ecAKAfRAC0F0AAiIEYxRitGAPAM+CFoBEvKWAGcokPKUP69wEYBADYBBDABAPC1ibAdRgKSDkZHaASQgGg5GgwJ//cQ/yQYOkZzSDgYQAoBJwsoBtMLIEACcElRGIFCANOw4ASbAZcDkhhocEkAlERQb0wTIQ8DwVnJBwjQACwG0DIg//ft/ASbZBwYaPHnaUkALBjQwBkAaAADFtQCmAAoA5wI0QEgDy0BRgDYACEBmlBAAUId0QAgECga0CFYBaoRUAAd+OcIRqTgWHwAKAOcB9EA8Ev7BJsAKALQVUjAHJjgACAQKATQBakAIgpQAB345wGYACgM0AWoAplAGAAtEtAxeAJ4CkMCcEAcbR52HPXnBagCmUAYAC0F0DF4AXBAHG0edhz35xhoQ01AGUFoAJqRQkPRGXwAKT5JUNDIHAMhiQMCkQAmAy5j0AAgA5oQKATQBakJWBFQAB345xhoQVkCmhFDQVExTMFZyQcI0AAsBtAyIP/3c/xkHASYAGjz5wAsO9DAGQBowAZEDwAgAiw/0wIuAdECLDvQAPDm+gAoBNBgHwMoBJsE0ivgIB8EKASbKtMfSIAddhzE5x1IQBwn4FALFkmIQgSbANFJ5xRIgkIC0xRIgkIS0wAnQecAIRApBNAFqlJYYlAJHfjnAyGJAwJoCkMCYAAgCuANSAjgAScu5wtIgB0D4MCygAAKoQhYCbDwvQDA370AwN+tgIACAAAAEEAAIBBACDABAIDH/v8DADYBBDABAAAAAAAAAAAACQA2AQkANgEQtYAAB0lCWBIFFA9BWA8gCEAA8An4YRxKCBAY//fK/BC9wEZAEkBSELUERgDwKvgCLAnYAiwD0GEBBkqJGADgBUkJaAApANQQvSBGAPCe+RC9wEYAFkBSABhAUoEAB0gKWAcgEEAHKAbRBUgIWB8hAUABIAACCBhwR8BGABJAUgABQFKAtf/36f8DKA7ZESEJAYhCIdD/IQpGEjKQQg3QFDGIQhfRE0iAaBjgeEQAeUAAh0QBGQoXD0iAvQEgwQMMSMBqQAMIQIC9CkgAaAMhAUADKQrQACCAvQZIgGnAD8ADgL0HSIC9BUgA4ANISUYIWIC9aBNAUoDw+gIQAAAADAAAAAASegD4tQxGBUZIaDQh//dM/KkBOEqLWGBoA3DcDwRxnACkD8RwXARkD4RwWwVbD0NwiRhKaDFLE0CDYBMBGw9DcxICUg8Cc4toASKcABNAg3PjD8NzzGgfIwCTJUYdQAV0ZQAtD4V1ZQEtD0V1ZQJtDwV1JQMtD8V0pQRtD4V0pAXkDkR0DWlOaYxp5wL/DyQjx1TGYesE2w9DdqsF2w4DdgCbHUDFdRVLI0ADYuMB3A8DRiQzXHDMaSJAmnDiAtIPWnHiA9IPGnGiB9IP2nAJasoPWnOKANIPGnPKANIMwoXIBsAPGHIIB8AP2HEHIAhAmHEAIPi9ABhAUv//HwD//wcA8LWRsAVGBK40ITBG//fL+wOWACQClAKpKEb/93H/qAEYSUBYACgq1fB4Aign0LB4QBwBkHB4RBwweEYcBp+oHP/3HP8CRgAvEdBwBQAlwBkpRmlBK0b/9+j6AZpUQyJGK0b/9/r6yQJADUQYB+BWQwGYREMwRiFG//eY+wRGIEYRsPC9ABhAUrC1DEYFRghoYCH/94j7aQEXSotYIGgDcJwApA8EcRwB5A/EcNwC5A6EcNsE2w5DcIkYSmjTD0Nz/yMbBhRGnEOEYIloyw/DdcuyA2EHIxsHE0BaHpNBA3PKANIPgnXKAdIPQnVJA0kPAXUAILC9wEYAFkBS8LWbsARGA69gIThG//dN+wAlApUBlwGpIEb/97f/YAEYSUBYACgq1Th5Aign0H54AC4k0L94AC8h0AOoBXgFmACQIEb/95z+AkYoBgAkAJlAGCFGYUEjRv/3afoFRgCROEYhRjJGI0b/92H6AkYLRihGAJn/93P6CQIADkUYKEYbsPC9ABZAUoC1ASgC2P/3t/+AvYAe//c1/4C9gLUDSUpGUVhIQ//3M/qAvSwAAACAtQDwEfiAvYC1APBF+IC9ACkH0EMcSR4AeJBCGEb30AEgcEcAIHBHf7UFRgAkA5QClAGUAJQmRrAKCNGoGWlGECIA8D34EDYAKPXQASQgRgSwcL28tQRGDU1IRkBdACgE0QDwTfhIRgEhQVVoRiFG//e0+wdISUYAmgpQCBgBmUFgS0JLQVBCUEEYQ7y9wEYEAAAAMAAAAIC1C0YRRhpGAPAO+IC9sLUAI5lCBtDUXMVcrEIB0Vsc9+cZRggYsL34tRRGDUYGRmQnAC8N0AlIMUYqRiNG//f1+wdJiEIG0QZI//eD/38e7+cBIPi9QR6IQfi9AAAgUgIANgEQJwAAcLUAJCBG//eh/QVGDEhORjVQDEg1UAxIKBgMSf/3cPoLSXBQC0goGH0hyQD/92j6CUlwUCBG//eJ/QhJcFBwvRwAAAAkAAAAP0IPAEBCDwAsAAAA5wMAACgAAAAgAAAAACBwR4C1//ee/4C9ACBwRwAAKlIAAB1UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIDw+gKA8PoCgPD6AlDDAAAyAAAAAAAAIgCgBgABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
   pc_init: 0x1
-  pc_uninit: 0xe19
-  pc_program_page: 0xc6d
-  pc_erase_sector: 0xc29
-  pc_verify: 0xe1d
+  pc_uninit: 0xd09
+  pc_program_page: 0xbb1
+  pc_erase_sector: 0xba9
+  pc_verify: 0xd0d
   pc_blank_check: 0x315
-  data_section_offset: 0xe30
+  data_section_offset: 0xd20
   flash_properties:
     address_range:
-      start: 0x32011000
+      start: 0x32000000
       end: 0x3206a000
     page_size: 0x400
     erased_byte_value: 0x0
@@ -768,19 +5707,19 @@ flash_algorithms:
   stack_size: 4096
 - name: pse84_smif
   description: PSE84_SMIF
-  instructions: ELUERgXwkvwgRgEhvegQQATwkLgt6fBNiLAPRgRGbk1uTgDw5fi0QgX1IHICkAFGBJII0Ab1oCoBLwvQAi8N0QAhKEYi4AEvEdACLxHRBfWAcBTgBfUoYAAhF+AoRgMhBC8YvwD1wGAIvwEhDuAQRgXgBfVgcAQvCL8F9UBweh4HIQb1gDoCKji/ACGrRgAlDiIBI0/wAQgAlQDwD/pQRgAhDiIBIwCVVkYA8Af6C/VgcAQvT/AECgi/C/VAcAeQWEYYvwD1wGAGkE/wAwAIvwEgBZAHJXgeAihYRji/ACUL9YBwA5C68QAPSNA7SMb4DICEQgjQAS8P0AIvEr/d6QUQACFYRg/gAS8L0AeYKUYCLwS/A5gpRgbgWEYAIQv1KGAB4ASYKUYI+gHxwWABIAPwHv0pSIRCCNABLw/QAi8Sv93pBRAAIVhGD+ABLwvQB5gpRgIvBL8DmClGBuBYRgAhC/UoYAHgBJgpRgj6AfHBYAEgA/D8/KrxAQqz5xdIhEII0AEvDdACLxK/3ekFUAAlWEYL4AEvCNACLwy/A5gHmATgC/UoYAAlAOAEmAghDiIBIwCRKUYA8ID5GyAAIQ4iASMAkDBGAPB4+QKYCLC96PBNAPAQuAAAgVIAAEZUgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHU+oCDADwaYAt6fBLT/AABgArH7+z+oP1A/oF9CT6BfZeQBK/FkOy+oL1AvoF9MXxIAUevyL6BfxE6gwEIDVW6gRMT+oURBi/ZBxP8AAIT/AACZBCcesDDDnTACkZv7H6gfcB+gf2sPqA9wD6B/bH8SAHHr8g+gf8RuoMBiA3tvv0/KfrBQcQPwfwHwvL8SAGLPoG9gz6C/tEv7NGACYgL6S/XkZP8AALW+oGDAi/T/ABCxnrCwlI6wYIq/sCfAb7AswL+wPMwBtx6wwBwecLRgJGQUZIRr3o8IsTtQhDGL9P8P8wAUav8wCAvegcQHBHQOoBAxC1mwcP0QQqDdMQyAjJEh+cQvjQILoZuohCAdkBIBC9T/D/MBC9GrHTBwPQUhwH4AAgEL0Q+AE7EfgBSxsbB9EQ+AE7EfgBSxsbAdGSHvHRGEYQvU/wAAIAtRNGlEaWRiA5Ir+g6AxQoOgMULHxIAG/9PevCQcov6DoDFBIvwzAXfgE64kAKL9A+AQrCL9wR0i/IPgCKxHwgE8YvwD4AStwRwhIfLV4RACQB0h4RACcBUYBkATgIEYBaAhEgEckHaxC+NF8vVRdAABSXQAAF0gAIU/w/zIbSwn4ABAVSEtECfgAEBRISfgAIBNIFUoJ+AAQEkhKRCn4ABBIRMDpFTIUSwF1gXARSRBKgmFJREtEwOknMQL1gCEBZgEhgPhcEPohoPhEEKD4jBBwRwC/CAAAAAQAAAC0KwAADAAAALgrAAC8JQAAnCgAAAAARlSsJQAAkCsAAATwMLgt6fBFh7AGRhhID0ZwIZBGT/AAChprASQdRq34GqAp+AAQSEQ5eM3pAqLN6QRDACJA8lVTzekAQDBGAPAy/ChrDfEaAjl4ACPN6QRFzekAQs3pAgowRgEiAPDu+734GhCo+AAQB7C96PCFAL9ADQAA+LUVRgaaHkYPRgRGAPDO+AEhBvABACJouUC4QCLqAQEIQ7kAIGAPIGJsiEAjb4JDI+oAAIAtBtEIIwP6AfEKQwhDYmQF4AXwDwMD+gHxEUNhZCBn+L0AAC3p+EUGRlJIAC4A8J+AF0YAKgDwm4AwRgAiDUYA8Oj4rAAHIHFubCKgQCHqAAC5aQHwBwGhQAhDHyFwZm/wHwAELQDrxQA4v+gAOL9oIvtpAfoA/LFYA/AfAyHqDAED+gDwCEMpRrBQMEY6egDwcvgPIE/wCAgA+gTxcGx7aNfpA67X+BTAIOoBAgPwDwCAKwi/CCCgQBBDMm8i6gEBcGSAKwj6BPAH8SADCL8BQzFnaAADIgrwAwGBQAL6APAybCLqAAAIQwEhMGQO8AEAAfoF+rFpqEAh6goBCEOwYQzwAQCxbKhAIeoKAQhDsGRP9H5wDssA6oUM1+kLBAHwAQFi80EBA/ABAgDwAwBB6oIBQerAAGEBybIIRDFtAPoM8CHw/wEIQylGMGUwRrprAPCn+DhoKUYAKAi/T/AECEb4CKAwRnprAPBT+AAgvej4hQEAWgBwtR1LHkwDRKBCC9AdTKBCCNAdTKBCBdAcTKBCHL8cTKBCIdEcTRVMBfWYJgX1gCWwQjq/RPIABcXyRkWj9YAjBOrTAChEb/AfBAQpKL8EMANoAvAfAgTrwQQ4v8wAHyGiQKFAA/DEugpMoELa0APwhfoA8aVA5ucAALmr8P//HwAAR1SAAEdUAAFHVAAAS1QAAUtUgABLVABARlRwtRlLG0wDRKBCC9AaTKBCCNAaTKBCBdAZTKBCHL8ZTKBCGdEZTRJMBfWWJgX1gCWwQjq/RfIABcXyRkWj9YAjBOrTAChEAvABAgEjikAD+gHxA2gD8H66C0ygQuLQA/A/+gJLGETu5wAAuasAEIBS8P//HwAAR1SAAEdUAAFHVAAAS1QAAUtUgABLVABQRlSJAENsy0BbB0/wAAMK0RC1BG/MQATwDwQILAi/AvAPA73oEEAD+gHyDyMD+gHxQ28j6gEBEUNBZ3BHAAABSUn4AQBwRzwMAAAwsQMhAWKBakkH/NQAIHBHAEhwRwQAsgABOMKyBkgHKgjYiyPTQNsHBNAEoFD4IgAIYAAgcEcAvwQAsgAAAAAAAQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAE/0QHEAIgFgCEmBYAAhwPiAEMD4wBDA+MgXAPUAYLL1AH8Iv3BHgVCAMvjnANCAAPC1LEsAKFLQAClQ0AAqTtBMfkyxDWgVuZL4KiAis4p+AipE0w0qQtgKfjqxSmmXKgrSACLA+NgnJEok4AAiwPjYJyJKCDIe4CFOACV+RAQtLdBW+CVwl0IE2AbrhQd/aLpCB9kBNfLnin4CKh/TDCra2RzgEKIUS1L4JSAC8AMCBeuCQhpEBPADA8x/QuoDEot+kfggEAPwDwNC6gMiBPADA0LqA1IAI0LqwXGBYBhG8L0AvwQAsgAAAAAAAAAAAAEAAAADAAAAgNCCAATQgAAIWAAAELUERgAgCGCIYMhgSGEIdiJoQvAAQiJgSGAIYaBoQAcL1KBoAAcI1GBowAf80AogA/Aa+WBoACj81BC9AkYBOQAgBykQ2N/oAfAECg8HDw8PDQL1AGBwRwL1EGBwRwL1CGBwRwL1GGBwRwAAAkYBOQAgBykQ2N/oAfAECg8HDw8PDQL1AGBwRwL1EGBwRwL1CGBwRwL1GGBwRwBoAPABAHBHCH5wRwAAELVTHgPwHwMAKQPxgETEZARMZPNfEoJlA0oYv0PqAgHBZhC9AIgABAAAAkAt6fBNiLAtToNGqiAURgAiASWIRgl4QPJVUyn4BgAAIAnrBgqt+B4AIGvN6QBazekEVM3pAiBYRiFPf0S4R1UgmPgAEAAiQPKqIwPw1PiAIJj4ABAAIkDyVVMD8Mz4qiCY+AAQACJA8lVTA/DE+FUgmPgAEAAiQPKqIwPwvPgQIJj4ABAAIkDyVVMD8LT4ZCYN8R4HWEYD8LH5A/Bz+QPwmvkB1AAo9dEAKAS/AiXA8rIFKEYIsL3o8I0Av0ANAAChAgAALenwTYiwMU6CRqogBpIBJwAiiEYJeBxGKfgGABhrCesGC83pBHNA8lVTzekCIM3pAHtQRiZNfUSoR1UgmPgAEAAiQPKqIwPwrPiAIJj4ABAAIkDyVVMD8KT4qiCY+AAQACJA8lVTA/Cc+FUgmPgAEAAiQPKqIwPwlPgwIJj4ABAAIgabKfgGACBrzekAewKSACYFlM3pAwdQRqhHrfgeYGQmDfEeB1BGA/BG+QPwCPkD8C/5AdQAKPXRACgEvwIlwPKyBShGCLC96PCNQA0AAOEBAAD4tQxGD2oJeAAmFUYBOQcpENjf6AHwBAoPBw8PDw0A9QBmB+AA9RBmBOAA9QhmAeAA9RhmgWgB9EARsfUAHwK/sWpB8IBxsWIBaMkHIdGV+DQQiQcd1Tl4Hkt6eE/wAAwZQxpDMWRP9OAhcWTG+EjAMWUyZnFmxvhowDFn4Wgh8P8BsWB5aElCIfD/AfFgByExYoBoumgA9EAQsPUAHwi/ATq5eDBG//fJ/gEgT/QAQYX4LAC4aChjYGgB6oAgIX8B8AcBQOoBMANJCEMwYAAg+L0AvwAAB0ABAACALenwRYmwA/Ai+AiszekEYUryPwED8D/4QPQAQAFAUEYC8Mj5ELEJsL3o8IXd6RIQEfoA8AfQQx5QRgMhASIC8NX4ACjv0d3pECEUmFIAOLEBIAMjzekACFBGAfDp/+LnA/A8+ALwjvjd5y3p8EWJsALw7f8IrM3pBGFC8j8BA/AK+AFAUEYC8JX5ELEJsL3o8IUSmAEoCdETmDixQx5QRgAhACIC8ML4ACjv0d3pECEUmFIAOLEBIAMjzekACFBGAvAW+uLnA/AJ+ALwr/rd5y3p8E2KsAdGQUjd+FygDkYUnA3xJgtP8AAIzekHMgDxggUSmIBFb9DUuzpKqiAxeEDyVVMp+AIACesCABVGASIGkM3pACAAIAPwEfgyTAiafESgR1UgMXgImkDyqiMp+AUAASAGnQCQACABlQLw//+gRyhJoCCkRgiaQPJVUxScKfgBAAEgMXjN6QAFACACkBWYA5AWmM3pBAo4RuBHgLsTmAEiMXgClADrSADN6QAgFZgImgOQFpjN6QQKB5gI6wADOEb/92n/DLEFRhbgACBkJK34JgA4RjFGWkZTRv/3C/sC8K3/vfgmAAE8AAZP6gRAAdQAKO7RFJwgsQjxAQiP5wVGAOACTShGCrC96PCNAgCyAEANAABH////LenwQQRGL0hUsw1GQbM7swAgGGCYYNhgWGEYdthhg/gsABhiWGAYYcPpDADD6QkgIGiw8f8/BNzABxy/ACC96PCB1PjIBylGGkYg8AMAxPjIByBG1ekAaO9o//fN/AixvejwgQbwAQAI8AcBZ/MYYEDqAUapfiBGAvA0+LC56X4E9QBgAvA++IC5KX8E9QhgAvA4+FC5aX8E9RBgAvAy+CC5qX8E9RhgAvAs+GppBkmSCEoqiL8B9aABMUMhYL3o8IEAvwQAsgAAA1AA8LWFsItp3GmMsSN4JHkJeAElBJL/JgAnzekCFRlGIkYAI83pAHYC8FT4BbDwvQFIBbDwvYAAsgBwtYawFEYFRgh4ACH/IgqezekAEgKqQ8IZRihGACMAIgLwO/gIsQawcL0KlihGIUYBIgAjBrC96HBAAfB5vgAALenwTYqwgEYrSOqxg0aIaRZGACKaRg9GRWkEaAAgCZKEQgTQMVwBMEHqAiL45wmpOEYB8Cn8AUYL8XwAJbFZRRy/Knn/KgLRCrC96PCNCZgAKQDxCAMoRgi/GEYDKgBoHdEAKRi/BfEgAxloan9P8AEMlfgkMD14QOoBIAMnzekCR83pADYEq4GyQEbN+Bygg+gkEAEiAyMB8PT/1Oc5eM3pAEIBIwKshOgKBMGyQEYzRgHw0v/H5wQAsgAt6fBBiLCLadxofLEC8M79T/D/Ds3pBsLaHs3pBGHN6QJeAvD7/QiwvejwgQFICLC96PCBgACyAC3p8EGGsN34MIAURh1GD0YGRkJG//fY/9i5umkBINFrAilP8AEBBtERawloASlP8AEBCL8CITp4ACPN+BCAzekAE83pAiAwRilGACIjRgHwiv8GsL3o8IFwtRRGDUYGRv/3sv8ouTBGKUYiRv/3Ev8AsXC9qGlP9HpxI0ZAbAD7AfIwRilGvehwQAHwJbsAAC3p8E2MsItGnBiJaRZGgEYAIB9GbU1iHktozekKAJpCgPDPgJJGimkDkQlsCZAHk1hGBpICkQmpMkYB8GP7zfgggJi5CZiIsQVoxGgJqVhGUkYB8Ff7gEZwG7D79PC48QAPAPsEVhrQPEYu4AaatPvy8Lb78vEA+xJAAfsC9kCxoBgCOLD78vEB+xIByUMA6wEKqusGAE/wAAhEHBbgCZhP8AAIAWjAaKrrAQIBMrL78PMD+xAiACoYvwEzA/sAEKDxAQqq6wYARBxATQeYzfgEoIJFddIImABowAcMvwAg/vfq/wCQBpgUnQ3xLAoALF/QBpBYRgqpMkYB8AP7AZoFkoi5Cpk3RiZG0ekAw9HpAxQGkQP7AcEClDRGPkYBOYpCOL8RRgWRAplP9HpyUUMEkQWZjkIv0giYWUYqRv/3+/5IuwOYMUYmRi9GAGgHkQrrAAIC+AEcCQoBOPjRCJ1ZRlJGO0Y8RihG//eH/rC5KEZZRgSaI0YB8Gb6gEYGmIZCEtk0Rj1GNBoHngZEACC48QAPzdAA4IBGBpin54BGJUY0RgaYB56h5wAkPUYHnp3nCJgAaMAHHL8AmP73gP9FRihGDLC96PCNAL8EALIALenwTYywhEbrSLzxAA8YvwApAtEMsL3o8I2WRgAq+dDR+ASwu/EAD/TQD2gAL/HQRPIQAE/wAApA8gomzfgswAeXYEQJkN1IYEQIkAAgBZADkFdFAPABglv4KiAAKgDwpYAJmEH2GzEBYBshAWHuIQiYAWALIcD4gBBA8gdxQWIHIcD4pBBc+CYAQPABAEz4JgBc+CYAQPAQAEz4JgCUaVBozvg0AFSzCpYWeIBGYEZdRvNGF0YxRv/38voAKADwzoE7egFoOkZj8wkhAWBf6khxJ9UHRgaSC5ghRjJGzfgAsAHwcfvIsQggBZnd+CzA3karRgD6CvABQwWRVOAQagAoAPCsgRFGYEZyRnRG//fH+934LMCmRgOQR+AGmjhG0vgEgN34LMBf6ohxAdTeRjngzfgIgN5G3PgAEMkHMtHUaAZGE0YRaVJpq0Yk8P8ABpObabBgSEIg8P8A8GAcaNP4CIAZamMeA/AHAwAqGL8D9YBzBJYzYgKYwgYa1LjxAA8HnwqeAPCKgNj4ACBTHDDQmPgEMNKyA/ADA0LqA0IC8YBCJ+CrRgefCp4gNgrxAQpO57jxAA8HnwqeAPCvgNj4ACBTHC3Q2PggMNKymPgeQGPzDyKY+CQwA/ABA0Lqg0KY+AQwA/ADA0LqA0JC6oRyGOAAIgScT/RAMyJkmPgFIAPqAkJiZNj4CCBTHDHQmPgMMNKyA/ADA0LqA0IC8YBCKOAAIgScT/RAMyJkmPgFIAPqAkKY+B0wY/OSQmJk2PgIIFMcOdDY+Bgw0rKY+BdAY/MPIpj4DDAD8AMDQuoDQpj4HDAD8AEDQuqDQkLqhHIk4AAiBJhP8AB0gmTY+BAgUx5k818TACoIvxNGw2SY+BQgT/RAMwPqAkICZQApAPCqgApoUxwW0At50rID8AMDQuoDQgLxgEIO4AAiBJuaZNj4ECDisQE6mPgWMALwHwJC6oNyFeAAIgScT/RAMyJmSnkD6gJCYmaKaFMcLtALe9KyA/ADA0LqA0IC8YBCJuAAIgSYT/RANMJkmPgUIJj4FTAE6gJCY/OSQgJlAClq0ApoUxwl0Atq0rKMf2PzDyKR+CQwA/ABA0Lqg0ILeQPwAwNC6gNCQuqEchPgACIEmE/wAHSCZgppUx5k818TACoIvxNGw2ZP9EAyCX0C6gFBQOAAIgScT/RAMyJmSnkD6gJCS39j85JCYmaKaFMcFtCLadKyzH1j8w8iC3sD8AMDQuoDQgt/A/ABA0Lqg0JC6oRyBeAAvwQAsgDEAAEAACIEm5pmCmlSsQE6i30C8B8CACtC6oNyGL8C9QAyAOAAIgSYwmYKfUt9T/RAMQHqAkFj85JBAWeY+BUABJkGmgtGjvgsAAEoAr+IakDwQHCIYtz4CAAA9EAQsPUAHwK/iGpA8IBwiGICnATwCAAE8AEBQepAAATwIAFA6oEgEXoSfwHwAwFA6gEgAvAHAUDqATAA8QBAGGCo5gOYAOADSAWZACkYv0H0MgDT5QQAsgAt6fBNrfUmfQVGCHgAJJH4CKAKk5NGCZEOkIhpjfj5QI34+ECN+PdAjfjDQI34wkCN+MFADJBAaw2Q/vcd/QuQDfWGeAAggCgD0Aj4AEABMPnnD5UAIA31g3EN8gkSDfIDE0CsDfH9Bw3x+gYAJQMtB9BIVVBVWFVgVXhVcFUBNfXnD5wOnVJGIEYpRgHwbvsgRilG/vcC/A2Z4kg5sTggDfIJEitGzekACALw1voAKFrRnfgMAVMoVtGd+A0BRihS0Z34DgFEKE7RnfgPAVAoStGd+BEBAShG0Z34EGFDqQ3yCRIN8cMDT/R/QATw0Pid+MNQy0iARsWzQ6zKTw31g3IN8cIDT/aEcH9EIUa4Rw3yAxIN8cEDT/aBcCFGuEdAqj6rT/aHcCFGuEcN8f0CDfH3A0/2BXAhRrhHDfH6Ag3x+QNP9gpwIUa4R534wRAIRgiRs0gA8XwIebGALZy/CJiAKALYD+CuSIBGC5j+94f8QEYN9SZ9vejwjQAgDJmALcHpEwDx2ACVQ6zd6Q0TrpgN8gkSApAPmAGUBPAW+TGt3fgwwIBGBPEdAAAhASLeRhgpDNAQ+AE8EPgCSwX4EUAF60EEAvoD8wYxY2Dw50SalkhRHBBEyQgAKki/QPAAQZ34DgHM+AQQwPNBAAIoDNABKATQACgMvwMgACAG4AMgsfGAf4i/BCAA4AQg3OkDEgYk3PgoMAQlDGAAJAxxFWAUccz4AAABIMz4OACIdwUgHHG+8QIPGGAM0534RgEKmQAuGL/A8wIRYEYE8FD43fgwwN5GYCHc+AhQ3PgcAARxAWCes534NAEBITdGAAkB+gDwsPWAfyi/T/SAcMz4JADd6UwQwPNBcsDzBCQDKhq/D/ZwQ1P4IiBP9HpCgwRP8AYDWL8DIwE0BPoD8x4kBOpABgTqQQHA8wRgAjEBMAI2SENzQ1BDzOkRAw3gWEhP9HpBN0bM6REQT/SAcMz4JAAKmAAoCL+GRgrw/QGd+A4BASkR0L7xAg8O04EGDfWGej5GJtRABkLU3PgAAAQoQPDVgE/w/wsC4b7xAA8N9YZ6GL8Q8BABJdG+8QAPGL8Q8AEAVNEDIE/wAQtP8P8xPkYoYAAghfgesKlgKHUoYaiAkeAAByfUnfgVAU/0AHGpgChgASCd+BQRqHcgKUTST/D/MEXgnfgbAU/0gHGpgChgnfgaASAoQdJP8P8wQuCd+BcRACCogClgnfgWESApSNJP8P8wSeAILtXTCZhAaBDwQADQ0Z34ZQEAIYX4JBAoYEDyARCl+B0AT/QAcKiAnfhkASAogPD/gU/w/zAB4p34GREAID5GqIApYJ34GBEgKTDST/D/MDHg6HUCIChz/yCoYE/wBQud+BQBG+ABIOh1KHP/IKhgPkZP8AMLnfgaASHgBQCyAINBAAD9//9/oIYBAAEhKHP/IOl1qGBP8AQLnfgWARDwHwAoYRy/ASCodQIgD+ABIShz/yDpdahgT/ACC534GAEQ8B8AKGEcvwEgqHUBICh13PgAAAQoHtGd+EtxeAYm0F/qh3on1dz4DABP8AAIILP/IwF4AnkBIHRGzekAgw6bzekCMK6YACMC8KP43fgwwKZGgEYR4Nz4IAAD8On/Q6kxqgyYA/BD/934MMBd4NxIAPF7CCDgT/AACPgHAtG68QAPF9W48QAPDfWGehTR/yEAIgEgACN0Rs3pACEOmc3pAhCumLchAvB0+N34MMCmRoBGAeAN9YZ6ACEN8UEAACKAKgLQgVQBMvrnuPEADxHRnfjCEA31g3J0Rs3pABDd6Q0TrpgCkA+YA/A8/934MMCmRoBG3PhoAJCx3PhsEHmxvvEDDwi/uPEADwDw5oBP8P8yACMKYIt3zOkcMgJgg3e48QAPAPC+gAEg3ekONDGtwLMA6woBASIR+AEcAvoB8cz4GBBWs0yZHiIF8QgDACQP9lQVAupBAgIyHCwS0CH6BPbG80EnxvMEFgMvFL9V+CdwT/R6dwE2BzRWQ35DQ/gMa+rnGzgxqd3pDjRACADrQAAB64AAUPgEDAHgT/R6cMz4QADc+FAAACgA8JGACJgN8gMSDZnN6QAKAvAa+IBGACh/9J+thq0AIAAhQ6sEKQLQaFQBMfrngUhP8AALDJ4A8QEIACDN+CiADZAT+AsAgAdn1FtEACAP9rgHnHiN+IwBWXiT+AOgogkDKhi/B+uCBjJoE0QEM8ayskIE2fdDATDfXa9V9+cAkgAiDpgrRs3pAgKumAGSAfCr/wTwDwGARg8pCL8IITGxuPEADwPRD5gB8Bf4gEa48QAPDJ4X0a6YASIAIwCQD5hjqQDwKv8IsYBGC+Cd+IwBT/AACBDqCgAYvwEgDZlA6kEBDZEMngvxCAsImINFQ6un2VBIAPECCC/lq/EBAN34QRAEKADynYDf6ADwA1hPU0oAiAdU1QwgkOC48QAPL9AKmIBFa9C48QAPf/QWrWngBy7/9Bevnfj5oLrxAA8A8KeBnfj3AAAoAPCigdz4ZBAAKQDwnYEJmQl5SQYA8ZiB3PgIEJ34+HDc+DRAACIAIwqRhqmAKwDwK4HKVAEz+ecNmMCyA+sLAUp4iXiQQi7QC+uBAQHxCAsImYtF8tmo54gGRNTc+CAAWeAIBwjVvCBE4MgGPdTc+CAAZeBIBzzU3PggAGLgASACISh36HX/IClzqGABIU/wBgud+GQBqXVP9IFxqYIA8B8AKGE75gExX/qB+sb4TKCKRQDwpoAAIMbpEwAJmEBogQdA8Y2CD5sZaMkHQPCIgg6ZATnJsgcpA9iLIspA0gdn0QAhZOLsIATgbCAC4AUAsgA8IChg3fhBELvxCQ8t2AEi3PggAAL6C/IS8A4PGdES9Bh/EdDKBRLVASEAIoF3PiECYQFgAiEBdQFzT/D/MYFgT/QAcYGAEOC78QQPDdEKBgfUSQYC1APw+f0E4APw4f0B4APw5f3d+DDADfFBATGqYEY3RmZGA/BI/bvxCQ8Z0XFpQPIDNDJqASOMgEDyASQNaIH4JDCh+B1ADWJA8gMRgvgkMKL4HUCRggMhEXFRcRFoEWLd6Q40tEYxrT5GReYP8hhiCZ1S+CEQDDUZRDzNIvD/AopgWkIi8P8CymAuaKpoK2p1HgXwBwUALBi/BfWAdcQGDWIA8ZaAACoA8FCBFGhlHADwEYEVeQHwEf4N4eJJ1vhQ4AAiT/T/cE/wAAgAJQAkAjENkVJFMtAL8QQLJUQAJBP4CxAB8A8HASE5QgjRZhwA6kEBBCw0RvfT3fg0gAUkBOtEAQ3xxAxe+CJwU/gLYBz4IUAM64EBPWC8YNHpARQ8YSbw/wQE9YB0jEIuv7T78fYBJiFGfmD5YAEyyucMnqfmzekAAa6YDfH9AiFGDpsCkA+YA/Dq/AAoUNGd+BkCAChM0M3pBkYKnAEmOUYCJ934MMAgYiBgQPIBEAApp3eE+CRgZnWgg0/w/zCgYEDyAzCggADw1YHc+FQAACgA8NCB3PhYEAApAPDLgQ9GBkaFqmOoACEN9QR7g6sAJAQsAPBvgRFVAVUL+AQQGVUBNPXnACoA8OmAFGhlHADwioAVauSyln9l8w8kkvgkUAXwAQVE6oVEFXkB8MT9e+Dd+DDAnfhDMNz4CCDc+DQQDfWGepgGnfj4AA3U2wZ/9WStnfhPQQHw8P2d+E5BICwX0k/w/zMY4J34TUEB8OX9nfhMQSAsAtJP8P8zA+DTdQMjE3P/I5NgT/AIC534TDEI4NN1AyMTc/8jk2BP8AcLnfhOMRPwHwMTYQHQASOTdQMjE3WGqs3pAAKumAKQQKoB8Pr83fgwwAAof/Qmrd34UwKw8f8/P/cgrdzpGhLDshNgwPMHIwtgwwDA8wdDwPMCYFi/T/D/M8z4dDABI5N3zPhwAIt3COUAJAxkT/RANFV5BOoFRU1klWhuHB/QFnsB8Bv9HOAAJAxkT/RANVR5BeoERFV/ZfOSRExklGhlHCfQlWnkstZ9ZfMPJBV7BfADBUTqBUQVfwHwWf0a4AAljWRP8AB3FWluHmfzXxYALQi/LkbOZBV9BOoFRAxlACsA8IiAHGhlHA7QHXkB8L/8C+AAJIxkFGmssQE8lX0E8B8EROqFdA/gACQMZk/0QDRdeQTqBUVNZp1obhwi0B57AfDL/B/gACTMZE/0QDYUfVV9BuoERGXzkkQMZQArWdAcaGUcHtAdauSynn9l8w8kk/gkUAXwAQVE6oVEHXkB8Nr8EOAAJY1mT/AAdx1pbh5n818WAC0Ivy5GzmYbfQTqA0M24AAkDGZP9EA1XHkF6gREXX9l85JETGacaGUcDdCdaeSy3n1l8w8kHXsF8AMFROoFRB1/AfDa/ADgACSMZhxpZLEBPJ19BPAfBAAtROqFdBi/BPUANALgBQCyAAAkzGYcfV19T/RAMwPqBENl85JDC2dSfa6bg/gsIADwCAIA8AEDAPAgAEPqQgIJm0LqgCAaeht/AvADAkDqAiAD8AcCQOoCMADxAEAIYE/wAAj/9xW6ACEAIkCsAyoE0KNcATJD6gEh+OcB8SACCDETDBK6jfgOEhIMjfgUMq34FSIKCgkMjfgNIgQijfgMEtz4NBDN6QAgrpgCkIWqAfDM+yi5nfmPAbDx/z9A85iAT/D/MDBgOGAMmEFrBCDN6QALrpgCkIOqAfC3+3C5nfkTArDx/z8J3J34EAKd+BESgAlh88MADJmJaghh3fgwwAqcAicBJgMgpnUgddz4DBDc+CggC2gIcYH4JGCPdwtiFCEAIyFhEHWWdVZ1EHGC+CRgl3dWd1BxEWgRYgAi3PgcEAhxCGiB+CRgj3cIYmOo3ekGFoAqAtCDVAEy+ufN6QCgrpgN8foCApAB8G773fgwwA31hnq4u9z4ZACd+I8hAnABOp34lxEGKkFwFNid+I5BnfiMIZ34jTHDcIRwAnGd+JMxnfiQIUNxAnKd+JIxnfiRIYNxwnEBOQYpFNid+JYxnfiUEZ34lSHCcoNyAXOd+JshnfiYEUJzAXSd+JohnfiZEYJzwXNP8AkL//deu534jRHAsv8iMWCd+IwROWDA80ERAjEC+gHxAPAHAslDkUAAB534jgFIv0/w/zAMmsLpFwFQ5wC/EAAAAAABAACgDwAAAQAAABAAAACAAAAAAAAAAAMAAAAEAAAAAAgAAIAIAAAACAAAAAkAAAAIAAAACAAAAAgAAIAJAAAt6fBFi7COaRVGBEYBILJqrfgqAAAqTdAQeQMoPNFP8AAMkvgkABdqDfEkClN5CXhP8AQIzfgkwLL4AOBSf83pAAo4As3pAoMDI83pBsWAss3pBCEBIkDqDgEgRgDwjPwBRgi7sGoDaTuxQXlCfyBGAPCe+wFGuLmwagN5kPgkAAEiDfEqAc3pAAUBKCBGCL8CIgDwr/oG4BN4DfEqAiBGAJX+9wf8AUa9+CoAEbmW+DgQCEAAKBi/ASALsL3o8IUt6fxNF0YaRppGiEYGRv/3l/+6+CgQACXJsQAoSNC5Qii/OUaMsjBowAcD0SBGAfAD+gLgIEYB8PX5AfA4+zkbOL8pRnCzp0IPRuzYKuB4s7gIGUygQji/vAhP9HpwBC84vwEktPvw8QH7EEABkR/6gPswaMAHBtEBmAHw2/lYRgHw2vkF4AGYAfCy+VhGAfDJ+QHwDPs5Gzi/KUYQsadCD0bm2BDwAQUcvwIlwPKyBShGvej8jQC/QEIPAPC1hGkMSGNok0IU2QIwI22LseRsfLEdaC5olkIG2NX4BMDvaAf7DGaWQgLYBDMBPPDnACANYPC9BACyAC3p8E2IsARGHUYORo9pUUgBKinRf24ALwDwmIA6eHqxMHhP8AEMACMBOrl4BJXN6QAjzekCDPscIEYAIgDwq/t6eAAqAPCCgDB4ACYBOrl6ASPN6QAmAqopwgfxCwMgRgAiAPCY+3HguW4AKW7Q+m4AKmvQ0vgAgAho+Wh6b9H4ALAAIRMMB5GN+BwwE7obDAEyrfgdMD7QMngDIw3xHAoElc3pADHN6QIhwbIgRgAiU0YA8HD7AChI0QrxAwEgRgEiACMAlU/wAAoA8K/56LuX+HAAnfgfEAAiACMIQ1/6i/GN+B8AMHjN6QCqApABIM3pAwUgRgDwTvs4uwAiBCMweAEhzekAMgKrI8Nf+ojxIEYHq6XnjfgbEMOyDfEbAiBGMUYAlf736fp4uZf4cACd+BsQX/qI8w3xGwIAlQhDMUaN+BsAIEb+93L7CLC96PCNAL+AALIALenwTYaw0fgYoAxGBkYAIDpPrfgWADhG2vgsELmxFUba+DAgmrHa+Cgwg7EYaA3xFggEkBB4QkYDkAhoIUYAlV/6gPswRltG/ves+hCxBrC96PCN2vg8AM34CLDDRt34EIACKCXQgCgK0EAoQ9Gd+BYADfEWCEDwQACN+BYAEOAL8QEIMEYhRgKbAJVCRv73ifoAKNvRnfgXAEDwgACN+BcAA5swRiFGQkYAlf73FPvN51/6iPMN8RYIMEYhRgCVQkb+92/6ACgCm8DRCPEBBzBGIUYAlTpG/vdk+gAottGd+BcAA5sxK0DwAgCN+BcACL+4Rtbnp/F9AKjngACyAIC1irCN+AQgACKN+AwwACPN6QYhDJkJko34ICDN6QQiSmsAkQKSAakDIv73Pf4KsIC9AAAt6fBNkLAERgAgikYYnQ6TXU8PkNr4GACpGENomUIA8q+A0OkIsA2SC5AgaMAHT/AAABi//fda+w3xPAgJkAqUAC0A8JeALkYNnQuatfvy8AyWAPsSUIEZkUIovxYaIEZRRhma/veC+gAoQPCCgNr4GADWRgFoCOsBAwP4AVwtCgE5+NGb+CRwu/gAwNv4ICAAaJv4BDCb+AVAm/gdUJ74ABDyRs3pAHgCrwWRMccAIAaQGZgAKgeQ0LIYvwEiCpxM6gAhIEYA8DX6AChR0dv4CABBHBPQm/gcEJr4ACD/J5v4DDAAJc3pAVUAkc3pA3EZmc3pBSUAIgHwC/nIu9v4EDAMnaOxoGgA9EAQsPUAHwXRm/gWAAAhAfCJ+Abgm/gUEJv4FSAgRgDwIPkHRgi7m/gVAJv4FDAZmTJGzekAASBGDpkA8JT6mLna+BgAgWoxsYJsIEZRRhmb//eP/UC5DZitGwAnMEQNkA6YMEQOkGbnB0YgaMAHHL8JmP33uvo4RhCwvejwjQQAsgACRgCIKbGReNJ4EgZC6gFBCERwR7y1BpwAJc3pAFQA8AH4vL0t6fBBhrAERlFIACoA8JmApWwtBwDxmIAMnYPwAweF8AEGPkMXRgLwAQYIvwbrVwd+Hk/0gCcH6oVFtrJj8xFFqxkD8QJzI2UAIwApAPB7gA2dRhxP8AMIACBtagWVBJEEIQOSAZON+AgQBa2d+AgQBClp0bBCZ9ADnwSY1PjEEAHwDwG5Qii/OUYIKQ3YD/IGAt/oAfA5BRccEiszJAoA1PjQEAFwASEr4NT42BABYNT42BBBYAghI+DU+NgQAWAEIR7g1PjUEAGAAiEZ4NT41BABgNT40BCBcAMhEeAA8Pj/1PjQEIFxByEK4NT42BABYNT40BABcQUhAuAA8On/BiF/GghEuecEkAOXp7nU+MQAAPAPAAEoCL/U+NAA1PjIByDwAgDE+MgHjfgIgAGYELEBmQMgiEcoRgOXAPD8+JTnAzAA4AAgBrC96PCBAL8BALIAcLUVTCKzhWwtByLUAPDt/gi/BetWBnUeT/SAJgbqhEStsmPzEURjGQPxAnMDZWmx3ekFQ9lgBCFaYRxiGXYaYdD4yBdB8AIBwPjIFwAkAOADNCBGcL0AvwEAsgALRgAhACIA8AG4AABwtQ5Mu7GFaIZsNgcU1AE7m7Jh8xFDAvABAQX0QBJD6oFBsvUAHwi/AfUAAQAkAfFAcQFlAOADNCBGcL0BALIAsLUKTHuxhWwtBw3UCEwAKRi/BPXABFkeYvMUVImyIUQAJAFlAOADNCBGsL0BALIAAAAnAxC1FEb990b9GLEBaGTzCSEBYBC9AmgAKSLwAQIYvwEyAmBwRwiFcEcctQRGAGgAKBnUoGgg9EAQoGAB8AMAoWhB6gBQoGABqRBG/fdh/EC5AZgE68AQ0PgoGEHwgHHA+CgYACAcvQFIHL0AvwQAsgAPKYS/BUhwR4JoIvRwYoJggmhC6gEhgWAAIHBHBACyABVLFEqYQhHQFEuYQhy/FEuYQgvQE0uYQgjQE0uYQgXQEkuYQhy/EkuYQg/RDykL2IJqIvDwAkLqARKCYoJqIvAPAhFDACKBYhBGcEcJS5hC7ND55wQAsgAACEZUgAhGVAAJRlSACUZUAAhKVIAISlSACUpUAAlKVLC1BUYAaAAkSLEBIADw1P0oaAE4KGAEvwIkwPKyBCBGsL2wtYiwFEYQmg2dB5IPmgOVDJ0Gkg6aBZIAIo3oLAAjRgSSAPAC+AiwsL0t6fxNBEYRmE/0cAXd+DjACp5AagGQD5gF6gBb3ekMcBCdwrEDKwi/AS4k0E/0QDIALwLqA0Jm85JCPk5C6gsCQuoRIyNlQerFQ8myCL8D6gYBEUMZ4MmyBvABAgAvY/MRQUHqgkEF8AECCL9B6sJBQeoLAQngBfABAgAvCL9B6sJBQeoLAUH04CEhZU/0ACHN+ACwAygB6sVLT/RAMQi/vPEBDwHqAEUjSYhGbPOSRR7QT/AACgGuACBf+orxuUI20kBFQkYz0KBsAAcM1AuYCvEBCkBcATG5Qii/QOoLAACZKEMIQyBlMEb/92P/5OcAJg3xBAoAIL5CGdJARUFGFtCgbAAHD9QLmrEckBlAeLlCKL9A6gsAkl3OskDqAiAAmihDEEMgZVBG//dD/+Pnvej8jf8ACAACALIALenwTYawBEZLSAAqAPCNgKVsLQcA8YyADp6D8AMHT/AACIbwAQVX6gUMAvABBxVGCL8H61UFT/SAJwfqhkYBPa2yY/MRRnMZA/GEcwApI2Vt0A+bvPqM9Q3xFApbam8JRRwAIAWTBJECIQOSzfgEgI34CBCd+AgQAilZ0ahCV9Dd+AywBJ7U+IgAAPAPAMDxCABYRSi/WEYIKBjY3+gA8CsfBQUSEgoKFwAwiMT4lAACIBzgMEYA8Br9sIjE+JQABiAU4DBGAPAS/QQgD+AwRgDwDf0wHQDwCv0IIAfgMHgALwy/xPiQAMT4nAABIKvrAAsGRMfnu/EADwSWzfgMsA/RxPiAgNT4yAcg8AEAxPjIBwEgjfgIAAGYELEBmQEgiEdQRv/3qP6k5wMwAOAAIAawvejwjQC/AQCyAHC1hGwkB0S/FUhwvQDwmfwIvwXrVgZ1Hk/0gCYG6oRGrbJj8xFGNUQF8YR1BWWhsd3pBWUpYAIhqmDuYSl2ASHA+IAQamCF+CswhfgqQND4yBdB8AEBwPjIFwAgcL0AvwEAsgBBHgwphL8FSHBHBUlR+CAgIvAAQkH4ICAAIHBHAQBKAEASQFINKIS/BUhwRwVJUfggIELwAEJB+CAgACBwRwC/AQBKAEASQFIQtQhJUfggIFH4IADC8wMiAPAPAFQcAPA7+ADrVACw+/TwEL1AEkBSDSiPvwAgAklR+CAAwA9wR0ASQFICRgdIDSqYvw8pANlwRwVIUPgiMGHzCyNA+CIwACBwRwEASgBAEkBSAkYISA0qmL8PKQDZcEcGSFD4IjAj8A8DGUNA+CIQACBwRwC/AQBKAEASQFIQtQRGAPAq+AIsCtgISQIsAetEEgi/AfUAchFosfH/PwDdEL0gRr3oEEAA8J27AL8AFkBSCEpP9IhTAuuAAclYAfAHAQcpAr9S+CAQCCBg818RiLJwRwC/AAFAUoC1//fp/wMoD9mw9Yh/ItBA8hERiEIO0EDyExGIQhy/ACCAvRJIgGgX4N/oAPACHQsbEEiAvQ5IT/QAQcBqAepAMIC9DEkKSABoWfgBEIAHAergcIC9BkiAaU/0AEEB6hBAgL0GSIC9BEhZ+AAAgL1oE0BSgPD6AkwNAABIDQAAABJ6AAUohL8JSHBHCUqx9YB/Mb8B8AcBAfAfAUL4IBAHIQLrgABP9IhSgVAAIHBHAQBKAAABQFKwtYQBAk0A8M77APDUuwC/ABhAUvi1DEYVSoEBACZTWALrgBUgRkPwAENTUEce6mlG8QAB0gcE0RmxAPDj+zhG9OcpaDyxMLkA8C/8KGgg8ABBCEgK4AHwQFCw8QBfHL8AIPi9KGhA8EBRACApYPi9ABhAUgIASgCwtQVGDEZIaDQh/Pfg/qgBPkkKWGBoAeuFEdMPAnADccLzAXPDcMLzAjPC8wIig3BCcEpowvMDY0NzwvNCUwNzM0sD9cATGkCCYIpowvNAcwLwAQKCc8NzymjC88Njg3XC88NTQ3XC8wJTA3XC8wNDw3TC88Ijg3TC80QTAvAfAgJ0Q3QKaUtpw2HC8wAzQ3bC80QTAvAfAsJ1A3aKaRNGb/PfQwNiwvMAY8LzAFKA+CUwgPgkIMppwvMAU4D4KTDC8wBDgPgoMMLzQAMC8AECgPgmIID4JzAJasoPgPgxIMHzQHKA+DAgwfMMQsKFwfMAEoD4LCDB88ACAfAHAYD4KhCA+CsgACCwvQC/ABhAUv//BwAt6fBBkLADrQRGNCEoRvz3VP4ClQAlIEYBlQGp//dm/6ABGkkIWLDx/z8r3J34DwACKCfQnfgMAJ34DRCd+A4gBZ1HHKAcAvEBCE4c//e2/p2xFetHUU/wAAJC8QACofsAMQL7ABEI+wbyGEYAI/z3gP1ADUDqwSUE4Aj7BvF4Q7D78fUoRhCwvejwgQAYQFJwtQJGUEyAASNYUEgAKwzUSWgLeAcrB9P5KwXYTXgHLZy/jngHLgLZcL0CMHC9BOuCEMp4AioA8IGAZfMKIwbwBwRD6gQzDHlD6sRzA2BASwP1wBOMaCNADHsE8AcEQ+pEU0x7BPAPBEPqBGNDYMt7jHtE6kNzg2AMfEt8BPAfBGPzSRSLfAPwBwNE6sMjzHwE8A8EQ+oEQwx9BPAHBEPqBFNMfQTwDwRD6sRTjH0E8A8EQ+rEY8NgzH0LfgTwHwRj80kUS35E6gMzA2HLaUNhDGqR+CQwb/PfRETqA1OR+CVAQ+oEY4NhkfgnQJH4JjCR+ChQkfgpYATwfwRD6kQDQ+oFQ0PqBlPDYZH4KjCR+CtAkfgsUJH4MGAD8AcDQ+rEA8yNkfgxEEPqBRPbsmTzHEND6kZzQ+rBcQFiAWhi8x1xAWAAIHC9ABhAUgEASgD//wcAsLVEAQJNAPAW+gDwHLoAvwAWQFL4tQxGFUpBAQAmU1gC60AVIEZD8ABDU1BHHuppRvEAAdIHBNEZsQDwK/o4RvTnKWg8sTC5APB3+ihoIPAAQQhICuAB8EBQsPEAXxy/ACD4vShoQPBAUQAgKWD4vQAWQFICAEoAsLUFRgxGCGhgIfz3KP1oARZJClggaAHrRRHC8wFzAnADccLzwGPDcMLzBEPC8wQig3BCcEpo0w9DcyLwf0MS8OBCg2AYvwEiAnOJaMoPwnXB8wBygnXB8wBiQnXB8wJCybIBYQJ1ACCwvQC/ABZAUi3p8EGasAKuBEZgITBG/Pfu/AAlaUYgRs3pAGX/97j/YAEVSQhYsPH/PyDcnfgMAAIoHNCd+AlgzrGd+Apwt7Gd+AgQACAEmhLrAWVA8QAIIEb/9039pfsAQaf7BiMI+wARIEb89x/8AA5A6gElKEYasL3o8IEAvwAWQFLwtQpoJCYsJwAhHCUnJCMjwukOdigmwukEEcLpE1XC6RBFICXC6RVDE2MpS8LpCBYPIcLpClSRYUEBXFglSQAsQ9SUeAAsQdAQLD/YVXjtsxAtO9gWeBAuONPILjbYEXkD60AQAikq0CsCQ+oEQxpMI0DUeDNEQ+rEYwNglGgTeyTwf0RE6gNzVHtD6sRzE0wlRkNgACODYBN/WwMPM8NgU2tj8x51BfUDcw1NA2GTbGPzHnVFYdJtYvMedIRhAmhh8x1yACECYADgAjEIRvC9ABZAUgEASgAAHx8AHM5pBCzSiQNwRwAAw7IACgEpA9BRuUAGB0kB4EAGBUlA6oMQCEQCYAAgcEcASHBHAQBKABRAAFIQQABSsLUNKwrYDUxU+CNQAC0F1FT4I1BF8ABFRPgjUEAGASMA64EQBkkD+gLyCERBaZFDQWEBaRFDAWGwvQC/QBJAUgBAAFKAtQEoAtj/95v+AuACOP/33/wAIIC9ASiEvwI4//fivP/3mL4BKIS/Ajj/95e9//f7vgEohL8COP/32L3/9zK/cLULTQRGT/D/MVn4BQCx+/D2WfgFALRCBNlwQ/z3KPukG/bnYEO96HBA/PchuwC/cCwAAAJJWfgBEEhD/PcYu3QsAAD/99y///f0vwDwDLoCSVn4ARAA8Du5AL9YDQAAAOvBAAEhFDAB8Ja+CesAAihGMEcD8eNwb/APAwPq0ABwRwScg/ADBoTwAQU1QxZGAvABBXBHKfgGACBrzekAWs3pBFTN6QIgWEY4R7T4AIAjeZT4IHBP8AEMZn+U+CRACXgAJXBHgmABYAAhAXUBYQFzgYBwRyBGKUZkIgDwl7wJ6wACIEYwRyPqAQERQwFgcL1N+AjtASH/9xL4xPiYAF34COtwRyn4BgAga83pAHvN6QR0zekCIFBGKEey+oLySOoHIc3pAEVSCf/3zbnd6Q4wAfBPvwIhKFlh8x1wKFEBIP/3d78oWSDwAEAoUQAgsL3H6QJDB/FQA0lEx+kHIXBHgkZYA0/2/3Xd+FSAASYDJ6hDA/AHBShEBCUAugiQACBwR+SyBfADBUTqBUQE8YBEcEcBIP/3Tb8AJ0/wAgtP8AEMT/AACnBHzekCV83pBgjYDAMjzekAZEDqQjABInBHAjiw+oDwQgkgRv/3uLjtsgbwAwZF6gZFBfGARXBHCesAAQnrAwJKYBEPDilwRwAgASPN+AiAzekAMFBGAyNwRwSQD5j/90q5MkY7Rs34AKD999m51PjYEAFg1PjUEIGAcEcFRmQg//fqvgXwAwVE6gVEROqGdHBHAiBg8x1xASApYP/39r5oaGlsMkb996O6ApAVmAOQFpjN6QQKOEZwR66YApAgRgHwtL4AJ0lEAfEkA3BHvfgeAAE+AAZP6gZAcEcF8AEFROqFRETqhnRwRwnrAAEJDw4pcEdBRjpGI0b89xu7B5GBsiBG//cMuQEjk3cUYE/0QHSUgHBHMEZBRlJG/vdEvAtGACEB8CC9LenwTYawACQORgdGBZQFqQDwKvkAKEDwm4AElAWcBKkgRgDwAflbSCF4AevBAUhEAOvBAAAhAPEUCEBGAfBE/WVoqWnoaApGGbkqagAqAPCDgNL4BKCHQgTRskWcvyppskJ82T8aACADkJGzA6koRjpG/vfD/Di7A5goswFo0PgMsAAuKEYCkQi/XkYDqT5Ech7+97P8BEYAKFbRA5gBaMBochqy+/DzA/sQIgAqGL8BMwKcOhuy+/vyAvsLRokbA/sAF6lpH+CpaRGxAfEYAAPgKGoYsQwwACEAaAHgACEAIAAuCL8GRvIZsvvw8wP7ECQBMwAsGL8D+wDyt/vw8wP7ECcD+wD2uBkqaVJFOL+SRoJFOL+q6wYH2PgEAAjxCAphsSlG//cI/wRGaLkEmFixQWjY+AQA//f//gTgKUYyRlNG/Pem/QRGACwYvwEkIEYGsL3o8I1P8AAKe+fY+AQACPEIBoGxKUYyRv33qPgERgAo6dEEmAAo5tBBaNj4BAAyRv33nPje5ylGMkb89x/92ee4KwAALen/TSBIIUkAJgQkA5ZZ+AAgCesBAJD4AoADrQGSRkUs0gnrAQsb+AQAgkIj0QnrAQAA68YKmvgFAChc2LkJ6wEHB+vGAIBo0OkDAf/3DP/AuZr4BRABIgvrBACX+AKAalQCqQDwFPgYuQKYASFAeClUBkkBmgg0ATbQ5wAgBLC96PCNASD657QrAAC4KwAA8LUAIgpgQmhTaauxC0wJ6wQFLB2teH2xJngHeLdCCNFmaLJCBdB2abNCAr8MYAAg8L0INAE97ucBIPC9uCsAAC3p8EEAIiDwgFwA8IBeCmAdSgnrAgMD8QgIm3g7s9j4AGC1aQ25NWr9sWpo1ukDdBVGlEI4vyVGACoIvyVGehlVHodCAdiFQhfSB/CAUpZFB9An8IBXvEUD0yXwgFKURQjZCPEICAE72OcAIt7nASC96PCBR+oOAPBgqPEEAAhgACC96PCBAL+4KwAALen8TYtGBUYA8Fz6ILkBqShG//ev/xCxASC96PyNAZzf+PSgO0gieALrwgIJ6woBWfgAAAHrwgUV+BQfiEIS0TdOMEb89zD7BvWAIPz3LPsoRllGAfC++y5JKHhJ+AEAACC96PyNAPB1+QXxCAZoaClsT/R6cjNG/Pdg/gAoy9H6IDFG/vem/mJoaGgReBJ6/veO/mhoMUb897b7H08Z+AcAWLlhaGhoCXj79xn/T/R6cP/33fwBIAn4BwD/9+L9GLH/99/9ACim0QnrCgAAJwAkBh2AeIdCstIpeDJ4ikIV0QnrCgEB68cBiWiR+ACAGOoEDwnRKEYxRgDwE/gAKH/0iq8J6woAgHhE6ggECDYBN+DntCsAALgrAAAMAAAAAABFVC3p8E2GsAApAPCvgARGCA8NRg4oAPKpgG5oAC4A8KWAMA8OKADyoYCwaRCxAQ8OKQnZMGoAKADwmICw8XBPgPCUgAAnkuCBaBGxCg8OKinZACLQ+CyAw2sweUAHH9W48QAPL9BP6hhwDigY2Nj4AAABMAEoE9gE8QgBYGiSRh9GAiIBI0/wAgsAkTFG/fdI+jtGUkZP8AEMgkYAJxbg//cI/RPgkfgUsEp9u/EDD2HQu/ECD83QT/AADAAnT/AACgAjAeD/9/X8T/AACFfqCgAm0bjxAA8g0E/qGHAOKBzY2PgAEMmxSBxP8AAHGL8AKxTQzekCwwSSy7JgaATxCAgN8RcCMUaN+BdwzfgAgPz3Bf4AKFbQgkY74AAnT/AACrvxAw8E0QEqCL9X6goABNC68QAPGL8BJxjgYGghbATxCAcCaDtGIvAAQgJgT/R6cvz3Yv1IufogOUb+96n9MngySAIh/vem/aixASc4RgawvejwjdD4aIAHb2BoBPEIAzFGBJL+90z6gLGCRgAnT/ADCwSaxOdqaGBoEXgSev73df1gaDlG/Ped+krn//cf/DtGB0ZP8AAMT/ADC0/wAAoEmoPnQkad+BcA3fgMgADqCABARQPRACdP8AAK2edgaDFGkEb89xj+gkYIsQAnAuD/9/37B0YEmlfqCgB/9JCvAplgaCGxMUZCRv73tfoE4DFGBJpDRv73A/qCRgixACe35//35PsHRtbnAL8AAEZUELUHTBn4BAA4uXK2AfAE/AHws/wBIAn4BAAAIBC9AL8EAAAALen4RQRGACDf+HyA6kYAkE/wATAC+wD2YBhHHrxChL8AIL3o+IUgRlFG//fn/QixBDTz5wCdCesIACl4AevBAf/3cPtoaIFpCbkBatGxSWjQ6QMCQxgVGBhGikI4vyhGQR4IRp9COL84Rq9CKL8IRoRC09ghaI5CHL8BIL3o+IUENPXnACHj57grAAAt6fhFiEYFRgDxCAoBJGhoUUb890j6B0ZoaEZoCiD/9yX7OB9P8AABGL8BILbx/z/IvwEhCEID0WAcREUERubZACC96PiFLen8TZJGg0YAIApGAZABqRBGAJL/92n9sPqA8N34BIAL8QgHASRP8P82RQngBwjQAJg6RkFo2/gEAP73gvgERgrg6AcV0Nj4BBDb+AQAOkb+93f4BUYAJAE2VkWEvwEgvej8jQog//fe+kTqBQDAB9zRACC96PyNAAAt6fhN3/gIbhn4BgABKCzR3/gADkhEhXgAICWz3/j0HfNIGfgBIFKx3/jsPd/41E0J6wECkGFLRExEwukVQwnrAQJSeFqx3/jALd/4wD1JRAD1gCAIZkpES0TB6ScyASAJ+AYAACC96PiN3/ioHQAgKfgBAElEiHDf+JwN//fF+wTY3/iYPf/3Z/sC2QEgvej4jVn4AOBP8AALvvEADwDw0YDf+HytCesKAAAPDigA8smA3/hwDXJG//en+5ZGAPLBgAnrCgEJ6wAC0fgEsEn4AxBSaAvwBAERQwfR3/hIDQAmCesAAgLxJABA4AnrAAbf+DgN3/g8Hd/4RC3f+ER9SERJREpET0TwYt/4JA3G6QJyACJIRMbpBxDf+BwN3/gcHUhESUTG6QQQ3/gcDd/4LB1IRElE8Gbf+BANSESwZt/4DA1IRDBj3/gIDUhEsGLf+AQNSETG6RUQ3/gEDUhEcGbf+AANSERwYwbxUADf+PxcCesKB9/48Bzf+AjN3/gATTpivmHf+PRsCesFAklECesMA0xEAmDf+NQMSfgFEN/40Bzf+NBcAvEkDE5ECesACN/41AxJRE1EwukNUd/40BzC+DyA3/jUXEhErOhZAN/4uAwJ6wEI3/jMHN/4tDzf+LRM3/i4bE1ECesADN/4tAxJRE5ES0RMRMLpA2XC6QVDwukHjEhEwukBEDhpqLHf+AAc3/gEPF/qi3BP8AALENUBIAnrCgIJ+AEASUSh+ASwT/ABC4pgiHAD4N/43DtP8AALvvECD8Dw1oDf+FxMCesEAAAPDigA8s6A3/hQDHJG//fS+pZGAPLGgAnrAwEJ6wQCSmAJ6wABUmgAkkloAvAEAhFDB9Hf+CgMACcJ6wABAfEkAEDgCesAB9/4GAzf+Bwc3/gkLN/4JDxIRElESkRLRPhi3/gEDMfpAjJIRMfpBxDf+PwL3/j8G0hESUTH6QQQ3/j8C9/4DBxIRElE+Gbf+PQLSES4Zt/48AtIRDhj3/jsC0hEuGLf+OgLSETH6RUQ3/jkCwAhSER4Zt/44AtIRHhjB/FQAN/42Cvf+Ng73/jka9/45FtKRE5ETURJ+AMgCesEAt/41EuXYQnrAwff+MA7EWLf+LQbB2Df+KwLB/EkDExESURLRAnrAArf+LALx+kNMd/4sBvf+LA7x/g8oEhECesBCEtErOhxAN/4lAvf+JxL3/icW9/4nGvf+KDLCesACt/4lAtMRE1ETkQJ6wwBx+kDZcfpBUPH6QeKSETH6QEQEGnYsQCY3/hUGt/4WDqABxbVASAL8QEKCfgBAAnrAQDf+NAagPgCoADrywBJRIFgT/SAcYGABOAAAEZU3/gkOtpGvvEDD8Dw1IDf+DRLCesEAAAPDigA8syA3/goC3JG//f3+ZZGAPLEgAnrAwEJ6wQCimAJ6wABUmgAkkloAvAEAhFDB9Hf+AALACcJ6wABAfEkAEDgCesAB9/48Arf+PQa3/j8Kt/4/DpIRElESkRLRPhi3/jYCsfpAjJIRMfpBxDf+NQK3/jUGkhESUTH6QQQ3/jUCt/45BpIRElE+Gbf+MgKSES4Zt/4xApIRDhj3/jACkhEuGLf+LwKSETH6RUQ3/i8CgAhSER4Zt/4tApIRHhjB/FQAN/4rCrf+Kw63/jAWt/4tGrf+NzKSkRNRE5ESfgDIAnrBALf+KRKl2EJ6wMH3/iQOhFi3/iIGgdg3/h8CkxESURLRMfpC0bf+JhK3/icagnrAAvf+HwKx+kNMd/4fBrf+Hw6x/g8sExETkRIRAnrAQgJ6wwBS0TH6QkF3/hYCt/4ZFrH6QVDCesAC9/4YApNRMfpA2XH6QeLSETH6QEQEGnIsQCY3/ikOIAHFtXf+JQYASAK8QEICfgBAAnrAQDf+KgZgPgCgADrygBJRIFgT/QAcYGAAuDf+HQ40Ebf+GBovvEED8Dwz4Df+AjKCesMAAAPDigA8seA3/j8GQnrAQAADw4oAPK/gAnrDAIJ6wMA0vgE4MJgCesBAEVoDvAEAipDBtHf+NQZACVJRAHxJAZA4AnrAQXf+MgZ3/jMKd/41Gnf+NR5SURKRE5ET0TpYt/4sBnF6QJ2BfFQBklExekHId/4qBnf+KgpSURKRMXpBCHf+KgZ3/i4KUlESkTpZt/4nBlJRKlm3/iYGUlEKWPf+JQZSUSpYt/4kBlJRMXpFSHf+JAZSURpZt/4jBlJRGljACHf+IQp3/iEed/4mEnf+JAJ3/iIOUpETERIREtESfgHIAnrDAIRYt/4aBmVYQnrBwXf+GR5NWDf+FxpCesBCt/4aBlPRE5ESUTF6Q5q3/hsacXpCRQF8SwB3/hcSYnB3/hMCd/4UDnf+Fh5TkTf+EAZTEQJ6wAK3/hMCUtET0QJ6wEL3/hEGcXpA3bF6QVDSETF6Qe6SUTF6QEQEGm4sd/47GZf6o5wFNXf+OQWASAI8QEFCfgBAAnrAQAJ6wwBhXAA68gAgWBP9EBxgYAC4N/4vGZFRt/49Aj/91X4BNjf+PA4/vf3/wHZASBU5Fn4AKC68QAPAPDQgN/42EgJ6wQBCQ8OKQDyyIDf+MwYCesBAhIPDioA8sCACesEAtL4BIBJ+AMgCesBA1toCPAEAhpDBNHf+KgY//cT+EDg3/i0ON/4tAgJ6wEH3/iUGN/4mChLREhESURKRMfpAgPf+JwI+WLf+IAYB/FQA0hESUT4Zt/4jAjH6Qch3/hwGN/4cChIRElESkS4Zt/4eAjH6QQh3/h8GEhESUQ4Y9/4bAhIRLhi3/hoCEhEx+kVEN/4ZAgAIUhEeGbf+GAISER4Y9/4XAjf+FxoCesEAt/4cOjf+GRIEWLf+FAYl2FIRAnrBgdMREn4BgDf+DwI3/hEaB9g3/g4OAnrAQwJ6w4BCesAC9/4NAhLRE5Ex+kLRt/4QGjH6Q083/g0SN/4LDjH+DywSETH6QkQ3/gYCN/4GBhORAnrAwvf+CQ4TEQJ6wAM3/gUCAnrAQ7f+BAYS0TH+CDASERJRMfpAwYH8RQAx+kBMYDoEEgQaaix3/hkN1/qiHAS1d/4HAXf+FwnBfEBCAEhSERKRID4AoBBcADrxQCCYIGAAuDf+Dg3qEa68QIPwPDLgN/4vFcJ6wUAAA8OKADyw4Df+LAXCesBAAAPDigA8ruACesDAAnrBQJCYAnrAQBDaFBoAPAEAgCQGkME0d/4iBf+9z3/O+AJ6wEH3/h8F9/4gCff+Ig33/iIR0lESkRLRExE+WLf+GgX/vec/t/4aBff+GgnSURKRMfpBCHf+GgX3/h4J0lESkT5Zt/4XBdJRLlm3/hYF0lEOWPf+FQXSUS5Yt/4UBdJRMfpFSHf+FAXSUR5Zt/4TBdJRHljACHf+EQn3/hER9/4VAff+FRn3/h0x0pESEROREn4BCAJ6wUC3/g4VxFi3/gkF5dhCesEB9/4JEdNRB9g3/gYNwnrAQvf+CQXx+kLBd/4IAdMRN/4KFfH+DywS0RJRAnrAAvf+CAHx+kNQ9/4CDff+AhHTUTH6QkW3/j4Ft/4BGdIREtETEQJ6wEOCesMAU5Ex+kFQ8fpARAQacfpA2XH6QfrwLEAmN/4yDWABxXV4EgI8QELASIJ6wAB3/hEBkpwgfgCsAHryAEJ6wACimBA8gESioAC4N/4mDXDRrrxAw/A8MaA3/ioBv73nv4A8sCA3/igFgnrAQISDw4qAPK4gAnrAwIJ6wADk2AJ6wECW2gAk1JoA/AEAxpDBNHf+HgW/vdv/jvgCesBB9/4bBbf+HAm3/h4Nt/4eEZJREpES0RMRPli3/hYFv73zv3f+FgW3/hYJklESkTH6QQh3/hYFt/4aCZJREpE+Wbf+EwWSUS5Zt/4SBZJRDlj3/hEFklEuWLf+EAWSUTH6RUh3/hAFklEeWbf+DwWSUR5YwAh3/g0Jt/4NEbf+EBm3/hAVt/4ZMZKRE5ETURJ+AQgCesAAt/4MAYRYt/4FBaXYQnrBAff+BRGSEQfYN/4CDbH6QtW3/goVt/4KGYJ6wEI3/gIFkxEx/g8gEtETURORElEx+kNQ9/4/DXf+PxFx+kDZcfpCRDf+OQF3/jkFUtETEQJ6wAI3/jsBQnrAQ4J6wwBx+kFQ8fpB+hIRMfpARAQaaixAJjf+Cw0gAd6SBHVSEQBIQvxAQVBcN/4NBWFcADrywBJRIFgQPIBIYGAAuDf+AQ0XUYBILrxBA/A8NCA3/icxWtOCesMAQkPDik/9tWp3/iMFQnrAQISDw4qP/bNqQnrDAIJ6wMA0vgE4MJgCesBAENoDvAEAhpDBtHf+GQVACNJRAHxJAZA4AnrAQPf+FgV3/hcJd/4ZGXf+GR1SURKRE5ET0TZYt/4QBXD6QJ2A/FQBklEw+kHId/4OBXf+DglSURKRMPpBCHf+DgV3/hIJUlESkTZZt/4LBVJRJlm3/goFUlEGWPf+CQVSUSZYt/4IBVJRMPpFSHf+CAVSURZZt/4HBVJRFljACHf+BQl3/gUdd/4JAXf+BxFSkRIRExESfgHIAnrDAKTYQnrBwMRYt/4+BTf+Px0M2Df+PBkCesBCN/4+BRPRAnrBgrf+PRkw/g8gElETkTD6QlhA/EsAd/48GSB6JEE3/jcBN/46HTf+NgU3/jYRE5ECesACN/42AQJ6wEKCesEC9/40BTf+NBET0TD6QVrw+kHqEhESURMRMPpAwcQacPpAUGosV/qjnAOTk/wAQB/9R6pDUlqHElESHCKcAHrxQEJ6wwAiGBA8gEwiID/9xC5ASAETv/3C7mcKAAArCUAAJArAAAIAAAAuCsAALwlAAAcDAAAXA0AAPwfAADcIwAAmA4AANANAACADQAAqA0AAOgOAAAQDwAA+A0AAGAPAABwDgAAiA8AAMAOAAA4DwAAIA4AABwlAABIDgAAXAAAABwAAACIAQAAdAEAAGABAABMAQAAOAEAACQBAAAQAQAA/AAAAOgAAADUAAAAwAAAAKwAAACYAAAAhAAAAHAAAACwDwAAeCAAAAQkAADsEAAAJBAAANQPAAD8DwAAPBEAAGQRAABMEAAAtBEAAMQQAADcEQAAFBEAAIwRAAB0EAAALiUAAJwQAADcAQAAnAEAAAgDAAD0AgAA4AIAAMwCAAC4AgAApAIAAJACAAB8AgAAaAIAAFQCAABAAgAALAIAABgCAAAEAgAA8AEAAAQSAAD0IAAALCQAAEATAAB4EgAAKBIAAFASAACQEwAAuBMAAKASAAAIFAAAGBMAADAUAABoEwAA4BMAAMgSAABAJQAA8BIAAFwDAAAcAwAAiAQAAHQEAABgBAAATAQAADgEAAAkBAAAEAQAAPwDAADoAwAA1AMAAMADAACsAwAAmAMAAIQDAABwAwAAWBQAAHAhAABUJAAAlBUAAMwUAAB8FAAApBQAAOQVAAAMFgAA9BQAAFwWAABsFQAAhBYAALwVAAA0FgAAHBUAAFIlAABEFQAA3AQAAJwEAAAIBgAA9AUAAOAFAADMBQAAuAUAAKQFAACQBQAAfAUAAGgFAABUBQAAQAUAACwFAAAYBQAABAUAAPAEAACsJQAALAwAAKwWAADsIQAAfCQAAOgXAAAgFwAA0BYAAPgWAAA4GAAAYBgAAEgXAACwGAAAwBcAANgYAAAQGAAAiBgAAHAXAABkJQAAmBcAAFwGAAAcBgAAiAcAAHQHAABgBwAATAcAADgHAAAkBwAAEAcAAPwGAADoBgAA1AYAAMAGAACsBgAAmAYAAIQGAABwBgAAABkAAGgiAACkJAAAPBoAAHQZAAAkGQAATBkAAIwaAAC0GgAAnBkAAAQbAAAUGgAALBsAAGQaAADcGgAAxBkAAHYlAADsGQAA3AcAAJwHAAAICQAA9AgAAOAIAADMCAAAuAgAAKQIAACQCAAAfAgAAGgIAABUCAAAQAgAACwIAAAYCAAABAgAAPAHAABUGwAA5CIAAMwkAACQHAAAyBsAAHgbAACgGwAA4BwAAAgdAADwGwAAWB0AAGgcAACAHQAAuBwAADAdAAAYHAAAiCUAAEAcAABcCQAAHAkAAIgKAAB0CgAAYAoAAEwKAAA4CgAAJAoAABAKAAD8CQAA6AkAANQJAADACQAArAkAAJgJAACECQAAcAkAAKgdAABgIwAA9CQAAOQeAAAcHgAAzB0AAPQdAAA0HwAAXB8AAEQeAACsHwAAvB4AANQfAAAMHwAAhB8AAGweAACaJQAAlB4AANwKAACcCgAACAwAAPQLAADgCwAAzAsAALgLAACkCwAAkAsAAHwLAABoCwAAVAsAAEALAAAsCwAAGAsAAAQLAADwCgAALenwTYiwDhgHqZtGkkYwRv73CvwIsQEgMeAHnBlIT/AACCF4AevBAUhEAOvBBQAhBfEUBzhGAPAn+GFoyGiKaTMaqGlCsQfxCALN6QCyGkZTRv33F/kP4ApqB/EIBAElT+pbBpJozekAas3pBFTN6QKCASL79y76ACgYvwEgCLC96PCNuCsAALC1BEZAaA1G+/dh+KhCB9BgaClG/ffs+iBGZCH+9wj+ACCwvXC1HUhZ+ABAtPH/PyVGAtz690D9ACUZSAXrxQFIRADrwQAA8RgGAS0i2AAsA9QwH2Qh/vfr/QEgASECIgEj/ve/+AEgASEDIgEj/ve5+AQgAC0IvwMg/ffH/Fb4SAsBaCHwAEEBYPr3Uf8BNQAs2tT69xD9ACBwvbQrAAC4KwAA+LUORmlGHEYXRgVGGGD+93X7CLEBIPi9AJkPSAl4AevBAUhE/vf++DhGKUYyRvr3iPxAsQAhjkIH0HhcalyQQgXRATH35wAgA+ABIAHgASAORnEZIWD4vbgrAADwtYx5CCXAsk/wAAxP8AAOBevEBAAlLkYINaVCD9gORDd6h0IEv/d7/y/00Xd6vkXx2LZ6AS4Ev6xGvkbr57zxAA8K0AHrDAABeZFwQXlRcIF5EXDAeIAAAOAAIBhw8L0AIwJrBikTcSzY3+gB8AoEIhIEBBkAAiMBIcNjwGo1IxzgT/D/McFjwGoRYAFgACEW4D4hEWCAIcFjwGo/IQXgMSERYAIhwWPAajUhAWABIQbgQCMBIcNjwGoFIxFgA2CRd4F3cEdwtQNGAGgEKBHRW2lP8P8wACQYYEh4wPNDBR0gBSwf0CX6BPb2Bw/RAjABNPbnHSAKXP8qA9EiKBHYAjD451tpASGZdxpgE+AlKAnQBDEAJQQtCdBOXQE1AvgMa/jnW2n/IBhxACBwvQldASKadxlgACGZgHC9LenwTYqwnEYIkAt5ACANRgAnAysF0ZX4JBABObH6gfFPCY34JAAJqQMoBNAMGBZcATBmcPjntfgA4JX4IABseZX4JKBP8AMIbn8AL0/wAAscv0/wBAgKRs3pAoQInM3pBGwUns34GLBO6gAhzekAoiBGOkYHlv33Pfp4uStpan9peSBG/fdS+UC53ekSIWh9K33N6QAGIEb992r4CrC96PCNASFP8P8ygXcSIf73IbgBIU/w/zKBdzQhgmABYAIhAXUAIQFhAXOBgHBHASFP8P8ygXcCIf73DLgAALC1HkwAIHxEoEcTTRNJSfgFAEn4AQAKIKBHEUkTSkn4AQBZ+AUAD0lJ+AEADkkBRADy5zCx+/LxDUpJ+AIQT/R6cbD78fALSUn4AQAAIKBHCUlJ+AEAsL1cLAAAZCwAAGgsAABsLAAAP0IPAEBCDwB0LAAAcCwAAGAsAAAz1///ELUdSHhE+veT/RxMASABIQAifESgR0DyARABIQAioEcBIAAhT/D/MqBHBSAEIQDwcfhkIP33Zv8BIP33U/tQuQEgACH992z7ASAAIf33VPsBIP33IftA8gEQACFP8P8y/ffc/v/3jP8CSAFoQfAAQQFgEL0EEEBSLAQAAAfe//8NSBn4ABCpuQEhACMJ+AAQCkkJaAHwf0KJsrLxgk96Rgi/CwkJ6wABQugA8kuAwvOAUkpwSERwRw4AAAAA7QDg//fkveC1AZABq//3H/4BmIy9AAAESAAhSfgAEANJSERJREFgcEcAvxQAAAB4LAAAAAEHShNYEFibsgAMy0DIQMAHT/ACAAi/A/ABAHBHAL8EAEFSsLUNRgRG//fp/wIoHL8FSLC9ASAhAQRKqEBTWBhDUFAAILC9/wBCAAAAQVL+54C1APD6+ADwEvi96IBAAPAeuIC1APBh+b3ogEAA8F65gLX/9+3/veiAQP/38r+AtQEgASECIgEj/fdn/gEgASEDIgEjveiAQP33X74AAC3p8E1PSAnrAAf/93H/QHhQSTpGgPABCEtIi0bH+DSACesABElIxPg0gAnrAAVISMX4NIAJ6wAKAfUgcAAhyvg0gFlOfkSwRwv1gHAAISJGsEcL9UBwByEqRrBHC/VgcAAhUkawRzxIC/HjdQAh/fed/jpIASH995n+OUgCIf33lf44SAMh/feR/jdIBCH9943+NkgFIf33if41SAYh/feF/jRIByH994H+M0gHIQnrAAIySML4NIAJ6wAEMEjE+DSACesABS9Ixfg0gAnrAAcL9Shgx/g0gLBHWEYAISJGsEdYRgEhKkawRwv1wGADITpGsEckSAvx5XQAIf33kP4iSAEh/feM/iFIAiH994j+IEgDIf33hP4fSAQh/feA/h5IBSH993z+HUgGIf33eP4cSAchM0YJ6wACIEa96PBNGEcAv6wnAADoJwAAJCgAAGAoAAAAAIFSzCUAAAgmAABEJgAAgCYAALwmAAD4JgAANCcAAHAnAACgKgAA3CoAABgrAABUKwAAwCgAAPwoAAA4KQAAdCkAALApAADsKQAAKCoAAGQqAACdpv//LenwQTFJ3/jAgAnrCABJREFg/fdj/QIkIEb995v9ATxgHPnRKkwBIAAhfESgRwIgACGgRwMgACGgRwQgACGgRwUgACGgRyNOASACIX5EsEchTwEgACF/RLhHIE0BIH1EqEcDIAIhsEcDIAMhuEcDIKhHBCACIbBHBCADIbhHBCCoRwAgACGgRwAgASG4RwAgAiGwRwIg/fdd/QnrCAECIP33cf0QsQMg//es/gIgQvIQcf33Wv0QsQMg//ej/r3o8EH/97+9AL8UAAAAeCwAAMPU//+V0///Y9P///vS//9wR3BHlgAAAMAAAAD1AAAAOQEAAJABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhfz//wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAIAAAAXAAAAAAAAAAAAAGAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAWgAAAAAAAAD/////AAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAgAAABUAAAAAAAAAAAAAYAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAABaAAAAAAAAAP////8AAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAACAAAAFQAAAAAAAAAAAABgAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAFoAAAAAAAAA/////wAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAIAAAAVAAAAAAAAAAAAAGAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAWgAAAAAAAAD/////AAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAgAAABcAAAAAAAAAAAAAZAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAABaAAAAAAAAAP////8AAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAACAAAAFQAAAAAAAAAAAABgAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAFoAAAAAAAAA/////wAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAIAAAAVAAAAAAAAAAAAAGQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAWgAAAAAAAAD/////AAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAgAAABUAAAAAAAAAAAAAZAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAABaAAAAAAAAAP////8AAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAABAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAEAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAABAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAEAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAABAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAEAAAAAAABAAAAgAAogMAAADRAQDbAQAAAAAAAAAAAACAAAAAAAAAABAAAAAAAAQAAAIAAKIDAAAA0QEA2wEAAAAAAAAAAAAAgAAAAAAAAAAQAAAAAAAEAAACAACiAwAAANEBANsBAAAAAAAAAAAAAIAAAAAAAAAAEAAAAAAABAAAAgAAogMAAADRAQDbAQAAAAAAAAAAAACAAAAAAAAAABAAAAAAAAQAAAIAAKIDAAAA0QEA2wEAAAAAAAAAAAAAgAAAAAAAAAAQAAAAAAAEAAACAACiAwAAANEBANsBAAAAAAAAAAAAAIAAAAAAAAAAEAAAAAAABAAAAgAAogMAAADRAQDbAQAAAAAAAAAAAACAAAAAAAAAABAAAAAAAAQAAAIAAKIDAAAA0QEA2wEAAAAAAAAAAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQAAAAAAAAACAAAAggAAAAEAAAAAAAAAAgAAAIIAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAAAAGQAAAABAAcHBwcHAAEAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAAAAGQAAAABAAcHBwcHAAEAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA8PoCgPD6AoDw+gKA8PoCgPD6AlDDAAAyAAAADwABAAAAAAAAAAAABwgBAAwFAwYHBAAUFAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  instructions: ELUERgXwIPggRgEhvegQQATwoLgt6fBNiLAORgdGb01vTADwFfmnQgX1IHEEkQKQCdAE9aArAS4R0AIuFdFnSAAhgkYp4AT1gDsBLhfQY0gCLoJGGNEA9YBwACEd4F9IACGCRgD1KGAX4FxIAyEELoJGGL8A9cBgCL8BIQ3gV0oAIQSYkkYI4AD1YHAAIQQuCL8K9UBwCL8HIQAlDiIBI0/wAQgAlQDwnfhYRgAhDiIBIwCVAPCW+Ar1YHAELgi/CvVAcAaQUEYYvwD1wGAFkAi/ByUHlVBGAyVP8AQKAPWAcAQuCL8BJQOQuvEAD0bQp0LL+AyACNABLg/QAi4ZvwWZKEYAIDVJD+ABLgvQ3ekGEAIuBL8AIAOZBuAvSAD1KGEAIAHgACAEmQj6APDIYAEgA/BP/adCCNABLg/QAi4ZvwWZKEYAICRJD+ABLgvQ3ekGEAIuBL8AIAOZBuAfSAD1KGEAIAHgACAEmQj6APDIYAEgA/Au/arxAQq156dCB9ABLg7QAi4USA7QBZgpRg/gAS4L0N3pBgECLgS/ACEDmAbgDUgA9ShgACEB4AAhBJgIIgEjAJIOIgDwE/gbIAAhDiIBIwCQWEYA8Av4ApgIsL3o8E0A8D+4AL8AAIFSAABGVPi1FUYGmh5GD0YERgDwPPoBIQbwAQAiaLlAuEAi6gEBCEO5ACBgDyBibIhAI2+CQyPqAACALQbRCCMD+gHxCkMIQ2JkBeAF8A8DA/oB8RFDYWQgZ/i9AAAAAAAAgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHU+oCDADwaYAt6fBLT/AABgArH7+z+oP1A/oF9CT6BfZeQBK/FkOy+oL1AvoF9MXxIAUevyL6BfxE6gwEIDVW6gRMT+oURBi/ZBxP8AAIT/AACZBCcesDDDnTACkZv7H6gfcB+gf2sPqA9wD6B/bH8SAHHr8g+gf8RuoMBiA3tvv0/KfrBQcQPwfwHwvL8SAGLPoG9gz6C/tEv7NGACYgL6S/XkZP8AALW+oGDAi/T/ABCxnrCwlI6wYIq/sCfAb7AswL+wPMwBtx6wwBwecLRgJGQUZIRr3o8IsTtQhDGL9P8P8wAUav8wCAvegcQHBHQOoBAxC1mwcP0QQqDdMQyAjJEh+cQvjQILoZuohCAdkBIBC9T/D/MBC9GrHTBwPQUhwH4AAgEL0Q+AE7EfgBSxsbB9EQ+AE7EfgBSxsbAdGSHvHRGEYQvU/wAAIAtRNGlEaWRiA5Ir+g6AxQoOgMULHxIAG/9PevCQcov6DoDFBIvwzAXfgE64kAKL9A+AQrCL9wR0i/IPgCKxHwgE8YvwD4AStwRwhIfLV4RACQB0h4RACcBUYBkATgIEYBaAhEgEckHaxC+NF8vWRUAABiVAAAFkgAIU/w/zIaSwn4ABAUSEtECfgAEBNICfgAEBJISfgAIBNKEUgp+AAQSERKRMDpFTITSwF1gXAQSQ9KgmFJREtEwOknMQL1gCEBZgEhgPhcEKD4RBCg+IwQcEcIAAAABAAAAAwAAADEHgAAyB4AAMwYAACsGwAAAABGVLwYAACgHgAABPAUuC3p8EWHsAZGGEgPRnAhkEZP8AAKGmsBJB1GrfgaoCn4ABBIRDl4zekCos3pBEMAIkDyVVPN6QBAMEYA8Ab8KGsN8RoCOXgAI83pBEXN6QBCzekCCjBGASIA8ML7vfgaEKj4ABAHsL3o8IUAv3gMAAAt6fhFBkZSSAAuAPCfgBdGACoA8JuAMEYAIg1GAPDo+KwAByBxbmwioEAh6gAAuWkB8AcBoUAIQx8hcGZv8B8ABC0A68UAOL/oADi/aCL7aQH6APyxWAPwHwMh6gwBA/oA8AhDKUawUDBGOnoA8HL4DyBP8AgIAPoE8XBse2jX6QOu1/gUwCDqAQID8A8AgCsIvwggoEAQQzJvIuoBAXBkgCsI+gTwB/EgAwi/AUMxZ2gAAyIK8AMBgUAC+gDwMmwi6gAACEMBITBkDvABAAH6BfqxaahAIeoKAQhDsGEM8AEAsWyoQCHqCgEIQ7BkT/R+cA7LAOqFDNfpCwQB8AEBYvNBAQPwAQIA8AMAQeqCAUHqwABhAcmyCEQxbQD6DPAh8P8BCEMpRjBlMEa6awDwp/g4aClGACgIv0/wBAhG+AigMEZ6awDwU/gAIL3o+IUBAFoAcLUdSx5MA0SgQgvQHUygQgjQHUygQgXQHEygQhy/HEygQiHRHE0VTAX1mCYF9YAlsEI6v0TyAAXF8kZFo/WAIwTq0wAoRG/wHwQEKSi/BDADaALwHwIE68EEOL/MAB8hokChQAPwBrsKTKBC2tAD8Mf6APGlQObnAAC5q/D//x8AAEdUgABHVAABR1QAAEtUAAFLVIAAS1QAQEZUcLUZSxtMA0SgQgvQGkygQgjQGkygQgXQGUygQhy/GUygQhnRGU0STAX1liYF9YAlsEI6v0XyAAXF8kZFo/WAIwTq0wAoRALwAQIBI4pAA/oB8QNoA/DAugtMoELi0APwgfoCSxhE7ucAALmrABCAUvD//x8AAEdUgABHVAABR1QAAEtUAAFLVIAAS1QAUEZUELWJAAcjRGyLQCNABG/MQATwDwSE8AgEI0NP8AADCL8C8A8DA/oB8g8jA/oB8UNvI+oBARFDQWcQvQAAAUlJ+AEAcEd0DAAAMLEDIQFigWpJB/zUACBwRwBIcEcEALIAATjCsgZIByoI2Isj00DbBwTQBKBQ+CIACGAAIHBHAL8EALIAAAAAAAEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAMAAABP9EBxACIBYAhJgWAAIcD4gBDA+MAQwPjIFwD1AGCy9QB/CL9wR4FQgDL45wDQgADwtSxLAChS0AApUNAAKk7QTH5MsQ1oFbmS+CogIrOKfgIqRNMNKkLYCn46sUpplyoK0gAiwPjYJyRKJOAAIsD42CciSggyHuAhTgAlfkQELS3QVvglcJdCBNgG64UHf2i6QgfZATXy54p+Aiof0wwq2tkc4BCiFEtS+CUgAvADAgXrgkIaRATwAwPMf0LqAxKLfpH4IBAD8A8DQuoDIgTwAwNC6gNSACNC6sFxgWAYRvC9AL8EALIAAAAAAAAAAAABAAAAAwAAAIDQggAE0IAAbE8AABC1BEYAIAhgiGDIYEhhCHYiaELwAEIiYEhgCGGgaEAHC9SgaAAHCNRgaMAH/NAKIAPwSvlgaAAo/NQQvQJGATkAIAcpENjf6AHwBAoPBw8PDw0C9QBgcEcC9RBgcEcC9QhgcEcC9RhgcEcAAAJGATkAIAcpENjf6AHwBAoPBw8PDw0C9QBgcEcC9RBgcEcC9QhgcEcC9RhgcEcAaADwAQBwRwh+cEcAABC1Ux4D8B8DACkD8YBExGQETGTzXxKCZQNKGL9D6gIBwWYQvQCIAAQAAAJALenwTYiwLU6DRqogFEYAIgEliEYJeEDyVVMp+AYAACAJ6wYKrfgeACBrzekAWs3pBFTN6QIgWEYhT39EuEdVIJj4ABAAIkDyqiMD8Bb5gCCY+AAQACJA8lVTA/AO+aogmPgAEAAiQPJVUwPwBvlVIJj4ABAAIkDyqiMD8P74ECCY+AAQACJA8lVTA/D2+GQmDfEeB1hGA/DA+QPwrfkD8LX5AdQAKPXRACgEvwIlwPKyBShGCLC96PCNAL94DAAAoQIAAC3p8E2IsDFOgkaqIAaSAScAIohGCXgcRin4BgAYawnrBgvN6QRzQPJVU83pAiDN6QB7UEYmTX1EqEdVIJj4ABAAIkDyqiMD8OT4gCCY+AAQACJA8lVTA/Dc+KogmPgAEAAiQPJVUwPw1PhVIJj4ABAAIkDyqiMD8Mz4MCCY+AAQACIGmyn4BgAga83pAHsCkgAmBZTN6QMHUEaoR634HmBkJg3xHgdQRgPwVfkD8EL5A/BK+QHUACj10QAoBL8CJcDysgUoRgiwvejwjXgMAADhAQAA+LUMRg9qCXgAJhVGATkHKRDY3+gB8AQKDwcPDw8NAPUAZgfgAPUQZgTgAPUIZgHgAPUYZoFoAfRAEbH1AB8Cv7FqQfCAcbFiAWjJByHRlfg0EIkHHdU5eB5LenhP8AAMGUMaQzFkT/TgIXFkxvhIwDFlMmZxZsb4aMAxZ+FoIfD/AbFgeWhJQiHw/wHxYAchMWKAaLpoAPRAELD1AB8IvwE6uXgwRv/3yf4BIE/0AEGF+CwAuGgoY2BoAeqAICF/AfAHAUDqATADSQhDMGAAIPi9AL8AAAdAAQAAgC3p8EWJsAPwY/gIrM3pBGFK8j8BA/B6+ED0AEABQFBGAvDs+RCxCbC96PCF3ekSEBH6APAH0EMeUEYDIQEiAvAh+QAo79Hd6RAhFJhSADixASADI83pAAhQRgLwMfji5wPwePgC8Nr43ect6fBFibAD8C74CKzN6QRhQvI/AQPwRfgBQFBGAvC5+RCxCbC96PCFEpgBKAnRE5g4sUMeUEYAIQAiAvAO+QAo79Hd6RAhFJhSADixASADI83pAAhQRgLwOvri5wPwRfgC8N363ect6fBNirAHRkFI3fhcoA5GFJwN8SYLT/AACM3pBzIA8YIFEpiARW/Q1Ls6SqogMXhA8lVTKfgCAAnrAgAVRgEiBpDN6QAgACAD8CX4MkwImnxEoEdVIDF4CJpA8qojKfgFAAEgBp0AkAAgAZUD8BP4oEcoSaAgpEYImkDyVVMUnCn4AQABIDF4zekABQAgApAVmAOQFpjN6QQKOEbgR4C7E5gBIjF4ApQA60gAzekAIBWYCJoDkBaYzekECgeYCOsAAzhG//dp/wyxBUYW4AAgZCSt+CYAOEYxRlpGU0b/9zf7AvDn/734JgABPAAGT+oEQAHUACju0RScILEI8QEIj+cFRgDgAk0oRgqwvejwjQIAsgB4DAAAR////y3p8EEERi9IVLMNRkGzO7MAIBhgmGDYYFhhGHbYYYP4LAAYYlhgGGHD6QwAw+kJICBosPH/PwTcwAccvwAgvejwgdT4yAcpRhpGIPADAMT4yAcgRtXpAGjvaP/3zfwIsb3o8IEG8AEACPAHAWfzGGBA6gFGqX4gRgLwgPiwuel+BPUAYALwiviAuSl/BPUIYALwhPhQuWl/BPUQYALwfvggual/BPUYYALwePhqaQZJkghKKoi/AfWgATFDIWC96PCBAL8EALIAAANQAPC1hbCLadxpjLEjeCR5CXgBJQSS/yYAJ83pAhUZRiJGACPN6QB2AvB4+AWw8L0BSAWw8L2AALIAcLWGsBRGBUYIeAAh/yIKns3pABICqkPCGUYoRgAjACIC8F/4CLEGsHC9CpYoRiFGASIAIwawvehwQAHwwb4AAC3p8E2KsIBGK0jqsYNGiGkWRgAimkYPRkVpBGgAIAmShEIE0DFcATBB6gIi+OcJqThGAfBx/AFGC/F8ACWxWUUcvyp5/yoC0QqwvejwjQmYACkA8QgDKEYIvxhGAyoAaB3RACkYvwXxIAMZaGp/T/ABDJX4JDA9eEDqASADJ83pAkfN6QA2BKuBskBGzfgcoIPoJBABIgMjAvAY+NTnOXjN6QBCASMCrIToCgTBskBGM0YB8Pb/x+cEALIALenwQYiwi2ncaHyxAvAQ/k/w/w7N6QbC2h7N6QRhzekCXgLwM/4IsL3o8IEBSAiwvejwgYAAsgAt6fBBhrDd+DCAFEYdRg9GBkZCRv/32P/YubppASDRawIpT/ABAQbREWsJaAEpT/ABAQi/AiE6eAAjzfgQgM3pABPN6QIgMEYpRgAiI0YB8K7/BrC96PCBcLUURg1GBkb/97L/KLkwRilGIkb/9xL/ALFwvahpT/R6cSNGQGwA+wHyMEYpRr3ocEAB8G27AAAt6fBNjLCKRp0YFkYAIR9Ga0va+BggpfEBC83pChHS+ASAw0WA8MiAB5CQaQOSCZEGkBBsMkYBkAmpUEYB8Kr7BEaouQmYmLFaRgVo0PgMsAmpUEYCkgHwnfsERnAbsPv78AD7C1b0sd34CLBUSzDgU0uYHIRCLNEGmrX78vC2+/LxAPsSUAH7AvZAsagYAjiw+/LxAfsSAclDAOsBC6vrBgAAJBTgCZgCmgFowGhSGgEysvvw8wP7ECIAKhi/ATMD+wAQACQ+S6DxAQur6wYARxzDRXDSB5gAaAiXwAcMvwAg//cX+ACQBpgUnw3xLAgHnc34CLAImQApVdAGkFBGCqkyRgHwRvvN+BSwcLkKmdHpACPR6QMUBpED+wEhAZRKHgKZkUI4vwpGBZIBmU/0enJRQwSRBZmOQiXSB5hRRjpG//f5/vi5A5gxRgBoAvDV/fzRKEZRRkJGO0a7Rv/3jf6wuShGUUYEmltGAfC0+gRGBpgImYFCEdkJGgZEACAALAiR19AA4ARG3fgIsAaYsecCmQRGX0YGmItGq+cAId34CLAIkabnB5gAaMAHHL8AmP73s/8jRhhGDLC96PCNBACyAC3p8E2MsIRG60i88QAPGL8AKQLRDLC96PCNlkYAKvnQ0fgEsLvxAA/00A9oAC/x0ETyEABP8AAKQPIKJs34LMAHl2BECZDdSGBECJAAIAWQA5BXRQDwAYJb+CogACoA8KWACZhB9hsxAWAbIQFh7iEImAFgCyHA+IAQQPIHcUFiByHA+KQQXPgmAEDwAQBM+CYAXPgmAEDwEABM+CYAlGlQaM74NABUswqWFniARmBGXUbzRhdGMUb/9/j6ACgA8M6BO3oBaDpGY/MJIQFgX+pIcSfVB0YGkguYIUYyRs34ALAB8L/7yLEIIAWZ3fgswN5Gq0YA+grwAUMFkVTgEGoAKADwrIERRmBGckZ0Rv/3zfvd+CzApkYDkEfgBpo4RtL4BIDd+CzAX+qIcQHU3kY54M34CIDeRtz4ABDJBzLR1GgGRhNGEWlSaatGJPD/AAaTm2mwYEhCIPD/APBgHGjT+AiAGWpjHgPwBwMAKhi/A/WAcwSWM2ICmMIGGtS48QAPB58KngDwioDY+AAgUxww0Jj4BDDSsgPwAwNC6gNCAvGAQifgq0YHnwqeIDYK8QEKTue48QAPB58KngDwr4DY+AAgUxwt0Nj4IDDSspj4HkBj8w8imPgkMAPwAQNC6oNCmPgEMAPwAwNC6gNCQuqEchjgACIEnE/0QDMiZJj4BSAD6gJCYmTY+AggUxwx0Jj4DDDSsgPwAwNC6gNCAvGAQijgACIEnE/0QDMiZJj4BSAD6gJCmPgdMGPzkkJiZNj4CCBTHDnQ2PgYMNKymPgXQGPzDyKY+AwwA/ADA0LqA0KY+BwwA/ABA0Lqg0JC6oRyJOAAIgSYT/AAdIJk2PgQIFMeZPNfEwAqCL8TRsNkmPgUIE/0QDMD6gJCAmUAKQDwqoAKaFMcFtALedKyA/ADA0LqA0IC8YBCDuAAIgSbmmTY+BAg4rEBOpj4FjAC8B8CQuqDchXgACIEnE/0QDMiZkp5A+oCQmJmimhTHC7QC3vSsgPwAwNC6gNCAvGAQibgACIEmE/0QDTCZJj4FCCY+BUwBOoCQmPzkkICZQApatAKaFMcJdALatKyjH9j8w8ikfgkMAPwAQNC6oNCC3kD8AMDQuoDQkLqhHIT4AAiBJhP8AB0gmYKaVMeZPNfEwAqCL8TRsNmT/RAMgl9AuoBQUDgACIEnE/0QDMiZkp5A+oCQkt/Y/OSQmJmimhTHBbQi2nSssx9Y/MPIgt7A/ADA0LqA0ILfwPwAQNC6oNCQuqEcgXgAL8EALIAxAABAAAiBJuaZgppUrEBOot9AvAfAgArQuqDchi/AvUAMgDgACIEmMJmCn1LfU/0QDEB6gJBY/OSQQFnmPgVAASZBpoLRo74LAABKAK/iGpA8EBwiGLc+AgAAPRAELD1AB8Cv4hqQPCAcIhiApwE8AgABPABAUHqQAAE8CABQOqBIBF6En8B8AMBQOoBIALwBwFA6gEwAPEAQBhgqOYDmADgA0gFmQApGL9B9DIA0+UEALIALenwTa31Jn0FRgh4ACSR+AigCpOTRgmRDpCIaY34+UCN+PhAjfj3QI34w0CN+MJAjfjBQAyQQGsNkP73Uf0LkA31hngAIIAoA9AI+ABAATD55w+VACAN9YNxDfIJEg3yAxNArA3x/QcN8foGACUDLQfQSFVQVVhVYFV4VXBVATX15w+cDp1SRiBGKUYB8MD7IEYpRv73BvwNmeNIObE4IA3yCRIrRs3pAAgC8M76ACha0Z34DAFTKFbRnfgNAUYoUtGd+A4BRChO0Z34DwFQKErRnfgRAQEoRtGd+BBhQ6kN8gkSDfHDA0/0f0AD8F78nfjDUMxIgEbFs0Osy08N9YNyDfHCA0/2hHB/RCFGuEcN8gMSDfHBA0/2gXAhRrhHQKo+q0/2h3AhRrhHDfH9Ag3x9wNP9gVwIUa4Rw3x+gIN8fkDT/YKcCFGuEed+MEQCEYIkbRIAPF8CHmxgC2cvwiYgCgC2A/gr0iARguY/ve7/EBGDfUmfb3o8I0AIAyZgC3B6RMA8dgAlUOs3ekNE66YDfIJEgKQD5gBlAPwpPwxrd34MMCARgTxHQAAIQEi3kYYKQzQEPgBPBD4AksF+BFABetBBAL6A/MGMWNg8OdEmpdIURwQRMkIACpIv0DwAEGd+A4BzPgEEMDzQQACKAzQASgE0AAoDL8DIAAgBuADILHxgH+IvwQgAOAEINzpAxIGJNz4KDAEJQxgACQMcRVgFHHM+AAAASDM+DgAiHcFIBxxvvECDxhgDNOd+EYBCpkALhi/wPMCEWBGA/De+934MMDeRmAh3PgIUNz4HAAEcQFgnrOd+DQBASE3RgAJAfoA8LD1gH8ov0/0gHDM+CQA3elMEMDzQXLA8wQkAyoavw/2DFNT+CIgT/R6QoMET/AGA1i/AyMBNAT6A/MeJATqQAYE6kEBwPMEYAIxATACNkhDc0NQQ8zpEQMN4FlIT/R6QTdGzOkREE/0gHDM+CQACpgAKAi/hkYK8P0BnfgOAQEpEdC+8QIPDtOBBg31hno+RibUQAZG1Nz4AAAEKEDw6IBP8P8LFeG+8QAPDfWGehi/EPAQASfRvvEADxi/EPABAFrRAyBP8AELT/D/MT5GKGAAIIX4HrCpYCh1KGGogKTgAAcr1J34FQGd+BQRASKqdyhgT/QAcCApqIAB8B8ASNJP8P8xTOCd+BoRnfgbAU/0gHKqgChgAfAfACApUtJP8P8xVuCd+BcRACCogClgnfgWESApV9JP8P8wWOAILtHTCZhAaBDwQADM0Z34ZQGd+GQRACKF+CQgKGBA8gEQICml+B0AT/QAcKiAAfAfAIDwDIJP8P8xEeKd+BkRACA+RqiAKWCd+BgRICk90k/w/zA+4ADrURDqdQIi/yEqcwI4KGGpYAixASCodQIgT/AFCzrgAL8FALIAnzgAAP3//3+ghgEAAOtREAEi/yHqdSpzBDg+RihhqWAIsQEgqHUBIE/wAwsg4AEhKHP/IOl1qGBP8AQLnfgWARDwHwAoYRy/ASCodQIgD+ABIShz/yDpdahgT/ACC534GAEQ8B8AKGEcvwEgqHUBICh13PgAAAQoHtGd+EtxeAYm0F/qh3on1dz4DABP8AAIILP/IwF4AnkBIHRGzekAgw6bzekCMK6YACMC8Jj43fgwwKZGgEYR4Nz4IAAD8GT7Q6kxqgyYA/C++t34MMBd4MpIAPF7CCDgT/AACPgHAtG68QAPF9W48QAPDfWGehTR/yEAIgEgACN0Rs3pACEOmc3pAhCumLchAvBp+N34MMCmRoBGAeAN9YZ6ACEN8UEAACKAKgLQgVQBMvrnuPEADxHRnfjCEA31g3J0Rs3pABDd6Q0TrpgCkA+YA/C3+t34MMCmRoBG3PhoAJCx3PhsEHmxvvEDDwi/uPEADwDw5oBP8P8yACMKYIt3zOkcMgJgg3e48QAPAPC+gAEg3ekONDGtwLMA6woBASIR+AEcAvoB8cz4GBBWs0yZHiIF8QgDACQP9swVAupBAgIyHCwS0CH6BPbG80EnxvMEFgMvFL9V+CdwT/R6dwE2BzRWQ35DQ/gMa+rnGzgxqd3pDjRACADrQAAB64AAUPgEDAHgT/R6cMz4QADc+FAAACgA8JGACJgN8gMSDZnN6QAKAfD//4BGACh/9Iythq0AIAAhQ6sEKQLQaFQBMfrncEhP8AALDJ4A8QEIACDN+CiADZAT+AsAgAdn1FtEACAP9jAXnHiN+IwBWXiT+AOgogkDKhi/B+uCBjJoE0QEM8ayskIE2fdDATDfXa9V9+cAkgAiDpgrRs3pAgKumAGSAfCg/wTwDwGARg8pCL8IITGxuPEADwPRD5gB8Fb4gEa48QAPDJ4X0a6YASIAIwCQD5hjqQDwZf8IsYBGC+Cd+IwBT/AACBDqCgAYvwEgDZlA6kEBDZEMngvxCAsImINFQ6un2T9IAPECCBzlq/EBAN34QRAEKADy04Df6ADwA1hPU0oAiAdU1QwgxuC48QAPL9AKmIBFbtC48QAPf/QDrWzgBy7/9Bevnfj5oLrxAA8A8J2Bnfj3AAAoAPCYgdz4ZBAAKQDwk4EJmQl5SQYA8Y6B3PgIEJ34+HDc+DRAACIAIwqRhqmAKwDwOYHKVAEz+ecNmMCyA+sLAUp4iXiQQjHQC+uBAQHxCAsImYtF8tmo54gGfNTc+CAAj+AIBwjVvCB64MgGddTc+CAAm+BIB3LU3PggAJjgAOtREAEiAiP/ISp3K3PqdQE4KGGpYAixASCodU/0gXBP8AYLqII75gC/BQCyAAExX/qB+sb4TKCKRQDwsYAAIMbpEwDd+CTA3PgEAIEHQPGJg9z4ECAAKgDwhIMPnCFoyQdA8H+DDpkBOcmyBykA8nmDiyPLQNsHAPB0gw/ySHNSQlP4IRDc+AwwIvD/AiFE3OkFRSPw/wOLYMpgLmiqaCtqdR4F8AcFACwYvwX1gHXEBg1iAPF4gQAqAPCbghRoZRwA8FOCFXnksgXwAwVE6gVEBPGAREri7CAC4GwgAOA8IChg3fhBELvxCQ8t2AEi3PggAAL6C/IS8A4PGdES9Bh/EdDKBRLVASEAIoF3PiECYQFgAiEBdQFzT/D/MYFgT/QAcYGAEOC78QQPDdEKBgfUSQYC1APwPvkE4APwJvkB4APwKvnd+DDADfFBATGqYEY3RmZGA/CN+LvxCQ8Z0XFpQPIDNDJqASOMgEDyASQNaIH4JDCh+B1ADWJA8gMRgvgkMKL4HUCRggMhEXFRcRFoEWLd6Q40tEYxrT5GD+bNSdb4UOAAIk/0/3BP8AAIACUAJAIxDZFSRTLQC/EECyVEACQT+AsQAfAPBwEhOUII0WYcAOpBAQQsNEb30934NIAFJATrRAEN8cQMXvgicFP4C2Ac+CFADOuBAT1gvGDR6QEUPGEm8P8EBPWAdIxCLr+0+/H2ASYhRn5g+WABMsrnDJ6Z5s3pAAGumA3x/QIhRg6bApAPmAPwV/jIu534GQKws83pBkYKnAEmOUYCJ934MMAgYiBgQPIBEAApp3eE+CRgZnWgg0/w/zCgYEDyAzCggADwAoHc+FQAACgA8P2A3PhYEAApAPD4gA9GBkaFqmOoACEN9QR7g6sAJAQsAPCcgBFVAVUL+AQQGVUBNPXn3fgwwJ34QzDc+Agg3Pg0EA31hnqYBp34+AAR1NsGf/VurZ34T0EBI5N3FGBP9EB0lICd+E5BICxP0k/w/zNQ4J34TTGd+ExBN0YBJpZ3E2BP9EBzICyTgATwHwMC0k/w/zQG4APrVBPWdQMm/yQWcwE7T/AICz5GE2GUYAuxASOTdQMjE3WGqs3pAAKumAKQQKoB8C793fgwwAAof/Qvrd34UwKw8f8/P/cprdzpGhLDshNgwPMHIwtgwwDA8wdDwPMCYFi/T/D/M8z4dDABI5N3zPhwAIt3EeXTdQMjE3P/I5NgT/AHC534TjET8B8DE2HE0cXnACoA8FyBFGhlHADw74AVauSyln9l8w8kkvgkUAXwAQVE6oVEFXkF8AMFROoFRETqhnTc4AAhACJArAMqBNCjXAEyQ+oBIfjnAfEgAggxEwwSuo34DhISDI34FDKt+BUiCgoJDI34DSIEIo34DBLc+DQQzekAIK6YApCFqgHwvvwouZ35jwGw8f8/QPObgU/w/zAwYDhgDJhBawQgzekAC66YApCDqgHwqfxwuZ35EwKw8f8/Cdyd+BACnfgREoAJYfPDAAyZiWoIYd34MMAKnAInASYDIKZ1IHXc+AwQ3PgoIAtoCHGB+CRgj3cLYhQhACMhYRB1lnVWdRBxgvgkYJd3VndQcRFoEWIAItz4HBAIcQhogfgkYI93CGJjqN3pBhaAKgXQg1QBMvrnAL8FALIAzekAoK6YDfH6AgKQAfBd/N34MMAN9YZ6uLvc+GQAnfiPIQJwATqd+JcRBipBcBTYnfiOQZ34jCGd+I0xw3CEcAJxnfiTMZ34kCFDcQJynfiSMZ34kSGDccJxATkGKRTYnfiWMZ34lBGd+JUhwnKDcgFznfibIZ34mBFCcwF0nfiaIZ34mRGCc8FzT/AJC//3IrwAJAxkT/RANFV5BOoFRU1klWhuHCjQFnvtsgbwAwZF6gZFBfGARSDgACQMZE/0QDVUeQXqBERVf2XzkkRMZJRoZRww0JVp5LLWfWXzDyQVewXwAwVE6gVEFX8F8AEFROqFRETqhnQf4AAljWRP8AB3FWluHmfzXxYALQi/LkbOZBV9BOoFRAxlACsA8JiAHGhlHBPQHXnksgXwAwVE6gVEBPGARAvgACSMZBRp1LEBPJV9BPAfBETqhXQU4AAkDGZP9EA0XXkE6gVFTWadaG4cK9Aee+2yBvADBkXqBkUF8YBFI+AAJMxkT/RANhR9VX0G6gREZfOSRAxlACtf0BxoZRwi0B1q5LKef2XzDyST+CRQBfABBUTqhUQdeQXwAwVE6gVEROqGdBDgACWNZk/wAHcdaW4eZ/NfFgAtCL8uRs5mG30E6gNDOOAAJAxmT/RANVx5BeoERF1/ZfOSRExmnGhlHBHQnWnkst59ZfMPJB17BfADBUTqBUQdfwXwAQVE6oVEROqGdADgACSMZhxpVLEBPJ19BPAfBAAtROqFdBi/BPUANADgACTMZhx9XX1P9EAzA+oEQ2XzkkMLZ1J9rpuD+CwgAPAIAgDwAQMA8CAAQ+pCApz4HDBC6oAgnPgIIALwAwJA6gIgA/AHAkDqAjAA8QBACGBP8AAI//cBuZ34jRHAsv8iMWCd+IwROWDA80ERAjEC+gHxAPAHAslDkUAAB534jgFIv0/w/zAMmsLpFwFN5hAAAAAAAQAAoA8AAAEAAAAQAAAAgAAAAAAAAAADAAAABAAAAAAIAACACAAAAAgAAAAJAAAACAAAAAgAAAAIAACACQAALenwRYuwjmkVRgRGASCyaq34KgAAKk3QEHkDKDzRT/AADJL4JAAXag3xJApTeQl4T/AECM34JMCy+ADgUn/N6QAKOALN6QKDAyPN6QbFgLLN6QQhASJA6g4BIEYA8Gj8AUYIu7BqA2k7sUF5Qn8gRgDwovsBRri5sGoDeZD4JAABIg3xKgHN6QAFASggRgi/AiIA8K/6BuATeA3xKgIgRgCV/ve/+wFGvfgqABG5lvg4EAhAACgYvwEgC7C96PCFLen8TRdGGkaaRohGBkb/95f/uvgoEAAlybEAKEjQuUIovzlGjLIwaMAHA9EgRgHw6/kC4CBGAfDd+QHwbPo5Gzi/KUZws6dCD0bs2CrgeLO4CBlMoEI4v7wIT/R6cAQvOL8BJLT78PEB+xBAAZEf+oD7MGjABwbRAZgB8MP5WEYB8ML5BeABmAHwmvlYRgHwsfkB8ED6ORs4vylGELGnQg9G5tgQ8AEFHL8CJcDysgUoRr3o/I0Av0BCDwDwtYRpDEhjaJNCFNkCMCNti7HkbHyxHWguaJZCBtjV+ATA72gH+wxmlkIC2AQzATzw5wAgDWDwvQQAsgAt6fBNiLAERh1GDkaPaVFIASop0X9uAC8A8JiAOnh6sTB4T/ABDAAjATq5eASVzekAI83pAgz7HCBGACIA8If7engAKgDwgoAweAAmATq5egEjzekAJgKqKcIH8QsDIEYAIgDwdPtx4LluAClu0PpuACpr0NL4AIAIaPloem/R+ACwACETDAeRjfgcMBO6GwwBMq34HTA+0DJ4AyMN8RwKBJXN6QAxzekCIcGyIEYAIlNGAPBM+wAoSNEK8QMBIEYBIgAjAJVP8AAKAPCv+ei7l/hwAJ34HxAAIgAjCENf+ovxjfgfADB4zekAqgKQASDN6QMFIEYA8Cr7OLsAIgQjMHgBIc3pADICqyPDX/qI8SBGB6ul5434GxDDsg3xGwIgRjFGAJX+96H6eLmX+HAAnfgbEF/6iPMN8RsCAJUIQzFGjfgbACBG/vcq+wiwvejwjQC/gACyAC3p8E2GsNH4GKAMRgZGACA6T634FgA4Rtr4LBC5sRVG2vgwIJqx2vgoMIOxGGgN8RYIBJAQeEJGA5AIaCFGAJVf+oD7MEZbRv73ZPoQsQawvejwjdr4PADN+Aiww0bd+BCAAigl0IAoCtBAKEPRnfgWAA3xFghA8EAAjfgWABDgC/EBCDBGIUYCmwCVQkb+90H6ACjb0Z34FwBA8IAAjfgXAAObMEYhRkJGAJX+98z6zedf+ojzDfEWCDBGIUYAlUJG/vcn+gAoApvA0QjxAQcwRiFGAJU6Rv73HPoAKLbRnfgXAAObMStA8AIAjfgXAAi/uEbW56fxfQCo54AAsgCAtYqwjfgEIAAijfgMMAAjzekGIQyZCZKN+CAgzekEIkprAJECkgGpAyL+9+/9CrCAvQAALenwTZCwBEYAIIpGGJ0Ok11PD5Da+BgAqRhDaJlCAPKvgNDpCLANkguQIGjAB0/wAAAYv/33QPsN8TwICZAKlAAtAPCXgC5GDZ0LmrX78vAMlgD7ElCBGZFCKL8WGiBGUUYZmv73OvoAKEDwgoDa+BgA1kYBaAjrAQMD+AFcLQoBOfjRm/gkcLv4AMDb+CAgAGib+AQwm/gFQJv4HVCe+AAQ8kbN6QB4Aq8FkTHHACAGkBmYACoHkNCyGL8BIgqcTOoAISBGAPAR+gAoUdHb+AgAQRwT0Jv4HBCa+AAg/yeb+AwwACXN6QFVAJHN6QNxGZnN6QUlACIB8Nn4yLvb+BAwDJ2jsaBoAPRAELD1AB8F0Zv4FgAAIQHwfPgG4Jv4FBCb+BUgIEYA8CT5B0YIu5v4FQCb+BQwGZkyRs3pAAEgRg6ZAPBw+pi52vgYAIFqMbGCbCBGUUYZm//3j/1AuQ2YrRsAJzBEDZAOmDBEDpBm5wdGIGjABxy/CZj996D6OEYQsL3o8I0EALIAAkYAiCmxkXjSeBIGQuoBQQhEcEe8tQacACXN6QBUAPAB+Ly9LenwQYawVE4AKgDwnoAERoBsAAcA8ZyADJgVRg9Gg/ADAoDwAQERQypGBfABAQi/AetSAlEeT/SAIgLqgECJsmPzEUAIRADxAnAgZQEgAPA3/wAgAC8A8HqADZlP8AMISWoFkQSXA5UBkAQgdxwAJo34CAAFrZ34CAAEKGjRvkJm0AOeBJjU+MQQAfAPAbFCKL8xRggpC9jf6AHwOQUXHBIrMyQKANT40BABcAEhK+DU+NgQAWDU+NgQQWAIISPg1PjYEAFgBCEe4NT41BABgAIhGeDU+NQQAYDU+NAQgXADIRHgAPDP/9T40BCBcQchCuDU+NgQAWDU+NAQAXEFIQLgAPDA/wYhdhoIRLvnBJADlqa51PjEAADwDwABKAi/1PjQANT4yAcg8AIAxPjIB434CIABmBCxAZkDIIhHKEYDlgDw1fgGRpXnAzYA4AAmMEYGsL3o8IEBALIAcLUVTCKzhWwtByLUAPDj/gi/BetWBnUeT/SAJgbqhEStsmPzEURjGQPxAnMDZWmx3ekFQ9lgBCFaYRxiGXYaYdD4yBdB8AIBwPjIFwAkAOADNCBGcL0AvwEAsgALRgAhACIA8AG4AABwtQ5Mu7GFaIZsNgcU1AE7m7Jh8xFDAvABAQX0QBJD6oFBsvUAHwi/AfUAAQAkAfFAcQFlAOADNCBGcL0BALIAsLUKTHuxhWwtBw3UCEwAKRi/BPXABFkeYvMUVImyIUQAJAFlAOADNCBGsL0BALIAAAAnAxC1FEb99/r8GLEBaGTzCSEBYBC9AmgAKSLwAQIYvwEyAmBwRwiFcEcctQRGAGgAKBnUoGgg9EAQoGAB8AMAoWhB6gBQoGABqRBG/fcV/EC5AZgE68AQ0PgoGEHwgHHA+CgYACAcvQFIHL0AvwQAsgAPKYS/BUhwR4JoIvRwYoJggmhC6gEhgWAAIHBHBACyAA8phL8HSHBHgmoi8PACQuoBEoJigmoi8A8CEUOBYgAgcEcAvwQAsgCwtQVGAGgAJEixASAA8OD9KGgBOChgBL8CJMDysgQgRrC9sLWIsBRGEJoNnQeSD5oDlQydBpIOmgWSACKN6CwAI0YEkgDwAvgIsLC9Len8TQRGEZhP9HAF3fg4wAqeQGoBkA+YBeoAW93pDHAQncKxAysIvwEuJNBP9EAyAC8C6gNCZvOSQj5OQuoLAkLqESMjZUHqxUPJsgi/A+oGARFDGeDJsgbwAQIAL2PzEUFB6oJBBfABAgi/QerCQUHqCwEJ4AXwAQIALwi/QerCQUHqCwFB9OAhIWVP9AAhzfgAsAMoAerFS0/0QDEIv7zxAQ8B6gBFI0mIRmzzkkUe0E/wAAoBrgAgX/qK8blCNtJARUJGM9CgbAAHDNQLmArxAQpAXAExuUIov0DqCwAAmShDCEMgZTBG//dj/+TnACYN8QQKACC+QhnSQEVBRhbQoGwABw/UC5qxHJAZQHi5Qii/QOoLAJJdzrJA6gIgAJooQxBDIGVQRv/3Q//j573o/I3/AAgAAgCyAC3p8E2GsARGUEgAKgDwl4ClbC0HAPGWgA6eg/ADB0/wAAiG8AEFV+oFDALwAQcVRgi/B+tVBU/0gCcH6oZGAT2tsmPzEUZzGQPxhHMAKSNlAPB3gA+bvPqM9Q3xFApbam8JRRwAIAWTBJECIQOSzfgEgI34CBCd+AgQAili0ahCYNDd+AywBJ7U+IgAAPAPAMDxCABYRSi/WEYIKBjY3+gA8DQfBQUSEgoKFwAwiMT4lAACIBzgMEYA8GT9sIjE+JQABiAU4DBGAPBc/QQgD+AwRgDwV/0wHQDwVP0IIAfgMHgALwy/xPiQAMT4nAABINT4iBAJB/vRq+sACwZEWEa78QgPKL8IIMfnu/EADwSWzfgMsA/RxPiAgNT4yAcg8AEAxPjIBwEgjfgIAAGYELEBmQEgiEdQRv/3nv6b5wMwAOAAIAawvejwjQC/AQCyAHC1hGwkB0S/FUhwvQDwrfwIvwXrVgZ1Hk/0gCYG6oRGrbJj8xFGNUQF8YR1BWWhsd3pBWUpYAIhqmDuYSl2ASHA+IAQamCF+CswhfgqQND4yBdB8AEBwPjIFwAgcL0AvwEAsgBBHgwphL8FSHBHBUlR+CAgIvAAQkH4ICAAIHBHAQBKAEASQFINKIS/BUhwRwVJUfggIELwAEJB+CAgACBwRwC/AQBKAEASQFIQtQhJUfggIFH4IADC8wMiAPAPAFQcAPA7+ADrVACw+/TwEL1AEkBSDSiPvwAgAklR+CAAwA9wR0ASQFICRgdIDSqYvw8pANlwRwVIUPgiMGHzCyNA+CIwACBwRwEASgBAEkBSAkYISA0qmL8PKQDZcEcGSFD4IjAj8A8DGUNA+CIQACBwRwC/AQBKAEASQFIQtQRGAPAq+AIsCtgISQIsAetEEgi/AfUAchFosfH/PwDdEL0gRr3oEEAA8J+7AL8AFkBSCEpP9IhTAuuAAclYAfAHAQcpAr9S+CAQCCBg818RiLJwRwC/AAFAUoC1//fp/wMoD9mw9Yh/JNBA8hERiEIO0EDyExGIQhy/ACCAvRNIgGgZ4N/oAPACHwsdEUiAvQ9IT/QAQcBqAepAMIC9C0gBaAxIAfADAVn4AAADKRi/ACCAvQZIgGlP9ABBAeoQQIC9BkiAvQRIWfgAAIC9aBNAUoDw+gKEDAAAgAwAAAASegAFKIS/CUhwRwlKsfWAfzG/AfAHAQHwHwFC+CAQByEC64AAT/SIUoFQACBwRwEASgAAAUBSsLWEAQJNAPDW+wDwUbwAvwAYQFL4tQxGFUqBAQAmU1gC64AVIEZD8ABDU1BHHuppRvEAAdIHBNEZsQDw8Ps4RvTnKWg8sTC5APAn/ChoIPAAQQhICuAB8EBQsPEAXxy/ACD4vShoQPBAUQAgKWD4vQAYQFICAEoAsLUFRgxGSGg0Ifz33v6oAT5JClhgaAHrhRHTDwJwA3HC8wFzw3DC8wIzwvMCIoNwQnBKaMLzA2NDc8LzQlMDczNLA/XAExpAgmCKaMLzQHMC8AECgnPDc8powvPDY4N1wvPDU0N1wvMCUwN1wvMDQ8N0wvPCI4N0wvNEEwLwHwICdEN0CmlLacNhwvMAM0N2wvNEEwLwHwLCdQN2imkTRm/z30MDYsLzAGPC8wBSgPglMID4JCDKacLzAFOA+CkwwvMAQ4D4KDDC80ADAvABAoD4JiCA+CcwCWrKD4D4MSDB80BygPgwIMHzDELChcHzABKA+CwgwfPAAgHwBwGA+CoQgPgrIAAgsL0AvwAYQFL//wcALenwQZCwA60ERjQhKEb891L+ApUAJSBGAZUBqf/3Zv+gARpJCFiw8f8/K9yd+A8AAign0J34DACd+A0QnfgOIAWdRxygHALxAQhOHP/3tP6dsRXrR1FP8AACQvEAAqH7ADEC+wARCPsG8hhGACP89379QA1A6sElBOAI+wbxeEOw+/H1KEYQsL3o8IEAGEBScLUCRlBMgAEjWFBIACsM1EloC3gHKwfT+SsF2E14By2cv454By4C2XC9AjBwvQTrghDKeAIqAPCBgGXzCiMG8AcEQ+oEMwx5Q+rEcwNgQEsD9cATjGgjQAx7BPAHBEPqRFNMewTwDwRD6gRjQ2DLe4x7ROpDc4NgDHxLfATwHwRj80kUi3wD8AcDROrDI8x8BPAPBEPqBEMMfQTwBwRD6gRTTH0E8A8EQ+rEU4x9BPAPBEPqxGPDYMx9C34E8B8EY/NJFEt+ROoDMwNhy2lDYQxqkfgkMG/z30RE6gNTkfglQEPqBGODYZH4J0CR+CYwkfgoUJH4KWAE8H8EQ+pEA0PqBUND6gZTw2GR+CowkfgrQJH4LFCR+DBgA/AHA0PqxAPMjZH4MRBD6gUT27Jk8xxDQ+pGc0PqwXEBYgFoYvMdcQFgACBwvQAYQFIBAEoA//8HALC1RAECTQDwHvoA8Jm6AL8AFkBS+LUMRhVKQQEAJlNYAutAFSBGQ/AAQ1NQRx7qaUbxAAHSBwTRGbEA8Dj6OEb05yloPLEwuQDwb/ooaCDwAEEISArgAfBAULDxAF8cvwAg+L0oaEDwQFEAIClg+L0AFkBSAgBKALC1BUYMRghoYCH89yb9aAEWSQpYIGgB60URwvMBcwJwA3HC88Bjw3DC8wRDwvMEIoNwQnBKaNMPQ3Mi8H9DEvDgQoNgGL8BIgJziWjKD8J1wfMAcoJ1wfMAYkJ1wfMCQsmyAWECdQAgsL0AvwAWQFIt6fBBmrACrgRGYCEwRvz37PwAJWlGIEbN6QBl//e4/2ABFUkIWLDx/z8g3J34DAACKBzQnfgJYM6xnfgKcLexnfgIEAAgBJoS6wFlQPEACCBG//dL/aX7AEGn+wYjCPsAESBG/Pcd/AAOQOoBJShGGrC96PCBAL8AFkBS8LUKaCQmLCcAIRwlJyQjI8LpDnYoJsLpBBHC6RNVwukQRSAlwukVQxNjKUvC6QgWDyHC6QpUkWFBAVxYJUkALEPUlHgALEHQECw/2FV47bMQLTvYFngQLjjTyC422BF5A+tAEAIpKtArAkPqBEMaTCNA1HgzREPqxGMDYJRoE3sk8H9EROoDc1R7Q+rEcxNMJUZDYAAjg2ATf1sDDzPDYFNrY/MedQX1A3MNTQNhk2xj8x51RWHSbWLzHnSEYQJoYfMdcgAhAmAA4AIxCEbwvQAWQFIBAEoAAB8fABzOaQQs0okDcEcAAMOyAAoBKQPQUblABgdJAeBABgVJQOqDEAhEAmAAIHBHAEhwRwEASgAUQABSEEAAUrC1DSsK2A1MVPgjUAAtBdRU+CNQRfAARUT4I1BABgEjAOuBEAZJA/oC8ghEQWmRQ0FhAWkRQwFhsL0Av0ASQFIAQABSgLUBKALY//eb/gLgAjj/99/8ACCAvQEohL8COP/34rz/95i+ASiEvwI4//eXvf/3+74BKIS/Ajj/99i9//cyv3C1C00ERk/w/zFZ+AUAsfvw9ln4BQC0QgTZcEP89yb7pBv252BDvehwQPz3H7sAv3gfAAACSVn4ARBIQ/z3Frt8HwAA//fcv//39L8FSAEiAWhi859xAWABaEHwAEEBYHBHAL8AwEBSAPDYuQJJWfgBEADwB7kAv5AMAAAJeAHrwQFIRADrwQABIRQwAfDguQnrAAIoRjBHA/HjcG/wDwMD6tAAcEcEnIPwAwaE8AEFNUMWRgLwAQVwRyn4BgAga83pAFrN6QRUzekCIFhGOEe0+ACAI3mU+CBwT/ABDGZ/lPgkQAl4ACVwR4JgAWAAIQF1AWEBc4GAcEcgRilGZCIA8Gm8CesAAiBGMEcj6gEBEUMBYHC9KfgGACBrzekAe83pBHTN6QIgUEYoR7L6gvJI6gchzekARVIJ//e5ud3pDjAB8J+6AiEoWWHzHXAoUQEg//dvvzBGQUZSRv73EL0AJ0/wAgtP8AEMT/AACnBHTfgI7QEh/vfr/8T4mABd+AjrcEeCRlgDT/b/dd34VIABJgMnqEMD8AcFKEQEJQC6CJAAIHBHBJAPmP/3bLkBIP/3QL8iRjNGzfgAoP331LnN6QJXzekGCNgMAyPN6QBkQOpCMAEicEcCOLD6gPBCCSBG//fJuK6YApAgRgHwSrpoaGlsMkb995m61PjYEAFg1PjUEIGAcEcAIAEjzfgIgM3pADBQRgMjcEcCkBWYA5AWmM3pBAo4RnBHAiBg8x1xASApYP/3/r4FRmQg//fgvihZIPAAQChRACCwvb34HgABPgAGT+oGQHBHQUY6RiNG/Pc4uwjrAAIC+AEcCQoBOHBHB5GBsiBG//cauQtGACEB8KK4LenwTYawACcORgRGBZcFqQDwLvkAKEDwmYAFnQSXBKkoRgDwBflaSCl4AevBAUhEAOvBAAAhAPEUCEBGAfDG+G1oqWnoaApGGbkqagAqAPCBgNL4BKCEQgTRskWcvyppskJ62SQaACADkGmzA6koRiJG/vcB/Ti7A5goswFo0PgMsAAuKEYCkQi/XkYDqSZEch7+9/H8B0YAKFTRA5gBaMBochqy+/DzA/sQIgAqGL8BMwKeohuy+/vyAvsLZAkbA/sAFqlpHeCpaTJPEbEB8RgAAuAoarCzDDAAaJizAC4IvwZGMhmy+/DzA/sQJgEzAC4YvwP7APK0+/DzA/sQJgP7APQwGSppUkU4v5JGgkU4v6rrBAbY+AQACPEICmGxKUb/9wX/B0ZouQSYWLFBaNj4BAD/9/z+BOApRiJGU0b89579B0YALxi/ASc4RgawvejwjU/wAAp959j4BAAI8QgEgbEpRiJG/feg+AdGACjp0QSYACjm0EFo2PgEACJG/feU+N7nKUYiRvz3F/3Z58geAAAEALIALen8TSJII08N8QQL6kYBJVn4AGAAIAGQCesHAJD4AoAEHWgeQEUkvwAgvej8jSB4hkIn0WBoKLMBDw4pItiCaQKzEQ8OKR3YAWnZsVJoyrFieBv4AiCqucBo//cF/6C5CesHAAEhkPgCgGB4C/gAECBGUUYA8BD4ASEYuQCYQHgL+AAQCDQBNcvnASC96PyNxB4AAMgeAADwtQAiCmBCaFNpq7ELTAnrBAUsHa14fbEmeAd4t0II0WZoskIF0HZps0ICvwxgACDwvQg0AT3u5wEg8L3IHgAALenwQQAiIPCAXADwgF4KYB1KCesCAwPxCAibeDuz2PgAYLVpDbk1av2xamjW6QN0FUaUQji/JUYAKgi/JUZ6GVUeh0IB2IVCF9IH8IBSlkUH0CfwgFe8RQPTJfCAUpRFCNkI8QgIATvY5wAi3ucBIL3o8IFH6g4A8GCo8QQACGAAIL3o8IEAv8geAAAt6fxNi0YFRgDwYvoguQGpKEb/96//ELEBIL3o/I0BnN/4+KA8SCJ4AuvCAgnrCgFZ+AAAAevCBRX4FB+IQhLROE4wRvz3IvsG9YAg/Pce+yhGWUYA8Dz/L0koeEn4AQAAIL3o/I0A8Hf5BfEIBmhoKWxP9HpyM0b891L+ACjL0QEgMUZP8AEI/vfi/mJoaGgReBJ6/vfK/mhoMUb896b7H08Z+AcAULlhaGhoCXj79wf/T/R6cP/3/fwJ+AeA//fX/Rix//fU/QAopdEJ6woAACcAJAYdgHiHQrHSKXgyeIpCFdEJ6woBAevHAYlokfgAgBjqBA8J0ShGMUYA8BT4ACh/9ImvCesKAIB4ROoIBAg2ATfg5wC/xB4AAMgeAAAMAAAAAABFVC3p8E2GsAApAPClgARGCA8NRg4oAPKfgG5oAC4A8JuAMA8OKADyl4CwaRCxAQ8OKQnZMGoAKADwjoCw8XBPgPCKgAAniOCBaBGxCg8OKinZACLQ+CyAw2sweUAHH9W48QAPL9BP6hhwDigY2Nj4AAABMAEoE9gE8QgBYGiSRh9GAiIBI0/wAgsAkTFG/fcy+jtGUkZP8AEMgkYAJxbg//cL/RPgkfgUsEp9u/EDD27Qu/ECD83QT/AADAAnT/AACgAjAeD/9/j8T/AACFfqCgAm0bjxAA8g0E/qGHAOKBzY2PgAEMmxSBxP8AAHGL8AKxTQzekCwwSSy7JgaATxCAgN8RcCMUaN+BdwzfgAgPz39f0AKFjQgkZI4AAnT/AACrvxAw8E0QEqCL9X6goABNC68QAPGL8BJw7gYGghbATxCAgCaENGIvAAQgJgT/R6cvz3Uv0gsQEnOEYGsL3o8I0BIEFGASf+99/9MnhgaAIh/vfc/QAo79FqaGBoEXgSev73wP1gaEFG/Pec+lnn0PhogAdvYGgE8QgDMUYEkv73d/oosYJGACdP8AMLBJq35//3T/w7RgdGT/AADE/wAwtP8AAKBJqB50JGnfgXAN34DIAA6ggAQEUD0QAnT/AACuTnYGgxRpBG/PcG/oJGCLEAJwLg//ct/AdGBJpX6goAf/SOrwKZYGghsTFGQkb+9+v6BOAxRgSaQ0b+9zn6gkYIsQAnwuf/9xT8B0bW5wAAELUHTBn4BAA4uXK2APBs/wHwRfgBIAn4BAAAIBC9AL8EAAAALen4RQRGACDf+ISA6kYAkE/wATAC+wD2YBhHHrxChL8AIL3o+IUgRlFG//fl/QixBDTz5wCdCesIACl4AevBAQDrwQABIRQwAPCE/WhogWkJuQFq0bFJaNDpAwJDGBUYGEaKQji/KEZBHghGn0I4vzhGr0IovwhGhELP2CFojkIcvwEgvej4hQQ09ecAIePnyB4AAC3p+EWIRgVGAPEICgEkaGhRRvz3NPoHRmhoRmgKIP/3Qfs4H0/wAAEYvwEgtvH/P8i/ASEIQgPRYBxERQRG5tkAIL3o+IUt6fxNkkaDRgAgCkYBkAGpEEYAkv/3Y/2w+oDw3fgEgAvxCAcBJE/w/zZFCeAHCNAAmDpGQWjb+AQA/ve2+ARGCuDoBxXQ2PgEENv4BAA6Rv73q/gFRgAkATZWRYS/ASC96PyNCiD/9/r6ROoFAMAH3NEAIL3o/I0AAC3p+E3f+CDnGfgOAAEoLdHf+BgHSESDeAAgK7Pf+Awn7UgZ+AIQUbHf+AQ33/hASQnrAgGIYUtETETB6RVDCesCAUl4YbHf+Cw5CesCAd/4jCgA9YAgCGZKREtEweknMgEgCfgOAAAgvej4jd/4vBYAIAnrAQIp+AEAkHDf+LAGCesAAhIPDioJ2N/4qEYJ6wACCesEA1NgGg8OKgLZASC96PiNWfgAsE/wAAq78QAPAPDRgN/4gBYJ6wEAAA8OKADyyYDf+HQGCesAAhIPDioA8sGACesBAtL4BKBJ+AQgCesABGVoCvAEAipDBtHf+FAGACZIRADxJAVA4AnrAAbf+EAG3/hEJt/4TFbf+Ex2SERKRE1ET0TwYt/4LAbG6QJ1BvFQBUhExukHIN/4IAbf+CAmSERKRMbpBCDf+CAG3/g4JkhESkTwZt/4GAZIRLBm3/gUBkhEcGPf+BAGSEQwY9/4DAZIRLBi3/gIBkhEcGbf+AQGSETG6RUgACDf+AAm3/gARgnrAQff+BDG3/gINjhivmHf+PxlSkQJ6wQACesMAUtESfgEIN/43CXf+NxFKGDf+NhVTkTA6Qs23/jsNd/49GUJ6wII3/jUJUxETUTA6Q1U3/jYRd/42FXA+DyAS0ROREpEwOkJId/4tBXf+LQlTERNRMDpA2XA6QVDCesBDAnrAgjf+LAV3/iwJcDpB4xJREpEwOkBIThpsLHf+AgV3/gMRd/4DCVf6opwT/AACg/VASBKRAn4AQBJRKH4BKBP8AEKimCIcAPg3/jkRE/wAAq78QIPI9Pf+GQVCesBAAAPDigc2N/4XAUJ6wACEg8OKhXYCesEAgnrAQNTYAnrAAJbaACTUmgD8AQDGkMJ0d/4NAUAJwnrAAIC8SQGQuDURq3gCesAB9/4IAXf+CQl3/gsNd/4LGVIREpES0RORPhi3/gMBcfpAmMH8VAGSETH6Qcg3/gABd/4ACVIREpEx+kEIN/4AAXf+BglSERKRPhm3/j4BEhEuGbf+PQESER4Y9/48ARIRDhj3/jsBEhEuGLf+OgESER4Zt/45ARIRMfpFSAAIt/44ATf+OA03/j4xN/47FTf+OxESERNRExESfgDAAnrAQDf+NAUh2EJ6wMHAmLf+Lgk3/i4NABpN2Df+LRkSUQJ6wIICesMAgfxJAxLRE5ErOg0AN/4tCTH6Q443/iwNN/4sETf+LBUx+kMFt/4mBTf+KhkCesCCN/4qCRLRExETUQJ6wEM3/iUFE5Ex+kFQ0pEx+kDZcfpB4xJRMfpASEQsQCYgAcE1NRGFeAAvwAARlTTSQEgCvEBDAn4AQAJ6wEA3/jUE4D4AsAA68oASUSBYE/0gHGBgMxMu/EDD8DwtoDf+EBUCesFAAAPDigA8q6A3/g0JAnrAgAADw4oAPKmgAnrBAAJ6wUBgWAJ6wIAQ2hIaADwBAEAkBlDB9Hf+AwUACMJ6wECAvEkB0Dg3/gAFAnrAgPf+AAk3/gIZN/4CHRJREpETkRPRNli3/joE8PpAnYD8VAHSUTD6Qch3/jcE9/43CNJREpEw+kEId/43BPf+PQjSURKRNlm3/jUE0lEmWbf+NATSURZY9/4zBNJRBlj3/jIE0lEmWLf+MQTSURZZt/4wBNJRMPpFSEAIt/4vBPf+LxDCesFBt/4yAPf+MhT3/joo7NhMmLf+KwjSUQJ6wQDSERNREn4BBA7YN/4oHPf+JAT3/iUQ0pECesBC9/4mBNPRExEw+kLB9/4kAPD+Dyww+kNQuNK5Ezf+JRzSUTD6QkVCesAC+NI3UngTUpETERPRMPpBUIJ6wEISEQJ6woBTUTD6QEQMGnD6QN1w+kHixCxAJiABzrUY0bYSAnrAAEJDw4pCNjWTQnrAAEJ6wUCSmARDw4pAdkBID7lWfgAEAEgACk/9Dmt3/g4wwnrDAEJDw4pP/YxrctKCesCAQkPDik/9iqtCesMAAnrAgFJ+AUAQGhJaADwBAUAkClDGNHCSQAlCesBAgLxJAdD4E9JASAM8QEDCfgBAAnrAQCUSYNwAOvMAElEgWBP9ABxgYCz57dJCesCBbdKuk66T0lESkRORE9E6WKyScXpAnYF8VAHSUTF6QchsEmxSklESkTF6QQhsUm4SklESkTpZrBJSUSpZq9JSURpY69JSUQpY65JSUSpYq5JSURpZq1JSUTF6RUhACKuTAnrDAarSbFI3/jowrVhMmKrSgnrBAVJREhEPWCqT0n4BBCmSadMCesCC6pKT0QJ6wEKp0lMREpExekLB6ZIqk/F+DygxekNS6ZMSUQJ6wAKpkjF6QkhoUmhSk9ETETF+CCgSEQJ6wELoUkJ6wIICesMAsXpAwcF8RQAgOgQCTBpSUQAKMXpASE/9EqvAJiAB0/wAQB/9YWsBklaHElEinBySkhwAevDAUpEiICKYHnkCAAAAMgeAADMGAAAVAwAAJQMAADkFQAA1BcAANANAAAIDQAAuAwAAOAMAAAgDgAASA4AADANAACYDgAAqA0AAIANAADADgAA+A0AAHQYAABwDgAAWA0AAJQAAABUAAAAwAEAAKwBAACYAQAAhAEAAHABAABcAQAASAEAADQBAAAgAQAADAEAAPgAAADkAAAA0AAAALwAAACoAAAA6A4AAGAWAAD8FwAAJBAAAFwPAAAMDwAANA8AAHQQAACcEAAAhA8AAOwQAAD8DwAA1A8AABQRAABMEAAAhhgAAMQQAACsDwAAFAIAANQBAABAAwAALAMAABgDAAAEAwAA8AIAANwCAADIAgAAtAIAAKACAACMAgAAeAIAAGQCAABQAgAAPAIAACgCAAA8EQAA3BYAACQYAAB4EgAAsBEAAGARAACIEQAAyBIAAPASAADYEQAAQBMAAFASAAAoEgAAaBMAAKASAACYGAAAGBMAAAASAACUAwAAVAMAAMAEAACsBAAAmAQAAIQEAABwBAAAXAQAAEgEAAA0BAAAIAQAAAwEAAD4AwAA5AMAANADAAC8AwAAqAMAALwYAABkDAAAkBMAAFgXAABMGAAAzBQAAAQUAAC0EwAA3BMAABwVAABEFQAALBQAAJQVAACkFAAAfBQAALwVAAD0FAAAqhgAAGwVAABUFAAAlAYAAFQGAADABwAArAcAAJgHAACEBwAAcAcAAFwHAABIBwAANAcAACAHAAAMBwAA+AYAAOQGAADQBgAAvAYAAKgGAACsGwAAoB4AAC3p8E2IsA4YB6mbRpJGMEb/94z4CLEBIDHgB5wZSE/wAAgheAHrwQFIRADrwQUAIQXxFAc4RgDwJ/hhaMhoimkzGqhpQrEH8QgCzekAshpGU0b999P9D+AKagfxCAQBJU/qWwaSaM3pAGrN6QRUzekCggEi+/ei/gAoGL8BIAiwvejwjcgeAACwtQRGQGgNRvv31fyoQgfQYGgpRv33rP8gRmQh//eQ+gAgsL1wtR1IWfgAQLTx/z8lRgLc+/fi+QAlGUgF68UBSEQA68EAAPEYBgEtItgALAPUMB9kIf/3c/oBIAEhAiIBI/73Y/0BIAEhAyIBI/73Xf0EIAAtCL8DIP73aflW+EgLAWgh8ABBAWD798X7ATUALNrU+/ey+QAgcL3EHgAAyB4AAPi1DkZpRhxGF0YFRhhg/vf3/wixASD4vQCZDUj+97T9OEYpRjJG+/cu+UCxACGOQgfQeFxqXJBCBdEBMffnACAD4AEgAeABIA5GcRkhYPi9yB4AAPC1jHkIJcCyT/AADE/wAA4F68QEACUuRgg1pUIP2A5EN3qHQgS/93v/L/TRd3q+RfHYtnoBLgS/rEa+RuvnvPEADwrQAesMAAF5kXBBeVFwgXkRcMB4gAAA4AAgGHDwvQAjAmsGKRNxLNjf6AHwCgQiEgQEGQACIwEhw2PAajUjHOBP8P8xwWPAahFgAWAAIRbgPiERYIAhwWPAaj8hBeAxIRFgAiHBY8BqNSEBYAEhBuBAIwEhw2PAagUjEWADYJF3gXdwR3C1A0YAaAQoEdFbaU/w/zAAJBhgSHjA80MFHSAFLB/QJfoE9vYHD9ECMAE09ucdIApc/yoD0SIoEdgCMPjnW2kBIZl3GmAT4CUoCdAEMQAlBC0J0E5dATUC+Axr+Odbaf8gGHEAIHC9CV0BIpp3GWAAIZmAcL0t6fBNirCcRgiQC3kAIA1GACcDKwXRlfgkEAE5sfqB8U8JjfgkAAmpAygE0AwYFlwBMGZw+Oe1+ADglfggAGx5lfgkoE/wAwhufwAvT/AACxy/T/AECApGzekChAiczekEbBSezfgYsE7qACHN6QCiIEY6RgeW/ffZ/ni5K2lqf2l5IEb99xb+QLnd6RIhaH0rfc3pAAYgRv33Kv0KsL3o8I0BIU/w/zKBdxIh/vfbvAEhT/D/MoF3NCGCYAFgAiEBdQAhAWEBc4GAcEcBIU/w/zKBdwIh/vfGvAAAgLUAIP73QPgOSRFKSfgBAA1JSfgBAA1JAUQA8ucwsfvy8QxKSfgCEE/0enGw+/HwCUlJ+AEAACD+9yb4B0lJ+AEAgL1sHwAAdB8AAD9CDwBAQg8AfB8AAHgfAABwHwAAELUdSHhE+/cb+hxMASABIQAifESgR0DyARABIQAioEcBIAAhT/D/MqBHBSAEIQDwkfhkIP73HvwBIP73CfhQuQEgACH+9yL4ASAAIf73CvgBIP331/9A8gEQACFP8P8y/veU+//3nP8CSAFoQfAAQQFgEL0EEEBSoAQAAHfn//8NSBn4ABCpuQEhACMJ+AAQCkkJaAHwf0KJsrLxgk96Rgi/CwkJ6wABQugA8kuAwvOAUkpwSERwRw4AAAAA7QDg//f4veC1AZABq//3M/4BmIy9AAAQtQ9IACEPSkn4ABBIRA9Le0RJ+AIwDEtLRENgCesCAAtKDEsMTHxEekR7RMDpAUHA6QMyFDAkIfr3gf8QvQC/FAAAABwAAACAHwAA3AMAAMoDAADGAwAAyAMAAAABB0oTWBBYm7IADMtAyEDAB0/wAgAIvwPwAQBwRwC/BABBUrC1DUYERv/36f8CKBy/BUiwvQEgIQEESqhAU1gYQ1BQACCwvf8AQgAAAEFS/uewtQ1GEUYERv33a/8gRilG/fd7/ySxIEa96LBA/fcxv7C9gLUA8An4APCN+L3ogEAA8Jm4//f1vwAAcLU+SDpNO054REn4BQAJ6wUAO0k7SnlEekTA6QMhOkl5REFgNEkJ6wYASURBYP73zfoDIAAhACT999L/ACADIf33Rv8AIAAh/fcu//73QPsDLATQIEb+9/X6ATT45wAkAywF0AYsBdAgRgAh/fe4/wE09ecAJFyxDiwL0AnrBQBQ+CQAILEBeEJ4IEb/95v/ATTw5wIg/vfV+gnrBgECIP736foAuwIgQvIQcf731frQuQAkDiwM0Ey5CesFAFD4JAAgsQF4QngAIP/3fP8BNPDnAyAAIf33g//IIP737Pq96HBA//d+vgMg//dr/wC/HAAAABQAAACAHwAA/AIAAPQCAADwAgAA5gIAAIC1ASABIQIiASP+93P6ASABIQMiASO96IBA/vdrugAALenwTU9ICesAB//3xf5AeFBJOkaA8AEIS0iLRsf4NIAJ6wAESUjE+DSACesABUhIxfg0gAnrAAoB9SBwACHK+DSAWU5+RLBHC/WAcAAhIkawRwv1QHAHISpGsEcL9WBwACFSRrBHPEgL8eN1ACH+97v6OkgBIf73t/o5SAIh/vez+jhIAyH+96/6N0gEIf73q/o2SAUh/ven+jVIBiH+96P6NEgHIf73n/ozSAchCesAAjJIwvg0gAnrAAQwSMT4NIAJ6wAFL0jF+DSACesABwv1KGDH+DSAsEdYRgAhIkawR1hGASEqRrBHC/XAYAMhOkawRyRIC/HldAAh/veu+iJIASH+96r6IUgCIf73pvogSAMh/vei+h9IBCH+9576HkgFIf73mvodSAYh/veW+hxIByEzRgnrAAIgRr3o8E0YRwC/vBoAAPgaAAA0GwAAcBsAAAAAgVLcGAAAGBkAAFQZAACQGQAAzBkAAAgaAABEGgAAgBoAALAdAADsHQAAKB4AAGQeAADQGwAADBwAAEgcAACEHAAAwBwAAPwcAAA4HQAAdB0AAFWu//+WAAAAwAAAAPUAAAA5AQAAkAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAQIAAgECAQn8//8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAgAAABcAAAAAAAAAAAAAYAAAAAQAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAABaAAAAAAAAAP////8AAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAACAAAAFQAAAAAAAAAAAABgAAAABAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAFoAAAAAAAAA/////wAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAIAAAAVAAAAAAAAAAAAAGAAAAAEAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAWgAAAAAAAAD/////AAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAgAAABcAAAAAAAAAAAAAZAAAAAQAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAABaAAAAAAAAAP////8AAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAABAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAEAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAABAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAQAAAAAAAEAAACAACiAwAAANEBANsBAAAAAAAAAAAAAIAAAAAAAAAAEAAAAAAABAAAAgAAogMAAADRAQDbAQAAAAAAAAAAAACAAAAAAAAAABAAAAAAAAQAAAIAAKIDAAAA0QEA2wEAAAAAAAAAAAAAgAAAAAAAAAAQAAAAAAAEAAACAACiAwAAANEBANsBAAAAAAAAAAAAAAgIAAAAAAAAAAAAAAAAAAAAAAgIAAAAAAAAAAAAAAAAAAAAAAgIAAAAAAAAAAAAAAAAAAAAAAgIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAIIAAAABAAAAAAAAAAIAAACCAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAADIAAAAAQEHBwcHBwABAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAADIAAAAAQEHBwcHBwABAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgPD6AoDw+gKA8PoCUMMAADIAAAAPAAEAAAAAAAAAAAAHCAEADAUDBgcEABQUAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
   pc_init: 0x1
-  pc_uninit: 0x5d61
-  pc_program_page: 0x3e39
-  pc_erase_sector: 0x3bc1
-  pc_erase_all: 0x3bbd
-  pc_verify: 0x5d65
-  pc_blank_check: 0x449
-  data_section_offset: 0x60f4
+  pc_uninit: 0x5455
+  pc_program_page: 0x3e51
+  pc_erase_sector: 0x3c41
+  #pc_erase_all: 0x3c3d
+  pc_verify: 0x5459
+  pc_blank_check: 0x4a5
+  data_section_offset: 0x5864
   flash_properties:
     address_range:
       start: 0x60000000
-      end: 0x64000000
+      end: 0x68000000
     page_size: 0x1000
     erased_byte_value: 0xff
     program_page_timeout: 5000
@@ -791,19 +5730,19 @@ flash_algorithms:
   stack_size: 4096
 - name: pse84_smif_s
   description: PSE84_SMIF
-  instructions: ELUERgXwkvwgRgEhvegQQATwkLgt6fBNiLAPRgRGbk1uTgDw5fi0QgX1IHICkAFGBJII0Ab1oCoBLwvQAi8N0QAhKEYi4AEvEdACLxHRBfWAcBTgBfUoYAAhF+AoRgMhBC8YvwD1wGAIvwEhDuAQRgXgBfVgcAQvCL8F9UBweh4HIQb1gDoCKji/ACGrRgAlDiIBI0/wAQgAlQDwD/pQRgAhDiIBIwCVVkYA8Af6C/VgcAQvT/AECgi/C/VAcAeQWEYYvwD1wGAGkE/wAwAIvwEgBZAHJXgeAihYRji/ACUL9YBwA5C68QAPSNA7SMb4DICEQgjQAS8P0AIvEr/d6QUQACFYRg/gAS8L0AeYKUYCLwS/A5gpRgbgWEYAIQv1KGAB4ASYKUYI+gHxwWABIAPwHv0pSIRCCNABLw/QAi8Sv93pBRAAIVhGD+ABLwvQB5gpRgIvBL8DmClGBuBYRgAhC/UoYAHgBJgpRgj6AfHBYAEgA/D8/KrxAQqz5xdIhEII0AEvDdACLxK/3ekFUAAlWEYL4AEvCNACLwy/A5gHmATgC/UoYAAlAOAEmAghDiIBIwCRKUYA8ID5GyAAIQ4iASMAkDBGAPB4+QKYCLC96PBNAPAQuAAAgVIAAEZUgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHU+oCDADwaYAt6fBLT/AABgArH7+z+oP1A/oF9CT6BfZeQBK/FkOy+oL1AvoF9MXxIAUevyL6BfxE6gwEIDVW6gRMT+oURBi/ZBxP8AAIT/AACZBCcesDDDnTACkZv7H6gfcB+gf2sPqA9wD6B/bH8SAHHr8g+gf8RuoMBiA3tvv0/KfrBQcQPwfwHwvL8SAGLPoG9gz6C/tEv7NGACYgL6S/XkZP8AALW+oGDAi/T/ABCxnrCwlI6wYIq/sCfAb7AswL+wPMwBtx6wwBwecLRgJGQUZIRr3o8IsTtQhDGL9P8P8wAUav8wCAvegcQHBHQOoBAxC1mwcP0QQqDdMQyAjJEh+cQvjQILoZuohCAdkBIBC9T/D/MBC9GrHTBwPQUhwH4AAgEL0Q+AE7EfgBSxsbB9EQ+AE7EfgBSxsbAdGSHvHRGEYQvU/wAAIAtRNGlEaWRiA5Ir+g6AxQoOgMULHxIAG/9PevCQcov6DoDFBIvwzAXfgE64kAKL9A+AQrCL9wR0i/IPgCKxHwgE8YvwD4AStwRwhIfLV4RACQB0h4RACcBUYBkATgIEYBaAhEgEckHaxC+NF8vVRdAABSXQAAF0gAIU/w/zIbSwn4ABAVSEtECfgAEBRISfgAIBNIFUoJ+AAQEkhKRCn4ABBIRMDpFTIUSwF1gXARSRBKgmFJREtEwOknMQL1gCEBZgEhgPhcEPohoPhEEKD4jBBwRwC/CAAAAAQAAAC0KwAADAAAALgrAAC8JQAAnCgAAAAARlSsJQAAkCsAAATwMLgt6fBFh7AGRhhID0ZwIZBGT/AAChprASQdRq34GqAp+AAQSEQ5eM3pAqLN6QRDACJA8lVTzekAQDBGAPAy/ChrDfEaAjl4ACPN6QRFzekAQs3pAgowRgEiAPDu+734GhCo+AAQB7C96PCFAL9ADQAA+LUVRgaaHkYPRgRGAPDO+AEhBvABACJouUC4QCLqAQEIQ7kAIGAPIGJsiEAjb4JDI+oAAIAtBtEIIwP6AfEKQwhDYmQF4AXwDwMD+gHxEUNhZCBn+L0AAC3p+EUGRlJIAC4A8J+AF0YAKgDwm4AwRgAiDUYA8Oj4rAAHIHFubCKgQCHqAAC5aQHwBwGhQAhDHyFwZm/wHwAELQDrxQA4v+gAOL9oIvtpAfoA/LFYA/AfAyHqDAED+gDwCEMpRrBQMEY6egDwcvgPIE/wCAgA+gTxcGx7aNfpA67X+BTAIOoBAgPwDwCAKwi/CCCgQBBDMm8i6gEBcGSAKwj6BPAH8SADCL8BQzFnaAADIgrwAwGBQAL6APAybCLqAAAIQwEhMGQO8AEAAfoF+rFpqEAh6goBCEOwYQzwAQCxbKhAIeoKAQhDsGRP9H5wDssA6oUM1+kLBAHwAQFi80EBA/ABAgDwAwBB6oIBQerAAGEBybIIRDFtAPoM8CHw/wEIQylGMGUwRrprAPCn+DhoKUYAKAi/T/AECEb4CKAwRnprAPBT+AAgvej4hQEAWgBwtR1LHkwDRKBCC9AdTKBCCNAdTKBCBdAcTKBCHL8cTKBCIdEcTRVMBfWYJgX1gCWwQjq/RPIABcXyRkWj9YAjBOrTAChEb/AfBAQpKL8EMANoAvAfAgTrwQQ4v8wAHyGiQKFAA/DEugpMoELa0APwhfoA8aVA5ucAALmr8P//HwAAR1SAAEdUAAFHVAAAS1QAAUtUgABLVABARlRwtRlLG0wDRKBCC9AaTKBCCNAaTKBCBdAZTKBCHL8ZTKBCGdEZTRJMBfWWJgX1gCWwQjq/RfIABcXyRkWj9YAjBOrTAChEAvABAgEjikAD+gHxA2gD8H66C0ygQuLQA/A/+gJLGETu5wAAuasAEIBS8P//HwAAR1SAAEdUAAFHVAAAS1QAAUtUgABLVABQRlSJAENsy0BbB0/wAAMK0RC1BG/MQATwDwQILAi/AvAPA73oEEAD+gHyDyMD+gHxQ28j6gEBEUNBZ3BHAAABSUn4AQBwRzwMAAAwsQMhAWKBakkH/NQAIHBHAEhwRwQAsgABOMKyBkgHKgjYiyPTQNsHBNAEoFD4IgAIYAAgcEcAvwQAsgAAAAAAAQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAE/0QHEAIgFgCEmBYAAhwPiAEMD4wBDA+MgXAPUAYLL1AH8Iv3BHgVCAMvjnANCAAPC1LEsAKFLQAClQ0AAqTtBMfkyxDWgVuZL4KiAis4p+AipE0w0qQtgKfjqxSmmXKgrSACLA+NgnJEok4AAiwPjYJyJKCDIe4CFOACV+RAQtLdBW+CVwl0IE2AbrhQd/aLpCB9kBNfLnin4CKh/TDCra2RzgEKIUS1L4JSAC8AMCBeuCQhpEBPADA8x/QuoDEot+kfggEAPwDwNC6gMiBPADA0LqA1IAI0LqwXGBYBhG8L0AvwQAsgAAAAAAAAAAAAEAAAADAAAAgNCCAATQgAAIWAAAELUERgAgCGCIYMhgSGEIdiJoQvAAQiJgSGAIYaBoQAcL1KBoAAcI1GBowAf80AogA/Aa+WBoACj81BC9AkYBOQAgBykQ2N/oAfAECg8HDw8PDQL1AGBwRwL1EGBwRwL1CGBwRwL1GGBwRwAAAkYBOQAgBykQ2N/oAfAECg8HDw8PDQL1AGBwRwL1EGBwRwL1CGBwRwL1GGBwRwBoAPABAHBHCH5wRwAAELVTHgPwHwMAKQPxgETEZARMZPNfEoJlA0oYv0PqAgHBZhC9AIgABAAAAkAt6fBNiLAtToNGqiAURgAiASWIRgl4QPJVUyn4BgAAIAnrBgqt+B4AIGvN6QBazekEVM3pAiBYRiFPf0S4R1UgmPgAEAAiQPKqIwPw1PiAIJj4ABAAIkDyVVMD8Mz4qiCY+AAQACJA8lVTA/DE+FUgmPgAEAAiQPKqIwPwvPgQIJj4ABAAIkDyVVMD8LT4ZCYN8R4HWEYD8LH5A/Bz+QPwmvkB1AAo9dEAKAS/AiXA8rIFKEYIsL3o8I0Av0ANAAChAgAALenwTYiwMU6CRqogBpIBJwAiiEYJeBxGKfgGABhrCesGC83pBHNA8lVTzekCIM3pAHtQRiZNfUSoR1UgmPgAEAAiQPKqIwPwrPiAIJj4ABAAIkDyVVMD8KT4qiCY+AAQACJA8lVTA/Cc+FUgmPgAEAAiQPKqIwPwlPgwIJj4ABAAIgabKfgGACBrzekAewKSACYFlM3pAwdQRqhHrfgeYGQmDfEeB1BGA/BG+QPwCPkD8C/5AdQAKPXRACgEvwIlwPKyBShGCLC96PCNQA0AAOEBAAD4tQxGD2oJeAAmFUYBOQcpENjf6AHwBAoPBw8PDw0A9QBmB+AA9RBmBOAA9QhmAeAA9RhmgWgB9EARsfUAHwK/sWpB8IBxsWIBaMkHIdGV+DQQiQcd1Tl4Hkt6eE/wAAwZQxpDMWRP9OAhcWTG+EjAMWUyZnFmxvhowDFn4Wgh8P8BsWB5aElCIfD/AfFgByExYoBoumgA9EAQsPUAHwi/ATq5eDBG//fJ/gEgT/QAQYX4LAC4aChjYGgB6oAgIX8B8AcBQOoBMANJCEMwYAAg+L0AvwAAB0ABAACALenwRYmwA/Ai+AiszekEYUryPwED8D/4QPQAQAFAUEYC8Mj5ELEJsL3o8IXd6RIQEfoA8AfQQx5QRgMhASIC8NX4ACjv0d3pECEUmFIAOLEBIAMjzekACFBGAfDp/+LnA/A8+ALwjvjd5y3p8EWJsALw7f8IrM3pBGFC8j8BA/AK+AFAUEYC8JX5ELEJsL3o8IUSmAEoCdETmDixQx5QRgAhACIC8ML4ACjv0d3pECEUmFIAOLEBIAMjzekACFBGAvAW+uLnA/AJ+ALwr/rd5y3p8E2KsAdGQUjd+FygDkYUnA3xJgtP8AAIzekHMgDxggUSmIBFb9DUuzpKqiAxeEDyVVMp+AIACesCABVGASIGkM3pACAAIAPwEfgyTAiafESgR1UgMXgImkDyqiMp+AUAASAGnQCQACABlQLw//+gRyhJoCCkRgiaQPJVUxScKfgBAAEgMXjN6QAFACACkBWYA5AWmM3pBAo4RuBHgLsTmAEiMXgClADrSADN6QAgFZgImgOQFpjN6QQKB5gI6wADOEb/92n/DLEFRhbgACBkJK34JgA4RjFGWkZTRv/3C/sC8K3/vfgmAAE8AAZP6gRAAdQAKO7RFJwgsQjxAQiP5wVGAOACTShGCrC96PCNAgCyAEANAABH////LenwQQRGL0hUsw1GQbM7swAgGGCYYNhgWGEYdthhg/gsABhiWGAYYcPpDADD6QkgIGiw8f8/BNzABxy/ACC96PCB1PjIBylGGkYg8AMAxPjIByBG1ekAaO9o//fN/AixvejwgQbwAQAI8AcBZ/MYYEDqAUapfiBGAvA0+LC56X4E9QBgAvA++IC5KX8E9QhgAvA4+FC5aX8E9RBgAvAy+CC5qX8E9RhgAvAs+GppBkmSCEoqiL8B9aABMUMhYL3o8IEAvwQAsgAAA1AA8LWFsItp3GmMsSN4JHkJeAElBJL/JgAnzekCFRlGIkYAI83pAHYC8FT4BbDwvQFIBbDwvYAAsgBwtYawFEYFRgh4ACH/IgqezekAEgKqQ8IZRihGACMAIgLwO/gIsQawcL0KlihGIUYBIgAjBrC96HBAAfB5vgAALenwTYqwgEYrSOqxg0aIaRZGACKaRg9GRWkEaAAgCZKEQgTQMVwBMEHqAiL45wmpOEYB8Cn8AUYL8XwAJbFZRRy/Knn/KgLRCrC96PCNCZgAKQDxCAMoRgi/GEYDKgBoHdEAKRi/BfEgAxloan9P8AEMlfgkMD14QOoBIAMnzekCR83pADYEq4GyQEbN+Bygg+gkEAEiAyMB8PT/1Oc5eM3pAEIBIwKshOgKBMGyQEYzRgHw0v/H5wQAsgAt6fBBiLCLadxofLEC8M79T/D/Ds3pBsLaHs3pBGHN6QJeAvD7/QiwvejwgQFICLC96PCBgACyAC3p8EGGsN34MIAURh1GD0YGRkJG//fY/9i5umkBINFrAilP8AEBBtERawloASlP8AEBCL8CITp4ACPN+BCAzekAE83pAiAwRilGACIjRgHwiv8GsL3o8IFwtRRGDUYGRv/3sv8ouTBGKUYiRv/3Ev8AsXC9qGlP9HpxI0ZAbAD7AfIwRilGvehwQAHwJbsAAC3p8E2MsItGnBiJaRZGgEYAIB9GbU1iHktozekKAJpCgPDPgJJGimkDkQlsCZAHk1hGBpICkQmpMkYB8GP7zfgggJi5CZiIsQVoxGgJqVhGUkYB8Ff7gEZwG7D79PC48QAPAPsEVhrQPEYu4AaatPvy8Lb78vEA+xJAAfsC9kCxoBgCOLD78vEB+xIByUMA6wEKqusGAE/wAAhEHBbgCZhP8AAIAWjAaKrrAQIBMrL78PMD+xAiACoYvwEzA/sAEKDxAQqq6wYARBxATQeYzfgEoIJFddIImABowAcMvwAg/vfq/wCQBpgUnQ3xLAoALF/QBpBYRgqpMkYB8AP7AZoFkoi5Cpk3RiZG0ekAw9HpAxQGkQP7AcEClDRGPkYBOYpCOL8RRgWRAplP9HpyUUMEkQWZjkIv0giYWUYqRv/3+/5IuwOYMUYmRi9GAGgHkQrrAAIC+AEcCQoBOPjRCJ1ZRlJGO0Y8RihG//eH/rC5KEZZRgSaI0YB8Gb6gEYGmIZCEtk0Rj1GNBoHngZEACC48QAPzdAA4IBGBpin54BGJUY0RgaYB56h5wAkPUYHnp3nCJgAaMAHHL8AmP73gP9FRihGDLC96PCNAL8EALIALenwTYywhEbrSLzxAA8YvwApAtEMsL3o8I2WRgAq+dDR+ASwu/EAD/TQD2gAL/HQRPIQAE/wAApA8gomzfgswAeXYEQJkN1IYEQIkAAgBZADkFdFAPABglv4KiAAKgDwpYAJmEH2GzEBYBshAWHuIQiYAWALIcD4gBBA8gdxQWIHIcD4pBBc+CYAQPABAEz4JgBc+CYAQPAQAEz4JgCUaVBozvg0AFSzCpYWeIBGYEZdRvNGF0YxRv/38voAKADwzoE7egFoOkZj8wkhAWBf6khxJ9UHRgaSC5ghRjJGzfgAsAHwcfvIsQggBZnd+CzA3karRgD6CvABQwWRVOAQagAoAPCsgRFGYEZyRnRG//fH+934LMCmRgOQR+AGmjhG0vgEgN34LMBf6ohxAdTeRjngzfgIgN5G3PgAEMkHMtHUaAZGE0YRaVJpq0Yk8P8ABpObabBgSEIg8P8A8GAcaNP4CIAZamMeA/AHAwAqGL8D9YBzBJYzYgKYwgYa1LjxAA8HnwqeAPCKgNj4ACBTHDDQmPgEMNKyA/ADA0LqA0IC8YBCJ+CrRgefCp4gNgrxAQpO57jxAA8HnwqeAPCvgNj4ACBTHC3Q2PggMNKymPgeQGPzDyKY+CQwA/ABA0Lqg0KY+AQwA/ADA0LqA0JC6oRyGOAAIgScT/RAMyJkmPgFIAPqAkJiZNj4CCBTHDHQmPgMMNKyA/ADA0LqA0IC8YBCKOAAIgScT/RAMyJkmPgFIAPqAkKY+B0wY/OSQmJk2PgIIFMcOdDY+Bgw0rKY+BdAY/MPIpj4DDAD8AMDQuoDQpj4HDAD8AEDQuqDQkLqhHIk4AAiBJhP8AB0gmTY+BAgUx5k818TACoIvxNGw2SY+BQgT/RAMwPqAkICZQApAPCqgApoUxwW0At50rID8AMDQuoDQgLxgEIO4AAiBJuaZNj4ECDisQE6mPgWMALwHwJC6oNyFeAAIgScT/RAMyJmSnkD6gJCYmaKaFMcLtALe9KyA/ADA0LqA0IC8YBCJuAAIgSYT/RANMJkmPgUIJj4FTAE6gJCY/OSQgJlAClq0ApoUxwl0Atq0rKMf2PzDyKR+CQwA/ABA0Lqg0ILeQPwAwNC6gNCQuqEchPgACIEmE/wAHSCZgppUx5k818TACoIvxNGw2ZP9EAyCX0C6gFBQOAAIgScT/RAMyJmSnkD6gJCS39j85JCYmaKaFMcFtCLadKyzH1j8w8iC3sD8AMDQuoDQgt/A/ABA0Lqg0JC6oRyBeAAvwQAsgDEAAEAACIEm5pmCmlSsQE6i30C8B8CACtC6oNyGL8C9QAyAOAAIgSYwmYKfUt9T/RAMQHqAkFj85JBAWeY+BUABJkGmgtGjvgsAAEoAr+IakDwQHCIYtz4CAAA9EAQsPUAHwK/iGpA8IBwiGICnATwCAAE8AEBQepAAATwIAFA6oEgEXoSfwHwAwFA6gEgAvAHAUDqATAA8QBAGGCo5gOYAOADSAWZACkYv0H0MgDT5QQAsgAt6fBNrfUmfQVGCHgAJJH4CKAKk5NGCZEOkIhpjfj5QI34+ECN+PdAjfjDQI34wkCN+MFADJBAaw2Q/vcd/QuQDfWGeAAggCgD0Aj4AEABMPnnD5UAIA31g3EN8gkSDfIDE0CsDfH9Bw3x+gYAJQMtB9BIVVBVWFVgVXhVcFUBNfXnD5wOnVJGIEYpRgHwbvsgRilG/vcC/A2Z4kg5sTggDfIJEitGzekACALw1voAKFrRnfgMAVMoVtGd+A0BRihS0Z34DgFEKE7RnfgPAVAoStGd+BEBAShG0Z34EGFDqQ3yCRIN8cMDT/R/QATw0Pid+MNQy0iARsWzQ6zKTw31g3IN8cIDT/aEcH9EIUa4Rw3yAxIN8cEDT/aBcCFGuEdAqj6rT/aHcCFGuEcN8f0CDfH3A0/2BXAhRrhHDfH6Ag3x+QNP9gpwIUa4R534wRAIRgiRs0gA8XwIebGALZy/CJiAKALYD+CuSIBGC5j+94f8QEYN9SZ9vejwjQAgDJmALcHpEwDx2ACVQ6zd6Q0TrpgN8gkSApAPmAGUBPAW+TGt3fgwwIBGBPEdAAAhASLeRhgpDNAQ+AE8EPgCSwX4EUAF60EEAvoD8wYxY2Dw50SalkhRHBBEyQgAKki/QPAAQZ34DgHM+AQQwPNBAAIoDNABKATQACgMvwMgACAG4AMgsfGAf4i/BCAA4AQg3OkDEgYk3PgoMAQlDGAAJAxxFWAUccz4AAABIMz4OACIdwUgHHG+8QIPGGAM0534RgEKmQAuGL/A8wIRYEYE8FD43fgwwN5GYCHc+AhQ3PgcAARxAWCes534NAEBITdGAAkB+gDwsPWAfyi/T/SAcMz4JADd6UwQwPNBcsDzBCQDKhq/D/ZwQ1P4IiBP9HpCgwRP8AYDWL8DIwE0BPoD8x4kBOpABgTqQQHA8wRgAjEBMAI2SENzQ1BDzOkRAw3gWEhP9HpBN0bM6REQT/SAcMz4JAAKmAAoCL+GRgrw/QGd+A4BASkR0L7xAg8O04EGDfWGej5GJtRABkLU3PgAAAQoQPDVgE/w/wsC4b7xAA8N9YZ6GL8Q8BABJdG+8QAPGL8Q8AEAVNEDIE/wAQtP8P8xPkYoYAAghfgesKlgKHUoYaiAkeAAByfUnfgVAU/0AHGpgChgASCd+BQRqHcgKUTST/D/MEXgnfgbAU/0gHGpgChgnfgaASAoQdJP8P8wQuCd+BcRACCogClgnfgWESApSNJP8P8wSeAILtXTCZhAaBDwQADQ0Z34ZQEAIYX4JBAoYEDyARCl+B0AT/QAcKiAnfhkASAogPD/gU/w/zAB4p34GREAID5GqIApYJ34GBEgKTDST/D/MDHg6HUCIChz/yCoYE/wBQud+BQBG+ABIOh1KHP/IKhgPkZP8AMLnfgaASHgBQCyAINBAAD9//9/oIYBAAEhKHP/IOl1qGBP8AQLnfgWARDwHwAoYRy/ASCodQIgD+ABIShz/yDpdahgT/ACC534GAEQ8B8AKGEcvwEgqHUBICh13PgAAAQoHtGd+EtxeAYm0F/qh3on1dz4DABP8AAIILP/IwF4AnkBIHRGzekAgw6bzekCMK6YACMC8KP43fgwwKZGgEYR4Nz4IAAD8On/Q6kxqgyYA/BD/934MMBd4NxIAPF7CCDgT/AACPgHAtG68QAPF9W48QAPDfWGehTR/yEAIgEgACN0Rs3pACEOmc3pAhCumLchAvB0+N34MMCmRoBGAeAN9YZ6ACEN8UEAACKAKgLQgVQBMvrnuPEADxHRnfjCEA31g3J0Rs3pABDd6Q0TrpgCkA+YA/A8/934MMCmRoBG3PhoAJCx3PhsEHmxvvEDDwi/uPEADwDw5oBP8P8yACMKYIt3zOkcMgJgg3e48QAPAPC+gAEg3ekONDGtwLMA6woBASIR+AEcAvoB8cz4GBBWs0yZHiIF8QgDACQP9lQVAupBAgIyHCwS0CH6BPbG80EnxvMEFgMvFL9V+CdwT/R6dwE2BzRWQ35DQ/gMa+rnGzgxqd3pDjRACADrQAAB64AAUPgEDAHgT/R6cMz4QADc+FAAACgA8JGACJgN8gMSDZnN6QAKAvAa+IBGACh/9J+thq0AIAAhQ6sEKQLQaFQBMfrngUhP8AALDJ4A8QEIACDN+CiADZAT+AsAgAdn1FtEACAP9rgHnHiN+IwBWXiT+AOgogkDKhi/B+uCBjJoE0QEM8ayskIE2fdDATDfXa9V9+cAkgAiDpgrRs3pAgKumAGSAfCr/wTwDwGARg8pCL8IITGxuPEADwPRD5gB8Bf4gEa48QAPDJ4X0a6YASIAIwCQD5hjqQDwKv8IsYBGC+Cd+IwBT/AACBDqCgAYvwEgDZlA6kEBDZEMngvxCAsImINFQ6un2VBIAPECCC/lq/EBAN34QRAEKADynYDf6ADwA1hPU0oAiAdU1QwgkOC48QAPL9AKmIBFa9C48QAPf/QWrWngBy7/9Bevnfj5oLrxAA8A8KeBnfj3AAAoAPCigdz4ZBAAKQDwnYEJmQl5SQYA8ZiB3PgIEJ34+HDc+DRAACIAIwqRhqmAKwDwK4HKVAEz+ecNmMCyA+sLAUp4iXiQQi7QC+uBAQHxCAsImYtF8tmo54gGRNTc+CAAWeAIBwjVvCBE4MgGPdTc+CAAZeBIBzzU3PggAGLgASACISh36HX/IClzqGABIU/wBgud+GQBqXVP9IFxqYIA8B8AKGE75gExX/qB+sb4TKCKRQDwpoAAIMbpEwAJmEBogQdA8Y2CD5sZaMkHQPCIgg6ZATnJsgcpA9iLIspA0gdn0QAhZOLsIATgbCAC4AUAsgA8IChg3fhBELvxCQ8t2AEi3PggAAL6C/IS8A4PGdES9Bh/EdDKBRLVASEAIoF3PiECYQFgAiEBdQFzT/D/MYFgT/QAcYGAEOC78QQPDdEKBgfUSQYC1APw+f0E4APw4f0B4APw5f3d+DDADfFBATGqYEY3RmZGA/BI/bvxCQ8Z0XFpQPIDNDJqASOMgEDyASQNaIH4JDCh+B1ADWJA8gMRgvgkMKL4HUCRggMhEXFRcRFoEWLd6Q40tEYxrT5GReYP8hhiCZ1S+CEQDDUZRDzNIvD/AopgWkIi8P8CymAuaKpoK2p1HgXwBwUALBi/BfWAdcQGDWIA8ZaAACoA8FCBFGhlHADwEYEVeQHwEf4N4eJJ1vhQ4AAiT/T/cE/wAAgAJQAkAjENkVJFMtAL8QQLJUQAJBP4CxAB8A8HASE5QgjRZhwA6kEBBCw0RvfT3fg0gAUkBOtEAQ3xxAxe+CJwU/gLYBz4IUAM64EBPWC8YNHpARQ8YSbw/wQE9YB0jEIuv7T78fYBJiFGfmD5YAEyyucMnqfmzekAAa6YDfH9AiFGDpsCkA+YA/Dq/AAoUNGd+BkCAChM0M3pBkYKnAEmOUYCJ934MMAgYiBgQPIBEAApp3eE+CRgZnWgg0/w/zCgYEDyAzCggADw1YHc+FQAACgA8NCB3PhYEAApAPDLgQ9GBkaFqmOoACEN9QR7g6sAJAQsAPBvgRFVAVUL+AQQGVUBNPXnACoA8OmAFGhlHADwioAVauSyln9l8w8kkvgkUAXwAQVE6oVEFXkB8MT9e+Dd+DDAnfhDMNz4CCDc+DQQDfWGepgGnfj4AA3U2wZ/9WStnfhPQQHw8P2d+E5BICwX0k/w/zMY4J34TUEB8OX9nfhMQSAsAtJP8P8zA+DTdQMjE3P/I5NgT/AIC534TDEI4NN1AyMTc/8jk2BP8AcLnfhOMRPwHwMTYQHQASOTdQMjE3WGqs3pAAKumAKQQKoB8Pr83fgwwAAof/Qmrd34UwKw8f8/P/cgrdzpGhLDshNgwPMHIwtgwwDA8wdDwPMCYFi/T/D/M8z4dDABI5N3zPhwAIt3COUAJAxkT/RANFV5BOoFRU1klWhuHB/QFnsB8Bv9HOAAJAxkT/RANVR5BeoERFV/ZfOSRExklGhlHCfQlWnkstZ9ZfMPJBV7BfADBUTqBUQVfwHwWf0a4AAljWRP8AB3FWluHmfzXxYALQi/LkbOZBV9BOoFRAxlACsA8IiAHGhlHA7QHXkB8L/8C+AAJIxkFGmssQE8lX0E8B8EROqFdA/gACQMZk/0QDRdeQTqBUVNZp1obhwi0B57AfDL/B/gACTMZE/0QDYUfVV9BuoERGXzkkQMZQArWdAcaGUcHtAdauSynn9l8w8kk/gkUAXwAQVE6oVEHXkB8Nr8EOAAJY1mT/AAdx1pbh5n818WAC0Ivy5GzmYbfQTqA0M24AAkDGZP9EA1XHkF6gREXX9l85JETGacaGUcDdCdaeSy3n1l8w8kHXsF8AMFROoFRB1/AfDa/ADgACSMZhxpZLEBPJ19BPAfBAAtROqFdBi/BPUANALgBQCyAAAkzGYcfV19T/RAMwPqBENl85JDC2dSfa6bg/gsIADwCAIA8AEDAPAgAEPqQgIJm0LqgCAaeht/AvADAkDqAiAD8AcCQOoCMADxAEAIYE/wAAj/9xW6ACEAIkCsAyoE0KNcATJD6gEh+OcB8SACCDETDBK6jfgOEhIMjfgUMq34FSIKCgkMjfgNIgQijfgMEtz4NBDN6QAgrpgCkIWqAfDM+yi5nfmPAbDx/z9A85iAT/D/MDBgOGAMmEFrBCDN6QALrpgCkIOqAfC3+3C5nfkTArDx/z8J3J34EAKd+BESgAlh88MADJmJaghh3fgwwAqcAicBJgMgpnUgddz4DBDc+CggC2gIcYH4JGCPdwtiFCEAIyFhEHWWdVZ1EHGC+CRgl3dWd1BxEWgRYgAi3PgcEAhxCGiB+CRgj3cIYmOo3ekGFoAqAtCDVAEy+ufN6QCgrpgN8foCApAB8G773fgwwA31hnq4u9z4ZACd+I8hAnABOp34lxEGKkFwFNid+I5BnfiMIZ34jTHDcIRwAnGd+JMxnfiQIUNxAnKd+JIxnfiRIYNxwnEBOQYpFNid+JYxnfiUEZ34lSHCcoNyAXOd+JshnfiYEUJzAXSd+JohnfiZEYJzwXNP8AkL//deu534jRHAsv8iMWCd+IwROWDA80ERAjEC+gHxAPAHAslDkUAAB534jgFIv0/w/zAMmsLpFwFQ5wC/EAAAAAABAACgDwAAAQAAABAAAACAAAAAAAAAAAMAAAAEAAAAAAgAAIAIAAAACAAAAAkAAAAIAAAACAAAAAgAAIAJAAAt6fBFi7COaRVGBEYBILJqrfgqAAAqTdAQeQMoPNFP8AAMkvgkABdqDfEkClN5CXhP8AQIzfgkwLL4AOBSf83pAAo4As3pAoMDI83pBsWAss3pBCEBIkDqDgEgRgDwjPwBRgi7sGoDaTuxQXlCfyBGAPCe+wFGuLmwagN5kPgkAAEiDfEqAc3pAAUBKCBGCL8CIgDwr/oG4BN4DfEqAiBGAJX+9wf8AUa9+CoAEbmW+DgQCEAAKBi/ASALsL3o8IUt6fxNF0YaRppGiEYGRv/3l/+6+CgQACXJsQAoSNC5Qii/OUaMsjBowAcD0SBGAfAD+gLgIEYB8PX5AfA4+zkbOL8pRnCzp0IPRuzYKuB4s7gIGUygQji/vAhP9HpwBC84vwEktPvw8QH7EEABkR/6gPswaMAHBtEBmAHw2/lYRgHw2vkF4AGYAfCy+VhGAfDJ+QHwDPs5Gzi/KUYQsadCD0bm2BDwAQUcvwIlwPKyBShGvej8jQC/QEIPAPC1hGkMSGNok0IU2QIwI22LseRsfLEdaC5olkIG2NX4BMDvaAf7DGaWQgLYBDMBPPDnACANYPC9BACyAC3p8E2IsARGHUYORo9pUUgBKinRf24ALwDwmIA6eHqxMHhP8AEMACMBOrl4BJXN6QAjzekCDPscIEYAIgDwq/t6eAAqAPCCgDB4ACYBOrl6ASPN6QAmAqopwgfxCwMgRgAiAPCY+3HguW4AKW7Q+m4AKmvQ0vgAgAho+Wh6b9H4ALAAIRMMB5GN+BwwE7obDAEyrfgdMD7QMngDIw3xHAoElc3pADHN6QIhwbIgRgAiU0YA8HD7AChI0QrxAwEgRgEiACMAlU/wAAoA8K/56LuX+HAAnfgfEAAiACMIQ1/6i/GN+B8AMHjN6QCqApABIM3pAwUgRgDwTvs4uwAiBCMweAEhzekAMgKrI8Nf+ojxIEYHq6XnjfgbEMOyDfEbAiBGMUYAlf736fp4uZf4cACd+BsQX/qI8w3xGwIAlQhDMUaN+BsAIEb+93L7CLC96PCNAL+AALIALenwTYaw0fgYoAxGBkYAIDpPrfgWADhG2vgsELmxFUba+DAgmrHa+Cgwg7EYaA3xFggEkBB4QkYDkAhoIUYAlV/6gPswRltG/ves+hCxBrC96PCN2vg8AM34CLDDRt34EIACKCXQgCgK0EAoQ9Gd+BYADfEWCEDwQACN+BYAEOAL8QEIMEYhRgKbAJVCRv73ifoAKNvRnfgXAEDwgACN+BcAA5swRiFGQkYAlf73FPvN51/6iPMN8RYIMEYhRgCVQkb+92/6ACgCm8DRCPEBBzBGIUYAlTpG/vdk+gAottGd+BcAA5sxK0DwAgCN+BcACL+4Rtbnp/F9AKjngACyAIC1irCN+AQgACKN+AwwACPN6QYhDJkJko34ICDN6QQiSmsAkQKSAakDIv73Pf4KsIC9AAAt6fBNkLAERgAgikYYnQ6TXU8PkNr4GACpGENomUIA8q+A0OkIsA2SC5AgaMAHT/AAABi//fda+w3xPAgJkAqUAC0A8JeALkYNnQuatfvy8AyWAPsSUIEZkUIovxYaIEZRRhma/veC+gAoQPCCgNr4GADWRgFoCOsBAwP4AVwtCgE5+NGb+CRwu/gAwNv4ICAAaJv4BDCb+AVAm/gdUJ74ABDyRs3pAHgCrwWRMccAIAaQGZgAKgeQ0LIYvwEiCpxM6gAhIEYA8DX6AChR0dv4CABBHBPQm/gcEJr4ACD/J5v4DDAAJc3pAVUAkc3pA3EZmc3pBSUAIgHwC/nIu9v4EDAMnaOxoGgA9EAQsPUAHwXRm/gWAAAhAfCJ+Abgm/gUEJv4FSAgRgDwIPkHRgi7m/gVAJv4FDAZmTJGzekAASBGDpkA8JT6mLna+BgAgWoxsYJsIEZRRhmb//eP/UC5DZitGwAnMEQNkA6YMEQOkGbnB0YgaMAHHL8JmP33uvo4RhCwvejwjQQAsgACRgCIKbGReNJ4EgZC6gFBCERwR7y1BpwAJc3pAFQA8AH4vL0t6fBBhrAERlFIACoA8JmApWwtBwDxmIAMnYPwAweF8AEGPkMXRgLwAQYIvwbrVwd+Hk/0gCcH6oVFtrJj8xFFqxkD8QJzI2UAIwApAPB7gA2dRhxP8AMIACBtagWVBJEEIQOSAZON+AgQBa2d+AgQBClp0bBCZ9ADnwSY1PjEEAHwDwG5Qii/OUYIKQ3YD/IGAt/oAfA5BRccEiszJAoA1PjQEAFwASEr4NT42BABYNT42BBBYAghI+DU+NgQAWAEIR7g1PjUEAGAAiEZ4NT41BABgNT40BCBcAMhEeAA8Pj/1PjQEIFxByEK4NT42BABYNT40BABcQUhAuAA8On/BiF/GghEuecEkAOXp7nU+MQAAPAPAAEoCL/U+NAA1PjIByDwAgDE+MgHjfgIgAGYELEBmQMgiEcoRgOXAPD8+JTnAzAA4AAgBrC96PCBAL8BALIAcLUVTCKzhWwtByLUAPDt/gi/BetWBnUeT/SAJgbqhEStsmPzEURjGQPxAnMDZWmx3ekFQ9lgBCFaYRxiGXYaYdD4yBdB8AIBwPjIFwAkAOADNCBGcL0AvwEAsgALRgAhACIA8AG4AABwtQ5Mu7GFaIZsNgcU1AE7m7Jh8xFDAvABAQX0QBJD6oFBsvUAHwi/AfUAAQAkAfFAcQFlAOADNCBGcL0BALIAsLUKTHuxhWwtBw3UCEwAKRi/BPXABFkeYvMUVImyIUQAJAFlAOADNCBGsL0BALIAAAAnAxC1FEb990b9GLEBaGTzCSEBYBC9AmgAKSLwAQIYvwEyAmBwRwiFcEcctQRGAGgAKBnUoGgg9EAQoGAB8AMAoWhB6gBQoGABqRBG/fdh/EC5AZgE68AQ0PgoGEHwgHHA+CgYACAcvQFIHL0AvwQAsgAPKYS/BUhwR4JoIvRwYoJggmhC6gEhgWAAIHBHBACyABVLFEqYQhHQFEuYQhy/FEuYQgvQE0uYQgjQE0uYQgXQEkuYQhy/EkuYQg/RDykL2IJqIvDwAkLqARKCYoJqIvAPAhFDACKBYhBGcEcJS5hC7ND55wQAsgAACEZUgAhGVAAJRlSACUZUAAhKVIAISlSACUpUAAlKVLC1BUYAaAAkSLEBIADw1P0oaAE4KGAEvwIkwPKyBCBGsL2wtYiwFEYQmg2dB5IPmgOVDJ0Gkg6aBZIAIo3oLAAjRgSSAPAC+AiwsL0t6fxNBEYRmE/0cAXd+DjACp5AagGQD5gF6gBb3ekMcBCdwrEDKwi/AS4k0E/0QDIALwLqA0Jm85JCPk5C6gsCQuoRIyNlQerFQ8myCL8D6gYBEUMZ4MmyBvABAgAvY/MRQUHqgkEF8AECCL9B6sJBQeoLAQngBfABAgAvCL9B6sJBQeoLAUH04CEhZU/0ACHN+ACwAygB6sVLT/RAMQi/vPEBDwHqAEUjSYhGbPOSRR7QT/AACgGuACBf+orxuUI20kBFQkYz0KBsAAcM1AuYCvEBCkBcATG5Qii/QOoLAACZKEMIQyBlMEb/92P/5OcAJg3xBAoAIL5CGdJARUFGFtCgbAAHD9QLmrEckBlAeLlCKL9A6gsAkl3OskDqAiAAmihDEEMgZVBG//dD/+Pnvej8jf8ACAACALIALenwTYawBEZLSAAqAPCNgKVsLQcA8YyADp6D8AMHT/AACIbwAQVX6gUMAvABBxVGCL8H61UFT/SAJwfqhkYBPa2yY/MRRnMZA/GEcwApI2Vt0A+bvPqM9Q3xFApbam8JRRwAIAWTBJECIQOSzfgEgI34CBCd+AgQAilZ0ahCV9Dd+AywBJ7U+IgAAPAPAMDxCABYRSi/WEYIKBjY3+gA8CsfBQUSEgoKFwAwiMT4lAACIBzgMEYA8Br9sIjE+JQABiAU4DBGAPAS/QQgD+AwRgDwDf0wHQDwCv0IIAfgMHgALwy/xPiQAMT4nAABIKvrAAsGRMfnu/EADwSWzfgMsA/RxPiAgNT4yAcg8AEAxPjIBwEgjfgIAAGYELEBmQEgiEdQRv/3qP6k5wMwAOAAIAawvejwjQC/AQCyAHC1hGwkB0S/FUhwvQDwmfwIvwXrVgZ1Hk/0gCYG6oRGrbJj8xFGNUQF8YR1BWWhsd3pBWUpYAIhqmDuYSl2ASHA+IAQamCF+CswhfgqQND4yBdB8AEBwPjIFwAgcL0AvwEAsgBBHgwphL8FSHBHBUlR+CAgIvAAQkH4ICAAIHBHAQBKAEASQFINKIS/BUhwRwVJUfggIELwAEJB+CAgACBwRwC/AQBKAEASQFIQtQhJUfggIFH4IADC8wMiAPAPAFQcAPA7+ADrVACw+/TwEL1AEkBSDSiPvwAgAklR+CAAwA9wR0ASQFICRgdIDSqYvw8pANlwRwVIUPgiMGHzCyNA+CIwACBwRwEASgBAEkBSAkYISA0qmL8PKQDZcEcGSFD4IjAj8A8DGUNA+CIQACBwRwC/AQBKAEASQFIQtQRGAPAq+AIsCtgISQIsAetEEgi/AfUAchFosfH/PwDdEL0gRr3oEEAA8J27AL8AFkBSCEpP9IhTAuuAAclYAfAHAQcpAr9S+CAQCCBg818RiLJwRwC/AAFAUoC1//fp/wMoD9mw9Yh/ItBA8hERiEIO0EDyExGIQhy/ACCAvRJIgGgX4N/oAPACHQsbEEiAvQ5IT/QAQcBqAepAMIC9DEkKSABoWfgBEIAHAergcIC9BkiAaU/0AEEB6hBAgL0GSIC9BEhZ+AAAgL1oE0BSgPD6AkwNAABIDQAAABJ6AAUohL8JSHBHCUqx9YB/Mb8B8AcBAfAfAUL4IBAHIQLrgABP9IhSgVAAIHBHAQBKAAABQFKwtYQBAk0A8M77APDUuwC/ABhAUvi1DEYVSoEBACZTWALrgBUgRkPwAENTUEce6mlG8QAB0gcE0RmxAPDj+zhG9OcpaDyxMLkA8C/8KGgg8ABBCEgK4AHwQFCw8QBfHL8AIPi9KGhA8EBRACApYPi9ABhAUgIASgCwtQVGDEZIaDQh/Pfg/qgBPkkKWGBoAeuFEdMPAnADccLzAXPDcMLzAjPC8wIig3BCcEpowvMDY0NzwvNCUwNzM0sD9cATGkCCYIpowvNAcwLwAQKCc8NzymjC88Njg3XC88NTQ3XC8wJTA3XC8wNDw3TC88Ijg3TC80QTAvAfAgJ0Q3QKaUtpw2HC8wAzQ3bC80QTAvAfAsJ1A3aKaRNGb/PfQwNiwvMAY8LzAFKA+CUwgPgkIMppwvMAU4D4KTDC8wBDgPgoMMLzQAMC8AECgPgmIID4JzAJasoPgPgxIMHzQHKA+DAgwfMMQsKFwfMAEoD4LCDB88ACAfAHAYD4KhCA+CsgACCwvQC/ABhAUv//BwAt6fBBkLADrQRGNCEoRvz3VP4ClQAlIEYBlQGp//dm/6ABGkkIWLDx/z8r3J34DwACKCfQnfgMAJ34DRCd+A4gBZ1HHKAcAvEBCE4c//e2/p2xFetHUU/wAAJC8QACofsAMQL7ABEI+wbyGEYAI/z3gP1ADUDqwSUE4Aj7BvF4Q7D78fUoRhCwvejwgQAYQFJwtQJGUEyAASNYUEgAKwzUSWgLeAcrB9P5KwXYTXgHLZy/jngHLgLZcL0CMHC9BOuCEMp4AioA8IGAZfMKIwbwBwRD6gQzDHlD6sRzA2BASwP1wBOMaCNADHsE8AcEQ+pEU0x7BPAPBEPqBGNDYMt7jHtE6kNzg2AMfEt8BPAfBGPzSRSLfAPwBwNE6sMjzHwE8A8EQ+oEQwx9BPAHBEPqBFNMfQTwDwRD6sRTjH0E8A8EQ+rEY8NgzH0LfgTwHwRj80kUS35E6gMzA2HLaUNhDGqR+CQwb/PfRETqA1OR+CVAQ+oEY4NhkfgnQJH4JjCR+ChQkfgpYATwfwRD6kQDQ+oFQ0PqBlPDYZH4KjCR+CtAkfgsUJH4MGAD8AcDQ+rEA8yNkfgxEEPqBRPbsmTzHEND6kZzQ+rBcQFiAWhi8x1xAWAAIHC9ABhAUgEASgD//wcAsLVEAQJNAPAW+gDwHLoAvwAWQFL4tQxGFUpBAQAmU1gC60AVIEZD8ABDU1BHHuppRvEAAdIHBNEZsQDwK/o4RvTnKWg8sTC5APB3+ihoIPAAQQhICuAB8EBQsPEAXxy/ACD4vShoQPBAUQAgKWD4vQAWQFICAEoAsLUFRgxGCGhgIfz3KP1oARZJClggaAHrRRHC8wFzAnADccLzwGPDcMLzBEPC8wQig3BCcEpo0w9DcyLwf0MS8OBCg2AYvwEiAnOJaMoPwnXB8wBygnXB8wBiQnXB8wJCybIBYQJ1ACCwvQC/ABZAUi3p8EGasAKuBEZgITBG/Pfu/AAlaUYgRs3pAGX/97j/YAEVSQhYsPH/PyDcnfgMAAIoHNCd+AlgzrGd+Apwt7Gd+AgQACAEmhLrAWVA8QAIIEb/9039pfsAQaf7BiMI+wARIEb89x/8AA5A6gElKEYasL3o8IEAvwAWQFLwtQpoJCYsJwAhHCUnJCMjwukOdigmwukEEcLpE1XC6RBFICXC6RVDE2MpS8LpCBYPIcLpClSRYUEBXFglSQAsQ9SUeAAsQdAQLD/YVXjtsxAtO9gWeBAuONPILjbYEXkD60AQAikq0CsCQ+oEQxpMI0DUeDNEQ+rEYwNglGgTeyTwf0RE6gNzVHtD6sRzE0wlRkNgACODYBN/WwMPM8NgU2tj8x51BfUDcw1NA2GTbGPzHnVFYdJtYvMedIRhAmhh8x1yACECYADgAjEIRvC9ABZAUgEASgAAHx8AHM5pBCzSiQNwRwAAw7IACgEpA9BRuUAGB0kB4EAGBUlA6oMQCEQCYAAgcEcASHBHAQBKABRAAFIQQABSsLUNKwrYDUxU+CNQAC0F1FT4I1BF8ABFRPgjUEAGASMA64EQBkkD+gLyCERBaZFDQWEBaRFDAWGwvQC/QBJAUgBAAFKAtQEoAtj/95v+AuACOP/33/wAIIC9ASiEvwI4//fivP/3mL4BKIS/Ajj/95e9//f7vgEohL8COP/32L3/9zK/cLULTQRGT/D/MVn4BQCx+/D2WfgFALRCBNlwQ/z3KPukG/bnYEO96HBA/PchuwC/cCwAAAJJWfgBEEhD/PcYu3QsAAD/99y///f0vwDwDLoCSVn4ARAA8Du5AL9YDQAAAOvBAAEhFDAB8Ja+CesAAihGMEcD8eNwb/APAwPq0ABwRwScg/ADBoTwAQU1QxZGAvABBXBHKfgGACBrzekAWs3pBFTN6QIgWEY4R7T4AIAjeZT4IHBP8AEMZn+U+CRACXgAJXBHgmABYAAhAXUBYQFzgYBwRyBGKUZkIgDwl7wJ6wACIEYwRyPqAQERQwFgcL1N+AjtASH/9xL4xPiYAF34COtwRyn4BgAga83pAHvN6QR0zekCIFBGKEey+oLySOoHIc3pAEVSCf/3zbnd6Q4wAfBPvwIhKFlh8x1wKFEBIP/3d78oWSDwAEAoUQAgsL3H6QJDB/FQA0lEx+kHIXBHgkZYA0/2/3Xd+FSAASYDJ6hDA/AHBShEBCUAugiQACBwR+SyBfADBUTqBUQE8YBEcEcBIP/3Tb8AJ0/wAgtP8AEMT/AACnBHzekCV83pBgjYDAMjzekAZEDqQjABInBHAjiw+oDwQgkgRv/3uLjtsgbwAwZF6gZFBfGARXBHCesAAQnrAwJKYBEPDilwRwAgASPN+AiAzekAMFBGAyNwRwSQD5j/90q5MkY7Rs34AKD999m51PjYEAFg1PjUEIGAcEcFRmQg//fqvgXwAwVE6gVEROqGdHBHAiBg8x1xASApYP/39r5oaGlsMkb996O6ApAVmAOQFpjN6QQKOEZwR66YApAgRgHwtL4AJ0lEAfEkA3BHvfgeAAE+AAZP6gZAcEcF8AEFROqFRETqhnRwRwnrAAEJDw4pcEdBRjpGI0b89xu7B5GBsiBG//cMuQEjk3cUYE/0QHSUgHBHMEZBRlJG/vdEvAtGACEB8CC9LenwTYawACQORgdGBZQFqQDwKvkAKEDwm4AElAWcBKkgRgDwAflbSCF4AevBAUhEAOvBAAAhAPEUCEBGAfBE/WVoqWnoaApGGbkqagAqAPCDgNL4BKCHQgTRskWcvyppskJ82T8aACADkJGzA6koRjpG/vfD/Di7A5goswFo0PgMsAAuKEYCkQi/XkYDqT5Ech7+97P8BEYAKFbRA5gBaMBochqy+/DzA/sQIgAqGL8BMwKcOhuy+/vyAvsLRokbA/sAF6lpH+CpaRGxAfEYAAPgKGoYsQwwACEAaAHgACEAIAAuCL8GRvIZsvvw8wP7ECQBMwAsGL8D+wDyt/vw8wP7ECcD+wD2uBkqaVJFOL+SRoJFOL+q6wYH2PgEAAjxCAphsSlG//cI/wRGaLkEmFixQWjY+AQA//f//gTgKUYyRlNG/Pem/QRGACwYvwEkIEYGsL3o8I1P8AAKe+fY+AQACPEIBoGxKUYyRv33qPgERgAo6dEEmAAo5tBBaNj4BAAyRv33nPje5ylGMkb89x/92ee4KwAALen/TSBIIUkAJgQkA5ZZ+AAgCesBAJD4AoADrQGSRkUs0gnrAQsb+AQAgkIj0QnrAQAA68YKmvgFAChc2LkJ6wEHB+vGAIBo0OkDAf/3DP/AuZr4BRABIgvrBACX+AKAalQCqQDwFPgYuQKYASFAeClUBkkBmgg0ATbQ5wAgBLC96PCNASD657QrAAC4KwAA8LUAIgpgQmhTaauxC0wJ6wQFLB2teH2xJngHeLdCCNFmaLJCBdB2abNCAr8MYAAg8L0INAE97ucBIPC9uCsAAC3p8EEAIiDwgFwA8IBeCmAdSgnrAgMD8QgIm3g7s9j4AGC1aQ25NWr9sWpo1ukDdBVGlEI4vyVGACoIvyVGehlVHodCAdiFQhfSB/CAUpZFB9An8IBXvEUD0yXwgFKURQjZCPEICAE72OcAIt7nASC96PCBR+oOAPBgqPEEAAhgACC96PCBAL+4KwAALen8TYtGBUYA8Fz6ILkBqShG//ev/xCxASC96PyNAZzf+PSgO0gieALrwgIJ6woBWfgAAAHrwgUV+BQfiEIS0TdOMEb89zD7BvWAIPz3LPsoRllGAfC++y5JKHhJ+AEAACC96PyNAPB1+QXxCAZoaClsT/R6cjNG/Pdg/gAoy9H6IDFG/vem/mJoaGgReBJ6/veO/mhoMUb897b7H08Z+AcAWLlhaGhoCXj79xn/T/R6cP/33fwBIAn4BwD/9+L9GLH/99/9ACim0QnrCgAAJwAkBh2AeIdCstIpeDJ4ikIV0QnrCgEB68cBiWiR+ACAGOoEDwnRKEYxRgDwE/gAKH/0iq8J6woAgHhE6ggECDYBN+DntCsAALgrAAAMAAAAAABFVC3p8E2GsAApAPCvgARGCA8NRg4oAPKpgG5oAC4A8KWAMA8OKADyoYCwaRCxAQ8OKQnZMGoAKADwmICw8XBPgPCUgAAnkuCBaBGxCg8OKinZACLQ+CyAw2sweUAHH9W48QAPL9BP6hhwDigY2Nj4AAABMAEoE9gE8QgBYGiSRh9GAiIBI0/wAgsAkTFG/fdI+jtGUkZP8AEMgkYAJxbg//cI/RPgkfgUsEp9u/EDD2HQu/ECD83QT/AADAAnT/AACgAjAeD/9/X8T/AACFfqCgAm0bjxAA8g0E/qGHAOKBzY2PgAEMmxSBxP8AAHGL8AKxTQzekCwwSSy7JgaATxCAgN8RcCMUaN+BdwzfgAgPz3Bf4AKFbQgkY74AAnT/AACrvxAw8E0QEqCL9X6goABNC68QAPGL8BJxjgYGghbATxCAcCaDtGIvAAQgJgT/R6cvz3Yv1IufogOUb+96n9MngySAIh/vem/aixASc4RgawvejwjdD4aIAHb2BoBPEIAzFGBJL+90z6gLGCRgAnT/ADCwSaxOdqaGBoEXgSev73df1gaDlG/Ped+krn//cf/DtGB0ZP8AAMT/ADC0/wAAoEmoPnQkad+BcA3fgMgADqCABARQPRACdP8AAK2edgaDFGkEb89xj+gkYIsQAnAuD/9/37B0YEmlfqCgB/9JCvAplgaCGxMUZCRv73tfoE4DFGBJpDRv73A/qCRgixACe35//35PsHRtbnAL8AAEZUELUHTBn4BAA4uXK2AfAE/AHws/wBIAn4BAAAIBC9AL8EAAAALen4RQRGACDf+HyA6kYAkE/wATAC+wD2YBhHHrxChL8AIL3o+IUgRlFG//fn/QixBDTz5wCdCesIACl4AevBAf/3cPtoaIFpCbkBatGxSWjQ6QMCQxgVGBhGikI4vyhGQR4IRp9COL84Rq9CKL8IRoRC09ghaI5CHL8BIL3o+IUENPXnACHj57grAAAt6fhFiEYFRgDxCAoBJGhoUUb890j6B0ZoaEZoCiD/9yX7OB9P8AABGL8BILbx/z/IvwEhCEID0WAcREUERubZACC96PiFLen8TZJGg0YAIApGAZABqRBGAJL/92n9sPqA8N34BIAL8QgHASRP8P82RQngBwjQAJg6RkFo2/gEAP73gvgERgrg6AcV0Nj4BBDb+AQAOkb+93f4BUYAJAE2VkWEvwEgvej8jQog//fe+kTqBQDAB9zRACC96PyNAAAt6fhN3/gIbhn4BgABKCzR3/gADkhEhXgAICWz3/j0HfNIGfgBIFKx3/jsPd/41E0J6wECkGFLRExEwukVQwnrAQJSeFqx3/jALd/4wD1JRAD1gCAIZkpES0TB6ScyASAJ+AYAACC96PiN3/ioHQAgKfgBAElEiHDf+JwN//fF+wTY3/iYPf/3Z/sC2QEgvej4jVn4AOBP8AALvvEADwDw0YDf+HytCesKAAAPDigA8smA3/hwDXJG//en+5ZGAPLBgAnrCgEJ6wAC0fgEsEn4AxBSaAvwBAERQwfR3/hIDQAmCesAAgLxJABA4AnrAAbf+DgN3/g8Hd/4RC3f+ER9SERJREpET0TwYt/4JA3G6QJyACJIRMbpBxDf+BwN3/gcHUhESUTG6QQQ3/gcDd/4LB1IRElE8Gbf+BANSESwZt/4DA1IRDBj3/gIDUhEsGLf+AQNSETG6RUQ3/gEDUhEcGbf+AANSERwYwbxUADf+PxcCesKB9/48Bzf+AjN3/gATTpivmHf+PRsCesFAklECesMA0xEAmDf+NQMSfgFEN/40Bzf+NBcAvEkDE5ECesACN/41AxJRE1EwukNUd/40BzC+DyA3/jUXEhErOhZAN/4uAwJ6wEI3/jMHN/4tDzf+LRM3/i4bE1ECesADN/4tAxJRE5ES0RMRMLpA2XC6QVDwukHjEhEwukBEDhpqLHf+AAc3/gEPF/qi3BP8AALENUBIAnrCgIJ+AEASUSh+ASwT/ABC4pgiHAD4N/43DtP8AALvvECD8Dw1oDf+FxMCesEAAAPDigA8s6A3/hQDHJG//fS+pZGAPLGgAnrAwEJ6wQCSmAJ6wABUmgAkkloAvAEAhFDB9Hf+CgMACcJ6wABAfEkAEDgCesAB9/4GAzf+Bwc3/gkLN/4JDxIRElESkRLRPhi3/gEDMfpAjJIRMfpBxDf+PwL3/j8G0hESUTH6QQQ3/j8C9/4DBxIRElE+Gbf+PQLSES4Zt/48AtIRDhj3/jsC0hEuGLf+OgLSETH6RUQ3/jkCwAhSER4Zt/44AtIRHhjB/FQAN/42Cvf+Ng73/jka9/45FtKRE5ETURJ+AMgCesEAt/41EuXYQnrAwff+MA7EWLf+LQbB2Df+KwLB/EkDExESURLRAnrAArf+LALx+kNMd/4sBvf+LA7x/g8oEhECesBCEtErOhxAN/4lAvf+JxL3/icW9/4nGvf+KDLCesACt/4lAtMRE1ETkQJ6wwBx+kDZcfpBUPH6QeKSETH6QEQEGnYsQCY3/hUGt/4WDqABxbVASAL8QEKCfgBAAnrAQDf+NAagPgCoADrywBJRIFgT/SAcYGABOAAAEZU3/gkOtpGvvEDD8Dw1IDf+DRLCesEAAAPDigA8syA3/goC3JG//f3+ZZGAPLEgAnrAwEJ6wQCimAJ6wABUmgAkkloAvAEAhFDB9Hf+AALACcJ6wABAfEkAEDgCesAB9/48Arf+PQa3/j8Kt/4/DpIRElESkRLRPhi3/jYCsfpAjJIRMfpBxDf+NQK3/jUGkhESUTH6QQQ3/jUCt/45BpIRElE+Gbf+MgKSES4Zt/4xApIRDhj3/jACkhEuGLf+LwKSETH6RUQ3/i8CgAhSER4Zt/4tApIRHhjB/FQAN/4rCrf+Kw63/jAWt/4tGrf+NzKSkRNRE5ESfgDIAnrBALf+KRKl2EJ6wMH3/iQOhFi3/iIGgdg3/h8CkxESURLRMfpC0bf+JhK3/icagnrAAvf+HwKx+kNMd/4fBrf+Hw6x/g8sExETkRIRAnrAQgJ6wwBS0TH6QkF3/hYCt/4ZFrH6QVDCesAC9/4YApNRMfpA2XH6QeLSETH6QEQEGnIsQCY3/ikOIAHFtXf+JQYASAK8QEICfgBAAnrAQDf+KgZgPgCgADrygBJRIFgT/QAcYGAAuDf+HQ40Ebf+GBovvEED8Dwz4Df+AjKCesMAAAPDigA8seA3/j8GQnrAQAADw4oAPK/gAnrDAIJ6wMA0vgE4MJgCesBAEVoDvAEAipDBtHf+NQZACVJRAHxJAZA4AnrAQXf+MgZ3/jMKd/41Gnf+NR5SURKRE5ET0TpYt/4sBnF6QJ2BfFQBklExekHId/4qBnf+KgpSURKRMXpBCHf+KgZ3/i4KUlESkTpZt/4nBlJRKlm3/iYGUlEKWPf+JQZSUSpYt/4kBlJRMXpFSHf+JAZSURpZt/4jBlJRGljACHf+IQp3/iEed/4mEnf+JAJ3/iIOUpETERIREtESfgHIAnrDAIRYt/4aBmVYQnrBwXf+GR5NWDf+FxpCesBCt/4aBlPRE5ESUTF6Q5q3/hsacXpCRQF8SwB3/hcSYnB3/hMCd/4UDnf+Fh5TkTf+EAZTEQJ6wAK3/hMCUtET0QJ6wEL3/hEGcXpA3bF6QVDSETF6Qe6SUTF6QEQEGm4sd/47GZf6o5wFNXf+OQWASAI8QEFCfgBAAnrAQAJ6wwBhXAA68gAgWBP9EBxgYAC4N/4vGZFRt/49Aj/91X4BNjf+PA4/vf3/wHZASBU5Fn4AKC68QAPAPDQgN/42EgJ6wQBCQ8OKQDyyIDf+MwYCesBAhIPDioA8sCACesEAtL4BIBJ+AMgCesBA1toCPAEAhpDBNHf+KgY//cT+EDg3/i0ON/4tAgJ6wEH3/iUGN/4mChLREhESURKRMfpAgPf+JwI+WLf+IAYB/FQA0hESUT4Zt/4jAjH6Qch3/hwGN/4cChIRElESkS4Zt/4eAjH6QQh3/h8GEhESUQ4Y9/4bAhIRLhi3/hoCEhEx+kVEN/4ZAgAIUhEeGbf+GAISER4Y9/4XAjf+FxoCesEAt/4cOjf+GRIEWLf+FAYl2FIRAnrBgdMREn4BgDf+DwI3/hEaB9g3/g4OAnrAQwJ6w4BCesAC9/4NAhLRE5Ex+kLRt/4QGjH6Q083/g0SN/4LDjH+DywSETH6QkQ3/gYCN/4GBhORAnrAwvf+CQ4TEQJ6wAM3/gUCAnrAQ7f+BAYS0TH+CDASERJRMfpAwYH8RQAx+kBMYDoEEgQaaix3/hkN1/qiHAS1d/4HAXf+FwnBfEBCAEhSERKRID4AoBBcADrxQCCYIGAAuDf+Dg3qEa68QIPwPDLgN/4vFcJ6wUAAA8OKADyw4Df+LAXCesBAAAPDigA8ruACesDAAnrBQJCYAnrAQBDaFBoAPAEAgCQGkME0d/4iBf+9z3/O+AJ6wEH3/h8F9/4gCff+Ig33/iIR0lESkRLRExE+WLf+GgX/vec/t/4aBff+GgnSURKRMfpBCHf+GgX3/h4J0lESkT5Zt/4XBdJRLlm3/hYF0lEOWPf+FQXSUS5Yt/4UBdJRMfpFSHf+FAXSUR5Zt/4TBdJRHljACHf+EQn3/hER9/4VAff+FRn3/h0x0pESEROREn4BCAJ6wUC3/g4VxFi3/gkF5dhCesEB9/4JEdNRB9g3/gYNwnrAQvf+CQXx+kLBd/4IAdMRN/4KFfH+DywS0RJRAnrAAvf+CAHx+kNQ9/4CDff+AhHTUTH6QkW3/j4Ft/4BGdIREtETEQJ6wEOCesMAU5Ex+kFQ8fpARAQacfpA2XH6QfrwLEAmN/4yDWABxXV4EgI8QELASIJ6wAB3/hEBkpwgfgCsAHryAEJ6wACimBA8gESioAC4N/4mDXDRrrxAw/A8MaA3/ioBv73nv4A8sCA3/igFgnrAQISDw4qAPK4gAnrAwIJ6wADk2AJ6wECW2gAk1JoA/AEAxpDBNHf+HgW/vdv/jvgCesBB9/4bBbf+HAm3/h4Nt/4eEZJREpES0RMRPli3/hYFv73zv3f+FgW3/hYJklESkTH6QQh3/hYFt/4aCZJREpE+Wbf+EwWSUS5Zt/4SBZJRDlj3/hEFklEuWLf+EAWSUTH6RUh3/hAFklEeWbf+DwWSUR5YwAh3/g0Jt/4NEbf+EBm3/hAVt/4ZMZKRE5ETURJ+AQgCesAAt/4MAYRYt/4FBaXYQnrBAff+BRGSEQfYN/4CDbH6QtW3/goVt/4KGYJ6wEI3/gIFkxEx/g8gEtETURORElEx+kNQ9/4/DXf+PxFx+kDZcfpCRDf+OQF3/jkFUtETEQJ6wAI3/jsBQnrAQ4J6wwBx+kFQ8fpB+hIRMfpARAQaaixAJjf+Cw0gAd6SBHVSEQBIQvxAQVBcN/4NBWFcADrywBJRIFgQPIBIYGAAuDf+AQ0XUYBILrxBA/A8NCA3/icxWtOCesMAQkPDik/9tWp3/iMFQnrAQISDw4qP/bNqQnrDAIJ6wMA0vgE4MJgCesBAENoDvAEAhpDBtHf+GQVACNJRAHxJAZA4AnrAQPf+FgV3/hcJd/4ZGXf+GR1SURKRE5ET0TZYt/4QBXD6QJ2A/FQBklEw+kHId/4OBXf+DglSURKRMPpBCHf+DgV3/hIJUlESkTZZt/4LBVJRJlm3/goFUlEGWPf+CQVSUSZYt/4IBVJRMPpFSHf+CAVSURZZt/4HBVJRFljACHf+BQl3/gUdd/4JAXf+BxFSkRIRExESfgHIAnrDAKTYQnrBwMRYt/4+BTf+Px0M2Df+PBkCesBCN/4+BRPRAnrBgrf+PRkw/g8gElETkTD6QlhA/EsAd/48GSB6JEE3/jcBN/46HTf+NgU3/jYRE5ECesACN/42AQJ6wEKCesEC9/40BTf+NBET0TD6QVrw+kHqEhESURMRMPpAwcQacPpAUGosV/qjnAOTk/wAQB/9R6pDUlqHElESHCKcAHrxQEJ6wwAiGBA8gEwiID/9xC5ASAETv/3C7mcKAAArCUAAJArAAAIAAAAuCsAALwlAAAcDAAAXA0AAPwfAADcIwAAmA4AANANAACADQAAqA0AAOgOAAAQDwAA+A0AAGAPAABwDgAAiA8AAMAOAAA4DwAAIA4AABwlAABIDgAAXAAAABwAAACIAQAAdAEAAGABAABMAQAAOAEAACQBAAAQAQAA/AAAAOgAAADUAAAAwAAAAKwAAACYAAAAhAAAAHAAAACwDwAAeCAAAAQkAADsEAAAJBAAANQPAAD8DwAAPBEAAGQRAABMEAAAtBEAAMQQAADcEQAAFBEAAIwRAAB0EAAALiUAAJwQAADcAQAAnAEAAAgDAAD0AgAA4AIAAMwCAAC4AgAApAIAAJACAAB8AgAAaAIAAFQCAABAAgAALAIAABgCAAAEAgAA8AEAAAQSAAD0IAAALCQAAEATAAB4EgAAKBIAAFASAACQEwAAuBMAAKASAAAIFAAAGBMAADAUAABoEwAA4BMAAMgSAABAJQAA8BIAAFwDAAAcAwAAiAQAAHQEAABgBAAATAQAADgEAAAkBAAAEAQAAPwDAADoAwAA1AMAAMADAACsAwAAmAMAAIQDAABwAwAAWBQAAHAhAABUJAAAlBUAAMwUAAB8FAAApBQAAOQVAAAMFgAA9BQAAFwWAABsFQAAhBYAALwVAAA0FgAAHBUAAFIlAABEFQAA3AQAAJwEAAAIBgAA9AUAAOAFAADMBQAAuAUAAKQFAACQBQAAfAUAAGgFAABUBQAAQAUAACwFAAAYBQAABAUAAPAEAACsJQAALAwAAKwWAADsIQAAfCQAAOgXAAAgFwAA0BYAAPgWAAA4GAAAYBgAAEgXAACwGAAAwBcAANgYAAAQGAAAiBgAAHAXAABkJQAAmBcAAFwGAAAcBgAAiAcAAHQHAABgBwAATAcAADgHAAAkBwAAEAcAAPwGAADoBgAA1AYAAMAGAACsBgAAmAYAAIQGAABwBgAAABkAAGgiAACkJAAAPBoAAHQZAAAkGQAATBkAAIwaAAC0GgAAnBkAAAQbAAAUGgAALBsAAGQaAADcGgAAxBkAAHYlAADsGQAA3AcAAJwHAAAICQAA9AgAAOAIAADMCAAAuAgAAKQIAACQCAAAfAgAAGgIAABUCAAAQAgAACwIAAAYCAAABAgAAPAHAABUGwAA5CIAAMwkAACQHAAAyBsAAHgbAACgGwAA4BwAAAgdAADwGwAAWB0AAGgcAACAHQAAuBwAADAdAAAYHAAAiCUAAEAcAABcCQAAHAkAAIgKAAB0CgAAYAoAAEwKAAA4CgAAJAoAABAKAAD8CQAA6AkAANQJAADACQAArAkAAJgJAACECQAAcAkAAKgdAABgIwAA9CQAAOQeAAAcHgAAzB0AAPQdAAA0HwAAXB8AAEQeAACsHwAAvB4AANQfAAAMHwAAhB8AAGweAACaJQAAlB4AANwKAACcCgAACAwAAPQLAADgCwAAzAsAALgLAACkCwAAkAsAAHwLAABoCwAAVAsAAEALAAAsCwAAGAsAAAQLAADwCgAALenwTYiwDhgHqZtGkkYwRv73CvwIsQEgMeAHnBlIT/AACCF4AevBAUhEAOvBBQAhBfEUBzhGAPAn+GFoyGiKaTMaqGlCsQfxCALN6QCyGkZTRv33F/kP4ApqB/EIBAElT+pbBpJozekAas3pBFTN6QKCASL79y76ACgYvwEgCLC96PCNuCsAALC1BEZAaA1G+/dh+KhCB9BgaClG/ffs+iBGZCH+9wj+ACCwvXC1HUhZ+ABAtPH/PyVGAtz690D9ACUZSAXrxQFIRADrwQAA8RgGAS0i2AAsA9QwH2Qh/vfr/QEgASECIgEj/ve/+AEgASEDIgEj/ve5+AQgAC0IvwMg/ffH/Fb4SAsBaCHwAEEBYPr3Uf8BNQAs2tT69xD9ACBwvbQrAAC4KwAA+LUORmlGHEYXRgVGGGD+93X7CLEBIPi9AJkPSAl4AevBAUhE/vf++DhGKUYyRvr3iPxAsQAhjkIH0HhcalyQQgXRATH35wAgA+ABIAHgASAORnEZIWD4vbgrAADwtYx5CCXAsk/wAAxP8AAOBevEBAAlLkYINaVCD9gORDd6h0IEv/d7/y/00Xd6vkXx2LZ6AS4Ev6xGvkbr57zxAA8K0AHrDAABeZFwQXlRcIF5EXDAeIAAAOAAIBhw8L0AIwJrBikTcSzY3+gB8AoEIhIEBBkAAiMBIcNjwGo1IxzgT/D/McFjwGoRYAFgACEW4D4hEWCAIcFjwGo/IQXgMSERYAIhwWPAajUhAWABIQbgQCMBIcNjwGoFIxFgA2CRd4F3cEdwtQNGAGgEKBHRW2lP8P8wACQYYEh4wPNDBR0gBSwf0CX6BPb2Bw/RAjABNPbnHSAKXP8qA9EiKBHYAjD451tpASGZdxpgE+AlKAnQBDEAJQQtCdBOXQE1AvgMa/jnW2n/IBhxACBwvQldASKadxlgACGZgHC9LenwTYqwnEYIkAt5ACANRgAnAysF0ZX4JBABObH6gfFPCY34JAAJqQMoBNAMGBZcATBmcPjntfgA4JX4IABseZX4JKBP8AMIbn8AL0/wAAscv0/wBAgKRs3pAoQInM3pBGwUns34GLBO6gAhzekAoiBGOkYHlv33Pfp4uStpan9peSBG/fdS+UC53ekSIWh9K33N6QAGIEb992r4CrC96PCNASFP8P8ygXcSIf73IbgBIU/w/zKBdzQhgmABYAIhAXUAIQFhAXOBgHBHASFP8P8ygXcCIf73DLgAALC1HkwAIHxEoEcTTRNJSfgFAEn4AQAKIKBHEUkTSkn4AQBZ+AUAD0lJ+AEADkkBRADy5zCx+/LxDUpJ+AIQT/R6cbD78fALSUn4AQAAIKBHCUlJ+AEAsL1cLAAAZCwAAGgsAABsLAAAP0IPAEBCDwB0LAAAcCwAAGAsAAAz1///ELUdSHhE+veT/RxMASABIQAifESgR0DyARABIQAioEcBIAAhT/D/MqBHBSAEIQDwcfhkIP33Zv8BIP33U/tQuQEgACH992z7ASAAIf33VPsBIP33IftA8gEQACFP8P8y/ffc/v/3jP8CSAFoQfAAQQFgEL0EEEBSLAQAAAfe//8NSBn4ABCpuQEhACMJ+AAQCkkJaAHwf0KJsrLxgk96Rgi/CwkJ6wABQugA8kuAwvOAUkpwSERwRw4AAAAA7QDg//fkveC1AZABq//3H/4BmIy9AAAESAAhSfgAEANJSERJREFgcEcAvxQAAAB4LAAAAAEHShNYEFibsgAMy0DIQMAHT/ACAAi/A/ABAHBHAL8EAEFSsLUNRgRG//fp/wIoHL8FSLC9ASAhAQRKqEBTWBhDUFAAILC9/wBCAAAAQVL+54C1APD6+ADwEvi96IBAAPAeuIC1APBh+b3ogEAA8F65gLX/9+3/veiAQP/38r+AtQEgASECIgEj/fdn/gEgASEDIgEjveiAQP33X74AAC3p8E1PSAnrAAf/93H/QHhQSTpGgPABCEtIi0bH+DSACesABElIxPg0gAnrAAVISMX4NIAJ6wAKAfUgcAAhyvg0gFlOfkSwRwv1gHAAISJGsEcL9UBwByEqRrBHC/VgcAAhUkawRzxIC/HjdQAh/fed/jpIASH995n+OUgCIf33lf44SAMh/feR/jdIBCH9943+NkgFIf33if41SAYh/feF/jRIByH994H+M0gHIQnrAAIySML4NIAJ6wAEMEjE+DSACesABS9Ixfg0gAnrAAcL9Shgx/g0gLBHWEYAISJGsEdYRgEhKkawRwv1wGADITpGsEckSAvx5XQAIf33kP4iSAEh/feM/iFIAiH994j+IEgDIf33hP4fSAQh/feA/h5IBSH993z+HUgGIf33eP4cSAchM0YJ6wACIEa96PBNGEcAv6wnAADoJwAAJCgAAGAoAAAAAIFSzCUAAAgmAABEJgAAgCYAALwmAAD4JgAANCcAAHAnAACgKgAA3CoAABgrAABUKwAAwCgAAPwoAAA4KQAAdCkAALApAADsKQAAKCoAAGQqAACdpv//LenwQTFJ3/jAgAnrCABJREFg/fdj/QIkIEb995v9ATxgHPnRKkwBIAAhfESgRwIgACGgRwMgACGgRwQgACGgRwUgACGgRyNOASACIX5EsEchTwEgACF/RLhHIE0BIH1EqEcDIAIhsEcDIAMhuEcDIKhHBCACIbBHBCADIbhHBCCoRwAgACGgRwAgASG4RwAgAiGwRwIg/fdd/QnrCAECIP33cf0QsQMg//es/gIgQvIQcf33Wv0QsQMg//ej/r3o8EH/97+9AL8UAAAAeCwAAMPU//+V0///Y9P///vS//9wR3BHlgAAAMAAAAD1AAAAOQEAAJABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhfz//wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAIAAAAXAAAAAAAAAAAAAGAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAWgAAAAAAAAD/////AAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAgAAABUAAAAAAAAAAAAAYAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAABaAAAAAAAAAP////8AAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAACAAAAFQAAAAAAAAAAAABgAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAFoAAAAAAAAA/////wAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAIAAAAVAAAAAAAAAAAAAGAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAWgAAAAAAAAD/////AAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAgAAABcAAAAAAAAAAAAAZAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAABaAAAAAAAAAP////8AAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAACAAAAFQAAAAAAAAAAAABgAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAFoAAAAAAAAA/////wAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAIAAAAVAAAAAAAAAAAAAGQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAWgAAAAAAAAD/////AAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAgAAABUAAAAAAAAAAAAAZAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAABaAAAAAAAAAP////8AAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAABAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAEAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAABAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAEAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAABAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAEAAAAAAABAAAAgAAogMAAADRAQDbAQAAAAAAAAAAAACAAAAAAAAAABAAAAAAAAQAAAIAAKIDAAAA0QEA2wEAAAAAAAAAAAAAgAAAAAAAAAAQAAAAAAAEAAACAACiAwAAANEBANsBAAAAAAAAAAAAAIAAAAAAAAAAEAAAAAAABAAAAgAAogMAAADRAQDbAQAAAAAAAAAAAACAAAAAAAAAABAAAAAAAAQAAAIAAKIDAAAA0QEA2wEAAAAAAAAAAAAAgAAAAAAAAAAQAAAAAAAEAAACAACiAwAAANEBANsBAAAAAAAAAAAAAIAAAAAAAAAAEAAAAAAABAAAAgAAogMAAADRAQDbAQAAAAAAAAAAAACAAAAAAAAAABAAAAAAAAQAAAIAAKIDAAAA0QEA2wEAAAAAAAAAAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQUGAAAAAAAAAHGAAAZDAAAAAQAAAAAAAAACAAAAggAAAAEAAAAAAAAAAgAAAIIAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAAAAGQAAAABAAcHBwcHAAEAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACgAAABsAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAABgAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAAAAGQAAAABAAcHBwcHAAEAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA8PoCgPD6AoDw+gKA8PoCgPD6AlDDAAAyAAAADwABAAAAAAAAAAAABwgBAAwFAwYHBAAUFAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  instructions: ELUERgXwIPggRgEhvegQQATwoLgt6fBNiLAORgdGb01vTADwFfmnQgX1IHEEkQKQCdAE9aArAS4R0AIuFdFnSAAhgkYp4AT1gDsBLhfQY0gCLoJGGNEA9YBwACEd4F9IACGCRgD1KGAX4FxIAyEELoJGGL8A9cBgCL8BIQ3gV0oAIQSYkkYI4AD1YHAAIQQuCL8K9UBwCL8HIQAlDiIBI0/wAQgAlQDwnfhYRgAhDiIBIwCVAPCW+Ar1YHAELgi/CvVAcAaQUEYYvwD1wGAFkAi/ByUHlVBGAyVP8AQKAPWAcAQuCL8BJQOQuvEAD0bQp0LL+AyACNABLg/QAi4ZvwWZKEYAIDVJD+ABLgvQ3ekGEAIuBL8AIAOZBuAvSAD1KGEAIAHgACAEmQj6APDIYAEgA/BP/adCCNABLg/QAi4ZvwWZKEYAICRJD+ABLgvQ3ekGEAIuBL8AIAOZBuAfSAD1KGEAIAHgACAEmQj6APDIYAEgA/Au/arxAQq156dCB9ABLg7QAi4USA7QBZgpRg/gAS4L0N3pBgECLgS/ACEDmAbgDUgA9ShgACEB4AAhBJgIIgEjAJIOIgDwE/gbIAAhDiIBIwCQWEYA8Av4ApgIsL3o8E0A8D+4AL8AAIFSAABGVPi1FUYGmh5GD0YERgDwPPoBIQbwAQAiaLlAuEAi6gEBCEO5ACBgDyBibIhAI2+CQyPqAACALQbRCCMD+gHxCkMIQ2JkBeAF8A8DA/oB8RFDYWQgZ/i9AAAAAAAAgByACAPQQByAHvzRAL9wR+/zEIBytnBHgPMQiHBHU+oCDADwaYAt6fBLT/AABgArH7+z+oP1A/oF9CT6BfZeQBK/FkOy+oL1AvoF9MXxIAUevyL6BfxE6gwEIDVW6gRMT+oURBi/ZBxP8AAIT/AACZBCcesDDDnTACkZv7H6gfcB+gf2sPqA9wD6B/bH8SAHHr8g+gf8RuoMBiA3tvv0/KfrBQcQPwfwHwvL8SAGLPoG9gz6C/tEv7NGACYgL6S/XkZP8AALW+oGDAi/T/ABCxnrCwlI6wYIq/sCfAb7AswL+wPMwBtx6wwBwecLRgJGQUZIRr3o8IsTtQhDGL9P8P8wAUav8wCAvegcQHBHQOoBAxC1mwcP0QQqDdMQyAjJEh+cQvjQILoZuohCAdkBIBC9T/D/MBC9GrHTBwPQUhwH4AAgEL0Q+AE7EfgBSxsbB9EQ+AE7EfgBSxsbAdGSHvHRGEYQvU/wAAIAtRNGlEaWRiA5Ir+g6AxQoOgMULHxIAG/9PevCQcov6DoDFBIvwzAXfgE64kAKL9A+AQrCL9wR0i/IPgCKxHwgE8YvwD4AStwRwhIfLV4RACQB0h4RACcBUYBkATgIEYBaAhEgEckHaxC+NF8vWRUAABiVAAAFkgAIU/w/zIaSwn4ABAUSEtECfgAEBNICfgAEBJISfgAIBNKEUgp+AAQSERKRMDpFTITSwF1gXAQSQ9KgmFJREtEwOknMQL1gCEBZgEhgPhcEKD4RBCg+IwQcEcIAAAABAAAAAwAAADEHgAAyB4AAMwYAACsGwAAAABGVLwYAACgHgAABPAUuC3p8EWHsAZGGEgPRnAhkEZP8AAKGmsBJB1GrfgaoCn4ABBIRDl4zekCos3pBEMAIkDyVVPN6QBAMEYA8Ab8KGsN8RoCOXgAI83pBEXN6QBCzekCCjBGASIA8ML7vfgaEKj4ABAHsL3o8IUAv3gMAAAt6fhFBkZSSAAuAPCfgBdGACoA8JuAMEYAIg1GAPDo+KwAByBxbmwioEAh6gAAuWkB8AcBoUAIQx8hcGZv8B8ABC0A68UAOL/oADi/aCL7aQH6APyxWAPwHwMh6gwBA/oA8AhDKUawUDBGOnoA8HL4DyBP8AgIAPoE8XBse2jX6QOu1/gUwCDqAQID8A8AgCsIvwggoEAQQzJvIuoBAXBkgCsI+gTwB/EgAwi/AUMxZ2gAAyIK8AMBgUAC+gDwMmwi6gAACEMBITBkDvABAAH6BfqxaahAIeoKAQhDsGEM8AEAsWyoQCHqCgEIQ7BkT/R+cA7LAOqFDNfpCwQB8AEBYvNBAQPwAQIA8AMAQeqCAUHqwABhAcmyCEQxbQD6DPAh8P8BCEMpRjBlMEa6awDwp/g4aClGACgIv0/wBAhG+AigMEZ6awDwU/gAIL3o+IUBAFoAcLUdSx5MA0SgQgvQHUygQgjQHUygQgXQHEygQhy/HEygQiHRHE0VTAX1mCYF9YAlsEI6v0TyAAXF8kZFo/WAIwTq0wAoRG/wHwQEKSi/BDADaALwHwIE68EEOL/MAB8hokChQAPwBrsKTKBC2tAD8Mf6APGlQObnAAC5q/D//x8AAEdUgABHVAABR1QAAEtUAAFLVIAAS1QAQEZUcLUZSxtMA0SgQgvQGkygQgjQGkygQgXQGUygQhy/GUygQhnRGU0STAX1liYF9YAlsEI6v0XyAAXF8kZFo/WAIwTq0wAoRALwAQIBI4pAA/oB8QNoA/DAugtMoELi0APwgfoCSxhE7ucAALmrABCAUvD//x8AAEdUgABHVAABR1QAAEtUAAFLVIAAS1QAUEZUELWJAAcjRGyLQCNABG/MQATwDwSE8AgEI0NP8AADCL8C8A8DA/oB8g8jA/oB8UNvI+oBARFDQWcQvQAAAUlJ+AEAcEd0DAAAMLEDIQFigWpJB/zUACBwRwBIcEcEALIAATjCsgZIByoI2Isj00DbBwTQBKBQ+CIACGAAIHBHAL8EALIAAAAAAAEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAMAAABP9EBxACIBYAhJgWAAIcD4gBDA+MAQwPjIFwD1AGCy9QB/CL9wR4FQgDL45wDQgADwtSxLAChS0AApUNAAKk7QTH5MsQ1oFbmS+CogIrOKfgIqRNMNKkLYCn46sUpplyoK0gAiwPjYJyRKJOAAIsD42CciSggyHuAhTgAlfkQELS3QVvglcJdCBNgG64UHf2i6QgfZATXy54p+Aiof0wwq2tkc4BCiFEtS+CUgAvADAgXrgkIaRATwAwPMf0LqAxKLfpH4IBAD8A8DQuoDIgTwAwNC6gNSACNC6sFxgWAYRvC9AL8EALIAAAAAAAAAAAABAAAAAwAAAIDQggAE0IAAbE8AABC1BEYAIAhgiGDIYEhhCHYiaELwAEIiYEhgCGGgaEAHC9SgaAAHCNRgaMAH/NAKIAPwSvlgaAAo/NQQvQJGATkAIAcpENjf6AHwBAoPBw8PDw0C9QBgcEcC9RBgcEcC9QhgcEcC9RhgcEcAAAJGATkAIAcpENjf6AHwBAoPBw8PDw0C9QBgcEcC9RBgcEcC9QhgcEcC9RhgcEcAaADwAQBwRwh+cEcAABC1Ux4D8B8DACkD8YBExGQETGTzXxKCZQNKGL9D6gIBwWYQvQCIAAQAAAJALenwTYiwLU6DRqogFEYAIgEliEYJeEDyVVMp+AYAACAJ6wYKrfgeACBrzekAWs3pBFTN6QIgWEYhT39EuEdVIJj4ABAAIkDyqiMD8Bb5gCCY+AAQACJA8lVTA/AO+aogmPgAEAAiQPJVUwPwBvlVIJj4ABAAIkDyqiMD8P74ECCY+AAQACJA8lVTA/D2+GQmDfEeB1hGA/DA+QPwrfkD8LX5AdQAKPXRACgEvwIlwPKyBShGCLC96PCNAL94DAAAoQIAAC3p8E2IsDFOgkaqIAaSAScAIohGCXgcRin4BgAYawnrBgvN6QRzQPJVU83pAiDN6QB7UEYmTX1EqEdVIJj4ABAAIkDyqiMD8OT4gCCY+AAQACJA8lVTA/Dc+KogmPgAEAAiQPJVUwPw1PhVIJj4ABAAIkDyqiMD8Mz4MCCY+AAQACIGmyn4BgAga83pAHsCkgAmBZTN6QMHUEaoR634HmBkJg3xHgdQRgPwVfkD8EL5A/BK+QHUACj10QAoBL8CJcDysgUoRgiwvejwjXgMAADhAQAA+LUMRg9qCXgAJhVGATkHKRDY3+gB8AQKDwcPDw8NAPUAZgfgAPUQZgTgAPUIZgHgAPUYZoFoAfRAEbH1AB8Cv7FqQfCAcbFiAWjJByHRlfg0EIkHHdU5eB5LenhP8AAMGUMaQzFkT/TgIXFkxvhIwDFlMmZxZsb4aMAxZ+FoIfD/AbFgeWhJQiHw/wHxYAchMWKAaLpoAPRAELD1AB8IvwE6uXgwRv/3yf4BIE/0AEGF+CwAuGgoY2BoAeqAICF/AfAHAUDqATADSQhDMGAAIPi9AL8AAAdAAQAAgC3p8EWJsAPwY/gIrM3pBGFK8j8BA/B6+ED0AEABQFBGAvDs+RCxCbC96PCF3ekSEBH6APAH0EMeUEYDIQEiAvAh+QAo79Hd6RAhFJhSADixASADI83pAAhQRgLwMfji5wPwePgC8Nr43ect6fBFibAD8C74CKzN6QRhQvI/AQPwRfgBQFBGAvC5+RCxCbC96PCFEpgBKAnRE5g4sUMeUEYAIQAiAvAO+QAo79Hd6RAhFJhSADixASADI83pAAhQRgLwOvri5wPwRfgC8N363ect6fBNirAHRkFI3fhcoA5GFJwN8SYLT/AACM3pBzIA8YIFEpiARW/Q1Ls6SqogMXhA8lVTKfgCAAnrAgAVRgEiBpDN6QAgACAD8CX4MkwImnxEoEdVIDF4CJpA8qojKfgFAAEgBp0AkAAgAZUD8BP4oEcoSaAgpEYImkDyVVMUnCn4AQABIDF4zekABQAgApAVmAOQFpjN6QQKOEbgR4C7E5gBIjF4ApQA60gAzekAIBWYCJoDkBaYzekECgeYCOsAAzhG//dp/wyxBUYW4AAgZCSt+CYAOEYxRlpGU0b/9zf7AvDn/734JgABPAAGT+oEQAHUACju0RScILEI8QEIj+cFRgDgAk0oRgqwvejwjQIAsgB4DAAAR////y3p8EEERi9IVLMNRkGzO7MAIBhgmGDYYFhhGHbYYYP4LAAYYlhgGGHD6QwAw+kJICBosPH/PwTcwAccvwAgvejwgdT4yAcpRhpGIPADAMT4yAcgRtXpAGjvaP/3zfwIsb3o8IEG8AEACPAHAWfzGGBA6gFGqX4gRgLwgPiwuel+BPUAYALwiviAuSl/BPUIYALwhPhQuWl/BPUQYALwfvggual/BPUYYALwePhqaQZJkghKKoi/AfWgATFDIWC96PCBAL8EALIAAANQAPC1hbCLadxpjLEjeCR5CXgBJQSS/yYAJ83pAhUZRiJGACPN6QB2AvB4+AWw8L0BSAWw8L2AALIAcLWGsBRGBUYIeAAh/yIKns3pABICqkPCGUYoRgAjACIC8F/4CLEGsHC9CpYoRiFGASIAIwawvehwQAHwwb4AAC3p8E2KsIBGK0jqsYNGiGkWRgAimkYPRkVpBGgAIAmShEIE0DFcATBB6gIi+OcJqThGAfBx/AFGC/F8ACWxWUUcvyp5/yoC0QqwvejwjQmYACkA8QgDKEYIvxhGAyoAaB3RACkYvwXxIAMZaGp/T/ABDJX4JDA9eEDqASADJ83pAkfN6QA2BKuBskBGzfgcoIPoJBABIgMjAvAY+NTnOXjN6QBCASMCrIToCgTBskBGM0YB8Pb/x+cEALIALenwQYiwi2ncaHyxAvAQ/k/w/w7N6QbC2h7N6QRhzekCXgLwM/4IsL3o8IEBSAiwvejwgYAAsgAt6fBBhrDd+DCAFEYdRg9GBkZCRv/32P/YubppASDRawIpT/ABAQbREWsJaAEpT/ABAQi/AiE6eAAjzfgQgM3pABPN6QIgMEYpRgAiI0YB8K7/BrC96PCBcLUURg1GBkb/97L/KLkwRilGIkb/9xL/ALFwvahpT/R6cSNGQGwA+wHyMEYpRr3ocEAB8G27AAAt6fBNjLCKRp0YFkYAIR9Ga0va+BggpfEBC83pChHS+ASAw0WA8MiAB5CQaQOSCZEGkBBsMkYBkAmpUEYB8Kr7BEaouQmYmLFaRgVo0PgMsAmpUEYCkgHwnfsERnAbsPv78AD7C1b0sd34CLBUSzDgU0uYHIRCLNEGmrX78vC2+/LxAPsSUAH7AvZAsagYAjiw+/LxAfsSAclDAOsBC6vrBgAAJBTgCZgCmgFowGhSGgEysvvw8wP7ECIAKhi/ATMD+wAQACQ+S6DxAQur6wYARxzDRXDSB5gAaAiXwAcMvwAg//cX+ACQBpgUnw3xLAgHnc34CLAImQApVdAGkFBGCqkyRgHwRvvN+BSwcLkKmdHpACPR6QMUBpED+wEhAZRKHgKZkUI4vwpGBZIBmU/0enJRQwSRBZmOQiXSB5hRRjpG//f5/vi5A5gxRgBoAvDV/fzRKEZRRkJGO0a7Rv/3jf6wuShGUUYEmltGAfC0+gRGBpgImYFCEdkJGgZEACAALAiR19AA4ARG3fgIsAaYsecCmQRGX0YGmItGq+cAId34CLAIkabnB5gAaMAHHL8AmP73s/8jRhhGDLC96PCNBACyAC3p8E2MsIRG60i88QAPGL8AKQLRDLC96PCNlkYAKvnQ0fgEsLvxAA/00A9oAC/x0ETyEABP8AAKQPIKJs34LMAHl2BECZDdSGBECJAAIAWQA5BXRQDwAYJb+CogACoA8KWACZhB9hsxAWAbIQFh7iEImAFgCyHA+IAQQPIHcUFiByHA+KQQXPgmAEDwAQBM+CYAXPgmAEDwEABM+CYAlGlQaM74NABUswqWFniARmBGXUbzRhdGMUb/9/j6ACgA8M6BO3oBaDpGY/MJIQFgX+pIcSfVB0YGkguYIUYyRs34ALAB8L/7yLEIIAWZ3fgswN5Gq0YA+grwAUMFkVTgEGoAKADwrIERRmBGckZ0Rv/3zfvd+CzApkYDkEfgBpo4RtL4BIDd+CzAX+qIcQHU3kY54M34CIDeRtz4ABDJBzLR1GgGRhNGEWlSaatGJPD/AAaTm2mwYEhCIPD/APBgHGjT+AiAGWpjHgPwBwMAKhi/A/WAcwSWM2ICmMIGGtS48QAPB58KngDwioDY+AAgUxww0Jj4BDDSsgPwAwNC6gNCAvGAQifgq0YHnwqeIDYK8QEKTue48QAPB58KngDwr4DY+AAgUxwt0Nj4IDDSspj4HkBj8w8imPgkMAPwAQNC6oNCmPgEMAPwAwNC6gNCQuqEchjgACIEnE/0QDMiZJj4BSAD6gJCYmTY+AggUxwx0Jj4DDDSsgPwAwNC6gNCAvGAQijgACIEnE/0QDMiZJj4BSAD6gJCmPgdMGPzkkJiZNj4CCBTHDnQ2PgYMNKymPgXQGPzDyKY+AwwA/ADA0LqA0KY+BwwA/ABA0Lqg0JC6oRyJOAAIgSYT/AAdIJk2PgQIFMeZPNfEwAqCL8TRsNkmPgUIE/0QDMD6gJCAmUAKQDwqoAKaFMcFtALedKyA/ADA0LqA0IC8YBCDuAAIgSbmmTY+BAg4rEBOpj4FjAC8B8CQuqDchXgACIEnE/0QDMiZkp5A+oCQmJmimhTHC7QC3vSsgPwAwNC6gNCAvGAQibgACIEmE/0QDTCZJj4FCCY+BUwBOoCQmPzkkICZQApatAKaFMcJdALatKyjH9j8w8ikfgkMAPwAQNC6oNCC3kD8AMDQuoDQkLqhHIT4AAiBJhP8AB0gmYKaVMeZPNfEwAqCL8TRsNmT/RAMgl9AuoBQUDgACIEnE/0QDMiZkp5A+oCQkt/Y/OSQmJmimhTHBbQi2nSssx9Y/MPIgt7A/ADA0LqA0ILfwPwAQNC6oNCQuqEcgXgAL8EALIAxAABAAAiBJuaZgppUrEBOot9AvAfAgArQuqDchi/AvUAMgDgACIEmMJmCn1LfU/0QDEB6gJBY/OSQQFnmPgVAASZBpoLRo74LAABKAK/iGpA8EBwiGLc+AgAAPRAELD1AB8Cv4hqQPCAcIhiApwE8AgABPABAUHqQAAE8CABQOqBIBF6En8B8AMBQOoBIALwBwFA6gEwAPEAQBhgqOYDmADgA0gFmQApGL9B9DIA0+UEALIALenwTa31Jn0FRgh4ACSR+AigCpOTRgmRDpCIaY34+UCN+PhAjfj3QI34w0CN+MJAjfjBQAyQQGsNkP73Uf0LkA31hngAIIAoA9AI+ABAATD55w+VACAN9YNxDfIJEg3yAxNArA3x/QcN8foGACUDLQfQSFVQVVhVYFV4VXBVATX15w+cDp1SRiBGKUYB8MD7IEYpRv73BvwNmeNIObE4IA3yCRIrRs3pAAgC8M76ACha0Z34DAFTKFbRnfgNAUYoUtGd+A4BRChO0Z34DwFQKErRnfgRAQEoRtGd+BBhQ6kN8gkSDfHDA0/0f0AD8F78nfjDUMxIgEbFs0Osy08N9YNyDfHCA0/2hHB/RCFGuEcN8gMSDfHBA0/2gXAhRrhHQKo+q0/2h3AhRrhHDfH9Ag3x9wNP9gVwIUa4Rw3x+gIN8fkDT/YKcCFGuEed+MEQCEYIkbRIAPF8CHmxgC2cvwiYgCgC2A/gr0iARguY/ve7/EBGDfUmfb3o8I0AIAyZgC3B6RMA8dgAlUOs3ekNE66YDfIJEgKQD5gBlAPwpPwxrd34MMCARgTxHQAAIQEi3kYYKQzQEPgBPBD4AksF+BFABetBBAL6A/MGMWNg8OdEmpdIURwQRMkIACpIv0DwAEGd+A4BzPgEEMDzQQACKAzQASgE0AAoDL8DIAAgBuADILHxgH+IvwQgAOAEINzpAxIGJNz4KDAEJQxgACQMcRVgFHHM+AAAASDM+DgAiHcFIBxxvvECDxhgDNOd+EYBCpkALhi/wPMCEWBGA/De+934MMDeRmAh3PgIUNz4HAAEcQFgnrOd+DQBASE3RgAJAfoA8LD1gH8ov0/0gHDM+CQA3elMEMDzQXLA8wQkAyoavw/2DFNT+CIgT/R6QoMET/AGA1i/AyMBNAT6A/MeJATqQAYE6kEBwPMEYAIxATACNkhDc0NQQ8zpEQMN4FlIT/R6QTdGzOkREE/0gHDM+CQACpgAKAi/hkYK8P0BnfgOAQEpEdC+8QIPDtOBBg31hno+RibUQAZG1Nz4AAAEKEDw6IBP8P8LFeG+8QAPDfWGehi/EPAQASfRvvEADxi/EPABAFrRAyBP8AELT/D/MT5GKGAAIIX4HrCpYCh1KGGogKTgAAcr1J34FQGd+BQRASKqdyhgT/QAcCApqIAB8B8ASNJP8P8xTOCd+BoRnfgbAU/0gHKqgChgAfAfACApUtJP8P8xVuCd+BcRACCogClgnfgWESApV9JP8P8wWOAILtHTCZhAaBDwQADM0Z34ZQGd+GQRACKF+CQgKGBA8gEQICml+B0AT/QAcKiAAfAfAIDwDIJP8P8xEeKd+BkRACA+RqiAKWCd+BgRICk90k/w/zA+4ADrURDqdQIi/yEqcwI4KGGpYAixASCodQIgT/AFCzrgAL8FALIAnzgAAP3//3+ghgEAAOtREAEi/yHqdSpzBDg+RihhqWAIsQEgqHUBIE/wAwsg4AEhKHP/IOl1qGBP8AQLnfgWARDwHwAoYRy/ASCodQIgD+ABIShz/yDpdahgT/ACC534GAEQ8B8AKGEcvwEgqHUBICh13PgAAAQoHtGd+EtxeAYm0F/qh3on1dz4DABP8AAIILP/IwF4AnkBIHRGzekAgw6bzekCMK6YACMC8Jj43fgwwKZGgEYR4Nz4IAAD8GT7Q6kxqgyYA/C++t34MMBd4MpIAPF7CCDgT/AACPgHAtG68QAPF9W48QAPDfWGehTR/yEAIgEgACN0Rs3pACEOmc3pAhCumLchAvBp+N34MMCmRoBGAeAN9YZ6ACEN8UEAACKAKgLQgVQBMvrnuPEADxHRnfjCEA31g3J0Rs3pABDd6Q0TrpgCkA+YA/C3+t34MMCmRoBG3PhoAJCx3PhsEHmxvvEDDwi/uPEADwDw5oBP8P8yACMKYIt3zOkcMgJgg3e48QAPAPC+gAEg3ekONDGtwLMA6woBASIR+AEcAvoB8cz4GBBWs0yZHiIF8QgDACQP9swVAupBAgIyHCwS0CH6BPbG80EnxvMEFgMvFL9V+CdwT/R6dwE2BzRWQ35DQ/gMa+rnGzgxqd3pDjRACADrQAAB64AAUPgEDAHgT/R6cMz4QADc+FAAACgA8JGACJgN8gMSDZnN6QAKAfD//4BGACh/9Iythq0AIAAhQ6sEKQLQaFQBMfrncEhP8AALDJ4A8QEIACDN+CiADZAT+AsAgAdn1FtEACAP9jAXnHiN+IwBWXiT+AOgogkDKhi/B+uCBjJoE0QEM8ayskIE2fdDATDfXa9V9+cAkgAiDpgrRs3pAgKumAGSAfCg/wTwDwGARg8pCL8IITGxuPEADwPRD5gB8Fb4gEa48QAPDJ4X0a6YASIAIwCQD5hjqQDwZf8IsYBGC+Cd+IwBT/AACBDqCgAYvwEgDZlA6kEBDZEMngvxCAsImINFQ6un2T9IAPECCBzlq/EBAN34QRAEKADy04Df6ADwA1hPU0oAiAdU1QwgxuC48QAPL9AKmIBFbtC48QAPf/QDrWzgBy7/9Bevnfj5oLrxAA8A8J2Bnfj3AAAoAPCYgdz4ZBAAKQDwk4EJmQl5SQYA8Y6B3PgIEJ34+HDc+DRAACIAIwqRhqmAKwDwOYHKVAEz+ecNmMCyA+sLAUp4iXiQQjHQC+uBAQHxCAsImYtF8tmo54gGfNTc+CAAj+AIBwjVvCB64MgGddTc+CAAm+BIB3LU3PggAJjgAOtREAEiAiP/ISp3K3PqdQE4KGGpYAixASCodU/0gXBP8AYLqII75gC/BQCyAAExX/qB+sb4TKCKRQDwsYAAIMbpEwDd+CTA3PgEAIEHQPGJg9z4ECAAKgDwhIMPnCFoyQdA8H+DDpkBOcmyBykA8nmDiyPLQNsHAPB0gw/ySHNSQlP4IRDc+AwwIvD/AiFE3OkFRSPw/wOLYMpgLmiqaCtqdR4F8AcFACwYvwX1gHXEBg1iAPF4gQAqAPCbghRoZRwA8FOCFXnksgXwAwVE6gVEBPGAREri7CAC4GwgAOA8IChg3fhBELvxCQ8t2AEi3PggAAL6C/IS8A4PGdES9Bh/EdDKBRLVASEAIoF3PiECYQFgAiEBdQFzT/D/MYFgT/QAcYGAEOC78QQPDdEKBgfUSQYC1APwPvkE4APwJvkB4APwKvnd+DDADfFBATGqYEY3RmZGA/CN+LvxCQ8Z0XFpQPIDNDJqASOMgEDyASQNaIH4JDCh+B1ADWJA8gMRgvgkMKL4HUCRggMhEXFRcRFoEWLd6Q40tEYxrT5GD+bNSdb4UOAAIk/0/3BP8AAIACUAJAIxDZFSRTLQC/EECyVEACQT+AsQAfAPBwEhOUII0WYcAOpBAQQsNEb30934NIAFJATrRAEN8cQMXvgicFP4C2Ac+CFADOuBAT1gvGDR6QEUPGEm8P8EBPWAdIxCLr+0+/H2ASYhRn5g+WABMsrnDJ6Z5s3pAAGumA3x/QIhRg6bApAPmAPwV/jIu534GQKws83pBkYKnAEmOUYCJ934MMAgYiBgQPIBEAApp3eE+CRgZnWgg0/w/zCgYEDyAzCggADwAoHc+FQAACgA8P2A3PhYEAApAPD4gA9GBkaFqmOoACEN9QR7g6sAJAQsAPCcgBFVAVUL+AQQGVUBNPXn3fgwwJ34QzDc+Agg3Pg0EA31hnqYBp34+AAR1NsGf/VurZ34T0EBI5N3FGBP9EB0lICd+E5BICxP0k/w/zNQ4J34TTGd+ExBN0YBJpZ3E2BP9EBzICyTgATwHwMC0k/w/zQG4APrVBPWdQMm/yQWcwE7T/AICz5GE2GUYAuxASOTdQMjE3WGqs3pAAKumAKQQKoB8C793fgwwAAof/Qvrd34UwKw8f8/P/cprdzpGhLDshNgwPMHIwtgwwDA8wdDwPMCYFi/T/D/M8z4dDABI5N3zPhwAIt3EeXTdQMjE3P/I5NgT/AHC534TjET8B8DE2HE0cXnACoA8FyBFGhlHADw74AVauSyln9l8w8kkvgkUAXwAQVE6oVEFXkF8AMFROoFRETqhnTc4AAhACJArAMqBNCjXAEyQ+oBIfjnAfEgAggxEwwSuo34DhISDI34FDKt+BUiCgoJDI34DSIEIo34DBLc+DQQzekAIK6YApCFqgHwvvwouZ35jwGw8f8/QPObgU/w/zAwYDhgDJhBawQgzekAC66YApCDqgHwqfxwuZ35EwKw8f8/Cdyd+BACnfgREoAJYfPDAAyZiWoIYd34MMAKnAInASYDIKZ1IHXc+AwQ3PgoIAtoCHGB+CRgj3cLYhQhACMhYRB1lnVWdRBxgvgkYJd3VndQcRFoEWIAItz4HBAIcQhogfgkYI93CGJjqN3pBhaAKgXQg1QBMvrnAL8FALIAzekAoK6YDfH6AgKQAfBd/N34MMAN9YZ6uLvc+GQAnfiPIQJwATqd+JcRBipBcBTYnfiOQZ34jCGd+I0xw3CEcAJxnfiTMZ34kCFDcQJynfiSMZ34kSGDccJxATkGKRTYnfiWMZ34lBGd+JUhwnKDcgFznfibIZ34mBFCcwF0nfiaIZ34mRGCc8FzT/AJC//3IrwAJAxkT/RANFV5BOoFRU1klWhuHCjQFnvtsgbwAwZF6gZFBfGARSDgACQMZE/0QDVUeQXqBERVf2XzkkRMZJRoZRww0JVp5LLWfWXzDyQVewXwAwVE6gVEFX8F8AEFROqFRETqhnQf4AAljWRP8AB3FWluHmfzXxYALQi/LkbOZBV9BOoFRAxlACsA8JiAHGhlHBPQHXnksgXwAwVE6gVEBPGARAvgACSMZBRp1LEBPJV9BPAfBETqhXQU4AAkDGZP9EA0XXkE6gVFTWadaG4cK9Aee+2yBvADBkXqBkUF8YBFI+AAJMxkT/RANhR9VX0G6gREZfOSRAxlACtf0BxoZRwi0B1q5LKef2XzDyST+CRQBfABBUTqhUQdeQXwAwVE6gVEROqGdBDgACWNZk/wAHcdaW4eZ/NfFgAtCL8uRs5mG30E6gNDOOAAJAxmT/RANVx5BeoERF1/ZfOSRExmnGhlHBHQnWnkst59ZfMPJB17BfADBUTqBUQdfwXwAQVE6oVEROqGdADgACSMZhxpVLEBPJ19BPAfBAAtROqFdBi/BPUANADgACTMZhx9XX1P9EAzA+oEQ2XzkkMLZ1J9rpuD+CwgAPAIAgDwAQMA8CAAQ+pCApz4HDBC6oAgnPgIIALwAwJA6gIgA/AHAkDqAjAA8QBACGBP8AAI//cBuZ34jRHAsv8iMWCd+IwROWDA80ERAjEC+gHxAPAHAslDkUAAB534jgFIv0/w/zAMmsLpFwFN5hAAAAAAAQAAoA8AAAEAAAAQAAAAgAAAAAAAAAADAAAABAAAAAAIAACACAAAAAgAAAAJAAAACAAAAAgAAAAIAACACQAALenwRYuwjmkVRgRGASCyaq34KgAAKk3QEHkDKDzRT/AADJL4JAAXag3xJApTeQl4T/AECM34JMCy+ADgUn/N6QAKOALN6QKDAyPN6QbFgLLN6QQhASJA6g4BIEYA8Gj8AUYIu7BqA2k7sUF5Qn8gRgDwovsBRri5sGoDeZD4JAABIg3xKgHN6QAFASggRgi/AiIA8K/6BuATeA3xKgIgRgCV/ve/+wFGvfgqABG5lvg4EAhAACgYvwEgC7C96PCFLen8TRdGGkaaRohGBkb/95f/uvgoEAAlybEAKEjQuUIovzlGjLIwaMAHA9EgRgHw6/kC4CBGAfDd+QHwbPo5Gzi/KUZws6dCD0bs2CrgeLO4CBlMoEI4v7wIT/R6cAQvOL8BJLT78PEB+xBAAZEf+oD7MGjABwbRAZgB8MP5WEYB8ML5BeABmAHwmvlYRgHwsfkB8ED6ORs4vylGELGnQg9G5tgQ8AEFHL8CJcDysgUoRr3o/I0Av0BCDwDwtYRpDEhjaJNCFNkCMCNti7HkbHyxHWguaJZCBtjV+ATA72gH+wxmlkIC2AQzATzw5wAgDWDwvQQAsgAt6fBNiLAERh1GDkaPaVFIASop0X9uAC8A8JiAOnh6sTB4T/ABDAAjATq5eASVzekAI83pAgz7HCBGACIA8If7engAKgDwgoAweAAmATq5egEjzekAJgKqKcIH8QsDIEYAIgDwdPtx4LluAClu0PpuACpr0NL4AIAIaPloem/R+ACwACETDAeRjfgcMBO6GwwBMq34HTA+0DJ4AyMN8RwKBJXN6QAxzekCIcGyIEYAIlNGAPBM+wAoSNEK8QMBIEYBIgAjAJVP8AAKAPCv+ei7l/hwAJ34HxAAIgAjCENf+ovxjfgfADB4zekAqgKQASDN6QMFIEYA8Cr7OLsAIgQjMHgBIc3pADICqyPDX/qI8SBGB6ul5434GxDDsg3xGwIgRjFGAJX+96H6eLmX+HAAnfgbEF/6iPMN8RsCAJUIQzFGjfgbACBG/vcq+wiwvejwjQC/gACyAC3p8E2GsNH4GKAMRgZGACA6T634FgA4Rtr4LBC5sRVG2vgwIJqx2vgoMIOxGGgN8RYIBJAQeEJGA5AIaCFGAJVf+oD7MEZbRv73ZPoQsQawvejwjdr4PADN+Aiww0bd+BCAAigl0IAoCtBAKEPRnfgWAA3xFghA8EAAjfgWABDgC/EBCDBGIUYCmwCVQkb+90H6ACjb0Z34FwBA8IAAjfgXAAObMEYhRkJGAJX+98z6zedf+ojzDfEWCDBGIUYAlUJG/vcn+gAoApvA0QjxAQcwRiFGAJU6Rv73HPoAKLbRnfgXAAObMStA8AIAjfgXAAi/uEbW56fxfQCo54AAsgCAtYqwjfgEIAAijfgMMAAjzekGIQyZCZKN+CAgzekEIkprAJECkgGpAyL+9+/9CrCAvQAALenwTZCwBEYAIIpGGJ0Ok11PD5Da+BgAqRhDaJlCAPKvgNDpCLANkguQIGjAB0/wAAAYv/33QPsN8TwICZAKlAAtAPCXgC5GDZ0LmrX78vAMlgD7ElCBGZFCKL8WGiBGUUYZmv73OvoAKEDwgoDa+BgA1kYBaAjrAQMD+AFcLQoBOfjRm/gkcLv4AMDb+CAgAGib+AQwm/gFQJv4HVCe+AAQ8kbN6QB4Aq8FkTHHACAGkBmYACoHkNCyGL8BIgqcTOoAISBGAPAR+gAoUdHb+AgAQRwT0Jv4HBCa+AAg/yeb+AwwACXN6QFVAJHN6QNxGZnN6QUlACIB8Nn4yLvb+BAwDJ2jsaBoAPRAELD1AB8F0Zv4FgAAIQHwfPgG4Jv4FBCb+BUgIEYA8CT5B0YIu5v4FQCb+BQwGZkyRs3pAAEgRg6ZAPBw+pi52vgYAIFqMbGCbCBGUUYZm//3j/1AuQ2YrRsAJzBEDZAOmDBEDpBm5wdGIGjABxy/CZj996D6OEYQsL3o8I0EALIAAkYAiCmxkXjSeBIGQuoBQQhEcEe8tQacACXN6QBUAPAB+Ly9LenwQYawVE4AKgDwnoAERoBsAAcA8ZyADJgVRg9Gg/ADAoDwAQERQypGBfABAQi/AetSAlEeT/SAIgLqgECJsmPzEUAIRADxAnAgZQEgAPA3/wAgAC8A8HqADZlP8AMISWoFkQSXA5UBkAQgdxwAJo34CAAFrZ34CAAEKGjRvkJm0AOeBJjU+MQQAfAPAbFCKL8xRggpC9jf6AHwOQUXHBIrMyQKANT40BABcAEhK+DU+NgQAWDU+NgQQWAIISPg1PjYEAFgBCEe4NT41BABgAIhGeDU+NQQAYDU+NAQgXADIRHgAPDP/9T40BCBcQchCuDU+NgQAWDU+NAQAXEFIQLgAPDA/wYhdhoIRLvnBJADlqa51PjEAADwDwABKAi/1PjQANT4yAcg8AIAxPjIB434CIABmBCxAZkDIIhHKEYDlgDw1fgGRpXnAzYA4AAmMEYGsL3o8IEBALIAcLUVTCKzhWwtByLUAPDj/gi/BetWBnUeT/SAJgbqhEStsmPzEURjGQPxAnMDZWmx3ekFQ9lgBCFaYRxiGXYaYdD4yBdB8AIBwPjIFwAkAOADNCBGcL0AvwEAsgALRgAhACIA8AG4AABwtQ5Mu7GFaIZsNgcU1AE7m7Jh8xFDAvABAQX0QBJD6oFBsvUAHwi/AfUAAQAkAfFAcQFlAOADNCBGcL0BALIAsLUKTHuxhWwtBw3UCEwAKRi/BPXABFkeYvMUVImyIUQAJAFlAOADNCBGsL0BALIAAAAnAxC1FEb99/r8GLEBaGTzCSEBYBC9AmgAKSLwAQIYvwEyAmBwRwiFcEcctQRGAGgAKBnUoGgg9EAQoGAB8AMAoWhB6gBQoGABqRBG/fcV/EC5AZgE68AQ0PgoGEHwgHHA+CgYACAcvQFIHL0AvwQAsgAPKYS/BUhwR4JoIvRwYoJggmhC6gEhgWAAIHBHBACyAA8phL8HSHBHgmoi8PACQuoBEoJigmoi8A8CEUOBYgAgcEcAvwQAsgCwtQVGAGgAJEixASAA8OD9KGgBOChgBL8CJMDysgQgRrC9sLWIsBRGEJoNnQeSD5oDlQydBpIOmgWSACKN6CwAI0YEkgDwAvgIsLC9Len8TQRGEZhP9HAF3fg4wAqeQGoBkA+YBeoAW93pDHAQncKxAysIvwEuJNBP9EAyAC8C6gNCZvOSQj5OQuoLAkLqESMjZUHqxUPJsgi/A+oGARFDGeDJsgbwAQIAL2PzEUFB6oJBBfABAgi/QerCQUHqCwEJ4AXwAQIALwi/QerCQUHqCwFB9OAhIWVP9AAhzfgAsAMoAerFS0/0QDEIv7zxAQ8B6gBFI0mIRmzzkkUe0E/wAAoBrgAgX/qK8blCNtJARUJGM9CgbAAHDNQLmArxAQpAXAExuUIov0DqCwAAmShDCEMgZTBG//dj/+TnACYN8QQKACC+QhnSQEVBRhbQoGwABw/UC5qxHJAZQHi5Qii/QOoLAJJdzrJA6gIgAJooQxBDIGVQRv/3Q//j573o/I3/AAgAAgCyAC3p8E2GsARGUEgAKgDwl4ClbC0HAPGWgA6eg/ADB0/wAAiG8AEFV+oFDALwAQcVRgi/B+tVBU/0gCcH6oZGAT2tsmPzEUZzGQPxhHMAKSNlAPB3gA+bvPqM9Q3xFApbam8JRRwAIAWTBJECIQOSzfgEgI34CBCd+AgQAili0ahCYNDd+AywBJ7U+IgAAPAPAMDxCABYRSi/WEYIKBjY3+gA8DQfBQUSEgoKFwAwiMT4lAACIBzgMEYA8GT9sIjE+JQABiAU4DBGAPBc/QQgD+AwRgDwV/0wHQDwVP0IIAfgMHgALwy/xPiQAMT4nAABINT4iBAJB/vRq+sACwZEWEa78QgPKL8IIMfnu/EADwSWzfgMsA/RxPiAgNT4yAcg8AEAxPjIBwEgjfgIAAGYELEBmQEgiEdQRv/3nv6b5wMwAOAAIAawvejwjQC/AQCyAHC1hGwkB0S/FUhwvQDwrfwIvwXrVgZ1Hk/0gCYG6oRGrbJj8xFGNUQF8YR1BWWhsd3pBWUpYAIhqmDuYSl2ASHA+IAQamCF+CswhfgqQND4yBdB8AEBwPjIFwAgcL0AvwEAsgBBHgwphL8FSHBHBUlR+CAgIvAAQkH4ICAAIHBHAQBKAEASQFINKIS/BUhwRwVJUfggIELwAEJB+CAgACBwRwC/AQBKAEASQFIQtQhJUfggIFH4IADC8wMiAPAPAFQcAPA7+ADrVACw+/TwEL1AEkBSDSiPvwAgAklR+CAAwA9wR0ASQFICRgdIDSqYvw8pANlwRwVIUPgiMGHzCyNA+CIwACBwRwEASgBAEkBSAkYISA0qmL8PKQDZcEcGSFD4IjAj8A8DGUNA+CIQACBwRwC/AQBKAEASQFIQtQRGAPAq+AIsCtgISQIsAetEEgi/AfUAchFosfH/PwDdEL0gRr3oEEAA8J+7AL8AFkBSCEpP9IhTAuuAAclYAfAHAQcpAr9S+CAQCCBg818RiLJwRwC/AAFAUoC1//fp/wMoD9mw9Yh/JNBA8hERiEIO0EDyExGIQhy/ACCAvRNIgGgZ4N/oAPACHwsdEUiAvQ9IT/QAQcBqAepAMIC9C0gBaAxIAfADAVn4AAADKRi/ACCAvQZIgGlP9ABBAeoQQIC9BkiAvQRIWfgAAIC9aBNAUoDw+gKEDAAAgAwAAAASegAFKIS/CUhwRwlKsfWAfzG/AfAHAQHwHwFC+CAQByEC64AAT/SIUoFQACBwRwEASgAAAUBSsLWEAQJNAPDW+wDwUbwAvwAYQFL4tQxGFUqBAQAmU1gC64AVIEZD8ABDU1BHHuppRvEAAdIHBNEZsQDw8Ps4RvTnKWg8sTC5APAn/ChoIPAAQQhICuAB8EBQsPEAXxy/ACD4vShoQPBAUQAgKWD4vQAYQFICAEoAsLUFRgxGSGg0Ifz33v6oAT5JClhgaAHrhRHTDwJwA3HC8wFzw3DC8wIzwvMCIoNwQnBKaMLzA2NDc8LzQlMDczNLA/XAExpAgmCKaMLzQHMC8AECgnPDc8powvPDY4N1wvPDU0N1wvMCUwN1wvMDQ8N0wvPCI4N0wvNEEwLwHwICdEN0CmlLacNhwvMAM0N2wvNEEwLwHwLCdQN2imkTRm/z30MDYsLzAGPC8wBSgPglMID4JCDKacLzAFOA+CkwwvMAQ4D4KDDC80ADAvABAoD4JiCA+CcwCWrKD4D4MSDB80BygPgwIMHzDELChcHzABKA+CwgwfPAAgHwBwGA+CoQgPgrIAAgsL0AvwAYQFL//wcALenwQZCwA60ERjQhKEb891L+ApUAJSBGAZUBqf/3Zv+gARpJCFiw8f8/K9yd+A8AAign0J34DACd+A0QnfgOIAWdRxygHALxAQhOHP/3tP6dsRXrR1FP8AACQvEAAqH7ADEC+wARCPsG8hhGACP89379QA1A6sElBOAI+wbxeEOw+/H1KEYQsL3o8IEAGEBScLUCRlBMgAEjWFBIACsM1EloC3gHKwfT+SsF2E14By2cv454By4C2XC9AjBwvQTrghDKeAIqAPCBgGXzCiMG8AcEQ+oEMwx5Q+rEcwNgQEsD9cATjGgjQAx7BPAHBEPqRFNMewTwDwRD6gRjQ2DLe4x7ROpDc4NgDHxLfATwHwRj80kUi3wD8AcDROrDI8x8BPAPBEPqBEMMfQTwBwRD6gRTTH0E8A8EQ+rEU4x9BPAPBEPqxGPDYMx9C34E8B8EY/NJFEt+ROoDMwNhy2lDYQxqkfgkMG/z30RE6gNTkfglQEPqBGODYZH4J0CR+CYwkfgoUJH4KWAE8H8EQ+pEA0PqBUND6gZTw2GR+CowkfgrQJH4LFCR+DBgA/AHA0PqxAPMjZH4MRBD6gUT27Jk8xxDQ+pGc0PqwXEBYgFoYvMdcQFgACBwvQAYQFIBAEoA//8HALC1RAECTQDwHvoA8Jm6AL8AFkBS+LUMRhVKQQEAJlNYAutAFSBGQ/AAQ1NQRx7qaUbxAAHSBwTRGbEA8Dj6OEb05yloPLEwuQDwb/ooaCDwAEEISArgAfBAULDxAF8cvwAg+L0oaEDwQFEAIClg+L0AFkBSAgBKALC1BUYMRghoYCH89yb9aAEWSQpYIGgB60URwvMBcwJwA3HC88Bjw3DC8wRDwvMEIoNwQnBKaNMPQ3Mi8H9DEvDgQoNgGL8BIgJziWjKD8J1wfMAcoJ1wfMAYkJ1wfMCQsmyAWECdQAgsL0AvwAWQFIt6fBBmrACrgRGYCEwRvz37PwAJWlGIEbN6QBl//e4/2ABFUkIWLDx/z8g3J34DAACKBzQnfgJYM6xnfgKcLexnfgIEAAgBJoS6wFlQPEACCBG//dL/aX7AEGn+wYjCPsAESBG/Pcd/AAOQOoBJShGGrC96PCBAL8AFkBS8LUKaCQmLCcAIRwlJyQjI8LpDnYoJsLpBBHC6RNVwukQRSAlwukVQxNjKUvC6QgWDyHC6QpUkWFBAVxYJUkALEPUlHgALEHQECw/2FV47bMQLTvYFngQLjjTyC422BF5A+tAEAIpKtArAkPqBEMaTCNA1HgzREPqxGMDYJRoE3sk8H9EROoDc1R7Q+rEcxNMJUZDYAAjg2ATf1sDDzPDYFNrY/MedQX1A3MNTQNhk2xj8x51RWHSbWLzHnSEYQJoYfMdcgAhAmAA4AIxCEbwvQAWQFIBAEoAAB8fABzOaQQs0okDcEcAAMOyAAoBKQPQUblABgdJAeBABgVJQOqDEAhEAmAAIHBHAEhwRwEASgAUQABSEEAAUrC1DSsK2A1MVPgjUAAtBdRU+CNQRfAARUT4I1BABgEjAOuBEAZJA/oC8ghEQWmRQ0FhAWkRQwFhsL0Av0ASQFIAQABSgLUBKALY//eb/gLgAjj/99/8ACCAvQEohL8COP/34rz/95i+ASiEvwI4//eXvf/3+74BKIS/Ajj/99i9//cyv3C1C00ERk/w/zFZ+AUAsfvw9ln4BQC0QgTZcEP89yb7pBv252BDvehwQPz3H7sAv3gfAAACSVn4ARBIQ/z3Frt8HwAA//fcv//39L8FSAEiAWhi859xAWABaEHwAEEBYHBHAL8AwEBSAPDYuQJJWfgBEADwB7kAv5AMAAAJeAHrwQFIRADrwQABIRQwAfDguQnrAAIoRjBHA/HjcG/wDwMD6tAAcEcEnIPwAwaE8AEFNUMWRgLwAQVwRyn4BgAga83pAFrN6QRUzekCIFhGOEe0+ACAI3mU+CBwT/ABDGZ/lPgkQAl4ACVwR4JgAWAAIQF1AWEBc4GAcEcgRilGZCIA8Gm8CesAAiBGMEcj6gEBEUMBYHC9KfgGACBrzekAe83pBHTN6QIgUEYoR7L6gvJI6gchzekARVIJ//e5ud3pDjAB8J+6AiEoWWHzHXAoUQEg//dvvzBGQUZSRv73EL0AJ0/wAgtP8AEMT/AACnBHTfgI7QEh/vfr/8T4mABd+AjrcEeCRlgDT/b/dd34VIABJgMnqEMD8AcFKEQEJQC6CJAAIHBHBJAPmP/3bLkBIP/3QL8iRjNGzfgAoP331LnN6QJXzekGCNgMAyPN6QBkQOpCMAEicEcCOLD6gPBCCSBG//fJuK6YApAgRgHwSrpoaGlsMkb995m61PjYEAFg1PjUEIGAcEcAIAEjzfgIgM3pADBQRgMjcEcCkBWYA5AWmM3pBAo4RnBHAiBg8x1xASApYP/3/r4FRmQg//fgvihZIPAAQChRACCwvb34HgABPgAGT+oGQHBHQUY6RiNG/Pc4uwjrAAIC+AEcCQoBOHBHB5GBsiBG//cauQtGACEB8KK4LenwTYawACcORgRGBZcFqQDwLvkAKEDwmYAFnQSXBKkoRgDwBflaSCl4AevBAUhEAOvBAAAhAPEUCEBGAfDG+G1oqWnoaApGGbkqagAqAPCBgNL4BKCEQgTRskWcvyppskJ62SQaACADkGmzA6koRiJG/vcB/Ti7A5goswFo0PgMsAAuKEYCkQi/XkYDqSZEch7+9/H8B0YAKFTRA5gBaMBochqy+/DzA/sQIgAqGL8BMwKeohuy+/vyAvsLZAkbA/sAFqlpHeCpaTJPEbEB8RgAAuAoarCzDDAAaJizAC4IvwZGMhmy+/DzA/sQJgEzAC4YvwP7APK0+/DzA/sQJgP7APQwGSppUkU4v5JGgkU4v6rrBAbY+AQACPEICmGxKUb/9wX/B0ZouQSYWLFBaNj4BAD/9/z+BOApRiJGU0b89579B0YALxi/ASc4RgawvejwjU/wAAp959j4BAAI8QgEgbEpRiJG/feg+AdGACjp0QSYACjm0EFo2PgEACJG/feU+N7nKUYiRvz3F/3Z58geAAAEALIALen8TSJII08N8QQL6kYBJVn4AGAAIAGQCesHAJD4AoAEHWgeQEUkvwAgvej8jSB4hkIn0WBoKLMBDw4pItiCaQKzEQ8OKR3YAWnZsVJoyrFieBv4AiCqucBo//cF/6C5CesHAAEhkPgCgGB4C/gAECBGUUYA8BD4ASEYuQCYQHgL+AAQCDQBNcvnASC96PyNxB4AAMgeAADwtQAiCmBCaFNpq7ELTAnrBAUsHa14fbEmeAd4t0II0WZoskIF0HZps0ICvwxgACDwvQg0AT3u5wEg8L3IHgAALenwQQAiIPCAXADwgF4KYB1KCesCAwPxCAibeDuz2PgAYLVpDbk1av2xamjW6QN0FUaUQji/JUYAKgi/JUZ6GVUeh0IB2IVCF9IH8IBSlkUH0CfwgFe8RQPTJfCAUpRFCNkI8QgIATvY5wAi3ucBIL3o8IFH6g4A8GCo8QQACGAAIL3o8IEAv8geAAAt6fxNi0YFRgDwYvoguQGpKEb/96//ELEBIL3o/I0BnN/4+KA8SCJ4AuvCAgnrCgFZ+AAAAevCBRX4FB+IQhLROE4wRvz3IvsG9YAg/Pce+yhGWUYA8Dz/L0koeEn4AQAAIL3o/I0A8Hf5BfEIBmhoKWxP9HpyM0b891L+ACjL0QEgMUZP8AEI/vfi/mJoaGgReBJ6/vfK/mhoMUb896b7H08Z+AcAULlhaGhoCXj79wf/T/R6cP/3/fwJ+AeA//fX/Rix//fU/QAopdEJ6woAACcAJAYdgHiHQrHSKXgyeIpCFdEJ6woBAevHAYlokfgAgBjqBA8J0ShGMUYA8BT4ACh/9ImvCesKAIB4ROoIBAg2ATfg5wC/xB4AAMgeAAAMAAAAAABFVC3p8E2GsAApAPClgARGCA8NRg4oAPKfgG5oAC4A8JuAMA8OKADyl4CwaRCxAQ8OKQnZMGoAKADwjoCw8XBPgPCKgAAniOCBaBGxCg8OKinZACLQ+CyAw2sweUAHH9W48QAPL9BP6hhwDigY2Nj4AAABMAEoE9gE8QgBYGiSRh9GAiIBI0/wAgsAkTFG/fcy+jtGUkZP8AEMgkYAJxbg//cL/RPgkfgUsEp9u/EDD27Qu/ECD83QT/AADAAnT/AACgAjAeD/9/j8T/AACFfqCgAm0bjxAA8g0E/qGHAOKBzY2PgAEMmxSBxP8AAHGL8AKxTQzekCwwSSy7JgaATxCAgN8RcCMUaN+BdwzfgAgPz39f0AKFjQgkZI4AAnT/AACrvxAw8E0QEqCL9X6goABNC68QAPGL8BJw7gYGghbATxCAgCaENGIvAAQgJgT/R6cvz3Uv0gsQEnOEYGsL3o8I0BIEFGASf+99/9MnhgaAIh/vfc/QAo79FqaGBoEXgSev73wP1gaEFG/Pec+lnn0PhogAdvYGgE8QgDMUYEkv73d/oosYJGACdP8AMLBJq35//3T/w7RgdGT/AADE/wAwtP8AAKBJqB50JGnfgXAN34DIAA6ggAQEUD0QAnT/AACuTnYGgxRpBG/PcG/oJGCLEAJwLg//ct/AdGBJpX6goAf/SOrwKZYGghsTFGQkb+9+v6BOAxRgSaQ0b+9zn6gkYIsQAnwuf/9xT8B0bW5wAAELUHTBn4BAA4uXK2APBs/wHwRfgBIAn4BAAAIBC9AL8EAAAALen4RQRGACDf+ISA6kYAkE/wATAC+wD2YBhHHrxChL8AIL3o+IUgRlFG//fl/QixBDTz5wCdCesIACl4AevBAQDrwQABIRQwAPCE/WhogWkJuQFq0bFJaNDpAwJDGBUYGEaKQji/KEZBHghGn0I4vzhGr0IovwhGhELP2CFojkIcvwEgvej4hQQ09ecAIePnyB4AAC3p+EWIRgVGAPEICgEkaGhRRvz3NPoHRmhoRmgKIP/3Qfs4H0/wAAEYvwEgtvH/P8i/ASEIQgPRYBxERQRG5tkAIL3o+IUt6fxNkkaDRgAgCkYBkAGpEEYAkv/3Y/2w+oDw3fgEgAvxCAcBJE/w/zZFCeAHCNAAmDpGQWjb+AQA/ve2+ARGCuDoBxXQ2PgEENv4BAA6Rv73q/gFRgAkATZWRYS/ASC96PyNCiD/9/r6ROoFAMAH3NEAIL3o/I0AAC3p+E3f+CDnGfgOAAEoLdHf+BgHSESDeAAgK7Pf+Awn7UgZ+AIQUbHf+AQ33/hASQnrAgGIYUtETETB6RVDCesCAUl4YbHf+Cw5CesCAd/4jCgA9YAgCGZKREtEweknMgEgCfgOAAAgvej4jd/4vBYAIAnrAQIp+AEAkHDf+LAGCesAAhIPDioJ2N/4qEYJ6wACCesEA1NgGg8OKgLZASC96PiNWfgAsE/wAAq78QAPAPDRgN/4gBYJ6wEAAA8OKADyyYDf+HQGCesAAhIPDioA8sGACesBAtL4BKBJ+AQgCesABGVoCvAEAipDBtHf+FAGACZIRADxJAVA4AnrAAbf+EAG3/hEJt/4TFbf+Ex2SERKRE1ET0TwYt/4LAbG6QJ1BvFQBUhExukHIN/4IAbf+CAmSERKRMbpBCDf+CAG3/g4JkhESkTwZt/4GAZIRLBm3/gUBkhEcGPf+BAGSEQwY9/4DAZIRLBi3/gIBkhEcGbf+AQGSETG6RUgACDf+AAm3/gARgnrAQff+BDG3/gINjhivmHf+PxlSkQJ6wQACesMAUtESfgEIN/43CXf+NxFKGDf+NhVTkTA6Qs23/jsNd/49GUJ6wII3/jUJUxETUTA6Q1U3/jYRd/42FXA+DyAS0ROREpEwOkJId/4tBXf+LQlTERNRMDpA2XA6QVDCesBDAnrAgjf+LAV3/iwJcDpB4xJREpEwOkBIThpsLHf+AgV3/gMRd/4DCVf6opwT/AACg/VASBKRAn4AQBJRKH4BKBP8AEKimCIcAPg3/jkRE/wAAq78QIPI9Pf+GQVCesBAAAPDigc2N/4XAUJ6wACEg8OKhXYCesEAgnrAQNTYAnrAAJbaACTUmgD8AQDGkMJ0d/4NAUAJwnrAAIC8SQGQuDURq3gCesAB9/4IAXf+CQl3/gsNd/4LGVIREpES0RORPhi3/gMBcfpAmMH8VAGSETH6Qcg3/gABd/4ACVIREpEx+kEIN/4AAXf+BglSERKRPhm3/j4BEhEuGbf+PQESER4Y9/48ARIRDhj3/jsBEhEuGLf+OgESER4Zt/45ARIRMfpFSAAIt/44ATf+OA03/j4xN/47FTf+OxESERNRExESfgDAAnrAQDf+NAUh2EJ6wMHAmLf+Lgk3/i4NABpN2Df+LRkSUQJ6wIICesMAgfxJAxLRE5ErOg0AN/4tCTH6Q443/iwNN/4sETf+LBUx+kMFt/4mBTf+KhkCesCCN/4qCRLRExETUQJ6wEM3/iUFE5Ex+kFQ0pEx+kDZcfpB4xJRMfpASEQsQCYgAcE1NRGFeAAvwAARlTTSQEgCvEBDAn4AQAJ6wEA3/jUE4D4AsAA68oASUSBYE/0gHGBgMxMu/EDD8DwtoDf+EBUCesFAAAPDigA8q6A3/g0JAnrAgAADw4oAPKmgAnrBAAJ6wUBgWAJ6wIAQ2hIaADwBAEAkBlDB9Hf+AwUACMJ6wECAvEkB0Dg3/gAFAnrAgPf+AAk3/gIZN/4CHRJREpETkRPRNli3/joE8PpAnYD8VAHSUTD6Qch3/jcE9/43CNJREpEw+kEId/43BPf+PQjSURKRNlm3/jUE0lEmWbf+NATSURZY9/4zBNJRBlj3/jIE0lEmWLf+MQTSURZZt/4wBNJRMPpFSEAIt/4vBPf+LxDCesFBt/4yAPf+MhT3/joo7NhMmLf+KwjSUQJ6wQDSERNREn4BBA7YN/4oHPf+JAT3/iUQ0pECesBC9/4mBNPRExEw+kLB9/4kAPD+Dyww+kNQuNK5Ezf+JRzSUTD6QkVCesAC+NI3UngTUpETERPRMPpBUIJ6wEISEQJ6woBTUTD6QEQMGnD6QN1w+kHixCxAJiABzrUY0bYSAnrAAEJDw4pCNjWTQnrAAEJ6wUCSmARDw4pAdkBID7lWfgAEAEgACk/9Dmt3/g4wwnrDAEJDw4pP/YxrctKCesCAQkPDik/9iqtCesMAAnrAgFJ+AUAQGhJaADwBAUAkClDGNHCSQAlCesBAgLxJAdD4E9JASAM8QEDCfgBAAnrAQCUSYNwAOvMAElEgWBP9ABxgYCz57dJCesCBbdKuk66T0lESkRORE9E6WKyScXpAnYF8VAHSUTF6QchsEmxSklESkTF6QQhsUm4SklESkTpZrBJSUSpZq9JSURpY69JSUQpY65JSUSpYq5JSURpZq1JSUTF6RUhACKuTAnrDAarSbFI3/jowrVhMmKrSgnrBAVJREhEPWCqT0n4BBCmSadMCesCC6pKT0QJ6wEKp0lMREpExekLB6ZIqk/F+DygxekNS6ZMSUQJ6wAKpkjF6QkhoUmhSk9ETETF+CCgSEQJ6wELoUkJ6wIICesMAsXpAwcF8RQAgOgQCTBpSUQAKMXpASE/9EqvAJiAB0/wAQB/9YWsBklaHElEinBySkhwAevDAUpEiICKYHnkCAAAAMgeAADMGAAAVAwAAJQMAADkFQAA1BcAANANAAAIDQAAuAwAAOAMAAAgDgAASA4AADANAACYDgAAqA0AAIANAADADgAA+A0AAHQYAABwDgAAWA0AAJQAAABUAAAAwAEAAKwBAACYAQAAhAEAAHABAABcAQAASAEAADQBAAAgAQAADAEAAPgAAADkAAAA0AAAALwAAACoAAAA6A4AAGAWAAD8FwAAJBAAAFwPAAAMDwAANA8AAHQQAACcEAAAhA8AAOwQAAD8DwAA1A8AABQRAABMEAAAhhgAAMQQAACsDwAAFAIAANQBAABAAwAALAMAABgDAAAEAwAA8AIAANwCAADIAgAAtAIAAKACAACMAgAAeAIAAGQCAABQAgAAPAIAACgCAAA8EQAA3BYAACQYAAB4EgAAsBEAAGARAACIEQAAyBIAAPASAADYEQAAQBMAAFASAAAoEgAAaBMAAKASAACYGAAAGBMAAAASAACUAwAAVAMAAMAEAACsBAAAmAQAAIQEAABwBAAAXAQAAEgEAAA0BAAAIAQAAAwEAAD4AwAA5AMAANADAAC8AwAAqAMAALwYAABkDAAAkBMAAFgXAABMGAAAzBQAAAQUAAC0EwAA3BMAABwVAABEFQAALBQAAJQVAACkFAAAfBQAALwVAAD0FAAAqhgAAGwVAABUFAAAlAYAAFQGAADABwAArAcAAJgHAACEBwAAcAcAAFwHAABIBwAANAcAACAHAAAMBwAA+AYAAOQGAADQBgAAvAYAAKgGAACsGwAAoB4AAC3p8E2IsA4YB6mbRpJGMEb/94z4CLEBIDHgB5wZSE/wAAgheAHrwQFIRADrwQUAIQXxFAc4RgDwJ/hhaMhoimkzGqhpQrEH8QgCzekAshpGU0b999P9D+AKagfxCAQBJU/qWwaSaM3pAGrN6QRUzekCggEi+/ei/gAoGL8BIAiwvejwjcgeAACwtQRGQGgNRvv31fyoQgfQYGgpRv33rP8gRmQh//eQ+gAgsL1wtR1IWfgAQLTx/z8lRgLc+/fi+QAlGUgF68UBSEQA68EAAPEYBgEtItgALAPUMB9kIf/3c/oBIAEhAiIBI/73Y/0BIAEhAyIBI/73Xf0EIAAtCL8DIP73aflW+EgLAWgh8ABBAWD798X7ATUALNrU+/ey+QAgcL3EHgAAyB4AAPi1DkZpRhxGF0YFRhhg/vf3/wixASD4vQCZDUj+97T9OEYpRjJG+/cu+UCxACGOQgfQeFxqXJBCBdEBMffnACAD4AEgAeABIA5GcRkhYPi9yB4AAPC1jHkIJcCyT/AADE/wAA4F68QEACUuRgg1pUIP2A5EN3qHQgS/93v/L/TRd3q+RfHYtnoBLgS/rEa+RuvnvPEADwrQAesMAAF5kXBBeVFwgXkRcMB4gAAA4AAgGHDwvQAjAmsGKRNxLNjf6AHwCgQiEgQEGQACIwEhw2PAajUjHOBP8P8xwWPAahFgAWAAIRbgPiERYIAhwWPAaj8hBeAxIRFgAiHBY8BqNSEBYAEhBuBAIwEhw2PAagUjEWADYJF3gXdwR3C1A0YAaAQoEdFbaU/w/zAAJBhgSHjA80MFHSAFLB/QJfoE9vYHD9ECMAE09ucdIApc/yoD0SIoEdgCMPjnW2kBIZl3GmAT4CUoCdAEMQAlBC0J0E5dATUC+Axr+Odbaf8gGHEAIHC9CV0BIpp3GWAAIZmAcL0t6fBNirCcRgiQC3kAIA1GACcDKwXRlfgkEAE5sfqB8U8JjfgkAAmpAygE0AwYFlwBMGZw+Oe1+ADglfggAGx5lfgkoE/wAwhufwAvT/AACxy/T/AECApGzekChAiczekEbBSezfgYsE7qACHN6QCiIEY6RgeW/ffZ/ni5K2lqf2l5IEb99xb+QLnd6RIhaH0rfc3pAAYgRv33Kv0KsL3o8I0BIU/w/zKBdxIh/vfbvAEhT/D/MoF3NCGCYAFgAiEBdQAhAWEBc4GAcEcBIU/w/zKBdwIh/vfGvAAAgLUAIP73QPgOSRFKSfgBAA1JSfgBAA1JAUQA8ucwsfvy8QxKSfgCEE/0enGw+/HwCUlJ+AEAACD+9yb4B0lJ+AEAgL1sHwAAdB8AAD9CDwBAQg8AfB8AAHgfAABwHwAAELUdSHhE+/cb+hxMASABIQAifESgR0DyARABIQAioEcBIAAhT/D/MqBHBSAEIQDwkfhkIP73HvwBIP73CfhQuQEgACH+9yL4ASAAIf73CvgBIP331/9A8gEQACFP8P8y/veU+//3nP8CSAFoQfAAQQFgEL0EEEBSoAQAAHfn//8NSBn4ABCpuQEhACMJ+AAQCkkJaAHwf0KJsrLxgk96Rgi/CwkJ6wABQugA8kuAwvOAUkpwSERwRw4AAAAA7QDg//f4veC1AZABq//3M/4BmIy9AAAQtQ9IACEPSkn4ABBIRA9Le0RJ+AIwDEtLRENgCesCAAtKDEsMTHxEekR7RMDpAUHA6QMyFDAkIfr3gf8QvQC/FAAAABwAAACAHwAA3AMAAMoDAADGAwAAyAMAAAABB0oTWBBYm7IADMtAyEDAB0/wAgAIvwPwAQBwRwC/BABBUrC1DUYERv/36f8CKBy/BUiwvQEgIQEESqhAU1gYQ1BQACCwvf8AQgAAAEFS/uewtQ1GEUYERv33a/8gRilG/fd7/ySxIEa96LBA/fcxv7C9gLUA8An4APCN+L3ogEAA8Jm4//f1vwAAcLU+SDpNO054REn4BQAJ6wUAO0k7SnlEekTA6QMhOkl5REFgNEkJ6wYASURBYP73zfoDIAAhACT999L/ACADIf33Rv8AIAAh/fcu//73QPsDLATQIEb+9/X6ATT45wAkAywF0AYsBdAgRgAh/fe4/wE09ecAJFyxDiwL0AnrBQBQ+CQAILEBeEJ4IEb/95v/ATTw5wIg/vfV+gnrBgECIP736foAuwIgQvIQcf731frQuQAkDiwM0Ey5CesFAFD4JAAgsQF4QngAIP/3fP8BNPDnAyAAIf33g//IIP737Pq96HBA//d+vgMg//dr/wC/HAAAABQAAACAHwAA/AIAAPQCAADwAgAA5gIAAIC1ASABIQIiASP+93P6ASABIQMiASO96IBA/vdrugAALenwTU9ICesAB//3xf5AeFBJOkaA8AEIS0iLRsf4NIAJ6wAESUjE+DSACesABUhIxfg0gAnrAAoB9SBwACHK+DSAWU5+RLBHC/WAcAAhIkawRwv1QHAHISpGsEcL9WBwACFSRrBHPEgL8eN1ACH+97v6OkgBIf73t/o5SAIh/vez+jhIAyH+96/6N0gEIf73q/o2SAUh/ven+jVIBiH+96P6NEgHIf73n/ozSAchCesAAjJIwvg0gAnrAAQwSMT4NIAJ6wAFL0jF+DSACesABwv1KGDH+DSAsEdYRgAhIkawR1hGASEqRrBHC/XAYAMhOkawRyRIC/HldAAh/veu+iJIASH+96r6IUgCIf73pvogSAMh/vei+h9IBCH+9576HkgFIf73mvodSAYh/veW+hxIByEzRgnrAAIgRr3o8E0YRwC/vBoAAPgaAAA0GwAAcBsAAAAAgVLcGAAAGBkAAFQZAACQGQAAzBkAAAgaAABEGgAAgBoAALAdAADsHQAAKB4AAGQeAADQGwAADBwAAEgcAACEHAAAwBwAAPwcAAA4HQAAdB0AAFWu//+WAAAAwAAAAPUAAAA5AQAAkAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAQIAAgECAQn8//8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAgAAABcAAAAAAAAAAAAAYAAAAAQAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAABaAAAAAAAAAP////8AAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAACAAAAFQAAAAAAAAAAAABgAAAABAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAFoAAAAAAAAA/////wAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAIAAAAVAAAAAAAAAAAAAGAAAAAEAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAWgAAAAAAAAD/////AAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAgAAABcAAAAAAAAAAAAAZAAAAAQAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAABaAAAAAAAAAP////8AAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAABAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAEAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAABAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAQAAAAAAAEAAACAACiAwAAANEBANsBAAAAAAAAAAAAAIAAAAAAAAAAEAAAAAAABAAAAgAAogMAAADRAQDbAQAAAAAAAAAAAACAAAAAAAAAABAAAAAAAAQAAAIAAKIDAAAA0QEA2wEAAAAAAAAAAAAAgAAAAAAAAAAQAAAAAAAEAAACAACiAwAAANEBANsBAAAAAAAAAAAAAAgIAAAAAAAAAAAAAAAAAAAAAAgIAAAAAAAAAAAAAAAAAAAAAAgIAAAAAAAAAAAAAAAAAAAAAAgIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAIIAAAABAAAAAAAAAAIAAACCAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAADIAAAAAQEHBwcHBwABAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAoAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAADIAAAAAQEHBwcHBwABAAAA/////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgPD6AoDw+gKA8PoCUMMAADIAAAAPAAEAAAAAAAAAAAAHCAEADAUDBgcEABQUAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
   pc_init: 0x1
-  pc_uninit: 0x5d61
-  pc_program_page: 0x3e39
-  pc_erase_sector: 0x3bc1
-  pc_erase_all: 0x3bbd
-  pc_verify: 0x5d65
-  pc_blank_check: 0x449
-  data_section_offset: 0x60f4
+  pc_uninit: 0x5455
+  pc_program_page: 0x3e51
+  pc_erase_sector: 0x3c41
+  #pc_erase_all: 0x3c3d
+  pc_verify: 0x5459
+  pc_blank_check: 0x4a5
+  data_section_offset: 0x5864
   flash_properties:
     address_range:
       start: 0x70000000
-      end: 0x74000000
+      end: 0x78000000
     page_size: 0x1000
     erased_byte_value: 0xff
     program_page_timeout: 5000
@@ -812,3 +5751,4 @@ flash_algorithms:
     - size: 0x40000
       address: 0x0
   stack_size: 4096
+


### PR DESCRIPTION
This PR fixes CM55 attach reliability and extends PSOC Edge E84 target support.

Functionality changes:

- CM55 attach/enable can hit a transient AHB stall when releasing the core from its post-reset wait state. This is now recovered from by clearing DP sticky error flags and retrying, only falling back to ArmError::CoreDisabled when the core truly isn't reachable yet.
- acquire_test_mode now polls the boot ROM's extended boot status and waits (with a timeout) for it to reach idle before proceeding, instead of racing the boot ROM.
- The GDB server now skips cores that aren't enabled yet (e.g. CM55 still held in reset) instead of failing the whole session, and returns EIO for accesses to them.
- Extended PSOC_E84.yaml with more device variants and corrected per-variant memory maps.