### PR TITLE
ci: move ARM linux release builds to GitHub runners + harden dry-run

### DIFF
--- a/.github/workflows/release_dry_run.yml
+++ b/.github/workflows/release_dry_run.yml
@@ -33,14 +33,34 @@ jobs:
           before=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow=v-release.yml --branch "$HEAD" --limit 1 --json databaseId --jq '.[0].databaseId // 0')
           gh workflow run v-release.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD" -f tag=dry-run
 
-          # Wait for the new run to appear, then mirror its result.
+          # Wait for the new run to appear.
+          run_id=0
           for _ in $(seq 1 30); do
             run_id=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow=v-release.yml --branch "$HEAD" --limit 1 --json databaseId --jq '.[0].databaseId // 0')
             [ "$run_id" != "$before" ] && break
             sleep 5
           done
           echo "Watching run $run_id"
-          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
+
+          # Poll until the run finishes. Abort if a build job can't get a runner
+          # (stuck in "queued"), instead of watching a never-starting job forever.
+          # Judging by the final conclusion means an API hiccup can't fail a green build.
+          start=$(date +%s)
+          while :; do
+            info=$(gh run view "$run_id" --repo "$GITHUB_REPOSITORY" --json status,jobs)
+            [ "$(jq -r .status <<<"$info")" = "completed" ] && break
+            queued=$(jq -r '[.jobs[] | select(.status == "queued")] | length' <<<"$info")
+            if [ "$queued" -gt 0 ] && [ $(( $(date +%s) - start )) -gt 600 ]; then
+              echo "::error::dist build has jobs stuck with no runner for >10min:"
+              jq -r '.jobs[] | select(.status == "queued") | "  - " + .name' <<<"$info"
+              gh run cancel "$run_id" --repo "$GITHUB_REPOSITORY" || true
+              exit 1
+            fi
+            sleep 60
+          done
+          result=$(gh run view "$run_id" --repo "$GITHUB_REPOSITORY" --json conclusion --jq .conclusion)
+          echo "dist dry-run build: $result"
+          [ "$result" = "success" ]
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           HEAD: ${{ github.head_ref }}

--- a/.github/workflows/release_dry_run.yml
+++ b/.github/workflows/release_dry_run.yml
@@ -42,21 +42,25 @@ jobs:
           done
           echo "Watching run $run_id"
 
-          # Poll until the run finishes. Abort if a build job can't get a runner
-          # (stuck in "queued"), instead of watching a never-starting job forever.
+          # Poll until the run finishes. The build jobs sit "queued" while `plan`
+          # runs (they need it), so only start the runner clock once plan is done:
+          # a healthy runner attaches within a minute, so if a build job is still
+          # queued 1 min after that, no runner is coming -> abort.
           # Judging by the final conclusion means an API hiccup can't fail a green build.
-          start=$(date +%s)
+          plan_done=0
           while :; do
             info=$(gh run view "$run_id" --repo "$GITHUB_REPOSITORY" --json status,jobs)
-            [ "$(jq -r .status <<<"$info")" = "completed" ] && break
-            queued=$(jq -r '[.jobs[] | select(.status == "queued")] | length' <<<"$info")
-            if [ "$queued" -gt 0 ] && [ $(( $(date +%s) - start )) -gt 600 ]; then
-              echo "::error::dist build has jobs stuck with no runner for >10min:"
-              jq -r '.jobs[] | select(.status == "queued") | "  - " + .name' <<<"$info"
+            if [ "$(jq -r .status <<<"$info")" = "completed" ]; then break; fi
+            plan_status=$(jq -r '.jobs[] | select(.name == "plan") | .status' <<<"$info")
+            if [ "$plan_status" = "completed" ] && [ "$plan_done" = 0 ]; then plan_done=$(date +%s); fi
+            stuck=$(jq '[.jobs[] | select(.name != "plan" and .status == "queued")] | length' <<<"$info")
+            if [ "$plan_done" != 0 ] && [ "$stuck" -gt 0 ] && [ "$(( $(date +%s) - plan_done ))" -gt 60 ]; then
+              echo "::error::a dist build job got no runner within 1 min of plan completing:"
+              jq -r '.jobs[] | select(.name != "plan" and .status == "queued") | "  - " + .name' <<<"$info"
               gh run cancel "$run_id" --repo "$GITHUB_REPOSITORY" || true
               exit 1
             fi
-            sleep 60
+            sleep 20
           done
           result=$(gh run view "$run_id" --repo "$GITHUB_REPOSITORY" --json conclusion --jq .conclusion)
           echo "dist dry-run build: $result"

--- a/.typos.toml
+++ b/.typos.toml
@@ -5,6 +5,9 @@
 # every current and future part number so they don't each need an entry below.
 extend-ignore-identifiers-re = ["[A-Za-z]*[0-9][A-Za-z0-9]*"]
 
+# GitHub @handles in changelog credits aren't words (e.g. @bastien-buil).
+extend-ignore-re = ["@[A-Za-z0-9-]+"]
+
 # Domain terms and abbreviations that look like typos but aren't.
 [default.extend-words]
 pn = "pn"           # Renesas register/field name

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -32,8 +32,8 @@ install-path = "CARGO_HOME"
 # Whether to enable GitHub Attestations
 github-attestations = true
 
-# Select custom runner for ARM Linux
+# Select custom runner for ARM Linux (GitHub-hosted ARM runners)
 [dist.github-custom-runners]
 global = "ubuntu-22.04"
-aarch64-unknown-linux-gnu = "buildjet-2vcpu-ubuntu-2204-arm"
-aarch64-unknown-linux-musl = "buildjet-2vcpu-ubuntu-2204-arm"
+aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"
+aarch64-unknown-linux-musl = "ubuntu-24.04-arm"


### PR DESCRIPTION
Three CI fixes, prompted by the 0.32.0 release attempt (#4157):

**ARM linux runner** — the `aarch64-unknown-linux-gnu` dist build was pinned to BuildJet's `buildjet-2vcpu-ubuntu-2204-arm`, which stalled in `queued` with no runner mid-release (the other 4 targets built fine). GitHub now offers hosted ARM runners, so build it on `ubuntu-24.04-arm` and drop the BuildJet dependency. Runner label is read from config at plan time, so no v-release.yml change.

**Abort if no runner** — the release dry-run used `gh run watch`, which waits forever on a job that never starts (exactly the BuildJet case) and hammers the API. Now it polls every 60s and aborts if any build job is stuck `queued` >10min (cancelling the run), and judges success by the final conclusion so an API hiccup can't red-X a green build.

**typos @handles** — changelog credits like `by @bastien-buil` split on the hyphen and look like typos. Ignore `@handle` tokens; real prose (incl. the rest of the changelog) is still checked.

The dry-run/typos fixes were first applied on the release branch to unblock #4157; transplanted here so they live in a proper PR to master.