### PR TITLE
feat(cargo-embed): feed RTT down channels from a TCP socket

### DIFF
--- a/changelog/added-rtt-down-channel-socket.md
+++ b/changelog/added-rtt-down-channel-socket.md
@@ -1,0 +1,1 @@
+`cargo-embed` down channels now accept a `socket` option. When set, cargo-embed listens on that TCP address and forwards anything a connected client sends to the target's RTT down channel, mirroring the existing up-channel `socket` option for host input.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -103,6 +103,9 @@ pub struct DownChannelConfig {
     pub channel: u32,
     #[serde(default)]
     pub mode: Option<ChannelMode>,
+    /// If set, bytes received on this TCP socket are forwarded to the target's down channel.
+    #[serde(default)]
+    pub socket: Option<SocketAddr>,
 }
 
 /// The rtt config struct holding all the possible rtt options.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -25,6 +25,7 @@ use crate::{
 
 use super::super::config;
 use super::channel::UpChannel;
+use super::tcp::TcpSubscriber;
 use super::{event::Events, tab::Tab};
 
 use event::KeyModifiers;
@@ -45,6 +46,9 @@ pub struct App {
     // than RefCell because the cargo-embed main loop runs the `.render()` step and the
     // `.poll_rtt()` step in alternation.
     up_channels: Vec<Rc<RefCell<UpChannel>>>,
+
+    // Down channels that are fed from a TCP socket instead of (or in addition to) keyboard input.
+    down_channel_sockets: Vec<(u32, TcpSubscriber)>,
 
     client: RttClient,
 }
@@ -68,6 +72,7 @@ impl App {
         // Create channel states
         let mut up_channels = Vec::new();
         let mut down_channels = Vec::new();
+        let mut down_channel_sockets = Vec::new();
 
         // Create tab config based on detected channels
         for up in client.up_channels() {
@@ -155,6 +160,16 @@ impl App {
                 });
             }
 
+            if let Some(socket) = config
+                .rtt
+                .down_channels
+                .iter()
+                .find(|down_config| down_config.channel == number)
+                .and_then(|down_config| down_config.socket)
+            {
+                down_channel_sockets.push((number, TcpSubscriber::new(socket)));
+            }
+
             down_channels.push(Rc::new(RefCell::new(down)));
         }
 
@@ -216,6 +231,7 @@ impl App {
             current_height: 0,
 
             up_channels,
+            down_channel_sockets,
             client,
         })
     }
@@ -308,6 +324,14 @@ impl App {
                 .borrow_mut()
                 .poll_rtt(core, &mut self.client)
                 .await?;
+        }
+
+        // Forward anything received on a down-channel socket to the target.
+        for (number, subscriber) in self.down_channel_sockets.iter_mut() {
+            let bytes = subscriber.recv();
+            if !bytes.is_empty() {
+                self.client.write_down_channel(core, *number, &bytes)?;
+            }
         }
 
         Ok(())

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/tcp.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/tcp.rs
@@ -1,5 +1,5 @@
-use std::io::Write;
-use std::net::{SocketAddr, TcpStream};
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
 
 #[derive(Debug)]
 pub struct TcpPublisher {
@@ -29,5 +29,74 @@ impl TcpPublisher {
             // Discard socket on error. Try reconnect next time.
             self.socket = None;
         }
+    }
+}
+
+/// Listens on a TCP socket and hands whatever a connected client sends to a down channel.
+///
+/// The counterpart to [`TcpPublisher`]: instead of streaming target output out, this feeds
+/// host input in. Everything is non-blocking so it can be polled from the main loop.
+#[derive(Debug)]
+pub struct TcpSubscriber {
+    address: SocketAddr,
+    listener: Option<TcpListener>,
+    socket: Option<TcpStream>,
+}
+
+impl TcpSubscriber {
+    pub fn new(address: SocketAddr) -> Self {
+        Self {
+            address,
+            listener: None,
+            socket: None,
+        }
+    }
+
+    /// Returns any bytes received since the last call. Never blocks.
+    ///
+    /// Binds the listener lazily and accepts a single client at a time; once that client
+    /// disconnects, the next one can connect.
+    pub fn recv(&mut self) -> Vec<u8> {
+        if self.listener.is_none() {
+            match TcpListener::bind(self.address) {
+                Ok(listener) => {
+                    // A failed non-blocking switch would make accept() block the UI, so bail.
+                    if listener.set_nonblocking(true).is_err() {
+                        return Vec::new();
+                    }
+                    self.listener = Some(listener);
+                }
+                Err(_) => return Vec::new(),
+            }
+        }
+
+        if self.socket.is_none()
+            && let Some(listener) = self.listener.as_ref()
+            && let Ok((stream, _)) = listener.accept()
+            && stream.set_nonblocking(true).is_ok()
+        {
+            self.socket = Some(stream);
+        }
+
+        let mut received = Vec::new();
+        if let Some(socket) = self.socket.as_mut() {
+            let mut buf = [0u8; 1024];
+            loop {
+                match socket.read(&mut buf) {
+                    // A clean 0-byte read means the peer closed; drop it and wait for the next.
+                    Ok(0) => {
+                        self.socket = None;
+                        break;
+                    }
+                    Ok(n) => received.extend_from_slice(&buf[..n]),
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                    Err(_) => {
+                        self.socket = None;
+                        break;
+                    }
+                }
+            }
+        }
+        received
     }
 }


### PR DESCRIPTION
Up channels already support a `socket` option that streams target output to a TCP listener. Down channels had no equivalent — the only way to get bytes *into* the target was typing them in the TUI, which is what #3174 ran into.

This adds a matching `socket` option to `DownChannelConfig`. When set, cargo-embed binds a TCP listener on that address; whatever a connected client sends is forwarded to the target's RTT down channel. It's polled non-blocking from the existing main loop alongside the up-channel poll, so it doesn't interfere with the TUI (keyboard input still works too).

```toml
[[rtt.down_channels]]
channel = 0
socket = "127.0.0.1:9091"
```

Non-blocking throughout (lazy bind, one client at a time, reconnect after disconnect). Verified it builds + clippy clean; haven't run it against a live target/socket yet, so marking draft.

Closes #3174