### PR TITLE
ci: check for unused deps with cargo-machete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,14 @@ jobs:
       - uses: actions/checkout@v6
       - uses: crate-ci/typos@master
 
+  machete:
+    name: Unused dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@cargo-machete
+      - run: cargo machete
+
   doc:
     name: Check docs
     runs-on: ubuntu-latest

--- a/probe-rs-debug/tests/gpio-hal-blinky/Cargo.toml
+++ b/probe-rs-debug/tests/gpio-hal-blinky/Cargo.toml
@@ -14,3 +14,7 @@ cortex-m = { version = "0.7", features = [
 ] }
 panic-halt = "1.0.0"
 microbit = "0.16.0"
+
+# panic-halt is only linked for its #[panic_handler], so it looks unused
+[package.metadata.cargo-machete]
+ignored = ["panic-halt"]


### PR DESCRIPTION
Adds a cargo-machete job to catch dependencies that are declared but not used.

Only hit was panic-halt in the blinky test fixture, which is a false positive (it's the panic handler), so it's ignored via package metadata.