### PR TITLE
Make debug info Send+Sync and expose RPC-friendly core helpers.

### DIFF
--- a/changelog/added-core-front-end-helpers.md
+++ b/changelog/added-core-front-end-helpers.md
@@ -1,0 +1,1 @@
+Added `CoreRegisters::for_core_type` and `DebugInfo::empty()` for custom and remote Core front-ends. `DebugInfo` is now `Send + Sync`.

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -12,19 +12,22 @@ use gimli::{
     read::RegisterRule,
 };
 use object::read::{Object, ObjectSection};
-use probe_rs::{CoreRegister, Error, InstructionSet, MemoryInterface, RegisterRole, RegisterValue};
+use probe_rs::{
+    CoreRegister, Endian, Error, InstructionSet, MemoryInterface, RegisterRole, RegisterValue,
+};
 use std::{
-    borrow, cmp::Ordering, num::NonZeroU64, ops::ControlFlow, path::Path, rc::Rc, str::from_utf8,
+    borrow, cmp::Ordering, num::NonZeroU64, ops::ControlFlow, path::Path, str::from_utf8,
+    sync::{Arc, Mutex},
 };
 use typed_path::{TypedPath, TypedPathBuf};
 
-pub(crate) type GimliReader = gimli::EndianReader<RunTimeEndian, std::rc::Rc<[u8]>>;
+pub(crate) type GimliReader = gimli::EndianReader<RunTimeEndian, std::sync::Arc<[u8]>>;
 pub(crate) type GimliReaderOffset =
-    <gimli::EndianReader<RunTimeEndian, Rc<[u8]>> as gimli::Reader>::Offset;
+    <gimli::EndianReader<RunTimeEndian, Arc<[u8]>> as gimli::Reader>::Offset;
 
 pub(crate) type GimliAttribute = gimli::Attribute<GimliReader>;
 
-pub(crate) type DwarfReader = gimli::read::EndianRcSlice<RunTimeEndian>;
+pub(crate) type DwarfReader = gimli::read::EndianArcSlice<RunTimeEndian>;
 
 /// Debug information which is parsed from DWARF debugging information.
 pub struct DebugInfo {
@@ -37,7 +40,11 @@ pub struct DebugInfo {
     pub(crate) unit_infos: Vec<UnitInfo>,
     pub(crate) endianness: gimli::RunTimeEndian,
 
-    pub(crate) addr2line: Option<addr2line::Loader>,
+    /// Cached symbol-table fallback for frames without DWARF.
+    ///
+    /// Wrapped in a [`Mutex`] because `addr2line::Loader` is `Send` but not
+    /// `Sync`, while [`DebugInfo`] must be both so an RPC server can share it.
+    pub(crate) addr2line: Option<Mutex<addr2line::Loader>>,
 }
 
 impl DebugInfo {
@@ -46,7 +53,7 @@ impl DebugInfo {
         let data = std::fs::read(path.as_ref())?;
 
         let mut this = DebugInfo::from_raw(&data)?;
-        this.addr2line = addr2line::Loader::new(path).ok();
+        this.addr2line = addr2line::Loader::new(path).ok().map(Mutex::new);
         Ok(this)
     }
 
@@ -67,8 +74,8 @@ impl DebugInfo {
                 .and_then(|section| section.uncompressed_data().ok())
                 .unwrap_or_else(|| borrow::Cow::Borrowed(&[][..]));
 
-            Ok(gimli::read::EndianRcSlice::new(
-                Rc::from(&*data),
+            Ok(gimli::read::EndianArcSlice::new(
+                Arc::from(&*data),
                 endianness,
             ))
         };
@@ -112,6 +119,44 @@ impl DebugInfo {
             endianness,
             addr2line: None,
         })
+    }
+
+    /// Create a [`DebugInfo`] that contains no debug information, for a target of the given
+    /// endianness.
+    ///
+    /// Unwinding with this still yields a backtrace: when the unwinder finds no unwind info for a
+    /// frame it falls back to the architecture's calling convention (for example the Xtensa window
+    /// save area). The resulting frames carry a program counter but no name or source location.
+    pub fn empty(endian: Endian) -> Self {
+        let endianness = match endian {
+            Endian::Little => RunTimeEndian::Little,
+            Endian::Big => RunTimeEndian::Big,
+        };
+        let load_section = |_id: gimli::SectionId| -> Result<DwarfReader, gimli::Error> {
+            Ok(gimli::read::EndianArcSlice::new(
+                Arc::from(&[][..]),
+                endianness,
+            ))
+        };
+
+        use gimli::Section;
+        let load = || -> Result<Self, gimli::Error> {
+            let debug_loc = gimli::DebugLoc::load(load_section)?;
+            let debug_loc_lists = gimli::DebugLocLists::load(load_section)?;
+
+            Ok(DebugInfo {
+                dwarf: gimli::Dwarf::load(&load_section)?,
+                frame_section: gimli::DebugFrame::load(load_section)?,
+                locations_section: gimli::LocationLists::new(debug_loc, debug_loc_lists),
+                address_section: gimli::DebugAddr::load(load_section)?,
+                debug_line_section: gimli::DebugLine::load(load_section)?,
+                unit_infos: Vec::new(),
+                endianness,
+                addr2line: None,
+            })
+        };
+
+        load().expect("loading empty DWARF sections cannot fail")
     }
 
     /// Try get the [`SourceLocation`] for a given address.
@@ -326,6 +371,10 @@ impl DebugInfo {
         let Some(ref addr2line) = self.addr2line else {
             return Ok(vec![]);
         };
+        // `Loader` is not `Sync`; serialize lookups against the shared cache.
+        let Ok(addr2line) = addr2line.lock() else {
+            return Ok(vec![]);
+        };
         let Some(fn_name) = addr2line.find_symbol(address) else {
             return Ok(vec![]);
         };
@@ -360,7 +409,7 @@ impl DebugInfo {
     /// Returns a populated (resolved) [`StackFrame`] struct.
     /// This function will also populate the `DebugInfo::VariableCache` with in scope `Variable`s for each `StackFrame`,
     /// while taking into account the appropriate strategy for lazy-loading of variables.
-    pub(crate) fn get_stackframe_info(
+    pub fn get_stackframe_info(
         &self,
         memory: &mut impl MemoryInterface,
         address: u64,

--- a/probe-rs-debug/src/language.rs
+++ b/probe-rs-debug/src/language.rs
@@ -15,7 +15,7 @@ pub mod rust;
 mod parsing;
 mod value;
 
-pub fn from_dwarf(language: DwLang) -> Box<dyn ProgrammingLanguage> {
+pub fn from_dwarf(language: DwLang) -> Box<dyn ProgrammingLanguage + Send + Sync> {
     match language {
         // Handle all C-like languages the same now.
         // We may have to split it later if this is not good enough.

--- a/probe-rs-debug/src/lib.rs
+++ b/probe-rs-debug/src/lib.rs
@@ -27,9 +27,15 @@ pub mod variable_cache;
 pub(crate) mod exception_handling;
 
 pub use self::{
-    debug_info::*, debug_step::SteppingMode, exception_handling::exception_handler_for_core,
-    registers::*, source_instructions::SourceLocation, source_instructions::VerifiedBreakpoint,
-    stack_frame::StackFrame, variable::*, variable_cache::VariableCache,
+    debug_info::*,
+    debug_step::SteppingMode,
+    exception_handling::exception_handler_for_core,
+    registers::*,
+    source_instructions::SourceLocation,
+    source_instructions::VerifiedBreakpoint,
+    stack_frame::{StackFrame, StackFrameInfo},
+    variable::*,
+    variable_cache::VariableCache,
 };
 
 use probe_rs::{Core, MemoryInterface};
@@ -38,7 +44,7 @@ use gimli::DebuggingInformationEntry;
 use gimli::EvaluationResult;
 use gimli::{AttributeValue, RunTimeEndian};
 use serde::Serialize;
-use typed_path::TypedPathBuf;
+pub use typed_path::{TypedPath, TypedPathBuf};
 
 use std::num::ParseIntError;
 use std::{
@@ -50,7 +56,16 @@ use std::{
 };
 
 /// A simplified type alias of the [`gimli::EndianReader`] type.
-pub type EndianReader = gimli::EndianReader<RunTimeEndian, std::rc::Rc<[u8]>>;
+pub type EndianReader = gimli::EndianReader<RunTimeEndian, std::sync::Arc<[u8]>>;
+
+// `DebugInfo` must be `Send + Sync` so a probe-rs RPC server can share it
+// across requests (e.g. behind `Arc`).
+const _: () = {
+    const fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<crate::DebugInfo>();
+    assert_send_sync::<crate::VariableCache>();
+    assert_send_sync::<crate::StackFrame>();
+};
 
 /// An error occurred while debugging the target.
 #[derive(Debug, thiserror::Error)]

--- a/probe-rs-debug/src/registers.rs
+++ b/probe-rs-debug/src/registers.rs
@@ -110,7 +110,7 @@ impl DebugRegisters {
         })
     }
 
-    fn from_core_registers(
+    pub fn from_core_registers(
         regs: &'static CoreRegisters,
         mut reg_value: impl FnMut(&RegisterId) -> Option<RegisterValue>,
     ) -> Self {

--- a/probe-rs-debug/src/unit_info.rs
+++ b/probe-rs-debug/src/unit_info.rs
@@ -22,7 +22,7 @@ pub(crate) enum ExpressionResult {
 pub struct UnitInfo {
     pub(crate) unit: gimli::Unit<GimliReader, usize>,
     dwarf_language: gimli::DwLang,
-    language: Box<dyn language::ProgrammingLanguage>,
+    language: Box<dyn language::ProgrammingLanguage + Send + Sync>,
     // A mapping from child die to parent die.
     parents: HashMap<UnitOffset, UnitOffset>,
     // Address => function DIE offset

--- a/probe-rs/src/core/registers.rs
+++ b/probe-rs/src/core/registers.rs
@@ -1,6 +1,6 @@
 //! Core registers are represented by the `CoreRegister` struct, and collected in a `RegisterFile` for each of the supported architectures.
 
-use crate::Error;
+use crate::{CoreType, Error};
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
@@ -469,6 +469,71 @@ impl CoreRegisters {
     /// The register file must contain at least the essential entries for program counter, stack pointer, frame pointer and return address registers.
     pub fn new(core_registers: Vec<&'static CoreRegister>) -> CoreRegisters {
         CoreRegisters(core_registers)
+    }
+
+    /// Return the register file that applies to the given [`CoreType`].
+    ///
+    /// Use this when an architecture-specific register file is needed but no
+    /// live [`crate::Core`] handle is available (for example, to drive a
+    /// remote target through an RPC-backed `Core`). `fpu_support` and
+    /// `floating_point_register_count` should reflect the actual target
+    /// configuration, as some cores select different register files based on
+    /// FPU presence or the number of FP registers.
+    pub fn for_core_type(
+        core_type: CoreType,
+        fpu_support: bool,
+        floating_point_register_count: Option<usize>,
+    ) -> &'static CoreRegisters {
+        use crate::architecture::arm::core::registers::aarch32::{
+            AARCH32_CORE_REGISTERS, AARCH32_WITH_FP_16_CORE_REGISTERS,
+            AARCH32_WITH_FP_32_CORE_REGISTERS,
+        };
+        use crate::architecture::arm::core::registers::aarch64::AARCH64_CORE_REGISTERS;
+        use crate::architecture::arm::core::registers::cortex_m::{
+            CORTEX_M_CORE_REGISTERS, CORTEX_M_WITH_FP_CORE_REGISTERS,
+        };
+        use crate::architecture::riscv::registers::{
+            RISCV_CORE_REGISTERS, RISCV_WITH_FP_CORE_REGISTERS,
+        };
+        use crate::architecture::riscv::registers64::{
+            RISCV64_CORE_REGISTERS, RISCV64_WITH_FP_CORE_REGISTERS,
+        };
+        use crate::architecture::xtensa::registers::XTENSA_CORE_REGISTERS;
+
+        match core_type {
+            CoreType::Armv6m => &CORTEX_M_CORE_REGISTERS,
+            CoreType::Armv7a | CoreType::Armv7r => match floating_point_register_count {
+                Some(16) => &AARCH32_WITH_FP_16_CORE_REGISTERS,
+                Some(32) => &AARCH32_WITH_FP_32_CORE_REGISTERS,
+                _ => &AARCH32_CORE_REGISTERS,
+            },
+            CoreType::Armv7m | CoreType::Armv7em | CoreType::Armv8m => {
+                if fpu_support {
+                    &CORTEX_M_WITH_FP_CORE_REGISTERS
+                } else {
+                    &CORTEX_M_CORE_REGISTERS
+                }
+            }
+            // TODO: This can be wrong if the CPU is 32 bit. For lack of better
+            // design at the time of writing this code this differentiation
+            // has been omitted.
+            CoreType::Armv8a => &AARCH64_CORE_REGISTERS,
+            CoreType::Riscv => {
+                if fpu_support {
+                    &RISCV_WITH_FP_CORE_REGISTERS
+                } else {
+                    &RISCV_CORE_REGISTERS
+                }
+            }
+            CoreType::Riscv64 => {
+                if fpu_support {
+                    &RISCV64_WITH_FP_CORE_REGISTERS
+                } else {
+                    &RISCV64_CORE_REGISTERS
+                }
+            }
+            CoreType::Xtensa => &XTENSA_CORE_REGISTERS,
+        }
     }
 
     /// Returns an iterator over the descriptions of all the non-FPU registers of this core.

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -43,6 +43,7 @@ pub enum Error {
     /// a contributor to implement functionality for all of them. This allows us to
     /// implement new functionality on selected architectures first, and then add support for
     /// the other architectures later.
+    #[ignore_extra_doc_attributes]
     NotImplemented(&'static str),
     /// Some uncategorized error occurred.
     #[display("{0}")]

--- a/probe-rs/src/semihosting.rs
+++ b/probe-rs/src/semihosting.rs
@@ -130,6 +130,15 @@ impl UnknownCommandDetails {
 pub struct GetCommandLineRequest(Buffer);
 
 impl GetCommandLineRequest {
+    /// Address of the `block` argument the target passed to
+    /// `SYS_GET_CMDLINE`.
+    ///
+    /// Useful when transporting semihosting halt metadata out of band
+    /// (for example over RPC) without serializing the full request.
+    pub fn block_address(&self) -> u32 {
+        self.0.buffer_location()
+    }
+
     /// Writes the command line to the target. You have to continue the core manually afterwards.
     pub fn write_command_line_to_target(
         &self,
@@ -407,6 +416,16 @@ pub struct Buffer {
 }
 
 impl Buffer {
+    /// The target address of the two-word block describing this buffer.
+    ///
+    /// This is the same value that was passed to [`Self::from_block_at`]
+    /// and is exposed so that debuggers can transport it out of band
+    /// (e.g. over RPC) and reconstruct the buffer on a machine without
+    /// direct access to the target.
+    pub fn buffer_location(&self) -> u32 {
+        self.buffer_location
+    }
+
     /// Constructs a new buffer, reading the address and length from the target.
     pub fn from_block_at(
         core: &mut dyn CoreInterface,


### PR DESCRIPTION
DebugInfo and related types need to be Send so an RPC server can own them; CoreRegisters::for_core_type to support remote debugger front-ends.