### PR TITLE
fix(gdb): don't emit a spurious SIGINT right after continue

### DIFF
--- a/changelog/fixed-gdb-spurious-sigint.md
+++ b/changelog/fixed-gdb-spurious-sigint.md
@@ -1,0 +1,1 @@
+Fixed the GDB stub sometimes reporting a spurious `SIGINT` right after `continue`, halting the debugger one instruction past the breakpoint instead of running to the next one. The resume path now waits for the core to actually leave the halted state before polling for the next stop.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/resume.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/resume.rs
@@ -6,8 +6,7 @@ use gdbstub::target::ext::base::multithread::MultiThreadSingleStepOps;
 use gdbstub::target::ext::base::multithread::{MultiThreadResume, MultiThreadSingleStep};
 use probe_rs::CoreStatus;
 
-/// How long to wait for a core to actually leave the halted state after resuming it
-/// before we hand back to the poll loop. See the note in `resume`.
+/// Max time to wait for a core to leave halt after resuming before we poll it.
 const RESUME_SETTLE_TIMEOUT: Duration = Duration::from_millis(100);
 
 impl MultiThreadResume for RuntimeTarget<'_> {
@@ -20,13 +19,8 @@ impl MultiThreadResume for RuntimeTarget<'_> {
                     let mut core = session.core(*core_id)?;
                     core.run()?;
 
-                    // `run()` returns as soon as it clears the halt bit, but the core can
-                    // still report halted for a moment afterwards. If the running-poll reads
-                    // that stale halted state it looks like an unexpected stop and GDB gets a
-                    // spurious SIGINT (#3965). Wait for the core to actually leave halt before
-                    // handing back to the poll loop. If it stays halted past the timeout it has
-                    // genuinely re-halted (e.g. a breakpoint on the next instruction), so we
-                    // give up and let the poll loop report that stop normally.
+                    // `run()` clears the halt bit but the core may still read halted briefly;
+                    // wait for it to resume so the poll loop doesn't misread that as a stop (#3965).
                     let start = Instant::now();
                     while matches!(core.status()?, CoreStatus::Halted(_)) {
                         if start.elapsed() >= RESUME_SETTLE_TIMEOUT {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/resume.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/resume.rs
@@ -1,8 +1,14 @@
+use std::time::{Duration, Instant};
+
 use super::{ResumeAction, RuntimeTarget};
 
 use gdbstub::target::ext::base::multithread::MultiThreadSingleStepOps;
 use gdbstub::target::ext::base::multithread::{MultiThreadResume, MultiThreadSingleStep};
 use probe_rs::CoreStatus;
+
+/// How long to wait for a core to actually leave the halted state after resuming it
+/// before we hand back to the poll loop. See the note in `resume`.
+const RESUME_SETTLE_TIMEOUT: Duration = Duration::from_millis(100);
 
 impl MultiThreadResume for RuntimeTarget<'_> {
     fn resume(&mut self) -> Result<(), Self::Error> {
@@ -17,14 +23,16 @@ impl MultiThreadResume for RuntimeTarget<'_> {
                     // `run()` returns as soon as it clears the halt bit, but the core can
                     // still report halted for a moment afterwards. If the running-poll reads
                     // that stale halted state it looks like an unexpected stop and GDB gets a
-                    // spurious SIGINT (#3965). Give the core a few reads to actually get going
-                    // before we hand control back to the poll loop. Bounded, so a core that
-                    // genuinely re-halts immediately (e.g. a breakpoint on the next
-                    // instruction) still falls through and gets reported normally.
-                    for _ in 0..10 {
-                        if !matches!(core.status()?, CoreStatus::Halted(_)) {
+                    // spurious SIGINT (#3965). Wait for the core to actually leave halt before
+                    // handing back to the poll loop. If it stays halted past the timeout it has
+                    // genuinely re-halted (e.g. a breakpoint on the next instruction), so we
+                    // give up and let the poll loop report that stop normally.
+                    let start = Instant::now();
+                    while matches!(core.status()?, CoreStatus::Halted(_)) {
+                        if start.elapsed() >= RESUME_SETTLE_TIMEOUT {
                             break;
                         }
+                        std::thread::sleep(Duration::from_millis(1));
                     }
                 }
             }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/resume.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/resume.rs
@@ -2,6 +2,7 @@ use super::{ResumeAction, RuntimeTarget};
 
 use gdbstub::target::ext::base::multithread::MultiThreadSingleStepOps;
 use gdbstub::target::ext::base::multithread::{MultiThreadResume, MultiThreadSingleStep};
+use probe_rs::CoreStatus;
 
 impl MultiThreadResume for RuntimeTarget<'_> {
     fn resume(&mut self) -> Result<(), Self::Error> {
@@ -12,6 +13,19 @@ impl MultiThreadResume for RuntimeTarget<'_> {
                 for core_id in self.cores.iter() {
                     let mut core = session.core(*core_id)?;
                     core.run()?;
+
+                    // `run()` returns as soon as it clears the halt bit, but the core can
+                    // still report halted for a moment afterwards. If the running-poll reads
+                    // that stale halted state it looks like an unexpected stop and GDB gets a
+                    // spurious SIGINT (#3965). Give the core a few reads to actually get going
+                    // before we hand control back to the poll loop. Bounded, so a core that
+                    // genuinely re-halts immediately (e.g. a breakpoint on the next
+                    // instruction) still falls through and gets reported normally.
+                    for _ in 0..10 {
+                        if !matches!(core.status()?, CoreStatus::Halted(_)) {
+                            break;
+                        }
+                    }
                 }
             }
             (core_id, ResumeAction::Step) => {


### PR DESCRIPTION
Reported in #3965: hit a breakpoint, `continue`, and GDB immediately gets a SIGINT and stops one instruction later instead of running to the next breakpoint. Reproduced across STM32 Nucleos and RP2350, with both gdb and lldb; OpenOCD doesn't do it.

**Cause:** `Core::run()` steps off the current breakpoint, clears `C_HALT`, and returns right away — the code literally says "we assume that the core is running now". The gdb stub's running-poll then reads `core.status()` almost immediately and can catch the core still reporting halted (with no breakpoint/step reason). `handle_running` doesn't match that as a breakpoint or a step, so it hits the catch-all arm that maps every other halt to `SIGINT`.

**Fix:** after resuming, wait for the core to actually leave the halted state before returning to the poll loop. It's bounded to a handful of status reads, so a core that genuinely re-halts immediately (e.g. a breakpoint on the very next instruction) still falls through and is reported normally. Kept in the gdb resume path rather than `run()` so it doesn't change resume semantics for flashing / `probe-rs run`.

I don't have the STM32/RP2350 setup in front of me to confirm the race is gone, so leaving this as draft for a hardware check.

Closes #3965