### PR TITLE
ci: report test coverage as a PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,3 +157,45 @@ jobs:
 
       - name: Check minimum Rust version
         run: cargo hack check --rust-version --workspace --all-targets --ignore-private
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v2.9.1
+
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@nextest
+
+      - name: Measure coverage
+        run: |
+          cargo llvm-cov nextest --all-features --locked --profile ci-unit --summary-only > cov.txt
+          lines=$(awk '/^TOTAL/{print $10}' cov.txt)
+          funcs=$(awk '/^TOTAL/{print $7}' cov.txt)
+          regions=$(awk '/^TOTAL/{print $4}' cov.txt)
+          {
+            echo "### Test coverage"
+            echo
+            echo "**Lines \`${lines}\` · Functions \`${funcs}\` · Regions \`${regions}\`**"
+            echo
+            echo "<details><summary>Per-file breakdown</summary>"
+            echo
+            echo '```'
+            cat cov.txt
+            echo '```'
+            echo
+            echo "</details>"
+          } > coverage.md
+
+      - name: Comment coverage on the PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: coverage
+          path: coverage.md


### PR DESCRIPTION
Runs cargo-llvm-cov over the nextest suite and posts the coverage summary as a sticky comment on the PR.

Went with this instead of Codecov: Codecov accepts the uploads but never processes them - the upload sessions sit in state=started with totals=null indefinitely, on both the new and legacy upload endpoints (verified via their API, ~90min+ unprocessed). The report we send is correct (valid yaml, repo-relative paths, 386 files / 67k lines), so it's their processing pipeline, not us. Rather than depend on that, this posts the numbers straight from CI.

- No external service, no token, no app install.
- Sticky comment updates in place on each push.
- Trade-off vs Codecov: no inline red/green annotations on the diff (only a hosted service does those). You get the total + per-file table as a comment.

Uses marocchino/sticky-pull-request-comment (needs pull-requests: write, scoped to this job).