### PR TITLE
fix(profile): fall back to `text` section for debug ID when `.text` is absent

### DIFF
--- a/changelog/fixed-profile-callstack-text-section-debug-id.md
+++ b/changelog/fixed-profile-callstack-text-section-debug-id.md
@@ -1,0 +1,1 @@
+Fixed `profile callstack` failing to compute a debug ID for ELF files whose code section is named `text` instead of `.text`.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/profile/callstack/samply_object.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/profile/callstack/samply_object.rs
@@ -32,7 +32,11 @@ pub(crate) fn debug_id_for_object<'data>(obj: &impl Object<'data>) -> Option<Deb
     }
     // We were not able to locate a build ID, so fall back to creating a synthetic
     // identifier from a hash of the first page of the ".text" (program code) section.
-    if let Some(section) = obj.section_by_name(".text") {
+    // Some toolchains (e.g. Zephyr) use "text" without a leading dot.
+    let text_section = obj
+        .section_by_name(".text")
+        .or_else(|| obj.section_by_name("text"));
+    if let Some(section) = text_section {
         let data_len = section.size().min(4096);
         if let Ok(Some(first_page_data)) = section.data_range(section.address(), data_len) {
             return Some(DebugId::from_text_first_page(


### PR DESCRIPTION
This PR fixes profile callstack failing to compute a debug ID for ELF files whose code section is named text instead of .text. The lookup now also checks for text to support toolchains that omit the leading dot.