### PR TITLE
fix(nrf53): reset application core through CTRL-AP

### DIFF
--- a/changelog/fixed-nrf5340-ctrl-ap-reset.md
+++ b/changelog/fixed-nrf5340-ctrl-ap-reset.md
@@ -1,0 +1,1 @@
+Reset the nRF5340 application core through CTRL-AP2 so debugger-triggered resets preserve the debug connection.

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
@@ -5,7 +5,9 @@ use crate::{
         ArmDebugInterface, ArmError, FullyQualifiedApAddress,
         dp::DpAddress,
         memory::ArmMemoryInterface,
-        sequences::{ArmDebugSequence, ArmDebugSequenceError, DebugEraseSequence},
+        sequences::{
+            ArmDebugSequence, ArmDebugSequenceError, DebugEraseSequence, cortex_m_wait_for_reset,
+        },
     },
     session::MissingPermissions,
 };
@@ -29,6 +31,14 @@ pub trait Nrf: Sync + Send + Debug {
 
     /// Returns true if a network core is present
     fn has_network_core(&self) -> bool;
+
+    /// Returns the CTRL-AP used to reset `core_ap`, or `None` to use the generic Cortex-M reset.
+    fn ctrl_ap_for_core(
+        &self,
+        _core_ap: &FullyQualifiedApAddress,
+    ) -> Result<Option<FullyQualifiedApAddress>, ArmError> {
+        Ok(None)
+    }
 
     /// Returns true if the chip must be soft-reset after an erase-all operation (ie to unlock APPROTECT).
     ///
@@ -109,6 +119,28 @@ fn set_network_core_running(interface: &mut dyn ArmMemoryInterface) -> Result<()
 }
 
 impl<T: Nrf> ArmDebugSequence for T {
+    fn reset_system(
+        &self,
+        interface: &mut dyn ArmMemoryInterface,
+        _core_type: crate::CoreType,
+        _debug_base: Option<u64>,
+    ) -> Result<(), ArmError> {
+        // Every current `Nrf` implementor is Cortex-M. A target without a
+        // CTRL-AP override therefore retains the existing Cortex-M reset path.
+        let core_ap = interface.fully_qualified_address();
+        let Some(ctrl_ap) = self.ctrl_ap_for_core(&core_ap)? else {
+            return crate::architecture::arm::sequences::cortex_m_reset_system(interface);
+        };
+
+        let arm_interface = interface.get_arm_debug_interface()?;
+        tracing::debug!(?core_ap, ?ctrl_ap, "Asserting core reset through CTRL-AP");
+        arm_interface.write_raw_ap_register(&ctrl_ap, RESET, 1)?;
+        arm_interface.write_raw_ap_register(&ctrl_ap, RESET, 0)?;
+        arm_interface.flush()?;
+
+        cortex_m_wait_for_reset(interface)
+    }
+
     fn debug_device_unlock(
         &self,
         interface: &mut dyn ArmDebugInterface,

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
@@ -5,7 +5,7 @@ use crate::{
         ArmDebugInterface, ArmError, FullyQualifiedApAddress,
         dp::DpAddress,
         memory::ArmMemoryInterface,
-        sequences::{ArmDebugSequence, ArmDebugSequenceError},
+        sequences::{ArmDebugSequence, ArmDebugSequenceError, cortex_m_wait_for_reset},
     },
     session::MissingPermissions,
 };
@@ -28,6 +28,14 @@ pub trait Nrf: Sync + Send + Debug {
 
     /// Returns true if a network core is present
     fn has_network_core(&self) -> bool;
+
+    /// Returns the CTRL-AP used to reset `core_ap`, or `None` to use the generic Cortex-M reset.
+    fn ctrl_ap_for_core(
+        &self,
+        _core_ap: &FullyQualifiedApAddress,
+    ) -> Result<Option<FullyQualifiedApAddress>, ArmError> {
+        Ok(None)
+    }
 
     /// Returns true if the chip must be soft-reset after an erase-all operation (ie to unlock APPROTECT).
     ///
@@ -108,6 +116,28 @@ fn set_network_core_running(interface: &mut dyn ArmMemoryInterface) -> Result<()
 }
 
 impl<T: Nrf> ArmDebugSequence for T {
+    fn reset_system(
+        &self,
+        interface: &mut dyn ArmMemoryInterface,
+        _core_type: crate::CoreType,
+        _debug_base: Option<u64>,
+    ) -> Result<(), ArmError> {
+        // Every current `Nrf` implementor is Cortex-M. A target without a
+        // CTRL-AP override therefore retains the existing Cortex-M reset path.
+        let core_ap = interface.fully_qualified_address();
+        let Some(ctrl_ap) = self.ctrl_ap_for_core(&core_ap)? else {
+            return crate::architecture::arm::sequences::cortex_m_reset_system(interface);
+        };
+
+        let arm_interface = interface.get_arm_debug_interface()?;
+        tracing::debug!(?core_ap, ?ctrl_ap, "Asserting core reset through CTRL-AP");
+        arm_interface.write_raw_ap_register(&ctrl_ap, RESET, 1)?;
+        arm_interface.write_raw_ap_register(&ctrl_ap, RESET, 0)?;
+        arm_interface.flush()?;
+
+        cortex_m_wait_for_reset(interface)
+    }
+
     fn debug_device_unlock(
         &self,
         interface: &mut dyn ArmDebugInterface,

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
@@ -3,11 +3,12 @@
 use std::sync::Arc;
 
 use super::nrf::Nrf;
+use crate::architecture::arm::sequences::ArmDebugSequenceError;
 use crate::architecture::arm::{
-    ArmDebugInterface, ArmError, FullyQualifiedApAddress, ap::CSW, dp::DpAddress,
-    sequences::ArmDebugSequence,
+    ApAddress as ArmApAddress, ArmDebugInterface, ArmError, FullyQualifiedApAddress, ap::CSW,
+    dp::DpAddress, sequences::ArmDebugSequence,
 };
-use probe_rs_target::{ApAddress, Chip, CoreAccessOptions};
+use probe_rs_target::{ApAddress as TargetApAddress, Chip, CoreAccessOptions};
 
 /// The sequence handle for the nRF5340.
 #[derive(Debug)]
@@ -39,8 +40,8 @@ impl Nrf5340 {
             };
 
             let ap_pair = match options.ap {
-                ApAddress::V1(0) => (0, 2),
-                ApAddress::V1(1) => (1, 3),
+                TargetApAddress::V1(0) => (0, 2),
+                TargetApAddress::V1(1) => (1, 3),
                 ref ap => {
                     tracing::error!(
                         "Unsupported nRF5340 core access port {ap:?} for core {}",
@@ -94,11 +95,35 @@ impl Nrf for Nrf5340 {
     fn has_network_core(&self) -> bool {
         self.core_aps.iter().any(|&(ahb_ap, _)| ahb_ap == 1)
     }
+
+    fn ctrl_ap_for_core(
+        &self,
+        core_ap: &FullyQualifiedApAddress,
+    ) -> Result<Option<FullyQualifiedApAddress>, ArmError> {
+        // The nRF5340 application CTRL-AP is documented at AP2:
+        // https://docs.nordicsemi.com/bundle/ps_nrf5340/page/ctrl-ap.html
+        let ctrl_ap = self
+            .core_aps(&core_ap.dp())
+            .into_iter()
+            .find_map(|(ahb_ap, ctrl_ap)| (ahb_ap == *core_ap).then_some(ctrl_ap))
+            .ok_or_else(|| {
+                ArmError::from(ArmDebugSequenceError::custom(format!(
+                    "No nRF5340 CTRL-AP reset mapping for core access port {:?}",
+                    core_ap.ap()
+                )))
+            })?;
+
+        if core_ap.ap() == &ArmApAddress::V1(0) {
+            Ok(Some(ctrl_ap))
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use probe_rs_target::{ApAddress, CoreAccessOptions, CoreType};
+    use probe_rs_target::{ApAddress as TargetApAddress, CoreAccessOptions, CoreType};
 
     use super::*;
 
@@ -122,7 +147,7 @@ mod tests {
         let CoreAccessOptions::Arm(options) = &mut network_core.core_access_options else {
             unreachable!();
         };
-        options.ap = ApAddress::V1(1);
+        options.ap = TargetApAddress::V1(1);
         chip.cores.push(network_core);
 
         let sequence = Nrf5340::from_chip(&chip);
@@ -137,7 +162,7 @@ mod tests {
         let CoreAccessOptions::Arm(options) = &mut chip.cores[0].core_access_options else {
             unreachable!();
         };
-        options.ap = ApAddress::V1(7);
+        options.ap = TargetApAddress::V1(7);
 
         let sequence = Nrf5340::from_chip(&chip);
 
@@ -153,7 +178,7 @@ mod tests {
         let CoreAccessOptions::Arm(options) = &mut unsupported_core.core_access_options else {
             unreachable!();
         };
-        options.ap = ApAddress::V1(7);
+        options.ap = TargetApAddress::V1(7);
         chip.cores.push(unsupported_core);
 
         let sequence = Nrf5340::from_chip(&chip);
@@ -201,5 +226,37 @@ mod tests {
                 .iter()
                 .all(|region| region.cores() == ["application"])
         );
+    }
+
+    #[test]
+    fn application_core_resets_through_application_ctrl_ap() {
+        let sequence = Nrf5340 {
+            core_aps: vec![(0, 2)],
+        };
+        let core_ap = FullyQualifiedApAddress::v1_with_default_dp(0);
+
+        let ctrl_ap = sequence.ctrl_ap_for_core(&core_ap).unwrap().unwrap();
+
+        assert_eq!(ctrl_ap.ap(), &ArmApAddress::V1(2));
+    }
+
+    #[test]
+    fn network_core_retains_the_generic_reset_path() {
+        let sequence = Nrf5340 {
+            core_aps: vec![(0, 2), (1, 3)],
+        };
+        let core_ap = FullyQualifiedApAddress::v1_with_default_dp(1);
+
+        assert!(sequence.ctrl_ap_for_core(&core_ap).unwrap().is_none());
+    }
+
+    #[test]
+    fn core_outside_the_selected_target_has_no_reset_mapping() {
+        let sequence = Nrf5340 {
+            core_aps: vec![(0, 2)],
+        };
+        let core_ap = FullyQualifiedApAddress::v1_with_default_dp(7);
+
+        assert!(sequence.ctrl_ap_for_core(&core_ap).is_err());
     }
 }


### PR DESCRIPTION
## Summary

Reset the nRF5340 application core through the AP0/CTRL-AP2 pair selected by the Nordic debug sequence instead of issuing a generic Cortex-M AIRCR reset.

The sequence asserts and releases CTRL-AP `RESET`, flushes both writes, and then uses the existing `cortex_m_wait_for_reset()` helper to preserve the `reset_system()` completion contract. A core AP outside the selected target returns an explicit error. Network AP1 and other Nordic targets keep the generic Cortex-M path.

This builds on the application-only target merged in #4111. The selected target scope and reset mapping are tested together, while the existing dual-core target behavior remains unchanged outside application-core reset.

## Motivation

On the tested nRF5340 product board, AIRCR `SYSRESETREQ` temporarily makes SWD unavailable. The generic recovery path can reinitialize the debug port after a NACK, but reset catch and `C_DEBUGEN` are no longer preserved. Flash algorithm initialization then times out before erase or programming.

Nordic documents CTRL-AP `RESET` as a debugger-triggered core reset and maps the application and network CTRL-APs to AP2 and AP3:

- [nRF5340 CTRL-AP](https://docs.nordicsemi.com/bundle/ps_nrf5340/page/ctrl-ap.html)
- [nRF5340 reset behavior](https://docs.nordicsemi.com/bundle/ps_nrf5340/page/chapters/reset/doc/reset.html)

The application CTRL-AP path preserves the armed AP0 reset catch and avoids the disconnect/reinitialize race without requiring physical NRST.

## Hardware evidence

Test setup:

- custom application-only nRF5340 board;
- Raspberry Pi Debug Probe with CMSIS-DAP firmware `v0230`;
- SWD at 100 kHz;
- no usable NRST signal;
- no erase-all permission.

The combined prototype reached the GDB server after `--reset-halt`, issued one AP2 reset assertion, produced no NACK or AP1/AP3 markers, and restored normal application USB enumeration after a following reset. The mechanism also passed five repeated reset-and-halt runs and a verified bootloader/application download during the investigation.

The exact revised app-only and application-reset commits were composed on local validation branch `validation/nrf5340-app-reset-v2` at `cf332e05`. A fresh `gdb --reset-halt` selected only `[(0, 2)]`, asserted AP2 once, reached the GDB server, and produced zero AP1, AP3, NACK, or error markers. A following normal reset used the same AP0/AP2-only path and returned successfully.

## Validation

- Tests cover AP0-to-AP2, the unchanged AP1 generic path, and out-of-target mappings.
- `cargo test --workspace --exclude smoke_tester --all-features --locked` passes. The exclusion matches the CI unit profile; `smoke_tester` is the separate hardware runner.
- `cargo clippy --all-features --all-targets --locked -- -D warnings` passes.
- `cargo fmt --all -- --check` passes.

AP1-to-AP3 reset is deliberately not included without nRF5340 DK evidence. Application reset also reasserts network FORCEOFF, so complete combined dual-core flash lifecycle is a separate change and is not claimed here.

## Checklist

- [x] The code compiles without errors or warnings.
- [x] Tests pass and new tests are included.
- [x] `cargo fmt` was run.
- [x] A changelog fragment is included.
- [x] Application-core behavior is supported by product-board evidence.
- [x] Revised commits were rerun together on the product board.