### PR TITLE
fix(cargo-embed): don't force SWD when the probe only does JTAG

### DIFF
--- a/changelog/fixed-cargo-embed-protocol-default.md
+++ b/changelog/fixed-cargo-embed-protocol-default.md
@@ -1,0 +1,1 @@
+`cargo-embed` no longer defaults to SWD, so probes that only support JTAG attach without setting `protocol` in `Embed.toml`.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
@@ -6,7 +6,8 @@
 # Serial number
 # serial = "12345678"
 # The protocol to be used for communicating with the target.
-protocol = "Swd"
+# If unset, the probe decides.
+# protocol = "Swd"
 # The speed in kHz of the data link to the target.
 # speed = 1337
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -40,7 +40,10 @@ pub struct Probe {
     pub usb_pid: Option<String>,
     pub interface: Option<u8>,
     pub serial: Option<String>,
-    pub protocol: WireProtocol,
+    /// Wire protocol to talk to the target with.
+    ///
+    /// Falls back to the probe default.
+    pub protocol: Option<WireProtocol>,
     pub speed: Option<u32>,
 }
 
@@ -282,6 +285,9 @@ impl Configs {
 
 #[cfg(test)]
 mod test {
+    use figment::providers::{Format, Toml};
+    use probe_rs::probe::WireProtocol;
+
     use super::Configs;
 
     #[test]
@@ -289,6 +295,23 @@ mod test {
         // Ensure the default config can be parsed.
         let configs = Configs::new(std::env::current_dir().unwrap());
         let _config = configs.select_defined("default").unwrap();
+    }
+    /// An explicitly configured protocol still reaches the config.
+    #[test]
+    fn explicit_protocol_is_preserved() {
+        let mut configs = Configs::new(std::env::current_dir().unwrap());
+        configs.figment = configs.figment.merge(
+            Toml::string(
+                r#"
+                [default.probe]
+                protocol = "Jtag"
+                "#,
+            )
+            .nested(),
+        );
+        let config = configs.select_defined("default").unwrap();
+
+        assert_eq!(config.probe.protocol, Some(WireProtocol::Jtag));
     }
     #[test]
     fn non_existent_profile_is_error() {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -219,7 +219,7 @@ async fn main_try(args: Vec<OsString>, config: Config, offset: UtcOffset) -> Res
     let probe_options = ProbeOptions {
         chip,
         chip_description_path: None,
-        protocol: Some(config.probe.protocol),
+        protocol: config.probe.protocol,
         non_interactive: false,
         probe: selector,
         cycle_power: false,


### PR DESCRIPTION
Fixes #2105.