### PR TITLE
fix(debug): resolve breakpoints to the next available line

### DIFF
--- a/changelog/fixed-breakpoint-next-available-line.md
+++ b/changelog/fixed-breakpoint-next-available-line.md
@@ -1,0 +1,1 @@
+Fixed breakpoints on a source line with no instructions of its own (e.g. a line a few levels deep, or one the compiler folded) being reported as unverified/disabled. Such a breakpoint now moves forward to the next line that has a halt location, matching the documented behaviour.

--- a/probe-rs-debug/src/source_instructions.rs
+++ b/probe-rs-debug/src/source_instructions.rs
@@ -84,6 +84,10 @@ impl VerifiedBreakpoint {
         line: u64,
         column: Option<u64>,
     ) -> Result<Self, DebugError> {
+        // Fallback for when no exact file/line match exists: the halt location on the nearest
+        // line at or after the requested one. Only used if every exact match below fails.
+        let mut next_available: Option<VerifiedBreakpoint> = None;
+
         for program_unit in &debug_info.unit_infos {
             let Some(ref line_program) = program_unit.unit.line_program else {
                 // Not all compilation units need to have debug line information, so we skip those.
@@ -165,9 +169,27 @@ impl VerifiedBreakpoint {
                     ) {
                         return Ok(verified_breakpoint);
                     }
+
+                    if let Some(candidate) = match_file_line_next_available(
+                        &instruction_sequence,
+                        *matching_file_index,
+                        line,
+                        debug_info,
+                        program_unit,
+                    ) && next_available.as_ref().is_none_or(|best| {
+                        candidate.source_location.line < best.source_location.line
+                    }) {
+                        next_available = Some(candidate);
+                    }
                 }
             }
         }
+
+        // No exact match, but we found a later line to move the breakpoint to.
+        if let Some(verified_breakpoint) = next_available {
+            return Ok(verified_breakpoint);
+        }
+
         // If we get here, we have not found a valid breakpoint location.
         Err(DebugError::Other(format!(
             "No valid breakpoint information found for file: {}, line: {line:?}, column: {column:?}",
@@ -255,6 +277,43 @@ fn match_file_line_first_available_column(
                     && matching_file_index == instruction_location.file_index
                     && NonZeroU64::new(line) == instruction_location.line
             })?;
+
+    let source_location =
+        SourceLocation::from_instruction_location(debug_info, program_unit, instruction_location)?;
+
+    Some(VerifiedBreakpoint {
+        address: instruction_location.address,
+        source_location,
+    })
+}
+
+/// Find the halt location on the first line at or after `line` in the file.
+///
+/// Used when the requested line has no halt location of its own (e.g. a blank line, or one
+/// the compiler folded), so the breakpoint moves forward to the next line that does have one.
+fn match_file_line_next_available(
+    instruction_sequence: &InstructionSequence<'_>,
+    matching_file_index: u64,
+    line: u64,
+    debug_info: &DebugInfo,
+    program_unit: &UnitInfo,
+) -> Option<VerifiedBreakpoint> {
+    let instruction_location = instruction_sequence
+        .instructions
+        .iter()
+        .filter(|instruction_location| {
+            instruction_location.instruction_type == InstructionType::HaltLocation
+                && matching_file_index == instruction_location.file_index
+                && instruction_location
+                    .line
+                    .is_some_and(|il_line| il_line.get() >= line)
+        })
+        .min_by_key(|instruction_location| {
+            (
+                instruction_location.line.map(NonZeroU64::get),
+                instruction_location.address,
+            )
+        })?;
 
     let source_location =
         SourceLocation::from_instruction_location(debug_info, program_unit, instruction_location)?;

--- a/probe-rs-debug/tests/source_location.rs
+++ b/probe-rs-debug/tests/source_location.rs
@@ -79,6 +79,34 @@ fn breakpoint_location_inexact() {
 }
 
 #[test]
+fn breakpoint_location_next_available_line() {
+    // Lines 239 and 255 have no halt location of their own, so a breakpoint on them should
+    // move forward to the next line that does (240 and 256 respectively) instead of being
+    // rejected as unverified. Regression test for #2180.
+    let test_data = [(239, 240, 0x80006EA), (255, 256, 0x8000958)];
+
+    let di = DebugInfo::from_file("tests/probe-rs-debugger-test").unwrap();
+    let path = UnixPathBuf::from("/Users/jacknoppe/dev/probe-rs-debugger-test/src/main.rs")
+        .to_typed_path_buf();
+
+    for (requested_line, resolved_line, addr) in test_data.iter() {
+        let bp = di
+            .get_breakpoint_location(path.to_path(), *requested_line, None)
+            .expect("Failed to find a next-available breakpoint location.");
+
+        assert_eq!(
+            *addr, bp.address,
+            "Address mismatch for line {requested_line}"
+        );
+        assert_eq!(
+            Some(*resolved_line),
+            bp.source_location.line,
+            "Breakpoint on line {requested_line} should resolve to line {resolved_line}"
+        );
+    }
+}
+
+#[test]
 fn source_location() {
     let di = DebugInfo::from_file("tests/probe-rs-debugger-test").unwrap();
 


### PR DESCRIPTION
Breakpoints on a line the compiler emitted no instructions for (lines a few levels deep, folded code) resolved to nothing and showed up unverified/disabled in the editor — #2180.

`for_source_location` only matched a halt location when the requested line had one exactly. The doc comment already described a "next available line" fallback, but it was never implemented. This adds it: when no exact file/line match exists, the breakpoint moves to the halt location on the nearest line at or after the requested one (what GDB/LLDB do).

Regression test added against the checked-in fixture: lines 239 and 255 (no rows of their own) now resolve to 240 and 256.