### PR TITLE
ci: dry-run and release via dispatch

### DIFF
--- a/.github/workflows/release_crates.yml
+++ b/.github/workflows/release_crates.yml
@@ -94,3 +94,12 @@ jobs:
           echo "::endgroup::"
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+
+      # dist releases run on workflow_dispatch (dispatch-releases), so kick off
+      # the build for the tag we just pushed.
+      - name: Trigger the release build
+        run: gh workflow run v-release.yml --ref "$RELEASE_BRANCH" -f tag="v$VERSION"
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          RELEASE_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
+          VERSION: ${{ steps.crate_version.outputs.version }}

--- a/.github/workflows/release_dry_run.yml
+++ b/.github/workflows/release_dry_run.yml
@@ -1,6 +1,7 @@
-# Dry-runs the crates.io publish on open release PRs (label 'release'), so
-# build/packaging/version problems surface on the PR instead of only when the
-# real release runs on merge. Never publishes, tags or pushes anything.
+# Dry-runs a release on PRs labelled 'release': a crates.io publish dry-run, plus
+# the full dist build (dispatched as a dry-run of the release workflow). Catches
+# publish/build/runner problems on the release PR instead of when we cut the
+# release. Nothing is published, tagged or pushed.
 
 on:
   pull_request:
@@ -11,11 +12,23 @@ on:
 name: Release dry-run
 
 jobs:
-  dry-run:
+  publish:
     name: Dry-run publish
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'release')
-
     steps:
       - uses: actions/checkout@v6
       - run: cargo publish --workspace --dry-run
+
+  # Dispatch the release workflow in dry-run mode against this PR's branch, so
+  # the real dist build (all targets) runs without publishing. Result shows up
+  # as a separate run under the Release workflow, not as a check on this PR.
+  build:
+    name: Dispatch dry-run build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release')
+    steps:
+      - run: gh workflow run v-release.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD" -f tag=dry-run
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          HEAD: ${{ github.head_ref }}

--- a/.github/workflows/release_dry_run.yml
+++ b/.github/workflows/release_dry_run.yml
@@ -20,15 +20,27 @@ jobs:
       - uses: actions/checkout@v6
       - run: cargo publish --workspace --dry-run
 
-  # Dispatch the release workflow in dry-run mode against this PR's branch, so
-  # the real dist build (all targets) runs without publishing. Result shows up
-  # as a separate run under the Release workflow, not as a check on this PR.
+  # Run the real dist build (all targets) as a dry-run without copying dist's
+  # workflow: dispatch it against this PR's branch and watch it, so this job's
+  # pass/fail mirrors the build and shows up as a check on the PR.
   build:
-    name: Dispatch dry-run build
+    name: Dry-run build
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release')
     steps:
-      - run: gh workflow run v-release.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD" -f tag=dry-run
+      - name: Dispatch and watch the dist dry-run build
+        run: |
+          before=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow=v-release.yml --branch "$HEAD" --limit 1 --json databaseId --jq '.[0].databaseId // 0')
+          gh workflow run v-release.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD" -f tag=dry-run
+
+          # Wait for the new run to appear, then mirror its result.
+          for _ in $(seq 1 30); do
+            run_id=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow=v-release.yml --branch "$HEAD" --limit 1 --json databaseId --jq '.[0].databaseId // 0')
+            [ "$run_id" != "$before" ] && break
+            sleep 5
+          done
+          echo "Watching run $run_id"
+          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           HEAD: ${{ github.head_ref }}

--- a/.github/workflows/v-release.yml
+++ b/.github/workflows/v-release.yml
@@ -17,7 +17,7 @@ name: Release
 permissions:
   "contents": "write"
 
-# This task will run whenever you push a git tag that looks like a version
+# This task will run whenever you workflow_dispatch with a tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
 # Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
@@ -39,10 +39,13 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
-  pull_request:
-  push:
-    tags:
-      - 'v**[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release Tag
+        required: true
+        default: dry-run
+        type: string
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
@@ -50,9 +53,9 @@ jobs:
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
-      publishing: ${{ !github.event.pull_request }}
+      tag: ${{ (inputs.tag != 'dry-run' && inputs.tag) || '' }}
+      tag-flag: ${{ inputs.tag && inputs.tag != 'dry-run' && format('--tag={0}', inputs.tag) || '' }}
+      publishing: ${{ inputs.tag && inputs.tag != 'dry-run' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -77,7 +80,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          dist ${{ (inputs.tag && inputs.tag != 'dry-run' && format('host --steps=create --tag={0}', inputs.tag)) || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -93,7 +96,7 @@ jobs:
     # Let the initial task tell us to not run (currently very blunt)
     needs:
       - plan
-    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
+    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') || inputs.tag == 'dry-run' }}
     strategy:
       fail-fast: false
       # Target platforms/runners are computed by dist in create-release.
@@ -131,10 +134,6 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
-      - uses: swatinem/rust-cache@v2
-        with:
-          key: ${{ join(matrix.targets, '-') }}
-          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -16,7 +16,9 @@ unix-archive = ".tar.xz"
 # The installers to generate for each app
 installers = ["shell", "powershell", "homebrew"]
 # Which actions to run on pull requests
-pr-run-mode = "upload"
+pr-run-mode = "skip"
+# Trigger releases via workflow_dispatch (with a dry-run option) instead of tag push
+dispatch-releases = true
 # A GitHub repo to push Homebrew formulas to
 tap = "probe-rs/homebrew-probe-rs"
 # A prefix git tags must include for dist to care about them


### PR DESCRIPTION
Goal: run the full dist build on the release PR (to catch broken/retired runners and toolchains before cutting a release), show it as a check on that PR, not build on other PRs, and not copy dist's generated workflow.

dist can't scope its PR builds to release PRs, so instead of duplicating its build jobs we reuse the release workflow itself:

- dispatch-releases = true: the release workflow runs on workflow_dispatch, with a dry-run tag that builds everything without publishing.
- pr-run-mode = skip: dist is dropped from PRs entirely - the Release workflow no longer triggers on PRs at all.
- release_dry_run.yml (on release-labelled PRs) dispatches a dry-run build for the PR's branch and watches it, so its own pass/fail mirrors the build and shows as a check on the PR. No copy of the generated workflow, nothing to drift.
- release_crates.yml dispatches the real build for the tag it just pushed, so releasing stays automatic: merge release PR -> crates publish -> tag pushed -> dist build + GitHub release.

Normal PR -> nothing dist-related. Release PR -> crates dry-run + full dist build, both as checks. Real release -> automatic.

Cost of the watch approach: the dry-run job holds a runner while it polls the dispatched build (~build duration). Fine for release PRs, which are rare.