### PR TITLE
fix(probe): handle raw AP/DP register access in FakeProbe for dry-run on ADIv6 chips

### DIFF
--- a/changelog/fixed-dry-run-adiv6-registers.md
+++ b/changelog/fixed-dry-run-adiv6-registers.md
@@ -1,0 +1,1 @@
+Fix `--dry-run` panic on ADIv6 chips by handling raw AP/DP register accesses with sensible defaults in `FakeProbe`.

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -60,8 +60,8 @@ enum Endianness {
 
 #[cfg(test)]
 impl From<Endianness> for object::Endianness {
-    fn from(endianess: Endianness) -> Self {
-        match endianess {
+    fn from(endianness: Endianness) -> Self {
+        match endianness {
             Endianness::Little => object::Endianness::Little,
             Endianness::Big => object::Endianness::Big,
         }

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -60,8 +60,8 @@ enum Endianness {
 
 #[cfg(test)]
 impl From<Endianness> for object::Endianness {
-    fn from(endianness: Endianness) -> Self {
-        match endianness {
+    fn from(endianess: Endianness) -> Self {
+        match endianess {
             Endianness::Little => object::Endianness::Little,
             Endianness::Big => object::Endianness::Big,
         }
@@ -420,10 +420,23 @@ impl FakeProbe {
 
                 Ok(result)
             }
-            None => panic!(
-                "No more operations expected, but got read_raw_ap_register ap={expected_ap:?}, address:{expected_address}"
-            ),
-            //other => panic!("Unexpected operation: {:?}", other),
+            None => {
+                // ADIv6 MEM-AP/APv2 register frame: CSW lives at offset 0xD00.
+                // Bit 6 of CSW is DeviceEn. Debug sequences read it to check
+                // whether the AP is ready, so report it as ready by default.
+                const ADI_V6_CSW_OFFSET: u64 = 0xD00;
+                const CSW_DEVICE_EN: u32 = 1 << 6;
+                let default = if expected_address == ADI_V6_CSW_OFFSET {
+                    CSW_DEVICE_EN
+                } else {
+                    0
+                };
+                tracing::warn!(
+                    "FakeProbe: no queued operation for read_raw_ap_register \
+                     ap={expected_ap:?}, address:{expected_address:#x} -- returning {default:#010x}"
+                );
+                Ok(default)
+            }
         }
     }
 
@@ -697,7 +710,13 @@ impl DapAccess for FakeArmInterface {
         _dp: DpAddress,
         _address: DpRegisterAddress,
     ) -> Result<u32, ArmError> {
-        todo!()
+        // Debug sequences may read DP registers directly. Hand back a harmless
+        // default instead of panicking, like the AP register fallback below.
+        tracing::warn!(
+            "FakeProbe: no queued operation for read_raw_dp_register dp={_dp:?}, \
+             address:{_address:?} -- returning 0"
+        );
+        Ok(0)
     }
 
     fn write_raw_dp_register(
@@ -706,7 +725,8 @@ impl DapAccess for FakeArmInterface {
         _address: DpRegisterAddress,
         _value: u32,
     ) -> Result<(), ArmError> {
-        todo!()
+        // See read_raw_dp_register: writes must not panic either.
+        Ok(())
     }
 
     fn read_raw_ap_register(
@@ -732,7 +752,7 @@ impl DapAccess for FakeArmInterface {
         _address: u64,
         _value: u32,
     ) -> Result<(), ArmError> {
-        todo!()
+        Ok(())
     }
 
     fn write_raw_ap_register_repeated(


### PR DESCRIPTION
This PR fixes `probe-rs dry-run` panicking on ADIv6-based chips when there's no queued mock operation for a raw AP/DP register access. FakeProbe now returns sensible defaults instead of panicking, including reporting DeviceEn set on the ADIv6 CSW register.