### PR TITLE
Use stderr rather than stdout for interactive probe selection

### DIFF
--- a/changelog/changed-interactive-probe-select-stderr.md
+++ b/changelog/changed-interactive-probe-select-stderr.md
@@ -1,0 +1,1 @@
+Interactive probe selection uses stderr instead of stdout

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -155,13 +155,13 @@ pub async fn select_probe(
     match client.select_probe(probe).await? {
         SelectProbeResult::Success(probe) => Ok(probe),
         SelectProbeResult::MultipleProbes(list) => {
-            println!("Available Probes:");
+            eprintln!("Available Probes:");
             for (i, probe_info) in list.iter().enumerate() {
-                println!("{i}: {probe_info}");
+                eprintln!("{i}: {probe_info}");
             }
 
-            print!("Selection: ");
-            std::io::stdout().flush().unwrap();
+            eprint!("Selection: ");
+            std::io::stderr().flush().unwrap();
 
             let mut input = String::new();
             std::io::stdin()

--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -238,13 +238,13 @@ impl<'r> LoadedProbeOptions<'r> {
     fn interactive_probe_select(
         list: &[DebugProbeInfo],
     ) -> Result<&DebugProbeInfo, OperationError> {
-        println!("Available Probes:");
+        eprintln!("Available Probes:");
         for (i, probe_info) in list.iter().enumerate() {
-            println!("{i}: {probe_info}");
+            eprintln!("{i}: {probe_info}");
         }
 
-        print!("Selection: ");
-        std::io::stdout().flush().unwrap();
+        eprint!("Selection: ");
+        std::io::stderr().flush().unwrap();
 
         let mut input = String::new();
         std::io::stdin()


### PR DESCRIPTION
This makes probe selection usable when probe-rs's output is piped somewhere else.