### PR TITLE
fix(dap): don't report the session entry halt as an exception

### DIFF
--- a/changelog/fixed-dap-session-entry-stop-reason.md
+++ b/changelog/fixed-dap-session-entry-stop-reason.md
@@ -1,0 +1,1 @@
+The DAP server now reports the halt at debug session entry with the `entry` reason instead of surfacing it as an exception.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -881,17 +881,17 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 // reset_and_halt arms DEMCR.VC_CORERESET, so we come up with DFSR.VCATCH set,
                 // which is an Exception as far as HaltReason is concerned. Reporting that
                 // verbatim makes the client throw up its exception UI on every session start.
-                let reason = if matches!(
+                let (reason, description) = if matches!(
                     current_core_status,
                     CoreStatus::Halted(HaltReason::Breakpoint(_))
                 ) {
-                    reason
+                    (reason, description)
                 } else {
-                    "entry"
+                    ("entry", "Core halted at entry".to_string())
                 };
 
                 let event_body = Some(StoppedEventBody {
-                    reason: reason.to_owned(),
+                    reason: reason.to_string(),
                     description: Some(description),
                     thread_id: Some(target_core.id() as i64),
                     preserve_focus_hint: None,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -876,12 +876,23 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                     .core
                     .read_core_reg(target_core.core.program_counter())
                     .ok();
+                let (reason, description) = current_core_status.short_long_status(program_counter);
+
+                // reset_and_halt arms DEMCR.VC_CORERESET, so we come up with DFSR.VCATCH set,
+                // which is an Exception as far as HaltReason is concerned. Reporting that
+                // verbatim makes the client throw up its exception UI on every session start.
+                let reason = if matches!(
+                    current_core_status,
+                    CoreStatus::Halted(HaltReason::Breakpoint(_))
+                ) {
+                    reason
+                } else {
+                    "entry"
+                };
+
                 let event_body = Some(StoppedEventBody {
-                    reason: current_core_status
-                        .short_long_status(program_counter)
-                        .0
-                        .to_owned(),
-                    description: Some(current_core_status.short_long_status(program_counter).1),
+                    reason: reason.to_owned(),
+                    description: Some(description),
                     thread_id: Some(target_core.id() as i64),
                     preserve_focus_hint: None,
                     text: None,
@@ -889,6 +900,11 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                     hit_breakpoint_ids: None,
                 });
                 self.send_event("stopped", event_body)?;
+
+                // Polling starts once configuration_done is set and would otherwise see a
+                // status different from last_known_status and announce this same halt again,
+                // with the raw reason, undoing the above.
+                target_core.core_data.last_known_status = current_core_status;
             } else {
                 tracing::debug!(
                     "Core is halted, but not due to a breakpoint and halt_after_reset is not set. Continuing."

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -1465,6 +1465,51 @@ mod test {
         execute_test(protocol_adapter, true).await.unwrap();
     }
 
+    /// The entry halt is a vector catch, reported as [`probe_rs::HaltReason::Exception`].
+    ///
+    /// Expects a single stopped event with reason `entry`: [`CoreHandle::poll_core`] used to
+    /// re-announce the same halt with the raw reason.
+    ///
+    /// [`CoreHandle::poll_core`]: crate::cmd::dap_server::server::core_data::CoreHandle::poll_core
+    #[tokio::test]
+    async fn session_entry_is_not_reported_as_exception() {
+        let mut protocol_adapter = initialized_protocol_adapter();
+
+        let launch_args = SessionConfig {
+            flashing_config: FlashingConfig {
+                halt_after_reset: true,
+                ..Default::default()
+            },
+            ..valid_session_config()
+        };
+
+        protocol_adapter
+            .add_request("launch")
+            .with_arguments(launch_args)
+            .and_successful_response();
+        protocol_adapter.expect_event("initialized", None::<u32>);
+
+        protocol_adapter
+            .add_request("configurationDone")
+            .and_successful_response();
+
+        // Mocked core has no real halt cause, hence the generic description. It's `reason`
+        // we care about here.
+        protocol_adapter.expect_event(
+            "stopped",
+            Some(json!({
+                "reason": "entry",
+                "description": "Core halted: unrecognized cause",
+                "threadId": 0,
+                "allThreadsStopped": false,
+            })),
+        );
+
+        disconnect_protocol_adapter(&mut protocol_adapter);
+
+        execute_test(protocol_adapter, true).await.unwrap();
+    }
+
     #[tokio::test]
     async fn launch_and_threads() {
         let mut protocol_adapter = launched_protocol_adapter();

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -1467,10 +1467,7 @@ mod test {
 
     /// The entry halt is a vector catch, reported as [`probe_rs::HaltReason::Exception`].
     ///
-    /// Expects a single stopped event with reason `entry`: [`CoreHandle::poll_core`] used to
-    /// re-announce the same halt with the raw reason.
-    ///
-    /// [`CoreHandle::poll_core`]: crate::cmd::dap_server::server::core_data::CoreHandle::poll_core
+    /// Expects a single stopped event with reason `entry`.
     #[tokio::test]
     async fn session_entry_is_not_reported_as_exception() {
         let mut protocol_adapter = initialized_protocol_adapter();
@@ -1493,13 +1490,11 @@ mod test {
             .add_request("configurationDone")
             .and_successful_response();
 
-        // Mocked core has no real halt cause, hence the generic description. It's `reason`
-        // we care about here.
         protocol_adapter.expect_event(
             "stopped",
             Some(json!({
                 "reason": "entry",
-                "description": "Core halted: unrecognized cause",
+                "description": "Core halted at entry",
                 "threadId": 0,
                 "allThreadsStopped": false,
             })),


### PR DESCRIPTION
Fixes #3381.