### PR TITLE
fix(gdb): advertise absolute flash sector addresses in memory map

### DIFF
--- a/changelog/fixed-gdb-load-flash-base.md
+++ b/changelog/fixed-gdb-load-flash-base.md
@@ -1,0 +1,1 @@
+Fixed the GDB `load` command failing immediately with "Load failed" on targets whose flash does not start at address 0. The GDB memory map advertised flash regions using the flash algorithm's region-relative sector offset instead of the absolute address, so `vFlashErase`/`vFlashWrite` targeted the wrong addresses. The region base is now added back to the advertised flash start.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/desc/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/desc/mod.rs
@@ -156,7 +156,10 @@ fn gdb_memory_map(session: &mut Session, primary_core_id: usize) -> Result<Strin
             // sector size.
             for (current, next) in sectors.iter().zip(sectors.iter().skip(1)) {
                 let region = FlashRegion {
-                    start: current.address,
+                    // Sector addresses in the flash algorithm are relative to
+                    // the region base, so add `start` to advertise the
+                    // absolute address GDB expects for vFlashErase/vFlashWrite.
+                    start: start + current.address,
                     length: next.address - current.address,
                     blocksize: current.size,
                 };

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/target/flash.rs
@@ -39,9 +39,15 @@ impl Flash for RuntimeTarget<'_> {
             .flash_loader
             .get_or_insert_with(|| self.session.lock().target().flash_loader());
 
-        flash_loader
-            .add_data(start_addr, data)
-            .map_err(|_e| TargetError::NonFatal)?;
+        flash_loader.add_data(start_addr, data).map_err(|e| {
+            tracing::error!(
+                "GDB flash_write failed to stage {} bytes at {:#010x}: {:#}",
+                data.len(),
+                start_addr,
+                e
+            );
+            TargetError::NonFatal
+        })?;
         Ok(())
     }
 
@@ -50,7 +56,10 @@ impl Flash for RuntimeTarget<'_> {
         let mut session = self.session.lock();
         flash_loader
             .commit(&mut session, DownloadOptions::default())
-            .map_err(|_e| TargetError::NonFatal)?;
+            .map_err(|e| {
+                tracing::error!("GDB flash_done failed to commit flash programming: {:#}", e);
+                TargetError::NonFatal
+            })?;
 
         let _drop = self.flash_loader.take();
         Ok(())


### PR DESCRIPTION
This PR fixes the GDB load command failing with "Load failed" on targets whose flash doesn't start at address 0. The memory map advertised flash sectors using a region-relative offset instead of the absolute address, so GDB erased/wrote the wrong locations. The region base is now added back to the advertised address.