### PR TITLE
targets: fix geckos2c3 page_size on EFR32FG23/MG24 (0x3000 -> 0x2000)

### DIFF
--- a/changelog/fixed-efr32-geckos2c3-page-size.md
+++ b/changelog/fixed-efr32-geckos2c3-page-size.md
@@ -1,0 +1,1 @@
+Fixed flashing on EFR32FG23/EFR32MG24 erasing a neighboring sector at image boundaries: the geckos2c3 page size was not aligned to the flash base address, which could brick devices (e.g. wipe the last bootloader sector when flashing the application).

--- a/probe-rs/targets/EFR32FG23_Series.yaml
+++ b/probe-rs/targets/EFR32FG23_Series.yaml
@@ -248,7 +248,7 @@ flash_algorithms:
     address_range:
       start: 0x8000000
       end: 0x81e0000
-    page_size: 0x3000
+    page_size: 0x2000
     erased_byte_value: 0xff
     program_page_timeout: 260
     erase_sector_timeout: 200

--- a/probe-rs/targets/EFR32MG24_Series.yaml
+++ b/probe-rs/targets/EFR32MG24_Series.yaml
@@ -1084,7 +1084,7 @@ flash_algorithms:
     address_range:
       start: 0x8000000
       end: 0x81e0000
-    page_size: 0x3000
+    page_size: 0x2000
     erased_byte_value: 0xff
     program_page_timeout: 260
     erase_sector_timeout: 200


### PR DESCRIPTION
Fixes #4183

The `geckos2c3` flash algorithm on the EFR32FG23/EFR32MG24 series declares `page_size: 0x3000` on a flash region based at `0x08000000` — the base is not a multiple of the page size. As discussed in the linked issue, this violates the layouting invariant: `page_info()` anchors the page grid at absolute zero while `iter_pages()` anchors it at `address_range.start`, so the grids are shifted by `0x2000` and `build_sectors_and_pages()` schedules a neighboring, never-re-programmed sector for erase whenever staged data falls into the misaligned page window.

Real-world impact: flashing an application image adjacent to a bootloader silently wipes the bootloader's last sector (and vice versa) while `verify` passes — bricked devices. Verified on EFR32MG24B210F1536IM48 hardware; flash map read-back matches the planner math in both directions.

The hardware write/erase page on these parts is 8 KiB, so `0x2000` is used: it matches the declared sector size and divides the region base, making both page grids coincide and the layouting exact. Verified on hardware: with `0x2000` the spurious neighbor-sector erase is gone in both flash orders (bootloader→app and app→bootloader).

Other built-in targets with `page_size: 0x3000` were checked and are not affected: the remaining gecko families use `address_range.start: 0x0`, and the STM32F7 QSPI algorithms use base `0x90000000` — both are multiples of `0x3000`.
