### PR TITLE
ci: drop x86_64-apple-darwin from dist targets

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,7 +8,7 @@ cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Build only the required packages, and individually
 precise-builds = true
 # The archive format to use for non-windows builds (defaults .tar.xz)


### PR DESCRIPTION
The x86_64 macOS build cross-compiles on the Apple-Silicon runner (GitHub has no Intel mac runners), and it's consistently the slowest job in the release - LTO codegen of the big probe-rs crate, from scratch, cross-target.

Intel Macs haven't been sold in years and Apple Silicon is covered by aarch64-apple-darwin, so drop the x86 darwin prebuilt. Intel Mac users can still `cargo install probe-rs-tools`.