### PR TITLE
ci: clippy every feature on all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,10 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check:
-    name: Check
+  clippy:
+    name: Clippy
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest
@@ -44,14 +45,12 @@ jobs:
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2.9.1
 
-      - name: cargo check for probe-rs, --no-default-features
-        run: cargo check -p probe-rs --no-default-features --locked
+      - uses: taiki-e/install-action@cargo-hack
 
-      - name: Run cargo check
-        run: cargo check --locked
-
-      - name: Run cargo check with all features
-        run: cargo check --all-features --locked
+      # --each-feature lints every feature on its own and also covers
+      # --all-features and --no-default-features.
+      - name: Run clippy
+        run: cargo hack clippy --each-feature --all-targets --workspace --locked -- -D warnings
 
   test:
     name: Test Suite
@@ -93,19 +92,6 @@ jobs:
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v6
-
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v2.9.1
-
-      - name: Run cargo clippy
-        run: cargo clippy --all-features --all-targets --locked -- -D warnings
 
   cargo-deny:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Replaces the cargo check matrix with clippy (clippy is a superset of check), and runs the same command on all three OSes:

    cargo hack clippy --each-feature --all-targets --workspace -- -D warnings

--each-feature lints every feature on its own and also covers --all-features and --no-default-features, so both feature-gated and platform-specific code get linted on every OS. Folds in what was the separate feature-combos PR (#4148). clippy -- -D warnings already denies plain rustc warnings, so no RUSTFLAGS needed.

Heads up: may surface pre-existing warnings on windows/macos that were only compiled before - I'll fix what CI turns up.