### PR TITLE
ci: dry-run publish with cargo-release instead of cargo publish

### DIFF
--- a/.github/workflows/release_dry_run.yml
+++ b/.github/workflows/release_dry_run.yml
@@ -18,7 +18,12 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'release')
     steps:
       - uses: actions/checkout@v6
-      - run: cargo publish --workspace --dry-run
+      - uses: taiki-e/install-action@cargo-release
+      # Use cargo-release (not `cargo publish --dry-run`) so the dry-run runs the
+      # exact checks the real release does: metadata validation (missing
+      # description etc.) plus the verification build. --allow-branch lets it run
+      # on the release PR branch; leaving off --execute keeps it a dry-run.
+      - run: cargo release publish --no-confirm --allow-branch '*'
 
   # Run the real dist build (all targets) as a dry-run without copying dist's
   # workflow: dispatch it against this PR's branch and watch it, so this job's


### PR DESCRIPTION
The crates dry-run ran `cargo publish --workspace --dry-run`, but the real release runs `cargo release publish`. Different tools:

- cargo publish only *warns* on a missing `description`; cargo-release hard-errors.
- they resolve inter-crate deps differently, so cargo publish didn't surface the `probe-rs-mi` version mismatch.

Both gaps let the 0.32.0 publish break despite a green dry-run (see #4161). Fix: run the same command the release does, minus `--execute`. `--allow-branch '*'` lets it run on the release PR branch.

Verified locally: `cargo release publish --no-confirm --allow-branch '*'` on the pre-fix tree reproduces both failures (missing description + `unresolved import probe_rs_mi::info`) that the old dry-run passed.