### PR TITLE
chore: stop typos flagging chip part numbers

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,10 @@
+[default]
+# Chip part numbers (e.g. PSC3P7GES3PAFQ1, STM32H747XI) are single caps+digit
+# tokens whose substrings keep tripping the checker (GES, ...). Ignore any
+# identifier containing a digit; real prose typos don't have one. This covers
+# every current and future part number so they don't each need an entry below.
+extend-ignore-identifiers-re = ["[A-Za-z]*[0-9][A-Za-z0-9]*"]
+
 # Domain terms and abbreviations that look like typos but aren't.
 [default.extend-words]
 pn = "pn"           # Renesas register/field name


### PR DESCRIPTION
Part numbers like `PSC3P7GES3PAFQ1` are single caps+digit tokens. The spell checker splits them into subwords and flags the ones that look like words (`GES`->`GOES`), so every new chip means another false positive to whitelist.

This ignores any identifier that contains a digit, which covers part numbers across YAML, source and changelog in one rule. Real prose typos don't contain digits, so they're still caught.

Verified locally with typos v1.48.0: `PSC3P7GES3PAFQ1`/`STM32H747XI` no longer flagged, `appropiate` still is.

Not covered on purpose: some non-SKU false positives (`pn`, `unstall`) and a couple of genuine typos (`stuct`, `hpe`) already exist in the tree; those are separate from the part-number problem.