### PR TITLE
ci: check each feature builds on its own

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,3 +149,18 @@ jobs:
 
       - name: Check minimum Rust version
         run: cargo hack check --rust-version --workspace --all-targets --ignore-private
+
+  feature-combos:
+    name: Feature combinations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v2.9.1
+
+      - uses: taiki-e/install-action@cargo-hack
+
+      - name: Check each feature
+        run: cargo hack check --each-feature --workspace --locked


### PR DESCRIPTION
Adds cargo hack check --each-feature over the workspace. Right now everything is built with the default set or --all-features, so a feature that only compiles when another happens to be on slips through. This builds each feature in isolation (and with none) to catch that.

--each-feature is linear in the number of features, so it's cheap here.