### PR TITLE
feat(cli): add `--reset-halt` to `probe-rs reset`

### DIFF
--- a/changelog/added-reset-halt-flag.md
+++ b/changelog/added-reset-halt-flag.md
@@ -1,0 +1,1 @@
+Added `--reset-halt` to `probe-rs reset`, which halts the core after resetting it.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -10,7 +10,8 @@ use crate::rpc::client::RpcClient;
 use crate::util::cargo::build_artifact;
 use crate::util::cargo::cargo_target;
 use crate::util::common_options::{
-    BinaryDownloadOptions, CargoOptions, OperationError, ProbeOptions,
+    BinaryDownloadOptions, CargoOptions, OperationError, ProbeOptions, RESET_HALT_TIMEOUT,
+    ResetHaltOptions,
 };
 use crate::util::logging::{LevelFilter, setup_logging};
 use crate::util::{cli, logging};
@@ -26,9 +27,8 @@ use crate::{Config, parse_and_resolve_cli_args, run_app};
     after_long_help = CargoOptions::help_message("cargo flash")
 )]
 struct CliOptions {
-    /// Use this flag to reset and halt (instead of just a reset) the attached core after flashing the target.
-    #[arg(long)]
-    pub reset_halt: bool,
+    #[clap(flatten)]
+    pub reset: ResetHaltOptions,
     /// Use this flag to set the log level.
     ///
     /// Configurable via the `RUST_LOG` environment variable.
@@ -192,8 +192,8 @@ async fn main_try(client: &mut RpcClient, opt: CliOptions) -> Result<(), Operati
     // Reset target according to CLI options
     let core = session.core(0);
 
-    if opt.reset_halt {
-        core.reset_and_halt(std::time::Duration::from_millis(500))
+    if opt.reset.reset_halt {
+        core.reset_and_halt(RESET_HALT_TIMEOUT)
             .await
             .context("Failed to reset and halt target")?;
     } else {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/gdb_server/mod.rs
@@ -8,12 +8,11 @@ pub(crate) use stub::{GdbInstanceConfiguration, run};
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::Duration;
 
 use parking_lot::FairMutex;
 use probe_rs::{config::Registry, probe::list::Lister};
 
-use crate::util::common_options::ProbeOptions;
+use crate::util::common_options::{ProbeOptions, RESET_HALT_TIMEOUT, ResetHaltOptions};
 
 #[derive(clap::Parser)]
 pub struct Cmd {
@@ -23,12 +22,8 @@ pub struct Cmd {
     )]
     gdb_connection_string: Option<String>,
 
-    #[clap(
-        name = "reset-halt",
-        long = "reset-halt",
-        help = "Use this flag to reset and halt (instead of just a halt) the attached core after attaching to the target."
-    )]
-    reset_halt: bool,
+    #[clap(flatten)]
+    reset: ResetHaltOptions,
 
     #[clap(long, help = "Spawn gdb after starting the gdbserver.")]
     gdb: Option<String>,
@@ -50,10 +45,8 @@ impl Cmd {
     pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, _probe_options) = self.common.simple_attach(registry, lister)?;
 
-        if self.reset_halt {
-            session
-                .core(0)?
-                .reset_and_halt(Duration::from_millis(100))?;
+        if self.reset.reset_halt {
+            session.core(0)?.reset_and_halt(RESET_HALT_TIMEOUT)?;
         }
 
         let gdb_connection_string = self

--- a/probe-rs-tools/src/bin/probe-rs/cmd/reset.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/reset.rs
@@ -1,7 +1,10 @@
 use crate::{
     CoreOptions,
     rpc::client::RpcClient,
-    util::{cli, common_options::ProbeOptions},
+    util::{
+        cli,
+        common_options::{ProbeOptions, RESET_HALT_TIMEOUT, ResetHaltOptions},
+    },
 };
 
 #[derive(clap::Parser)]
@@ -11,6 +14,9 @@ pub struct Cmd {
 
     #[clap(flatten)]
     common: ProbeOptions,
+
+    #[clap(flatten)]
+    reset: ResetHaltOptions,
 }
 
 impl Cmd {
@@ -18,7 +24,11 @@ impl Cmd {
         let session = cli::attach_probe(&client, self.common, None, false).await?;
         let core = session.core(self.shared.core);
 
-        core.reset().await?;
+        if self.reset.reset_halt {
+            core.reset_and_halt(RESET_HALT_TIMEOUT).await?;
+        } else {
+            core.reset().await?;
+        }
 
         Ok(())
     }

--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -1,4 +1,4 @@
-use std::{io::Write, path::PathBuf};
+use std::{io::Write, path::PathBuf, time::Duration};
 
 use super::cargo::ArtifactError;
 use crate::util::parse_u64;
@@ -87,6 +87,17 @@ pub struct ReadWriteOptions {
     /// Takes an integer as an argument, and can be specified in decimal (16), hexadecimal (0x10) or octal (0o20) format.
     #[clap(value_parser = parse_u64)]
     pub address: u64,
+}
+
+/// How long to wait for a core to come to a halt after being reset.
+pub const RESET_HALT_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Common options for commands that reset the target core.
+#[derive(Debug, clap::Parser)]
+pub struct ResetHaltOptions {
+    /// Halt the core after resetting it.
+    #[arg(long = "reset-halt")]
+    pub reset_halt: bool,
 }
 
 /// Common options and logic when interfacing with a [Probe].


### PR DESCRIPTION
Fixes #2763.

This adds a `--reset-halt` flag to the `reset` command, together with a shared struct to be used with other commands.
Maybe this is a bit akward considering the command is already called reset, but the flag is a bit more uniform, so I chose to make it the consistent rather than just `--halt`. What do you think @bugadani?