### PR TITLE
fix(profile): skip disabled cores when resetting before profiling

### DIFF
--- a/changelog/fixed-profile-reset-disabled-core.md
+++ b/changelog/fixed-profile-reset-disabled-core.md
@@ -1,0 +1,1 @@
+Fixed `probe-rs profile --reset` aborting when a disabled core was encountered; disabled cores are now skipped instead of returning an error.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/profile.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/profile.rs
@@ -57,7 +57,11 @@ impl ProfileCmd {
 
         if self.reset {
             for (core_idx, _) in session.list_cores() {
-                let mut core = session.core(core_idx)?;
+                let mut core = match session.core(core_idx) {
+                    Ok(core) => core,
+                    Err(probe_rs::Error::CoreDisabled(_)) => continue,
+                    Err(e) => return Err(e.into()),
+                };
                 core.reset()?;
             }
         }


### PR DESCRIPTION
This PR fixes `probe-rs profile --reset` erroring out when a core is disabled. It now skips disabled cores instead of failing.