### PR TITLE
Key remote upload cache by content, not just path

### DIFF
--- a/changelog/fixed-stale-remote-uploads.md
+++ b/changelog/fixed-stale-remote-uploads.md
@@ -1,0 +1,1 @@
+Fixed remote sessions reusing a previously uploaded file after its contents changed, so rebuilt binaries are now uploaded instead of the stale copy being flashed.

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -20,7 +20,6 @@ use tokio::{
 };
 
 use std::{
-    collections::HashMap,
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -64,6 +63,7 @@ use crate::{
             test::{ListTestsRequest, RunTestRequest, Test, TestResult, Tests},
         },
         transport::memory::{PostcardReceiver, PostcardSender, WireRx, WireTx},
+        upload_cache::{ContentHash, UploadCache},
         utils::semihosting::SemihostingOptions,
     },
     util::{
@@ -241,14 +241,14 @@ mod tls {
 #[derive(Clone)]
 pub struct RpcClient {
     client: HostClient<String>,
-    uploaded_files: Arc<Mutex<HashMap<PathBuf, PathBuf>>>,
+    upload_cache: Arc<Mutex<UploadCache>>,
     registry: Arc<Mutex<Registry>>,
     is_localhost: bool,
 }
 
 impl Drop for RpcClient {
     fn drop(&mut self) {
-        if Arc::strong_count(&self.uploaded_files) == 1 {
+        if Arc::strong_count(&self.upload_cache) == 1 {
             // Dropping the last client
             self.client.close();
         }
@@ -272,7 +272,7 @@ impl RpcClient {
                     subscriber_timeout_if_full: Duration::from_secs(1),
                 },
             ),
-            uploaded_files: Arc::new(Mutex::new(HashMap::new())),
+            upload_cache: Arc::new(Mutex::new(UploadCache::default())),
             registry: Arc::new(Mutex::new(Registry::from_builtin_families())),
             is_localhost: false,
         }
@@ -356,6 +356,12 @@ impl RpcClient {
         res
     }
 
+    /// Make a local file available to the RPC server, returning the path the
+    /// server should read.
+    ///
+    /// A prior upload is reused only when the path *and* its contents match, so
+    /// rebuilding a binary between calls uploads the new bytes rather than
+    /// silently reusing the stale copy. Failed uploads never update the cache.
     pub async fn upload_file(&self, src_path: impl AsRef<Path>) -> anyhow::Result<PathBuf> {
         use anyhow::Context as _;
 
@@ -368,14 +374,35 @@ impl RpcClient {
             return Ok(src_path);
         }
 
-        let mut uploaded = self.uploaded_files.lock().await;
-        if let Some(path) = uploaded.get(&src_path) {
-            return Ok(path.clone());
-        }
-
         let data = tokio::fs::read(&src_path)
             .await
-            .context("Failed to read file")?;
+            .with_context(|| format!("Failed to read {}", src_path.display()))?;
+        let content_hash = ContentHash::from_bytes(&data);
+
+        if let Some(remote_path) = self
+            .upload_cache
+            .lock()
+            .await
+            .lookup(&src_path, content_hash)
+        {
+            tracing::debug!("Reusing cached upload for {}", src_path.display());
+            return Ok(remote_path);
+        }
+
+        let remote_path = self
+            .upload_bytes(&src_path, &data)
+            .await
+            .context("Failed to upload file")?;
+
+        self.upload_cache
+            .lock()
+            .await
+            .insert(src_path, content_hash, remote_path.clone());
+
+        Ok(remote_path)
+    }
+
+    async fn upload_bytes(&self, src_path: &Path, data: &[u8]) -> anyhow::Result<PathBuf> {
         tracing::debug!("Uploading {} ({} bytes)", src_path.display(), data.len());
 
         let TempFile { key, path } = self.send_resp::<CreateTempFileEndpoint, _>(&()).await?;
@@ -388,11 +415,8 @@ impl RpcClient {
             .await?;
         }
 
-        tracing::debug!("Uploaded file to {}", path);
-        let path = PathBuf::from(path);
-        uploaded.insert(src_path, path.clone());
-
-        Ok(path)
+        tracing::debug!("Uploaded file to {path}");
+        Ok(PathBuf::from(path))
     }
 
     pub async fn attach_probe(&self, request: AttachRequest) -> anyhow::Result<AttachResult> {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/mod.rs
@@ -22,6 +22,7 @@ use tokio_util::sync::CancellationToken;
 pub mod client;
 pub mod functions;
 pub mod transport;
+pub(crate) mod upload_cache;
 pub mod utils;
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/probe-rs-tools/src/bin/probe-rs/rpc/upload_cache.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/upload_cache.rs
@@ -1,0 +1,125 @@
+//! Content-addressed client upload cache for remote RPC sessions.
+//!
+//! Remote uploads are keyed by `(canonical source path, content hash)` so
+//! changed bytes at the same path produce a new upload instead of reusing the
+//! stale one. Entries are never evicted: the server keeps every uploaded temp
+//! file for the lifetime of the connection, so a recorded upload stays valid
+//! and dropping the entry would only cause the same bytes to be sent again.
+
+use sha2::{Digest, Sha256};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+/// SHA-256 digest of a local file's contents.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct ContentHash([u8; 32]);
+
+impl ContentHash {
+    pub(crate) fn from_bytes(data: &[u8]) -> Self {
+        let digest = Sha256::digest(data);
+        Self(digest.into())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct UploadCacheKey {
+    canonical_path: PathBuf,
+    content_hash: ContentHash,
+}
+
+/// Cache of prior remote uploads for one connection.
+#[derive(Debug, Default)]
+pub(crate) struct UploadCache {
+    entries: HashMap<UploadCacheKey, PathBuf>,
+}
+
+impl UploadCache {
+    pub(crate) fn lookup(
+        &self,
+        canonical_path: &Path,
+        content_hash: ContentHash,
+    ) -> Option<PathBuf> {
+        self.entries
+            .get(&UploadCacheKey {
+                canonical_path: canonical_path.to_path_buf(),
+                content_hash,
+            })
+            .cloned()
+    }
+
+    /// Record a successful upload.
+    pub(crate) fn insert(
+        &mut self,
+        canonical_path: PathBuf,
+        content_hash: ContentHash,
+        remote_path: PathBuf,
+    ) {
+        self.entries.insert(
+            UploadCacheKey {
+                canonical_path,
+                content_hash,
+            },
+            remote_path,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash(bytes: &[u8]) -> ContentHash {
+        ContentHash::from_bytes(bytes)
+    }
+
+    #[test]
+    fn changed_content_at_same_path_is_a_miss() {
+        let mut cache = UploadCache::default();
+        let path = PathBuf::from("/tmp/firmware.elf");
+
+        cache.insert(path.clone(), hash(b"v1"), PathBuf::from("/remote/v1"));
+
+        assert_eq!(
+            cache.lookup(&path, hash(b"v1")),
+            Some(PathBuf::from("/remote/v1"))
+        );
+        assert_eq!(cache.lookup(&path, hash(b"v2")), None);
+    }
+
+    /// Rebuilding back to a previously uploaded binary reuses that upload,
+    /// since the server still holds the temp file.
+    #[test]
+    fn earlier_content_at_same_path_stays_cached() {
+        let mut cache = UploadCache::default();
+        let path = PathBuf::from("/tmp/firmware.elf");
+
+        cache.insert(path.clone(), hash(b"v1"), PathBuf::from("/remote/v1"));
+        cache.insert(path.clone(), hash(b"v2"), PathBuf::from("/remote/v2"));
+
+        assert_eq!(
+            cache.lookup(&path, hash(b"v1")),
+            Some(PathBuf::from("/remote/v1"))
+        );
+        assert_eq!(
+            cache.lookup(&path, hash(b"v2")),
+            Some(PathBuf::from("/remote/v2"))
+        );
+    }
+
+    #[test]
+    fn identical_content_at_different_paths_is_tracked_separately() {
+        let mut cache = UploadCache::default();
+        let elf = PathBuf::from("/tmp/firmware.elf");
+        let copy = PathBuf::from("/tmp/copy.elf");
+
+        cache.insert(elf.clone(), hash(b"elf"), PathBuf::from("/remote/elf"));
+
+        assert_eq!(
+            cache.lookup(&elf, hash(b"elf")),
+            Some(PathBuf::from("/remote/elf"))
+        );
+        assert_eq!(cache.lookup(&copy, hash(b"elf")), None);
+    }
+}


### PR DESCRIPTION
Previously, trying to upload a different file from the same path (e.g. an updated build artifact) silently did nothing.