### PR TITLE
chore: bump probe-rs-mi to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "probe-rs-mi"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ exclude = ["probe-rs/tests/gpio-hal-blinky"]
 [workspace.dependencies]
 probe-rs = { path = "probe-rs", version = "0.32.0" }
 probe-rs-target = { path = "probe-rs-target", version = "0.32.0" }
-probe-rs-mi = { path = "probe-rs-mi", version = "0.1.0" }
+probe-rs-mi = { path = "probe-rs-mi", version = "0.2.0" }
 probe-rs-espressif = { path = "probe-rs-espressif", version = "0.32.0" }
 probe-rs-linux = { path = "probe-rs-linux", version = "0.32.0" }
 

--- a/probe-rs-mi/Cargo.toml
+++ b/probe-rs-mi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.1.0"
+version = "0.2.0"
 name = "probe-rs-mi"
 edition.workspace = true
 documentation.workspace = true


### PR DESCRIPTION
probe-rs-mi's `info` changes (#3990, 2026-05-30) are breaking, and it was never bumped after 0.1.0 was published. probe-rs-tools uses `probe_rs_mi::info`, so publishing probe-rs-tools 0.32.0 against the published mi 0.1.0 fails (`unresolved import probe_rs_mi::info`) - for CI and end users.

Bump mi to 0.2.0 (breaking change = minor bump for a 0.x crate) and point the workspace dep at it.

Plan: publish mi 0.2.0 once by hand, then the automated 0.32.0 release resolves against the published 0.2.0 (and skips re-publishing it).