### PR TITLE
feat(target): RP2040/RP2350 target autodetection

### DIFF
--- a/changelog/added-rp2-target-detection.md
+++ b/changelog/added-rp2-target-detection.md
@@ -1,0 +1,1 @@
+Added support for autodetecting RP2040 and RP2350 family chips.

--- a/probe-rs/src/vendor/mod.rs
+++ b/probe-rs/src/vendor/mod.rs
@@ -148,8 +148,13 @@ fn try_detect_arm_chip(
 
     // We have no information about the target, so we must assume it's using the default DP.
     // We cannot automatically detect DPs if SWD multi-drop is used.
-    // TODO: collect known DP addresses for known targets.
-    let dp_addresses = [DpAddress::Default];
+    // Most multi-drop implementations will expose enough info via the default DP to do detection
+    // so at least when there's only one SWD target, DpAddress::Default works fine.
+    // RP2040 isn't one of those - it's only accessible via multi-drop, so try it after Default.
+    let dp_addresses = [
+        DpAddress::Default,
+        DpAddress::Multidrop(0x01002927), // RP2040 core0
+    ];
 
     for dp_address in dp_addresses {
         // TODO: do not consume probe
@@ -157,9 +162,8 @@ fn try_detect_arm_chip(
             Ok(mut interface) => {
                 if let Err(error) = interface.select_debug_port(dp_address) {
                     probe = interface.close();
-                    tracing::debug!("Error during ARM chip detection: {error}");
-                    // If we can't connect, assume this is not an ARM chip and not an error.
-                    return Ok((probe, None));
+                    tracing::debug!("Error during ARM chip detection on {dp_address:?}: {error}");
+                    continue;
                 }
 
                 let found_arm_chip = read_chip_info_from_rom_table(interface.as_mut(), dp_address)
@@ -188,6 +192,10 @@ fn try_detect_arm_chip(
                 }
 
                 probe = interface.close();
+
+                if found_target.is_some() {
+                    break;
+                }
             }
             Err((returned_probe, error)) => {
                 probe = returned_probe;

--- a/probe-rs/src/vendor/raspberrypi/mod.rs
+++ b/probe-rs/src/vendor/raspberrypi/mod.rs
@@ -38,7 +38,20 @@ impl Vendor for RaspberryPi {
         chip_info: ArmChipInfo,
     ) -> Result<Option<String>, Error> {
         const JEP_ARM: JEP106Code = JEP106Code { id: 0x3b, cc: 0x4 };
+        const CHIPID_RP2040: u32 = 0x0000_2927;
         const CHIPID_RP235X: u32 = 0x0000_4927;
+
+        // Check for RP2040. We can immediately rule out RP2040 existing if we aren't probing via multidrop.
+        if let Some(DpAddress::Multidrop(dp)) = interface.current_debug_port() {
+            let ap = FullyQualifiedApAddress::v1_with_dp(DpAddress::Multidrop(dp), 0);
+            // Read SYSINFO.CHIP_ID and compare against RP2040 chip_id
+            if let Ok(mut memory) = interface.memory_interface(&ap)
+                && let Ok(chip_id) = memory.read_word_32(0x4000_0000)
+                && (chip_id & 0x0fff_ffff) == CHIPID_RP2040
+            {
+                return Ok(Some("RP2040".to_string()));
+            }
+        }
 
         // Check for RP235X.
         // Before we go poking memory, check that we have a CoreSight Class-1 ROM with a part number of 1225.

--- a/probe-rs/src/vendor/raspberrypi/mod.rs
+++ b/probe-rs/src/vendor/raspberrypi/mod.rs
@@ -1,8 +1,17 @@
 //! RaspberryPi microcontroller support
-use crate::{config::DebugSequence, vendor::Vendor};
+use jep106::JEP106Code;
 use probe_rs_target::Chip;
 use sequences::rp235x::Rp235x;
 use sequences::rp2040::Rp2040;
+
+use crate::{
+    architecture::arm::{
+        ApV2Address, ArmChipInfo, ArmDebugInterface, FullyQualifiedApAddress, dp::DpAddress,
+    },
+    config::{DebugSequence, Registry},
+    error::Error,
+    vendor::Vendor,
+};
 
 pub mod sequences;
 
@@ -20,5 +29,32 @@ impl Vendor for RaspberryPi {
             return None;
         };
         Some(sequence)
+    }
+
+    fn try_detect_arm_chip(
+        &self,
+        _registry: &Registry,
+        interface: &mut dyn ArmDebugInterface,
+        chip_info: ArmChipInfo,
+    ) -> Result<Option<String>, Error> {
+        const JEP_ARM: JEP106Code = JEP106Code { id: 0x3b, cc: 0x4 };
+        const CHIPID_RP235X: u32 = 0x0000_4927;
+
+        // Check for RP235X.
+        // Before we go poking memory, check that we have a CoreSight Class-1 ROM with a part number of 1225.
+        if chip_info.manufacturer != JEP_ARM || chip_info.part != 1225 {
+            return Ok(None);
+        }
+
+        // Read SYSINFO.CHIP_ID and compare against RP235x chip_id
+        let ap = FullyQualifiedApAddress::v2_with_dp(DpAddress::Default, ApV2Address(Some(0x2000)));
+        if let Ok(mut memory) = interface.memory_interface(&ap)
+            && let Ok(chip_id) = memory.read_word_32(0x4000_0000)
+            && (chip_id & 0x0fff_ffff) == CHIPID_RP235X
+        {
+            return Ok(Some("RP235x".to_string()));
+        }
+
+        Ok(None)
     }
 }


### PR DESCRIPTION
Add auto-detection for RP2040 and RP2350 targets.

Tested on RP2040 and RP2350 with cmsis-dap, and RP2040 with j-link.
Also tested that `probe-rs info` still detects the nrf chip on micro:bit V2, esp32c3 is still detected via the usb-jtag peripheral. None of my ST devices are detected via stlink (but they weren't before, either).

RP2350 turned out to be trivial. Like most other devices that support SWD multi-drop it also will let you access MEM-APs via the default DP.

RP2040 doesn't expose anything useful over the default DP so you can't do that, and have to just try its TARGET_SEL and hope for the best.

Because we'll always try this second TARGET_SEL if nothing responds, `probe info` will take twice as long. On my machine, it used to take 5 seconds before timing out when there was nothing attached to a probe, now it takes 10 seconds.

We might need to do something more tricky in the future if we want to support detecting multiple multi-drop devices on the same SWD interface. But most people do not need that, and we barely handle 2 cores as-is so multiple targets is a distant future concern as far as I'm concerned.
