### PR TITLE
usb_util: Make Bulk[Read|Write]Ext traits

### DIFF
--- a/changelog/changed-cmsisdap2-usb-endpoint.md
+++ b/changelog/changed-cmsisdap2-usb-endpoint.md
@@ -1,0 +1,4 @@
+
+The write_bulk_endpoint/read_bulk_endpoint functions are now trait implementations on Endpoint.
+They were renamed as well to write_bulk/read_bulk as the traits already imply they are
+implemented and operate on Endpoint.

--- a/probe-rs/src/probe/cmsisdap/commands/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/mod.rs
@@ -6,7 +6,7 @@ pub mod swo;
 pub mod transfer;
 
 use crate::probe::cmsisdap::commands::general::info::PacketSizeCommand;
-use crate::probe::usb_util::{read_bulk_endpoint, write_bulk_endpoint};
+use crate::probe::usb_util::{BulkReadExt, BulkWriteExt};
 use crate::probe::{ProbeError, WireProtocol};
 use nusb::{
     Endpoint,
@@ -224,7 +224,7 @@ impl CmsisDapDevice {
             }
             CmsisDapDevice::V2 {
                 in_ep, usb_timeout, ..
-            } => Ok(read_bulk_endpoint(in_ep, buf, *usb_timeout)?),
+            } => Ok(in_ep.read_bulk(buf, *usb_timeout)?),
         }
     }
 
@@ -239,7 +239,7 @@ impl CmsisDapDevice {
                 ..
             } => {
                 // Skip first byte as it's set to 0 for HID transfers
-                Ok(write_bulk_endpoint(out_ep, &buf[1..], *usb_timeout)?)
+                Ok(out_ep.write_bulk(&buf[1..], *usb_timeout)?)
             }
         }
     }
@@ -272,7 +272,7 @@ impl CmsisDapDevice {
                 let timeout = Duration::from_millis(1);
                 let mut discard = vec![0u8; *max_packet_size];
                 loop {
-                    match read_bulk_endpoint(in_ep, &mut discard, timeout) {
+                    match in_ep.read_bulk(&mut discard, timeout) {
                         Ok(n) if n != 0 => continue,
                         _ => break,
                     }
@@ -359,7 +359,7 @@ impl CmsisDapDevice {
             CmsisDapDevice::V2 { swo_ep, .. } => match swo_ep {
                 Some(ep) => {
                     let mut buf = vec![0u8; ep.max_packet_size()];
-                    match read_bulk_endpoint(ep, &mut buf, timeout) {
+                    match ep.read_bulk(&mut buf, timeout) {
                         Ok(n) => {
                             buf.truncate(n);
                             Ok(buf)

--- a/probe-rs/src/probe/usb_util.rs
+++ b/probe-rs/src/probe/usb_util.rs
@@ -15,96 +15,104 @@ pub(crate) fn to_hex(s: &str) -> String {
     })
 }
 
-/// Submit a single buffer to a bulk OUT endpoint and wait for it to complete.
-///
-/// On timeout, the pending transfer is cancelled and drained so the endpoint is
-/// left with no outstanding transfers, and a `TimedOut` error is returned.
-pub fn write_bulk_endpoint(
-    endpoint: &mut Endpoint<Bulk, Out>,
-    buf: &[u8],
-    timeout: Duration,
-) -> io::Result<usize> {
-    let mut transfer_buffer = Buffer::new(buf.len());
-    transfer_buffer.extend_from_slice(buf);
-
-    endpoint.submit(transfer_buffer);
-
-    let Some(completion) = endpoint.wait_next_complete(timeout) else {
-        // Request cancellation...
-        endpoint.cancel_all();
-
-        // ...and then immediately drain the completion. Whether the the response is the
-        // result of the original write, the cancellation, or a timeout of the cancellation, we
-        // drop it and return a timeout.
-        let _ = endpoint.wait_next_complete(Duration::from_millis(100));
-
-        return Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            "bulk write timed out",
-        ));
-    };
-
-    completion.status.map_err(io::Error::from)?;
-
-    Ok(completion.actual_len)
+/// An extension to write bulk transfers
+pub trait BulkWriteExt {
+    /// Writes data to the given bulk endpoint from the provided buffer.
+    fn write_bulk(&mut self, buf: &[u8], timeout: Duration) -> io::Result<usize>;
 }
 
-/// Submit a read to a bulk IN endpoint and wait for it to complete, copying the
-/// received bytes into `buf`.
-///
-/// On timeout, the pending transfer is cancelled and drained so the endpoint is
-/// left with no outstanding transfers, and a `TimedOut` error is returned.
-pub fn read_bulk_endpoint(
-    endpoint: &mut Endpoint<Bulk, In>,
-    buf: &mut [u8],
-    timeout: Duration,
-) -> io::Result<usize> {
-    let max_packet_size = endpoint.max_packet_size().max(1);
-    let requested_len = buf.len().div_ceil(max_packet_size) * max_packet_size;
+/// An extension to read bulk transfers
+pub trait BulkReadExt {
+    /// Reads data from the given bulk endpoint into the provided buffer.
+    fn read_bulk(&mut self, buf: &mut [u8], timeout: Duration) -> io::Result<usize>;
+}
 
-    let transfer_buffer = Buffer::new(requested_len);
-    endpoint.submit(transfer_buffer);
+impl BulkWriteExt for Endpoint<Bulk, Out> {
+    /// Submit a single buffer to a bulk OUT endpoint and wait for it to complete.
+    ///
+    /// On timeout, the pending transfer is cancelled and drained so the endpoint is
+    /// left with no outstanding transfers, and a `TimedOut` error is returned.
+    fn write_bulk(&mut self, buf: &[u8], timeout: Duration) -> io::Result<usize> {
+        let mut transfer_buffer = Buffer::new(buf.len());
+        transfer_buffer.extend_from_slice(buf);
 
-    let Some(completion) = endpoint.wait_next_complete(timeout) else {
-        // Request cancellation...
-        endpoint.cancel_all();
+        self.submit(transfer_buffer);
 
-        // ...and then immediately drain the completion. Whether the the response is the
-        // result of the original read, the cancellation, or a timeout of the cancellation, we
-        // drop it and return a timeout.
-        let _ = endpoint.wait_next_complete(Duration::from_millis(100));
+        let Some(completion) = self.wait_next_complete(timeout) else {
+            // Request cancellation...
+            self.cancel_all();
 
-        return Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            "bulk read timed out",
-        ));
-    };
+            // ...and then immediately drain the completion. Whether the the response is the
+            // result of the original write, the cancellation, or a timeout of the cancellation, we
+            // drop it and return a timeout.
+            let _ = self.wait_next_complete(Duration::from_millis(100));
 
-    completion.status.map_err(io::Error::from)?;
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "bulk write timed out",
+            ));
+        };
 
-    let actual_len = completion.actual_len;
-    let data = completion.buffer;
+        completion.status.map_err(io::Error::from)?;
 
-    if actual_len > buf.len() || data.len() > buf.len() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "device returned {actual_len} bytes, buffer length is {}",
-                buf.len()
-            ),
-        ));
+        Ok(completion.actual_len)
     }
+}
 
-    buf[..actual_len].copy_from_slice(&data[..actual_len]);
+impl BulkReadExt for Endpoint<Bulk, In> {
+    /// Submit a read to a bulk IN endpoint and wait for it to complete, copying the
+    /// received bytes into `buf`.
+    ///
+    /// On timeout, the pending transfer is cancelled and drained so the endpoint is
+    /// left with no outstanding transfers, and a `TimedOut` error is returned.
+    fn read_bulk(&mut self, buf: &mut [u8], timeout: Duration) -> io::Result<usize> {
+        let max_packet_size = self.max_packet_size().max(1);
+        let requested_len = buf.len().div_ceil(max_packet_size) * max_packet_size;
 
-    Ok(actual_len)
+        let transfer_buffer = Buffer::new(requested_len);
+        self.submit(transfer_buffer);
+
+        let Some(completion) = self.wait_next_complete(timeout) else {
+            // Request cancellation...
+            self.cancel_all();
+
+            // ...and then immediately drain the completion. Whether the the response is the
+            // result of the original read, the cancellation, or a timeout of the cancellation, we
+            // drop it and return a timeout.
+            let _ = self.wait_next_complete(Duration::from_millis(100));
+
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "bulk read timed out",
+            ));
+        };
+
+        completion.status.map_err(io::Error::from)?;
+
+        let actual_len = completion.actual_len;
+        let data = completion.buffer;
+
+        if actual_len > buf.len() || data.len() > buf.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "device returned {actual_len} bytes, buffer length is {}",
+                    buf.len()
+                ),
+            ));
+        }
+
+        buf[..actual_len].copy_from_slice(&data[..actual_len]);
+
+        Ok(actual_len)
+    }
 }
 
 /// USB bulk transfer utility functions.
 ///
 /// These claim a fresh endpoint for every transfer. For hot paths where the
 /// same endpoint is used repeatedly, claim an [`Endpoint`] once and use
-/// [`write_bulk_endpoint`] / [`read_bulk_endpoint`] instead to avoid the
+/// [`BulkWriteExt::write_bulk`] / [`BulkReadExt::read_bulk`] instead to avoid the
 /// per-transfer endpoint setup/teardown cost.
 pub trait InterfaceExt {
     /// Reads data from the given bulk endpoint into the provided buffer.
@@ -120,7 +128,7 @@ impl InterfaceExt for Interface {
             .endpoint::<Bulk, Out>(endpoint)
             .map_err(io::Error::from)?;
 
-        write_bulk_endpoint(&mut endpoint, buf, timeout)
+        endpoint.write_bulk(buf, timeout)
     }
 
     fn read_bulk(&self, endpoint: u8, buf: &mut [u8], timeout: Duration) -> io::Result<usize> {
@@ -128,6 +136,6 @@ impl InterfaceExt for Interface {
             .endpoint::<Bulk, In>(endpoint)
             .map_err(io::Error::from)?;
 
-        read_bulk_endpoint(&mut endpoint, buf, timeout)
+        endpoint.read_bulk(buf, timeout)
     }
 }


### PR DESCRIPTION
Rather than stand alone functions for bulk read/write transfers as
helpers add some extension traits that any Endpoint instance can
utilize with implementations provided.

Signed-off-by: Tom Burdick <thomas.burdick@infineon.com>

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo fmt` was run.
- [ ] Add a changelog fragment describing your changes in `changelogs/`. See https://github.com/probe-rs/probe-rs/blob/master/CONTRIBUTING.md#changelog-entries. 

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs (in code, rustdoc and README.md) for your newly added features and code.
