### PR TITLE
RAM download progress

### DIFF
--- a/changelog/added-ram-progress-reporting.md
+++ b/changelog/added-ram-progress-reporting.md
@@ -1,0 +1,2 @@
+Added RAM progress reporting. The RAM download process can now be split into chunks
+using the `--ram-chunk-size` option.

--- a/probe-rs-rpc/src/flash.rs
+++ b/probe-rs-rpc/src/flash.rs
@@ -12,6 +12,7 @@ pub struct DownloadOptions {
     pub verify: bool,
     pub disable_double_buffering: bool,
     pub preferred_algos: Vec<String>,
+    pub ram_chunk_size: Option<u64>,
 }
 
 impl DownloadOptions {
@@ -103,6 +104,7 @@ pub enum Operation {
     Erase,
     Program,
     Verify,
+    Ram,
 }
 
 #[derive(Clone, Serialize, Deserialize, Schema)]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -310,6 +310,7 @@ async fn main_try(args: Vec<OsString>, config: Config, offset: UtcOffset) -> Res
             chip_erase: config.flashing.do_chip_erase,
             read_flasher_rtt: config.flashing.read_flasher_rtt,
             prefer_flash_algorithm: Vec::new(),
+            ram_chunk_size: None,
         };
         let loader = build_loader(&mut session, &path, format_options, image_instr_set)?;
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/backend/rpc.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/backend/rpc.rs
@@ -838,6 +838,7 @@ impl RpcBackend {
                 verify: config.verify_after_flashing,
                 disable_double_buffering: false,
                 preferred_algos: Vec::new(),
+                ram_chunk_size: None,
             };
 
             session

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -851,6 +851,7 @@ impl Debugger {
             Operation::Erase => "Erasing Sectors",
             Operation::Program => "Programming Pages",
             Operation::Verify => "Verifying",
+            Operation::Ram => "Writing RAM",
         };
 
         let result = {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
@@ -286,6 +286,7 @@ pub(crate) mod convert {
             flashing::ProgressOperation::Erase => Operation::Erase,
             flashing::ProgressOperation::Program => Operation::Program,
             flashing::ProgressOperation::Verify => Operation::Verify,
+            flashing::ProgressOperation::Ram => Operation::Ram,
         }
     }
 

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -458,6 +458,7 @@ pub async fn flash(
         verify: download_options.verify,
         disable_double_buffering: download_options.disable_double_buffering,
         preferred_algos: download_options.prefer_flash_algorithm,
+        ram_chunk_size: download_options.ram_chunk_size,
     };
 
     options.sanitize();

--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -66,6 +66,12 @@ pub struct BinaryDownloadOptions {
         help_heading = "PROBE CONFIGURATION"
     )]
     pub prefer_flash_algorithm: Vec<String>,
+
+    /// Chunk size, in bytes, for writing data directly to RAM.
+    ///
+    /// If unset, each RAM region is written in one go, so progress jumps straight to 100%.
+    #[arg(long, help_heading = "DOWNLOAD CONFIGURATION")]
+    pub ram_chunk_size: Option<u64>,
 }
 
 /// Supported bit-widths for read/write commands (not every device may support each width).

--- a/probe-rs-tools/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/flash.rs
@@ -55,6 +55,7 @@ fn run_flash_download_inner(
     options.disable_double_buffering = download_options.disable_double_buffering;
     options.verify = download_options.verify;
     options.preverify = download_options.preverify;
+    options.ram_chunk_size = download_options.ram_chunk_size;
 
     let pb = if download_options.disable_progressbars {
         None
@@ -220,6 +221,7 @@ impl ProgressBars {
                 Operation::Fill => "Reading flash",
                 Operation::Program => "Programming",
                 Operation::Verify => "Verifying",
+                Operation::Ram => "Writing RAM",
             };
             ProgressBarGroup::new(format!("{message:>13}"))
         })

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -136,6 +136,8 @@ pub struct DownloadOptions<'p> {
     /// If there are multiple valid flash algorithms for a memory region, this list allows
     /// overriding the default selection.
     pub preferred_algos: Vec<String>,
+    /// RAM chunk size relevant for loading into RAM. [None] disables the chunking.
+    pub ram_chunk_size: Option<u64>,
 }
 
 impl DownloadOptions<'_> {

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -7,7 +7,7 @@ use probe_rs_target::{
 use std::io::{Read, Seek};
 use std::ops::Range;
 use std::sync::LazyLock;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use yaml_serde::Value;
 
 use super::builder::FlashBuilder;
@@ -744,8 +744,11 @@ impl FlashLoader {
             }
         }
 
+        let mut ram_write_result = Ok(());
+        let mut ram_progress_start: Option<Instant> = None;
+
         // Commit RAM last, because NVM flashing overwrites RAM
-        for region in self
+        'ram_regions: for region in self
             .memory_map
             .iter()
             .filter_map(MemoryRegion::as_ram_region)
@@ -755,6 +758,11 @@ impl FlashLoader {
             if ranges_in_region.is_empty() {
                 continue;
             }
+
+            let ram_progress_start = *ram_progress_start.get_or_insert_with(|| {
+                options.progress.started(ProgressOperation::Ram);
+                Instant::now()
+            });
 
             tracing::debug!(
                 "    region: {:#010X?} ({} bytes)",
@@ -793,10 +801,49 @@ impl FlashLoader {
                     address + data.len() as u64,
                     data.len()
                 );
-                // Write data to memory.
-                core.write(address, data).map_err(FlashError::Core)?;
+
+                match options.ram_chunk_size {
+                    None => {
+                        // No progress to report, so skip the chunking overhead and write in one go.
+                        if let Err(error) = core.write(address, data) {
+                            ram_write_result = Err(FlashError::Core(error));
+                            break 'ram_regions;
+                        }
+                        options.progress.progressed(
+                            ProgressOperation::Ram,
+                            data.len() as u64,
+                            ram_progress_start.elapsed(),
+                        );
+                        continue;
+                    }
+                    Some(chunk_size) => {
+                        for (chunk_index, chunk) in data.chunks(chunk_size as usize).enumerate() {
+                            let chunk_address = address + (chunk_index as u64 * chunk_size);
+
+                            // Write data to memory.
+                            if let Err(error) = core.write(chunk_address, chunk) {
+                                ram_write_result = Err(FlashError::Core(error));
+                                break 'ram_regions;
+                            }
+                            options.progress.progressed(
+                                ProgressOperation::Ram,
+                                chunk.len() as u64,
+                                ram_progress_start.elapsed(),
+                            );
+                        }
+                    }
+                }
             }
         }
+
+        if ram_progress_start.is_some() {
+            match ram_write_result {
+                Ok(()) => options.progress.finished(ProgressOperation::Ram),
+                Err(_) => options.progress.failed(ProgressOperation::Ram),
+            }
+        }
+
+        ram_write_result?;
 
         if options.verify {
             self.verify_ram(session)?;
@@ -976,6 +1023,19 @@ impl FlashLoader {
             }
 
             phases.push(phase_layout);
+        }
+
+        let ram_size: u64 = self
+            .memory_map
+            .iter()
+            .filter_map(MemoryRegion::as_ram_region)
+            .flat_map(|region| self.builder.data_in_range(&region.range))
+            .map(|(_, data)| data.len() as u64)
+            .sum();
+        if ram_size > 0 {
+            options
+                .progress
+                .add_progress_bar(ProgressOperation::Ram, Some(ram_size));
         }
 
         options.progress.initialized(phases);

--- a/probe-rs/src/flashing/progress.rs
+++ b/probe-rs/src/flashing/progress.rs
@@ -184,6 +184,9 @@ pub enum ProgressOperation {
 
     /// Checking flash contents.
     Verify,
+
+    /// Writing data directly to RAM.
+    Ram,
 }
 
 /// Possible events during the flashing process.


### PR DESCRIPTION
The `disable_progressbar`  option already exists somewhere else, but is not propagated into `commit` function. it is required so the chunking can be made optional.. maybe there is another solution to also avoid the new flag, but that would probably require changing the `FlashProgress` field.