### PR TITLE
fix(gdb_server): sort core groups deterministically by discovery order

### DIFF
--- a/changelog/fixed-gdb-core-mapping.md
+++ b/changelog/fixed-gdb-core-mapping.md
@@ -1,0 +1,1 @@
+- Fixed non-deterministic TCP port bindings in probe-rs gdb for multi-core targets with distinct core types.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/stub.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/stub.rs
@@ -48,13 +48,19 @@ impl GdbInstanceConfiguration {
         // Build a grouped list of cores by core type
         // GDB only supports one architecture per stub so if we have two core types,
         // such as ARMv7-a + ARMv7-m, we must create two stubs to connect to.
-        let groups = session
+        let mut groups: Vec<_> = session
             .target()
             .cores
             .iter()
             .enumerate()
             .map(|(i, core)| (core.core_type, i))
-            .into_group_map();
+            .into_group_map()
+            .into_iter()
+            .collect();
+
+        // Sort core groups deterministically by the index of their first appearance
+        // in target core definitions (ascending APSEL discovery order).
+        groups.sort_by_key(|(_, cores)| cores.first().copied().unwrap_or(usize::MAX));
 
         // Create a GDB instance for each group, starting at the specified connection and adding one to the port each time
         // For example - consider two groups computed above and an input of localhost:1337.


### PR DESCRIPTION
## Summary

Fixes non-deterministic TCP port bindings in `probe-rs gdb` when serving multi-core targets with distinct core types (e.g. ARMv7-a + ARMv7-m).

## Cause

`GdbInstanceConfiguration::from_session` previously grouped target cores by `CoreType` using `into_group_map()`, which returns an unordered `HashMap`. Because Rust's `HashMap` uses a randomized default seed per process execution, iterating `groups` resulted in randomized assignment of `socket_addrs` to core types across runs.

## Solution

Sort core groups deterministically by the index of the first core of each type in `target.cores` (following AP discovery order / ascending APSEL) before binding TCP ports:

```rust
groups.sort_by_key(|(_, cores)| cores.first().copied().unwrap_or(usize::MAX));
```

This guarantees consistent TCP port mapping across multiple executions.