### PR TITLE
fix(debug): return error instead of panicking when CLI event channel is full

### DIFF
--- a/changelog/fixed-debug-cli-channel-panic.md
+++ b/changelog/fixed-debug-cli-channel-panic.md
@@ -1,0 +1,1 @@
+Fixed a panic in the `probe-rs debug` CLI when its internal event channel filled up under heavy RTT or output load.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
@@ -71,7 +71,9 @@ impl ProtocolAdapter for CliAdapter {
     ) -> anyhow::Result<()> {
         self.msg_sender
             .try_send((event_type.to_string(), event_body))
-            .unwrap();
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to send event '{event_type}': channel full ({e})")
+            })?;
 
         Ok(())
     }
@@ -82,7 +84,7 @@ impl ProtocolAdapter for CliAdapter {
                 "response".to_string(),
                 Some(serde_json::to_value(response)?),
             ))
-            .unwrap();
+            .map_err(|e| anyhow::anyhow!("Failed to send response: channel full ({e})"))?;
 
         Ok(())
     }
@@ -196,8 +198,8 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(self, client: RpcClient, utc_offset: UtcOffset) -> anyhow::Result<()> {
-        let (req_sender, req_receiver) = mpsc::channel(10);
-        let (msg_sender, mut msg_receiver) = mpsc::channel(10);
+        let (req_sender, req_receiver) = mpsc::channel(100);
+        let (msg_sender, mut msg_receiver) = mpsc::channel(100);
 
         let debug_adapter = DebugAdapter::new(CliAdapter {
             req_receiver,


### PR DESCRIPTION
This PR fixes a panic in the probe-rs debug CLI when its internal event channel filled up under heavy load. Send failures are now returned as errors instead of panicking, and the channel capacity was increased from 10 to 100.