### PR TITLE
ci: don't build release artifacts on every PR

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -16,7 +16,7 @@ unix-archive = ".tar.xz"
 # The installers to generate for each app
 installers = ["shell", "powershell", "homebrew"]
 # Which actions to run on pull requests
-pr-run-mode = "upload"
+pr-run-mode = "plan"
 # A GitHub repo to push Homebrew formulas to
 tap = "probe-rs/homebrew-probe-rs"
 # A prefix git tags must include for dist to care about them


### PR DESCRIPTION
pr-run-mode = upload builds the full dist matrix (mac/windows/linux) on every PR, which is way too much - it was firing on unrelated PRs. Back to plan.

To check the dist build before an actual release, push an rc tag (vX.Y.Z-rc.N) - that runs the real pipeline as a prerelease.

Separately, the 0.32.0 installer was failing with a digest mismatch on those PR builds - worth a look before the next release.