### PR TITLE
Remove run and flash options from profile command

### DIFF
--- a/changelog/fixed-profile-command-parse.md
+++ b/changelog/fixed-profile-command-parse.md
@@ -1,0 +1,1 @@
+Fixed failure to parse `profile` sub-command arguments due to repetition of `reset` option. Removing flashing options fixes this.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/profile.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/profile.rs
@@ -1,19 +1,22 @@
+use std::path::PathBuf;
+
 mod callstack;
 mod flat;
 
 use probe_rs::config::Registry;
 use probe_rs::probe::list::Lister;
 
-use crate::util::flash::{build_loader, run_flash_download};
+use crate::util::common_options::ProbeOptions;
+
 use tracing::info;
 
 #[derive(clap::Parser)]
 pub(crate) struct ProfileCmd {
     #[clap(flatten)]
-    run: super::run::Cmd,
-    /// Flash the ELF before profiling
-    #[clap(long)]
-    flash: bool,
+    probe_options: ProbeOptions,
+    /// The path to the flashed ELF file to profile.
+    #[clap(index = 1)]
+    path: PathBuf,
     /// Reset before profiling
     #[clap(long)]
     reset: bool,
@@ -38,22 +41,9 @@ enum ProfileType {
 
 impl ProfileCmd {
     pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
-        let (mut session, probe_options) =
-            self.run.probe_options.simple_attach(registry, lister)?;
+        let (mut session, _) = self.probe_options.simple_attach(registry, lister)?;
 
-        let loader = build_loader(&mut session, &self.run.path, self.run.format_options, None)?;
-
-        let file_location = self.run.path.as_path();
-
-        if self.flash {
-            run_flash_download(
-                &mut session,
-                file_location,
-                &self.run.download_options,
-                &probe_options,
-                loader,
-            )?;
-        }
+        let file_location = self.path.as_path();
 
         if self.reset {
             for (core_idx, _) in session.list_cores() {


### PR DESCRIPTION
Reduces the scope of the profile sub-command to remove flashing. The desired behaviour for flashing should be achievable with a flash followed by a profile with reset.

This fixes a bug described [in this comment](https://github.com/probe-rs/probe-rs/pull/3789#issuecomment-5146772221), which appeared after #4006 which introduced a second reset option, leading to options failing to parse. Dropping the flashing options for profile avoids this duplicated reset option. I initially tried removing the second `reset` option under `profile` but I think it's cleaner to reduce the scope of this command.

I'm away from any microcontrollers for a week so I'd appreciate if someone could test this (e.g. as [documented here](https://probe.rs/docs/knowledge-base/performance-profiling/)) since I haven't actually run it all the way through.

Thanks @d3d9 for reporting and @yatekii for looking into this.