### PR TITLE
feat(defmt): print supported wire formats, hint when they don't match

### DIFF
--- a/changelog/added-defmt-version-info.md
+++ b/changelog/added-defmt-version-info.md
@@ -1,0 +1,1 @@
+`probe-rs --version` (and `cargo embed`/`cargo flash`) now report the defmt wire formats the built-in decoder supports, and a failure to parse defmt data now says that a defmt version mismatch is the likely cause instead of surfacing a bare `missing field` error.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -37,7 +37,7 @@ use crate::{Config, FormatKind, FormatOptions, parse_and_resolve_cli_args};
     name = "cargo embed",
     bin_name = "cargo embed",
     version = env!("PROBE_RS_VERSION"),
-    long_version = env!("PROBE_RS_LONG_VERSION"),
+    long_version = crate::util::long_version(),
     after_long_help = CargoOptions::help_message("cargo embed")
 )]
 struct CliOptions {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -22,7 +22,7 @@ use crate::{Config, parse_and_resolve_cli_args, run_app};
     name = "cargo flash",
     bin_name = "cargo flash",
     version = env!("PROBE_RS_VERSION"),
-    long_version = env!("PROBE_RS_LONG_VERSION"),
+    long_version = crate::util::long_version(),
     after_long_help = CargoOptions::help_message("cargo flash")
 )]
 struct CliOptions {

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -50,7 +50,7 @@ pub(crate) struct Config {
     name = "probe-rs",
     about = "The probe-rs CLI",
     version = env!("PROBE_RS_VERSION"),
-    long_version = env!("PROBE_RS_LONG_VERSION")
+    long_version = crate::util::long_version()
 )]
 struct Cli {
     /// Location for log file for probe-rs's own debug output

--- a/probe-rs-tools/src/bin/probe-rs/util/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/mod.rs
@@ -9,7 +9,28 @@ pub mod rtt;
 pub mod setup_hints;
 pub mod visualizer;
 
-use std::num::ParseIntError;
+use std::{num::ParseIntError, sync::LazyLock};
+
+/// Long version string for `--version`, listing the defmt wire formats this build can decode.
+///
+/// Shared by the `probe-rs`, `cargo embed` and `cargo flash` clap definitions. Firmware built
+/// against a defmt version we cannot read fails deep inside the decoder with an opaque serde
+/// error (see [`rtt::processing`]), so naming the formats we do support gives users something
+/// concrete to compare against.
+///
+/// Only the *long* version grows: [`meta::current_meta`] parses `PROBE_RS_VERSION` as semver,
+/// so that one has to stay a bare version number.
+pub fn long_version() -> &'static str {
+    static LONG_VERSION: LazyLock<String> = LazyLock::new(|| {
+        format!(
+            "{}\ndefmt wire formats: {}",
+            env!("PROBE_RS_LONG_VERSION"),
+            defmt_decoder::DEFMT_VERSIONS.join(", ")
+        )
+    });
+
+    &LONG_VERSION
+}
 
 pub fn parse_u32(input: &str) -> Result<u32, ParseIntError> {
     parse_int::parse(input)

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/processing.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/processing.rs
@@ -169,17 +169,34 @@ pub struct DefmtStateInner {
     pub locs: Option<defmt_decoder::Locations>,
 }
 
+/// Context attached to a failed [`defmt_decoder::Table::parse`].
+///
+/// The bare error is unhelpfully low level: a defmt 0.3 firmware trips a
+/// `missing field crate_name` serde error, because its symbol payload changed shape even
+/// though it still advertises a wire format listed in [`defmt_decoder::DEFMT_VERSIONS`].
+/// Upstream's own version check therefore never fires, and the user is left with a serde
+/// message that gives no hint the two defmt versions disagree.
+fn defmt_parse_error_hint() -> String {
+    format!(
+        "Failed to parse defmt data. The `defmt` version used to build the firmware is likely \
+         incompatible with the decoder in this build of probe-rs, which supports defmt wire \
+         formats {}. Check that the `defmt` version in your firmware matches the one reported \
+         by `probe-rs --version`.",
+        defmt_decoder::DEFMT_VERSIONS.join(", ")
+    )
+}
+
 impl DefmtStateInner {
     pub fn try_from_bytes(buffer: &[u8]) -> Result<Option<Self>, Error> {
         let Some(table) =
-            defmt_decoder::Table::parse(buffer).with_context(|| "Failed to parse defmt data")?
+            defmt_decoder::Table::parse(buffer).with_context(defmt_parse_error_hint)?
         else {
             return Ok(None);
         };
 
         let locs = table
             .get_locations(buffer)
-            .with_context(|| "Failed to parse defmt data")?;
+            .with_context(defmt_parse_error_hint)?;
 
         let locs = if !table.is_empty() && locs.is_empty() {
             tracing::warn!(


### PR DESCRIPTION
Fixes #1577.

When the firmware's defmt version doesn't match ours you currently get:

```
failed to demangle defmt symbol `{"package":"firmware",...}`: missing field `crate_name` at line 1 column 97
```

which is useless. defmt-decoder's own wire format check doesn't catch this one, because a 0.3.x firmware still reports a `_defmt_version` we claim to support and it's the symbol payload that changed shape. There was also no way to see what the host can decode in the first place.

So the long `--version` now lists the wire formats we understand (probe-rs, cargo embed and cargo flash all read the same env var, so one helper covers all three), and the parse error points at a version mismatch:

```
$ probe-rs --version
probe-rs 0.32.0 (git commit: v0.31.0-260-g48f5e4d5)
defmt wire formats: 3, 4
```

Short `-V` is unchanged. Left `PROBE_RS_VERSION` alone because `util::meta` parses it as semver, only the long string grows.

Using `DEFMT_VERSIONS`, the singular one is deprecated upstream.

I didn't have an old-defmt ELF lying around to see the new error text in place, so the wording is somewhat a guess. Happy to reword if it reads badly.