### PR TITLE
fix: make 0.32.0 publishable (descriptions + probe-rs-mi bump)

### DIFF
--- a/probe-rs-espressif/Cargo.toml
+++ b/probe-rs-espressif/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "probe-rs-espressif"
+description = "Espressif chip support built on top of the probe-rs crate"
 version.workspace = true
 edition.workspace = true
 documentation.workspace = true

--- a/probe-rs-linux/Cargo.toml
+++ b/probe-rs-linux/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "probe-rs-linux"
+description = "Linux debug probe backends built on top of the probe-rs crate"
 version.workspace = true
 edition.workspace = true
 documentation.workspace = true


### PR DESCRIPTION
The 0.32.0 `cargo release publish` failed. Two separate reasons, both fixed here:

1. **Missing descriptions** — `cargo release` rejects crates without a `description`, and `probe-rs-espressif` and `probe-rs-linux` (both published, since probe-rs depends on them) had none. Added one to each.

2. **probe-rs-mi stale version** — `probe-rs-mi` gained the `info` module in #3990 (after 0.1.0 was published) but was never version-bumped. `probe-rs-tools` uses `probe_rs_mi::info`, so publishing it against the published 0.1.0 fails with `unresolved import probe_rs_mi::info`. Bumped `probe-rs-mi` to 0.1.1 (additive change) and pointed the workspace dep at it.

Both were found by running `cargo release publish` in dry mode locally - which is exactly what the dry-run *should* do (separate PR for that). The current dry-run used `cargo publish --workspace --dry-run`, which only warns on the first and resolves deps differently, so it caught neither.

Master is already at 0.32.0 (unpublished, no tag pushed). After this merges, re-dispatch `Release on crates.io` to publish.