### PR TITLE
Move the probe-rs domain conversions out of the RPC wire modules

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/backend/rpc.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/backend/rpc.rs
@@ -15,7 +15,7 @@ use crate::cmd::dap_server::debug_adapter::dap::dap_types::{
 };
 use crate::cmd::dap_server::server::configuration::FlashingConfig;
 use crate::rpc::{
-    Key,
+    Key, Session,
     client::{CoreInterface as RpcCoreClient, RpcClient, SessionInterface},
     functions::{
         RpcError,
@@ -34,7 +34,7 @@ use crate::rpc::{
 };
 use probe_rs::{
     Architecture, CoreInformation, CoreRegisters, CoreStatus, CoreType, Error, RegisterId,
-    RegisterValue, Session, VectorCatchCondition,
+    RegisterValue, VectorCatchCondition,
 };
 use probe_rs_debug::{
     ColumnType, DebugRegisters, ObjectRef, SourceLocation as DebugSourceLocation, StackFrame,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -2,9 +2,8 @@ use std::any::Any;
 
 use super::session_data;
 use crate::cmd::dap_server::debug_adapter::dap::repl_commands::ReplCommand;
-use crate::rpc::Key;
 use crate::rpc::functions::rtt_client::ScanRegion as WireScanRegion;
-use crate::util::rtt::client::RttClient;
+use crate::rpc::{Key, RttClient};
 
 /// `(channel number, channel name)` pairs returned while attaching to RTT.
 pub(crate) type ChannelNames = Vec<(u32, String)>;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
@@ -1,7 +1,7 @@
 use crate::{
     cmd::dap_server::{DebuggerError, debug_adapter::dap::adapter::*},
-    rpc::{Key, client::SessionInterface},
-    util::rtt::{RttDecoder, client::RttClient},
+    rpc::{Key, RttClient, client::SessionInterface},
+    util::rtt::RttDecoder,
 };
 use anyhow::anyhow;
 use probe_rs::rtt::Error as RttError;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -21,14 +21,13 @@ use crate::{
         run::EmbeddedTestElfInfo,
     },
     rpc::{
-        Key,
+        Key, RttClient,
         client::RpcClient,
         functions::{
             breakpoints::SourceBreakpointLocation, rtt_client::ScanRegion as WireScanRegion,
         },
     },
     util::cli::attach_probe as attach_probe_rpc,
-    util::rtt::client::RttClient,
 };
 use anyhow::{Result, anyhow};
 use probe_rs::{BreakpointCause, CoreStatus, HaltReason, rtt::find_rtt_control_block_in_raw_file};

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -12,7 +12,7 @@ use postcard_rpc::{
     host_client::{HostClient, HostClientConfig, HostErr, IoClosed, SubscribeError, Subscription},
 };
 use postcard_schema::Schema;
-use probe_rs::{Session, config::Registry, flashing::FlashLoader};
+use probe_rs::config::Registry;
 use serde::{Serialize, de::DeserializeOwned};
 use tokio::{
     sync::{Mutex, MutexGuard, Notify},
@@ -28,7 +28,7 @@ use std::{
 use crate::{
     FormatOptions,
     rpc::{
-        Key,
+        FlashLoader, Key, RttClient, Session,
         functions::{
             AttachEndpoint, BootEndpoint, BuildEndpoint, ChipInfoEndpoint, CleanUpRttEndpoint,
             ClearCoreDebugStateEndpoint, ClearRttControlBlockEndpoint, CoreClearHwBpsEndpoint,
@@ -98,10 +98,7 @@ use crate::{
         upload_cache::{ContentHash, ResolvedUpload, UploadCache},
         utils::semihosting::SemihostingOptions,
     },
-    util::{
-        cli::MonitorEvent,
-        rtt::{RttChannelConfig, client::RttClient},
-    },
+    util::{cli::MonitorEvent, rtt::RttChannelConfig},
 };
 
 /// Host and optional authentication token identifying a remote probe-rs RPC

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
@@ -1,13 +1,12 @@
-use std::{any::Any, ops::DerefMut, sync::Arc};
 use std::{collections::HashMap, convert::Infallible, future::Future};
+use std::{ops::DerefMut, sync::Arc};
 
-use crate::rpc::SessionState;
 use crate::rpc::debug_state::{CoreDebugState, ServerDebugState};
 use crate::rpc::functions::file::{
     AppendFileRequest, CreateFileResponse, append_temp_file, create_temp_file,
 };
 use crate::rpc::{
-    ConnectionState, Key,
+    ConnectionState, Key, Session, SessionState,
     functions::{
         breakpoints::{
             ResolveSourceBreakpointsRequest, ResolveSourceLocationsRequest,
@@ -76,9 +75,9 @@ use postcard_rpc::{Topic, TopicDirection, endpoints, host_client, server, topics
 use postcard_schema::Schema;
 use probe_rs::config::Registry;
 use probe_rs::integration::ProbeLister;
+use probe_rs::probe::list::Lister;
 use probe_rs::probe::list::{AllProbesLister, ProbeListItem};
 use probe_rs::probe::{DebugProbeError, DebugProbeSelector, Probe, ProbeCreationError};
-use probe_rs::{Session, probe::list::Lister};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{
     Mutex,
@@ -210,7 +209,10 @@ impl RpcSpawnContext {
         self.shared_session(sessid).dry_run()
     }
 
-    fn session_blocking(&self, sessid: Key<Session>) -> impl DerefMut<Target = Session> + use<> {
+    fn session_blocking(
+        &self,
+        sessid: Key<Session>,
+    ) -> impl DerefMut<Target = probe_rs::Session> + use<> {
         self.shared_session(sessid).session_blocking()
     }
 
@@ -218,10 +220,10 @@ impl RpcSpawnContext {
         self.state.shared_session(sessid)
     }
 
-    pub fn object_mut_blocking<T: Any + Send>(
+    pub fn object_mut_blocking<M: crate::rpc::ObjectMarker>(
         &self,
-        key: Key<T>,
-    ) -> impl DerefMut<Target = T> + Send + use<T> {
+        key: Key<M>,
+    ) -> impl DerefMut<Target = M::Object> + Send + use<M> {
         self.state.object_mut_blocking(key)
     }
 
@@ -381,25 +383,25 @@ impl RpcContext {
             .map_err(|e| anyhow!("{e:?}"))
     }
 
-    pub async fn object_mut<T: Any + Send>(
+    pub async fn object_mut<M: crate::rpc::ObjectMarker>(
         &self,
-        key: Key<T>,
-    ) -> impl DerefMut<Target = T> + Send + use<T> {
+        key: Key<M>,
+    ) -> impl DerefMut<Target = M::Object> + Send + use<M> {
         self.state.object_mut(key).await
     }
 
-    pub async fn store_object<T: Any + Send>(&mut self, obj: T) -> Key<T> {
+    pub async fn store_object<M: crate::rpc::ObjectMarker>(&mut self, obj: M::Object) -> Key<M> {
         self.state.store_object(obj).await
     }
 
-    pub async fn set_session(&mut self, session: Session, dry_run: bool) -> Key<Session> {
+    pub async fn set_session(&mut self, session: probe_rs::Session, dry_run: bool) -> Key<Session> {
         self.state.set_session(session, dry_run).await
     }
 
     pub async fn session(
         &self,
         sid: Key<Session>,
-    ) -> impl DerefMut<Target = Session> + Send + use<> {
+    ) -> impl DerefMut<Target = probe_rs::Session> + Send + use<> {
         self.object_mut(sid).await
     }
 

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
@@ -6,71 +6,65 @@ use crate::rpc::debug_state::{CoreDebugState, ServerDebugState};
 use crate::rpc::functions::file::{
     AppendFileRequest, CreateFileResponse, append_temp_file, create_temp_file,
 };
-use crate::{
-    rpc::{
-        ConnectionState, Key,
-        functions::{
-            breakpoints::{
-                ResolveSourceBreakpointsRequest, ResolveSourceLocationsRequest,
-                resolve_source_breakpoints, resolve_source_locations,
-            },
-            chip::{
-                ChipInfoRequest, ChipInfoResponse, ListFamiliesResponse, LoadChipFamilyRequest,
-                chip_info, list_families, load_chip_family,
-            },
-            core_ops::{
-                CoreAccessRequest, CoreBreakpointsRequest, CoreDumpRequest, CoreHaltRequest,
-                CoreReadRegistersRequest, CoreVectorCatchRequest, CoreWriteRegRequest,
-                HandleSemihostingRequest, StepRequest, WireCoreDump, WireCoreInformation,
-                WireCoreMetadata, WireCoreStatus, WireRegisterReadResult, core_clear_hw_bps,
-                core_dump, core_enable_vc, core_halt, core_handle_semihosting, core_metadata,
-                core_read_registers, core_run, core_set_hw_bps, core_status, core_step,
-                core_write_reg,
-            },
-            debug_vars::{
-                ClearCoreDebugStateRequest, EvaluateRequest, LoadSvdRequest, ScopesRequest,
-                SetVariableRequest, VariablesRequest, clear_core_debug_state,
-                evaluate as debug_evaluate, load_svd as debug_load_svd, scopes as debug_scopes,
-                set_variable as debug_set_variable, variables as debug_variables,
-            },
-            disassemble::{DisassembleRequest, disassemble as disassemble_handler},
-            flash::{
-                BootRequest, BuildRequest, BuildResponse, EraseRequest, FlashRequest,
-                ProgressEvent, VerifyRequest, VerifyResponse, boot, build, erase, flash, verify,
-            },
-            info::{
-                InfoEvent, TargetInfoRequest, TargetMetadataRequest, target_info, target_metadata,
-            },
-            memory::{
-                ReadBytesRequest, ReadMemoryRequest, WriteMemoryRequest, read_bytes, read_memory,
-                write_memory,
-            },
-            monitor::{MonitorRequest, MonitorResponse, RttEvent, SemihostingEvent, monitor},
-            probe::{
-                AttachRequest, AttachResponse, ListProbesResponse, SelectProbeRequest,
-                SelectProbeResponse, attach, list_probes, select_probe,
-            },
-            reset::{ResetCoreAndHaltRequest, ResetCoreRequest, reset, reset_and_halt},
-            resume::{ResumeAllCoresRequest, resume_all_cores},
-            rtt_client::{
-                CreateRttClientRequest, CreateRttClientResponse, PollRttUpRequest,
-                PollRttUpResponse, RttChannelRequest, RttChannelsResponse, RttDownRequest,
-                clean_up_rtt, clear_rtt_control_block, create_rtt_client, get_rtt_channels,
-                poll_rtt_up, write_rtt_down,
-            },
-            stack_trace::{
-                LoadDebugInfoRequest, LoadDebugInfoResponse, TakeRichStackTraceRequest,
-                TakeRichStackTraceResponse, TakeStackTraceRequest, TakeStackTraceResponse,
-                load_debug_info, take_rich_stack_trace, take_stack_trace,
-            },
-            test::{
-                ListTestsRequest, ListTestsResponse, RunTestRequest, RunTestResponse,
-                TestKickoffRequest, TestKickoffResponse, list_tests, run_test, test_kickoff,
-            },
+use crate::rpc::{
+    ConnectionState, Key,
+    functions::{
+        breakpoints::{
+            ResolveSourceBreakpointsRequest, ResolveSourceLocationsRequest,
+            resolve_source_breakpoints, resolve_source_locations,
         },
-        transport::memory::{WireRx, WireTx},
+        chip::{
+            ChipInfoRequest, ChipInfoResponse, ListFamiliesResponse, LoadChipFamilyRequest,
+            chip_info, list_families, load_chip_family,
+        },
+        core_ops::{
+            CoreAccessRequest, CoreBreakpointsRequest, CoreDumpRequest, CoreHaltRequest,
+            CoreReadRegistersRequest, CoreVectorCatchRequest, CoreWriteRegRequest,
+            HandleSemihostingRequest, StepRequest, WireCoreDump, WireCoreInformation,
+            WireCoreMetadata, WireCoreStatus, WireRegisterReadResult, core_clear_hw_bps, core_dump,
+            core_enable_vc, core_halt, core_handle_semihosting, core_metadata, core_read_registers,
+            core_run, core_set_hw_bps, core_status, core_step, core_write_reg,
+        },
+        debug_vars::{
+            ClearCoreDebugStateRequest, EvaluateRequest, LoadSvdRequest, ScopesRequest,
+            SetVariableRequest, VariablesRequest, clear_core_debug_state,
+            evaluate as debug_evaluate, load_svd as debug_load_svd, scopes as debug_scopes,
+            set_variable as debug_set_variable, variables as debug_variables,
+        },
+        disassemble::{DisassembleRequest, disassemble as disassemble_handler},
+        flash::{
+            BootRequest, BuildRequest, BuildResponse, EraseRequest, FlashRequest, ProgressEvent,
+            VerifyRequest, VerifyResponse, boot, build, erase, flash, verify,
+        },
+        info::{InfoEvent, TargetInfoRequest, TargetMetadataRequest, target_info, target_metadata},
+        memory::{
+            ReadBytesRequest, ReadMemoryRequest, WriteMemoryRequest, read_bytes, read_memory,
+            write_memory,
+        },
+        monitor::{MonitorRequest, MonitorResponse, RttEvent, SemihostingEvent, monitor},
+        probe::{
+            AttachRequest, AttachResponse, ListProbesResponse, SelectProbeRequest,
+            SelectProbeResponse, attach, list_probes, select_probe,
+        },
+        reset::{ResetCoreAndHaltRequest, ResetCoreRequest, reset, reset_and_halt},
+        resume::{ResumeAllCoresRequest, resume_all_cores},
+        rtt_client::{
+            CreateRttClientRequest, CreateRttClientResponse, PollRttUpRequest, PollRttUpResponse,
+            RttChannelRequest, RttChannelsResponse, RttDownRequest, clean_up_rtt,
+            clear_rtt_control_block, create_rtt_client, get_rtt_channels, poll_rtt_up,
+            write_rtt_down,
+        },
+        stack_trace::{
+            LoadDebugInfoRequest, LoadDebugInfoResponse, TakeRichStackTraceRequest,
+            TakeRichStackTraceResponse, TakeStackTraceRequest, TakeStackTraceResponse,
+            load_debug_info, take_rich_stack_trace, take_stack_trace,
+        },
+        test::{
+            ListTestsRequest, ListTestsResponse, RunTestRequest, RunTestResponse,
+            TestKickoffRequest, TestKickoffResponse, list_tests, run_test, test_kickoff,
+        },
     },
-    util::common_options::OperationError,
+    transport::memory::{WireRx, WireTx},
 };
 
 use anyhow::anyhow;
@@ -122,7 +116,6 @@ impl std::fmt::Display for RpcError {
     }
 }
 
-// TODO: replace most of these with anyhow context wrappers
 impl From<&str> for RpcError {
     fn from(e: &str) -> Self {
         Self(e.to_string())
@@ -132,54 +125,6 @@ impl From<&str> for RpcError {
 impl From<String> for RpcError {
     fn from(e: String) -> Self {
         Self(e)
-    }
-}
-
-impl From<anyhow::Error> for RpcError {
-    fn from(e: anyhow::Error) -> Self {
-        Self(format!("{e:?}"))
-    }
-}
-
-impl From<probe_rs::Error> for RpcError {
-    fn from(e: probe_rs::Error) -> Self {
-        Self::from(anyhow!(e))
-    }
-}
-
-impl From<probe_rs_debug::DebugError> for RpcError {
-    fn from(e: probe_rs_debug::DebugError) -> Self {
-        Self::from(anyhow!(e))
-    }
-}
-
-impl From<probe_rs::flashing::FileDownloadError> for RpcError {
-    fn from(e: probe_rs::flashing::FileDownloadError) -> Self {
-        Self::from(anyhow!(e))
-    }
-}
-
-impl From<probe_rs::flashing::FlashError> for RpcError {
-    fn from(e: probe_rs::flashing::FlashError) -> Self {
-        Self::from(anyhow!(e))
-    }
-}
-
-impl From<probe_rs::config::RegistryError> for RpcError {
-    fn from(e: probe_rs::config::RegistryError) -> Self {
-        Self::from(anyhow!(e))
-    }
-}
-
-impl From<OperationError> for RpcError {
-    fn from(e: OperationError) -> Self {
-        Self::from(anyhow!(e))
-    }
-}
-
-impl From<probe_rs::rtt::Error> for RpcError {
-    fn from(e: probe_rs::rtt::Error) -> Self {
-        Self::from(anyhow!(e))
     }
 }
 
@@ -829,5 +774,60 @@ impl RpcApp {
             client_to_server.0,
             server_to_client.1,
         )
+    }
+}
+
+pub(crate) mod convert {
+    use super::RpcError;
+    use crate::util::common_options::OperationError;
+    use anyhow::anyhow;
+
+    // TODO: replace most of these with anyhow context wrappers
+    impl From<anyhow::Error> for RpcError {
+        fn from(e: anyhow::Error) -> Self {
+            Self(format!("{e:?}"))
+        }
+    }
+
+    impl From<probe_rs::Error> for RpcError {
+        fn from(e: probe_rs::Error) -> Self {
+            Self::from(anyhow!(e))
+        }
+    }
+
+    impl From<probe_rs_debug::DebugError> for RpcError {
+        fn from(e: probe_rs_debug::DebugError) -> Self {
+            Self::from(anyhow!(e))
+        }
+    }
+
+    impl From<probe_rs::flashing::FileDownloadError> for RpcError {
+        fn from(e: probe_rs::flashing::FileDownloadError) -> Self {
+            Self::from(anyhow!(e))
+        }
+    }
+
+    impl From<probe_rs::flashing::FlashError> for RpcError {
+        fn from(e: probe_rs::flashing::FlashError) -> Self {
+            Self::from(anyhow!(e))
+        }
+    }
+
+    impl From<probe_rs::config::RegistryError> for RpcError {
+        fn from(e: probe_rs::config::RegistryError) -> Self {
+            Self::from(anyhow!(e))
+        }
+    }
+
+    impl From<OperationError> for RpcError {
+        fn from(e: OperationError) -> Self {
+            Self::from(anyhow!(e))
+        }
+    }
+
+    impl From<probe_rs::rtt::Error> for RpcError {
+        fn from(e: probe_rs::rtt::Error) -> Self {
+            Self::from(anyhow!(e))
+        }
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/breakpoints.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/breakpoints.rs
@@ -2,10 +2,7 @@ use crate::rpc::{
     Key,
     functions::{RpcContext, RpcResult},
 };
-use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;
-use probe_rs::Session;
-use probe_rs_debug::{ColumnType, SourceLocation, TypedPath, VerifiedBreakpoint};
 use serde::{Deserialize, Serialize};
 
 /// Reported per breakpoint when the session was attached without a program
@@ -24,34 +21,6 @@ pub struct WireSourceLocation {
     pub line: Option<u64>,
     pub column: Option<WireColumn>,
     pub address: Option<u64>,
-}
-
-impl From<&SourceLocation> for WireSourceLocation {
-    fn from(location: &SourceLocation) -> Self {
-        Self {
-            path: location.path.to_path().display().to_string(),
-            line: location.line,
-            column: location.column.map(|column| match column {
-                ColumnType::LeftEdge => WireColumn::LeftEdge,
-                ColumnType::Column(column) => WireColumn::Column(column),
-            }),
-            address: location.address,
-        }
-    }
-}
-
-impl From<WireSourceLocation> for SourceLocation {
-    fn from(location: WireSourceLocation) -> Self {
-        Self {
-            path: TypedPath::derive(location.path.as_bytes()).to_path_buf(),
-            line: location.line,
-            column: location.column.map(|column| match column {
-                WireColumn::LeftEdge => ColumnType::LeftEdge,
-                WireColumn::Column(column) => ColumnType::Column(column),
-            }),
-            address: location.address,
-        }
-    }
 }
 
 #[derive(Serialize, Deserialize, Schema)]
@@ -73,15 +42,6 @@ pub struct WireVerifiedBreakpoint {
     pub source_location: WireSourceLocation,
 }
 
-impl From<VerifiedBreakpoint> for WireVerifiedBreakpoint {
-    fn from(breakpoint: VerifiedBreakpoint) -> Self {
-        Self {
-            address: breakpoint.address,
-            source_location: WireSourceLocation::from(&breakpoint.source_location),
-        }
-    }
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize, Schema)]
 pub struct BreakpointResolution {
     pub breakpoint: Option<WireVerifiedBreakpoint>,
@@ -89,6 +49,18 @@ pub struct BreakpointResolution {
 }
 
 pub type ResolveSourceBreakpointsResponse = RpcResult<Vec<BreakpointResolution>>;
+
+#[derive(Serialize, Deserialize, Schema)]
+pub struct ResolveSourceLocationsRequest {
+    pub sessid: Key<Session>,
+    pub addresses: Vec<u64>,
+}
+
+pub type ResolveSourceLocationsResponse = RpcResult<Vec<Option<WireSourceLocation>>>;
+
+use postcard_rpc::header::VarHeader;
+use probe_rs::Session;
+use probe_rs_debug::TypedPath;
 
 pub async fn resolve_source_breakpoints(
     ctx: &mut RpcContext,
@@ -134,14 +106,6 @@ pub async fn resolve_source_breakpoints(
         .collect())
 }
 
-#[derive(Serialize, Deserialize, Schema)]
-pub struct ResolveSourceLocationsRequest {
-    pub sessid: Key<Session>,
-    pub addresses: Vec<u64>,
-}
-
-pub type ResolveSourceLocationsResponse = RpcResult<Vec<Option<WireSourceLocation>>>;
-
 pub async fn resolve_source_locations(
     ctx: &mut RpcContext,
     _header: VarHeader,
@@ -167,24 +131,66 @@ pub async fn resolve_source_locations(
         .collect())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+pub(crate) mod convert {
+    use super::{WireColumn, WireSourceLocation, WireVerifiedBreakpoint};
+    use probe_rs_debug::{ColumnType, SourceLocation, TypedPath, VerifiedBreakpoint};
 
-    #[test]
-    fn source_location_wire_conversion_preserves_breakpoint_metadata() {
-        let location = SourceLocation {
-            path: TypedPath::derive(b"C:\\src\\main.rs").to_path_buf(),
-            line: Some(42),
-            column: Some(ColumnType::LeftEdge),
-            address: Some(0x1234),
-        };
+    impl From<&SourceLocation> for WireSourceLocation {
+        fn from(location: &SourceLocation) -> Self {
+            Self {
+                path: location.path.to_path().display().to_string(),
+                line: location.line,
+                column: location.column.map(|column| match column {
+                    ColumnType::LeftEdge => WireColumn::LeftEdge,
+                    ColumnType::Column(column) => WireColumn::Column(column),
+                }),
+                address: location.address,
+            }
+        }
+    }
 
-        let wire = WireSourceLocation::from(&location);
-        assert_eq!(wire.column, Some(WireColumn::LeftEdge));
-        assert_eq!(wire.address, Some(0x1234));
+    impl From<WireSourceLocation> for SourceLocation {
+        fn from(location: WireSourceLocation) -> Self {
+            Self {
+                path: TypedPath::derive(location.path.as_bytes()).to_path_buf(),
+                line: location.line,
+                column: location.column.map(|column| match column {
+                    WireColumn::LeftEdge => ColumnType::LeftEdge,
+                    WireColumn::Column(column) => ColumnType::Column(column),
+                }),
+                address: location.address,
+            }
+        }
+    }
 
-        let round_trip = SourceLocation::from(wire);
-        assert_eq!(round_trip, location);
+    impl From<VerifiedBreakpoint> for WireVerifiedBreakpoint {
+        fn from(breakpoint: VerifiedBreakpoint) -> Self {
+            Self {
+                address: breakpoint.address,
+                source_location: WireSourceLocation::from(&breakpoint.source_location),
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn source_location_wire_conversion_preserves_breakpoint_metadata() {
+            let location = SourceLocation {
+                path: TypedPath::derive(b"C:\\src\\main.rs").to_path_buf(),
+                line: Some(42),
+                column: Some(ColumnType::LeftEdge),
+                address: Some(0x1234),
+            };
+
+            let wire = WireSourceLocation::from(&location);
+            assert_eq!(wire.column, Some(WireColumn::LeftEdge));
+            assert_eq!(wire.address, Some(0x1234));
+
+            let round_trip = SourceLocation::from(wire);
+            assert_eq!(round_trip, location);
+        }
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/breakpoints.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/breakpoints.rs
@@ -1,5 +1,5 @@
 use crate::rpc::{
-    Key,
+    Key, Session,
     functions::{RpcContext, RpcResult},
 };
 use postcard_schema::Schema;
@@ -59,7 +59,6 @@ pub struct ResolveSourceLocationsRequest {
 pub type ResolveSourceLocationsResponse = RpcResult<Vec<Option<WireSourceLocation>>>;
 
 use postcard_rpc::header::VarHeader;
-use probe_rs::Session;
 use probe_rs_debug::TypedPath;
 
 pub async fn resolve_source_breakpoints(

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/chip.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/chip.rs
@@ -2,7 +2,6 @@ use std::ops::Range;
 
 use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;
-use probe_rs::Target;
 use serde::{Deserialize, Serialize};
 
 use crate::rpc::functions::{NoResponse, RpcContext, RpcResult};
@@ -17,24 +16,6 @@ pub struct JEP106Code {
     pub cc: u8,
 }
 
-impl From<jep106::JEP106Code> for JEP106Code {
-    fn from(value: jep106::JEP106Code) -> Self {
-        Self {
-            id: value.id,
-            cc: value.cc,
-        }
-    }
-}
-
-impl From<JEP106Code> for jep106::JEP106Code {
-    fn from(value: JEP106Code) -> Self {
-        Self {
-            id: value.id,
-            cc: value.cc,
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Clone, Schema)]
 pub struct ChipFamily {
     /// This is the name of the chip family in base form.
@@ -44,16 +25,6 @@ pub struct ChipFamily {
     pub manufacturer: Option<JEP106Code>,
     /// This vector holds all the variants of the family.
     pub variants: Vec<Chip>,
-}
-
-impl From<&probe_rs_target::ChipFamily> for ChipFamily {
-    fn from(value: &probe_rs_target::ChipFamily) -> Self {
-        Self {
-            name: value.name.clone(),
-            manufacturer: value.manufacturer.map(|m| m.into()),
-            variants: value.variants.iter().map(|v| v.into()).collect(),
-        }
-    }
 }
 
 /// A single chip variant.
@@ -69,29 +40,7 @@ pub struct Chip {
     pub name: String,
 }
 
-impl From<&probe_rs_target::Chip> for Chip {
-    fn from(value: &probe_rs_target::Chip) -> Self {
-        Self {
-            name: value.name.clone(),
-        }
-    }
-}
-
 pub type ListFamiliesResponse = RpcResult<Vec<ChipFamily>>;
-
-pub async fn list_families(
-    ctx: &mut RpcContext,
-    _header: VarHeader,
-    _req: (),
-) -> ListFamiliesResponse {
-    Ok(ctx
-        .registry()
-        .await
-        .families()
-        .iter()
-        .map(|f| f.into())
-        .collect())
-}
 
 #[derive(Serialize, Deserialize, Schema)]
 pub struct ChipInfoRequest {
@@ -104,19 +53,6 @@ pub struct ChipData {
     pub memory_map: Vec<MemoryRegion>,
 }
 
-impl From<Target> for ChipData {
-    fn from(value: Target) -> Self {
-        Self {
-            cores: value.cores.into_iter().map(|core| core.into()).collect(),
-            memory_map: value
-                .memory_map
-                .into_iter()
-                .map(|mmap| mmap.into())
-                .collect(),
-        }
-    }
-}
-
 /// An individual core inside a chip
 #[derive(Debug, Clone, Serialize, Deserialize, Schema)]
 pub struct Core {
@@ -125,15 +61,6 @@ pub struct Core {
 
     /// The core type.
     pub core_type: CoreType,
-}
-
-impl From<probe_rs_target::Core> for Core {
-    fn from(value: probe_rs_target::Core) -> Self {
-        Self {
-            name: value.name,
-            core_type: value.core_type.into(),
-        }
-    }
 }
 
 /// Type of a supported core.
@@ -161,23 +88,6 @@ pub enum CoreType {
     Xtensa,
 }
 
-impl From<probe_rs_target::CoreType> for CoreType {
-    fn from(value: probe_rs_target::CoreType) -> Self {
-        match value {
-            probe_rs_target::CoreType::Armv6m => CoreType::Armv6m,
-            probe_rs_target::CoreType::Armv7a => CoreType::Armv7a,
-            probe_rs_target::CoreType::Armv7r => CoreType::Armv7r,
-            probe_rs_target::CoreType::Armv7m => CoreType::Armv7m,
-            probe_rs_target::CoreType::Armv7em => CoreType::Armv7em,
-            probe_rs_target::CoreType::Armv8a => CoreType::Armv8a,
-            probe_rs_target::CoreType::Armv8m => CoreType::Armv8m,
-            probe_rs_target::CoreType::Riscv => CoreType::Riscv,
-            probe_rs_target::CoreType::Riscv64 => CoreType::Riscv64,
-            probe_rs_target::CoreType::Xtensa => CoreType::Xtensa,
-        }
-    }
-}
-
 /// Declares the type of a memory region.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Schema)]
 pub enum MemoryRegion {
@@ -187,16 +97,6 @@ pub enum MemoryRegion {
     Generic(GenericRegion),
     /// Memory region describing flash, EEPROM or other non-volatile memory.
     Nvm(NvmRegion),
-}
-
-impl From<probe_rs_target::MemoryRegion> for MemoryRegion {
-    fn from(value: probe_rs_target::MemoryRegion) -> Self {
-        match value {
-            probe_rs_target::MemoryRegion::Ram(rr) => MemoryRegion::Ram(rr.into()),
-            probe_rs_target::MemoryRegion::Generic(gr) => MemoryRegion::Generic(gr.into()),
-            probe_rs_target::MemoryRegion::Nvm(nr) => MemoryRegion::Nvm(nr.into()),
-        }
-    }
 }
 
 impl MemoryRegion {
@@ -226,18 +126,6 @@ pub struct NvmRegion {
     pub access: Option<MemoryAccess>,
 }
 
-impl From<probe_rs_target::NvmRegion> for NvmRegion {
-    fn from(value: probe_rs_target::NvmRegion) -> Self {
-        Self {
-            name: value.name,
-            range: (value.range.start, value.range.end),
-            cores: value.cores,
-            is_alias: value.is_alias,
-            access: value.access.map(|a| a.into()),
-        }
-    }
-}
-
 /// Represents a region in RAM.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Schema)]
 pub struct RamRegion {
@@ -250,17 +138,6 @@ pub struct RamRegion {
     /// Access permissions for the region.
     #[serde(default)]
     pub access: Option<MemoryAccess>,
-}
-
-impl From<probe_rs_target::RamRegion> for RamRegion {
-    fn from(value: probe_rs_target::RamRegion) -> Self {
-        Self {
-            name: value.name,
-            range: (value.range.start, value.range.end),
-            cores: value.cores,
-            access: value.access.map(|a| a.into()),
-        }
-    }
 }
 
 /// Represents a generic region.
@@ -276,17 +153,6 @@ pub struct GenericRegion {
     pub access: Option<MemoryAccess>,
 }
 
-impl From<probe_rs_target::GenericRegion> for GenericRegion {
-    fn from(value: probe_rs_target::GenericRegion) -> Self {
-        Self {
-            name: value.name,
-            range: (value.range.start, value.range.end),
-            cores: value.cores,
-            access: value.access.map(|a| a.into()),
-        }
-    }
-}
-
 /// Represents access permissions of a region in RAM.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Schema)]
 pub struct MemoryAccess {
@@ -298,17 +164,6 @@ pub struct MemoryAccess {
     pub execute: bool,
     /// True if the chip boots from this memory
     pub boot: bool,
-}
-
-impl From<probe_rs_target::MemoryAccess> for MemoryAccess {
-    fn from(value: probe_rs_target::MemoryAccess) -> Self {
-        Self {
-            read: value.read,
-            write: value.write,
-            execute: value.execute,
-            boot: value.boot,
-        }
-    }
 }
 
 impl Default for MemoryAccess {
@@ -324,6 +179,28 @@ impl Default for MemoryAccess {
 
 pub type ChipInfoResponse = RpcResult<ChipData>;
 
+// Used to avoid uploading a temp file to the remote.
+#[derive(Serialize, Deserialize, Schema)]
+pub struct LoadChipFamilyRequest {
+    /// Chip description in YAML format.
+    // TODO: instead, serialize the whole ChipFamily struct
+    pub families_yaml: String,
+}
+
+pub async fn list_families(
+    ctx: &mut RpcContext,
+    _header: VarHeader,
+    _req: (),
+) -> ListFamiliesResponse {
+    Ok(ctx
+        .registry()
+        .await
+        .families()
+        .iter()
+        .map(|f| f.into())
+        .collect())
+}
+
 pub async fn chip_info(
     ctx: &mut RpcContext,
     _header: VarHeader,
@@ -336,14 +213,6 @@ pub async fn chip_info(
         .into())
 }
 
-// Used to avoid uploading a temp file to the remote.
-#[derive(Serialize, Deserialize, Schema)]
-pub struct LoadChipFamilyRequest {
-    /// Chip description in YAML format.
-    // TODO: instead, serialize the whole ChipFamily struct
-    pub families_yaml: String,
-}
-
 pub async fn load_chip_family(
     ctx: &mut RpcContext,
     _header: VarHeader,
@@ -354,4 +223,142 @@ pub async fn load_chip_family(
         .add_target_family_from_yaml(&request.families_yaml)?;
 
     Ok(())
+}
+
+pub(crate) mod convert {
+    use super::{
+        Chip, ChipData, ChipFamily, Core, CoreType, GenericRegion, JEP106Code, MemoryAccess,
+        MemoryRegion, NvmRegion, RamRegion,
+    };
+    use probe_rs::Target;
+
+    impl From<jep106::JEP106Code> for JEP106Code {
+        fn from(value: jep106::JEP106Code) -> Self {
+            Self {
+                id: value.id,
+                cc: value.cc,
+            }
+        }
+    }
+
+    impl From<JEP106Code> for jep106::JEP106Code {
+        fn from(value: JEP106Code) -> Self {
+            Self {
+                id: value.id,
+                cc: value.cc,
+            }
+        }
+    }
+
+    impl From<&probe_rs_target::ChipFamily> for ChipFamily {
+        fn from(value: &probe_rs_target::ChipFamily) -> Self {
+            Self {
+                name: value.name.clone(),
+                manufacturer: value.manufacturer.map(|m| m.into()),
+                variants: value.variants.iter().map(|v| v.into()).collect(),
+            }
+        }
+    }
+
+    impl From<&probe_rs_target::Chip> for Chip {
+        fn from(value: &probe_rs_target::Chip) -> Self {
+            Self {
+                name: value.name.clone(),
+            }
+        }
+    }
+
+    impl From<Target> for ChipData {
+        fn from(value: Target) -> Self {
+            Self {
+                cores: value.cores.into_iter().map(|core| core.into()).collect(),
+                memory_map: value
+                    .memory_map
+                    .into_iter()
+                    .map(|mmap| mmap.into())
+                    .collect(),
+            }
+        }
+    }
+
+    impl From<probe_rs_target::Core> for Core {
+        fn from(value: probe_rs_target::Core) -> Self {
+            Self {
+                name: value.name,
+                core_type: value.core_type.into(),
+            }
+        }
+    }
+
+    impl From<probe_rs_target::CoreType> for CoreType {
+        fn from(value: probe_rs_target::CoreType) -> Self {
+            match value {
+                probe_rs_target::CoreType::Armv6m => CoreType::Armv6m,
+                probe_rs_target::CoreType::Armv7a => CoreType::Armv7a,
+                probe_rs_target::CoreType::Armv7r => CoreType::Armv7r,
+                probe_rs_target::CoreType::Armv7m => CoreType::Armv7m,
+                probe_rs_target::CoreType::Armv7em => CoreType::Armv7em,
+                probe_rs_target::CoreType::Armv8a => CoreType::Armv8a,
+                probe_rs_target::CoreType::Armv8m => CoreType::Armv8m,
+                probe_rs_target::CoreType::Riscv => CoreType::Riscv,
+                probe_rs_target::CoreType::Riscv64 => CoreType::Riscv64,
+                probe_rs_target::CoreType::Xtensa => CoreType::Xtensa,
+            }
+        }
+    }
+
+    impl From<probe_rs_target::MemoryRegion> for MemoryRegion {
+        fn from(value: probe_rs_target::MemoryRegion) -> Self {
+            match value {
+                probe_rs_target::MemoryRegion::Ram(rr) => MemoryRegion::Ram(rr.into()),
+                probe_rs_target::MemoryRegion::Generic(gr) => MemoryRegion::Generic(gr.into()),
+                probe_rs_target::MemoryRegion::Nvm(nr) => MemoryRegion::Nvm(nr.into()),
+            }
+        }
+    }
+
+    impl From<probe_rs_target::NvmRegion> for NvmRegion {
+        fn from(value: probe_rs_target::NvmRegion) -> Self {
+            Self {
+                name: value.name,
+                range: (value.range.start, value.range.end),
+                cores: value.cores,
+                is_alias: value.is_alias,
+                access: value.access.map(|a| a.into()),
+            }
+        }
+    }
+
+    impl From<probe_rs_target::RamRegion> for RamRegion {
+        fn from(value: probe_rs_target::RamRegion) -> Self {
+            Self {
+                name: value.name,
+                range: (value.range.start, value.range.end),
+                cores: value.cores,
+                access: value.access.map(|a| a.into()),
+            }
+        }
+    }
+
+    impl From<probe_rs_target::GenericRegion> for GenericRegion {
+        fn from(value: probe_rs_target::GenericRegion) -> Self {
+            Self {
+                name: value.name,
+                range: (value.range.start, value.range.end),
+                cores: value.cores,
+                access: value.access.map(|a| a.into()),
+            }
+        }
+    }
+
+    impl From<probe_rs_target::MemoryAccess> for MemoryAccess {
+        fn from(value: probe_rs_target::MemoryAccess) -> Self {
+            Self {
+                read: value.read,
+                write: value.write,
+                execute: value.execute,
+                boot: value.boot,
+            }
+        }
+    }
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/core_ops.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/core_ops.rs
@@ -6,15 +6,8 @@ use std::time::Duration;
 
 use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;
-use probe_rs::{
-    BreakpointCause, CoreDump, CoreInformation, CoreStatus, HaltReason, InstructionSet, RegisterId,
-    RegisterValue, Session, VectorCatchCondition,
-    semihosting::{ExitErrorDetails, SemihostingCommand, UnknownCommandDetails},
-};
-use probe_rs_debug::{DebugError, SteppingMode};
 use serde::{Deserialize, Serialize};
 
-use crate::rpc::debug_state::{CoreSemihostingState, SemihostingFile};
 use crate::util::rtt::DataFormat;
 
 use crate::rpc::{
@@ -89,18 +82,6 @@ pub struct CoreVectorCatchRequest {
 #[derive(Debug, Serialize, Deserialize, Schema, Copy, Clone, PartialEq, Eq)]
 pub struct WireRegisterId(pub u16);
 
-impl From<RegisterId> for WireRegisterId {
-    fn from(value: RegisterId) -> Self {
-        WireRegisterId(value.0)
-    }
-}
-
-impl From<WireRegisterId> for RegisterId {
-    fn from(value: WireRegisterId) -> Self {
-        RegisterId(value.0)
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, Schema, Copy, Clone, PartialEq)]
 pub enum WireRegisterValue {
     U32(u32),
@@ -108,41 +89,9 @@ pub enum WireRegisterValue {
     U128(u128),
 }
 
-impl From<RegisterValue> for WireRegisterValue {
-    fn from(value: RegisterValue) -> Self {
-        match value {
-            RegisterValue::U32(v) => WireRegisterValue::U32(v),
-            RegisterValue::U64(v) => WireRegisterValue::U64(v),
-            RegisterValue::U128(v) => WireRegisterValue::U128(v),
-        }
-    }
-}
-
-impl From<WireRegisterValue> for RegisterValue {
-    fn from(value: WireRegisterValue) -> Self {
-        match value {
-            WireRegisterValue::U32(v) => RegisterValue::U32(v),
-            WireRegisterValue::U64(v) => RegisterValue::U64(v),
-            WireRegisterValue::U128(v) => RegisterValue::U128(v),
-        }
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, Schema, Copy, Clone)]
 pub struct WireCoreInformation {
     pub pc: u64,
-}
-
-impl From<CoreInformation> for WireCoreInformation {
-    fn from(value: CoreInformation) -> Self {
-        Self { pc: value.pc }
-    }
-}
-
-impl From<WireCoreInformation> for CoreInformation {
-    fn from(value: WireCoreInformation) -> Self {
-        Self { pc: value.pc }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Schema, Copy, Clone, PartialEq, Eq)]
@@ -214,149 +163,6 @@ pub struct WireExitErrorDetails {
     pub subcode: Option<u32>,
 }
 
-impl From<&ExitErrorDetails> for WireExitErrorDetails {
-    fn from(value: &ExitErrorDetails) -> Self {
-        Self {
-            reason: value.reason,
-            exit_status: value.exit_status,
-            subcode: value.subcode,
-        }
-    }
-}
-
-impl From<WireExitErrorDetails> for ExitErrorDetails {
-    fn from(value: WireExitErrorDetails) -> Self {
-        Self {
-            reason: value.reason,
-            exit_status: value.exit_status,
-            subcode: value.subcode,
-        }
-    }
-}
-
-impl From<&SemihostingCommand> for WireSemihostingCommand {
-    fn from(value: &SemihostingCommand) -> Self {
-        match value {
-            SemihostingCommand::ExitSuccess => WireSemihostingCommand::ExitSuccess,
-            SemihostingCommand::ExitError(details) => {
-                WireSemihostingCommand::ExitError(details.into())
-            }
-            SemihostingCommand::GetCommandLine(request) => WireSemihostingCommand::GetCommandLine {
-                block_address: request.block_address(),
-            },
-            _ => WireSemihostingCommand::Other,
-        }
-    }
-}
-
-impl From<CoreStatus> for WireCoreStatus {
-    fn from(value: CoreStatus) -> Self {
-        match value {
-            CoreStatus::Running => WireCoreStatus::Running,
-            CoreStatus::Halted(reason) => WireCoreStatus::Halted(reason.into()),
-            CoreStatus::LockedUp => WireCoreStatus::LockedUp,
-            CoreStatus::Sleeping => WireCoreStatus::Sleeping,
-            CoreStatus::Unknown => WireCoreStatus::Unknown,
-        }
-    }
-}
-
-impl From<HaltReason> for WireHaltReason {
-    fn from(value: HaltReason) -> Self {
-        use probe_rs::BreakpointCause;
-        match value {
-            HaltReason::Multiple => WireHaltReason::Multiple,
-            HaltReason::Breakpoint(cause) => WireHaltReason::Breakpoint(match cause {
-                BreakpointCause::Hardware => WireBreakpointCause::Hardware,
-                BreakpointCause::Software => WireBreakpointCause::Software,
-                BreakpointCause::Unknown => WireBreakpointCause::Unknown,
-                BreakpointCause::Semihosting(ref cmd) => {
-                    WireBreakpointCause::Semihosting(cmd.into())
-                }
-            }),
-            HaltReason::Exception => WireHaltReason::Exception,
-            HaltReason::Watchpoint => WireHaltReason::Watchpoint,
-            HaltReason::Step => WireHaltReason::Step,
-            HaltReason::Request => WireHaltReason::Request,
-            HaltReason::External => WireHaltReason::External,
-            HaltReason::Unknown => WireHaltReason::Unknown,
-        }
-    }
-}
-
-// `WireHaltReason` cannot round-trip perfectly because the general semihosting
-// payload carries target-memory pointers. The exit / exit-error classification
-// (and exit status / reason codes) is preserved so the DAP server can emit the
-// same "Application has exited with …" message on both the local and remote
-// paths.
-//
-// `GetCommandLine` is surfaced as a placeholder `SemihostingCommand::Unknown`;
-// the server-side `core/handle_semihosting` endpoint re-derives the real
-// command from the live core, so the client never needs target memory access
-// for it.
-impl From<WireBreakpointCause> for probe_rs::BreakpointCause {
-    fn from(value: WireBreakpointCause) -> Self {
-        match value {
-            WireBreakpointCause::Hardware => probe_rs::BreakpointCause::Hardware,
-            WireBreakpointCause::Software => probe_rs::BreakpointCause::Software,
-            WireBreakpointCause::Unknown => probe_rs::BreakpointCause::Unknown,
-            WireBreakpointCause::Semihosting(cmd) => {
-                probe_rs::BreakpointCause::Semihosting(match cmd {
-                    WireSemihostingCommand::ExitSuccess => SemihostingCommand::ExitSuccess,
-                    WireSemihostingCommand::ExitError(details) => {
-                        SemihostingCommand::ExitError(details.into())
-                    }
-                    // Placeholder: the server-side `core/handle_semihosting`
-                    // endpoint re-derives the real `GetCommandLineRequest`
-                    // from the live core.
-                    WireSemihostingCommand::GetCommandLine { .. } => {
-                        SemihostingCommand::Unknown(UnknownCommandDetails {
-                            operation: 0,
-                            parameter: 0,
-                        })
-                    }
-                    // The server handles the real command payload; surface a
-                    // placeholder so the DAP server recognizes the halt as
-                    // semihosting-induced.
-                    WireSemihostingCommand::Other => {
-                        SemihostingCommand::Unknown(UnknownCommandDetails {
-                            operation: 0,
-                            parameter: 0,
-                        })
-                    }
-                })
-            }
-        }
-    }
-}
-
-impl From<WireHaltReason> for HaltReason {
-    fn from(value: WireHaltReason) -> Self {
-        match value {
-            WireHaltReason::Multiple => HaltReason::Multiple,
-            WireHaltReason::Breakpoint(cause) => HaltReason::Breakpoint(cause.into()),
-            WireHaltReason::Exception => HaltReason::Exception,
-            WireHaltReason::Watchpoint => HaltReason::Watchpoint,
-            WireHaltReason::Step => HaltReason::Step,
-            WireHaltReason::Request => HaltReason::Request,
-            WireHaltReason::External => HaltReason::External,
-            WireHaltReason::Unknown => HaltReason::Unknown,
-        }
-    }
-}
-
-impl From<WireCoreStatus> for CoreStatus {
-    fn from(value: WireCoreStatus) -> Self {
-        match value {
-            WireCoreStatus::Running => CoreStatus::Running,
-            WireCoreStatus::Halted(reason) => CoreStatus::Halted(reason.into()),
-            WireCoreStatus::LockedUp => CoreStatus::LockedUp,
-            WireCoreStatus::Sleeping => CoreStatus::Sleeping,
-            WireCoreStatus::Unknown => CoreStatus::Unknown,
-        }
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, Schema, Copy, Clone, PartialEq, Eq)]
 pub enum WireVectorCatchCondition {
     HardFault,
@@ -365,32 +171,6 @@ pub enum WireVectorCatchCondition {
     All,
     Svc,
     Hlt,
-}
-
-impl From<VectorCatchCondition> for WireVectorCatchCondition {
-    fn from(value: VectorCatchCondition) -> Self {
-        match value {
-            VectorCatchCondition::HardFault => WireVectorCatchCondition::HardFault,
-            VectorCatchCondition::CoreReset => WireVectorCatchCondition::CoreReset,
-            VectorCatchCondition::SecureFault => WireVectorCatchCondition::SecureFault,
-            VectorCatchCondition::All => WireVectorCatchCondition::All,
-            VectorCatchCondition::Svc => WireVectorCatchCondition::Svc,
-            VectorCatchCondition::Hlt => WireVectorCatchCondition::Hlt,
-        }
-    }
-}
-
-impl From<WireVectorCatchCondition> for VectorCatchCondition {
-    fn from(value: WireVectorCatchCondition) -> Self {
-        match value {
-            WireVectorCatchCondition::HardFault => VectorCatchCondition::HardFault,
-            WireVectorCatchCondition::CoreReset => VectorCatchCondition::CoreReset,
-            WireVectorCatchCondition::SecureFault => VectorCatchCondition::SecureFault,
-            WireVectorCatchCondition::All => VectorCatchCondition::All,
-            WireVectorCatchCondition::Svc => VectorCatchCondition::Svc,
-            WireVectorCatchCondition::Hlt => VectorCatchCondition::Hlt,
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Schema, Copy, Clone, PartialEq, Eq)]
@@ -405,37 +185,107 @@ pub enum WireInstructionSet {
     Xtensa,
 }
 
-impl From<InstructionSet> for WireInstructionSet {
-    fn from(value: InstructionSet) -> Self {
-        match value {
-            InstructionSet::Thumb2 => WireInstructionSet::Thumb2,
-            InstructionSet::A32 => WireInstructionSet::A32,
-            InstructionSet::A64 => WireInstructionSet::A64,
-            InstructionSet::RV32 => WireInstructionSet::RV32,
-            InstructionSet::RV32C => WireInstructionSet::RV32C,
-            InstructionSet::RV64 => WireInstructionSet::RV64,
-            InstructionSet::RV64C => WireInstructionSet::RV64C,
-            InstructionSet::Xtensa => WireInstructionSet::Xtensa,
-        }
-    }
+#[derive(Serialize, Deserialize, Schema, Clone, Copy)]
+pub enum WireSteppingMode {
+    StepInstruction,
+    OverStatement,
+    IntoStatement,
+    OutOfStatement,
 }
 
-impl From<WireInstructionSet> for InstructionSet {
-    fn from(value: WireInstructionSet) -> Self {
-        match value {
-            WireInstructionSet::Thumb2 => InstructionSet::Thumb2,
-            WireInstructionSet::A32 => InstructionSet::A32,
-            WireInstructionSet::A64 => InstructionSet::A64,
-            WireInstructionSet::RV32 => InstructionSet::RV32,
-            WireInstructionSet::RV32C => InstructionSet::RV32C,
-            WireInstructionSet::RV64 => InstructionSet::RV64,
-            WireInstructionSet::RV64C => InstructionSet::RV64C,
-            WireInstructionSet::Xtensa => InstructionSet::Xtensa,
-        }
-    }
+#[derive(Serialize, Deserialize, Schema)]
+pub struct StepRequest {
+    pub sessid: Key<Session>,
+    pub core: u32,
+    pub mode: WireSteppingMode,
 }
+
+#[derive(Serialize, Deserialize, Schema, Clone)]
+pub struct StepResponse {
+    pub status: WireCoreStatus,
+    pub program_counter: u64,
+    pub warning: Option<String>,
+}
+
+pub type StepResult = RpcResult<StepResponse>;
+
+// -- core dump ---------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Schema, Clone)]
+pub struct CoreDumpRequest {
+    pub sessid: Key<Session>,
+    pub core: u32,
+    pub ranges: Vec<Range<u64>>,
+}
+
+/// Wire form of [`probe_rs::CoreDump`]. The client reconstructs a `CoreDump`
+/// from these fields.
+#[derive(Serialize, Deserialize, Schema, Clone)]
+pub struct WireCoreDump {
+    pub registers: Vec<(WireRegisterId, WireRegisterValue)>,
+    pub data: Vec<(Range<u64>, Vec<u8>)>,
+    pub instruction_set: WireInstructionSet,
+    pub supports_native_64bit_access: bool,
+    pub core_type: WireCoreType,
+    pub fpu_support: bool,
+    pub floating_point_register_count: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Schema, Clone, Copy, PartialEq, Eq)]
+pub enum WireCoreType {
+    Armv6m,
+    Armv7a,
+    Armv7r,
+    Armv7m,
+    Armv7em,
+    Armv8a,
+    Armv8m,
+    Riscv,
+    Riscv64,
+    Xtensa,
+}
+
+// -- semihosting -------------------------------------------------------------
+
+/// UI event produced by server-side semihosting handling, to be replayed on
+/// the client so the DAP UI behaves as if the call ran locally.
+#[derive(Serialize, Deserialize, Schema, Clone)]
+pub enum WireSemihostingUiEvent {
+    /// Open an RTT window for a newly-allocated semihosting file handle.
+    RttWindow {
+        handle: u32,
+        path: String,
+        format: DataFormat,
+    },
+    /// Write a line to the DAP console.
+    LogToConsole(String),
+    /// Emit RTT output for a previously-opened handle.
+    RttOutput { handle: u32, data: String },
+}
+
+#[derive(Serialize, Deserialize, Schema, Clone)]
+pub struct HandleSemihostingRequest {
+    pub sessid: Key<Session>,
+    pub core: u32,
+}
+
+#[derive(Serialize, Deserialize, Schema, Clone)]
+pub struct HandleSemihostingResult {
+    pub status: WireCoreStatus,
+    pub events: Vec<WireSemihostingUiEvent>,
+}
+
+pub type HandleSemihostingResponse = RpcResult<HandleSemihostingResult>;
 
 // -- handlers -----------------------------------------------------------------
+
+use probe_rs::{
+    BreakpointCause, CoreDump, CoreStatus, HaltReason, RegisterId, RegisterValue, Session,
+    VectorCatchCondition, semihosting::SemihostingCommand,
+};
+use probe_rs_debug::{DebugError, SteppingMode};
+
+use crate::rpc::debug_state::{CoreSemihostingState, SemihostingFile};
 
 macro_rules! with_core {
     ($ctx:expr, $sessid:expr, $core:expr, |$core_var:ident| $body:block) => {{
@@ -474,41 +324,6 @@ pub async fn core_run(
     with_core!(ctx, request.sessid, request.core, |core| { core.run() })?;
     Ok(())
 }
-
-#[derive(Serialize, Deserialize, Schema, Clone, Copy)]
-pub enum WireSteppingMode {
-    StepInstruction,
-    OverStatement,
-    IntoStatement,
-    OutOfStatement,
-}
-
-impl From<WireSteppingMode> for SteppingMode {
-    fn from(mode: WireSteppingMode) -> Self {
-        match mode {
-            WireSteppingMode::StepInstruction => SteppingMode::StepInstruction,
-            WireSteppingMode::OverStatement => SteppingMode::OverStatement,
-            WireSteppingMode::IntoStatement => SteppingMode::IntoStatement,
-            WireSteppingMode::OutOfStatement => SteppingMode::OutOfStatement,
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Schema)]
-pub struct StepRequest {
-    pub sessid: Key<Session>,
-    pub core: u32,
-    pub mode: WireSteppingMode,
-}
-
-#[derive(Serialize, Deserialize, Schema, Clone)]
-pub struct StepResponse {
-    pub status: WireCoreStatus,
-    pub program_counter: u64,
-    pub warning: Option<String>,
-}
-
-pub type StepResult = RpcResult<StepResponse>;
 
 /// Full `SteppingMode::step` (over/into/out/instruction) run server-side
 /// against the cached `DebugInfo` and the live `Core`. On
@@ -684,76 +499,6 @@ pub async fn core_read_registers(
         .collect())
 }
 
-// -- core dump ---------------------------------------------------------------
-
-#[derive(Serialize, Deserialize, Schema, Clone)]
-pub struct CoreDumpRequest {
-    pub sessid: Key<Session>,
-    pub core: u32,
-    pub ranges: Vec<Range<u64>>,
-}
-
-/// Wire form of [`probe_rs::CoreDump`]. The client reconstructs a `CoreDump`
-/// from these fields.
-#[derive(Serialize, Deserialize, Schema, Clone)]
-pub struct WireCoreDump {
-    pub registers: Vec<(WireRegisterId, WireRegisterValue)>,
-    pub data: Vec<(Range<u64>, Vec<u8>)>,
-    pub instruction_set: WireInstructionSet,
-    pub supports_native_64bit_access: bool,
-    pub core_type: WireCoreType,
-    pub fpu_support: bool,
-    pub floating_point_register_count: Option<u64>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Schema, Clone, Copy, PartialEq, Eq)]
-pub enum WireCoreType {
-    Armv6m,
-    Armv7a,
-    Armv7r,
-    Armv7m,
-    Armv7em,
-    Armv8a,
-    Armv8m,
-    Riscv,
-    Riscv64,
-    Xtensa,
-}
-
-impl From<probe_rs::CoreType> for WireCoreType {
-    fn from(value: probe_rs::CoreType) -> Self {
-        match value {
-            probe_rs::CoreType::Armv6m => WireCoreType::Armv6m,
-            probe_rs::CoreType::Armv7a => WireCoreType::Armv7a,
-            probe_rs::CoreType::Armv7r => WireCoreType::Armv7r,
-            probe_rs::CoreType::Armv7m => WireCoreType::Armv7m,
-            probe_rs::CoreType::Armv7em => WireCoreType::Armv7em,
-            probe_rs::CoreType::Armv8a => WireCoreType::Armv8a,
-            probe_rs::CoreType::Armv8m => WireCoreType::Armv8m,
-            probe_rs::CoreType::Riscv => WireCoreType::Riscv,
-            probe_rs::CoreType::Riscv64 => WireCoreType::Riscv64,
-            probe_rs::CoreType::Xtensa => WireCoreType::Xtensa,
-        }
-    }
-}
-
-impl From<WireCoreType> for probe_rs::CoreType {
-    fn from(value: WireCoreType) -> Self {
-        match value {
-            WireCoreType::Armv6m => probe_rs::CoreType::Armv6m,
-            WireCoreType::Armv7a => probe_rs::CoreType::Armv7a,
-            WireCoreType::Armv7r => probe_rs::CoreType::Armv7r,
-            WireCoreType::Armv7m => probe_rs::CoreType::Armv7m,
-            WireCoreType::Armv7em => probe_rs::CoreType::Armv7em,
-            WireCoreType::Armv8a => probe_rs::CoreType::Armv8a,
-            WireCoreType::Armv8m => probe_rs::CoreType::Armv8m,
-            WireCoreType::Riscv => probe_rs::CoreType::Riscv,
-            WireCoreType::Riscv64 => probe_rs::CoreType::Riscv64,
-            WireCoreType::Xtensa => probe_rs::CoreType::Xtensa,
-        }
-    }
-}
-
 pub async fn core_dump(
     ctx: &mut RpcContext,
     _header: VarHeader,
@@ -778,38 +523,6 @@ pub async fn core_dump(
         floating_point_register_count: dump.floating_point_register_count.map(|c| c as u64),
     })
 }
-
-// -- semihosting -------------------------------------------------------------
-
-/// UI event produced by server-side semihosting handling, to be replayed on
-/// the client so the DAP UI behaves as if the call ran locally.
-#[derive(Serialize, Deserialize, Schema, Clone)]
-pub enum WireSemihostingUiEvent {
-    /// Open an RTT window for a newly-allocated semihosting file handle.
-    RttWindow {
-        handle: u32,
-        path: String,
-        format: DataFormat,
-    },
-    /// Write a line to the DAP console.
-    LogToConsole(String),
-    /// Emit RTT output for a previously-opened handle.
-    RttOutput { handle: u32, data: String },
-}
-
-#[derive(Serialize, Deserialize, Schema, Clone)]
-pub struct HandleSemihostingRequest {
-    pub sessid: Key<Session>,
-    pub core: u32,
-}
-
-#[derive(Serialize, Deserialize, Schema, Clone)]
-pub struct HandleSemihostingResult {
-    pub status: WireCoreStatus,
-    pub events: Vec<WireSemihostingUiEvent>,
-}
-
-pub type HandleSemihostingResponse = RpcResult<HandleSemihostingResult>;
 
 /// Read the core status server-side; if it halted on a semihosting command,
 /// perform the file I/O next to the target, mutating the server-owned
@@ -969,4 +682,308 @@ fn handle_semihosting_impl(
 
     core.run()?;
     Ok(CoreStatus::Running)
+}
+
+pub(crate) mod convert {
+    use super::{
+        WireBreakpointCause, WireCoreInformation, WireCoreStatus, WireCoreType,
+        WireExitErrorDetails, WireHaltReason, WireInstructionSet, WireRegisterId,
+        WireRegisterValue, WireSemihostingCommand, WireSteppingMode, WireVectorCatchCondition,
+    };
+    use probe_rs::{
+        CoreInformation, CoreStatus, HaltReason, InstructionSet, RegisterId, RegisterValue,
+        VectorCatchCondition,
+        semihosting::{ExitErrorDetails, SemihostingCommand, UnknownCommandDetails},
+    };
+    use probe_rs_debug::SteppingMode;
+
+    impl From<RegisterId> for WireRegisterId {
+        fn from(value: RegisterId) -> Self {
+            WireRegisterId(value.0)
+        }
+    }
+
+    impl From<WireRegisterId> for RegisterId {
+        fn from(value: WireRegisterId) -> Self {
+            RegisterId(value.0)
+        }
+    }
+
+    impl From<RegisterValue> for WireRegisterValue {
+        fn from(value: RegisterValue) -> Self {
+            match value {
+                RegisterValue::U32(v) => WireRegisterValue::U32(v),
+                RegisterValue::U64(v) => WireRegisterValue::U64(v),
+                RegisterValue::U128(v) => WireRegisterValue::U128(v),
+            }
+        }
+    }
+
+    impl From<WireRegisterValue> for RegisterValue {
+        fn from(value: WireRegisterValue) -> Self {
+            match value {
+                WireRegisterValue::U32(v) => RegisterValue::U32(v),
+                WireRegisterValue::U64(v) => RegisterValue::U64(v),
+                WireRegisterValue::U128(v) => RegisterValue::U128(v),
+            }
+        }
+    }
+
+    impl From<CoreInformation> for WireCoreInformation {
+        fn from(value: CoreInformation) -> Self {
+            Self { pc: value.pc }
+        }
+    }
+
+    impl From<WireCoreInformation> for CoreInformation {
+        fn from(value: WireCoreInformation) -> Self {
+            Self { pc: value.pc }
+        }
+    }
+
+    impl From<&ExitErrorDetails> for WireExitErrorDetails {
+        fn from(value: &ExitErrorDetails) -> Self {
+            Self {
+                reason: value.reason,
+                exit_status: value.exit_status,
+                subcode: value.subcode,
+            }
+        }
+    }
+
+    impl From<WireExitErrorDetails> for ExitErrorDetails {
+        fn from(value: WireExitErrorDetails) -> Self {
+            Self {
+                reason: value.reason,
+                exit_status: value.exit_status,
+                subcode: value.subcode,
+            }
+        }
+    }
+
+    impl From<&SemihostingCommand> for WireSemihostingCommand {
+        fn from(value: &SemihostingCommand) -> Self {
+            match value {
+                SemihostingCommand::ExitSuccess => WireSemihostingCommand::ExitSuccess,
+                SemihostingCommand::ExitError(details) => {
+                    WireSemihostingCommand::ExitError(details.into())
+                }
+                SemihostingCommand::GetCommandLine(request) => {
+                    WireSemihostingCommand::GetCommandLine {
+                        block_address: request.block_address(),
+                    }
+                }
+                _ => WireSemihostingCommand::Other,
+            }
+        }
+    }
+
+    impl From<CoreStatus> for WireCoreStatus {
+        fn from(value: CoreStatus) -> Self {
+            match value {
+                CoreStatus::Running => WireCoreStatus::Running,
+                CoreStatus::Halted(reason) => WireCoreStatus::Halted(reason.into()),
+                CoreStatus::LockedUp => WireCoreStatus::LockedUp,
+                CoreStatus::Sleeping => WireCoreStatus::Sleeping,
+                CoreStatus::Unknown => WireCoreStatus::Unknown,
+            }
+        }
+    }
+
+    impl From<HaltReason> for WireHaltReason {
+        fn from(value: HaltReason) -> Self {
+            use probe_rs::BreakpointCause;
+            match value {
+                HaltReason::Multiple => WireHaltReason::Multiple,
+                HaltReason::Breakpoint(cause) => WireHaltReason::Breakpoint(match cause {
+                    BreakpointCause::Hardware => WireBreakpointCause::Hardware,
+                    BreakpointCause::Software => WireBreakpointCause::Software,
+                    BreakpointCause::Unknown => WireBreakpointCause::Unknown,
+                    BreakpointCause::Semihosting(ref cmd) => {
+                        WireBreakpointCause::Semihosting(cmd.into())
+                    }
+                }),
+                HaltReason::Exception => WireHaltReason::Exception,
+                HaltReason::Watchpoint => WireHaltReason::Watchpoint,
+                HaltReason::Step => WireHaltReason::Step,
+                HaltReason::Request => WireHaltReason::Request,
+                HaltReason::External => WireHaltReason::External,
+                HaltReason::Unknown => WireHaltReason::Unknown,
+            }
+        }
+    }
+
+    // `WireHaltReason` cannot round-trip perfectly because the general semihosting
+    // payload carries target-memory pointers. The exit / exit-error classification
+    // (and exit status / reason codes) is preserved so the DAP server can emit the
+    // same "Application has exited with …" message on both the local and remote
+    // paths.
+    //
+    // `GetCommandLine` is surfaced as a placeholder `SemihostingCommand::Unknown`;
+    // the server-side `core/handle_semihosting` endpoint re-derives the real
+    // command from the live core, so the client never needs target memory access
+    // for it.
+    impl From<WireBreakpointCause> for probe_rs::BreakpointCause {
+        fn from(value: WireBreakpointCause) -> Self {
+            match value {
+                WireBreakpointCause::Hardware => probe_rs::BreakpointCause::Hardware,
+                WireBreakpointCause::Software => probe_rs::BreakpointCause::Software,
+                WireBreakpointCause::Unknown => probe_rs::BreakpointCause::Unknown,
+                WireBreakpointCause::Semihosting(cmd) => {
+                    probe_rs::BreakpointCause::Semihosting(match cmd {
+                        WireSemihostingCommand::ExitSuccess => SemihostingCommand::ExitSuccess,
+                        WireSemihostingCommand::ExitError(details) => {
+                            SemihostingCommand::ExitError(details.into())
+                        }
+                        // Placeholder: the server-side `core/handle_semihosting`
+                        // endpoint re-derives the real `GetCommandLineRequest`
+                        // from the live core.
+                        WireSemihostingCommand::GetCommandLine { .. } => {
+                            SemihostingCommand::Unknown(UnknownCommandDetails {
+                                operation: 0,
+                                parameter: 0,
+                            })
+                        }
+                        // The server handles the real command payload; surface a
+                        // placeholder so the DAP server recognizes the halt as
+                        // semihosting-induced.
+                        WireSemihostingCommand::Other => {
+                            SemihostingCommand::Unknown(UnknownCommandDetails {
+                                operation: 0,
+                                parameter: 0,
+                            })
+                        }
+                    })
+                }
+            }
+        }
+    }
+
+    impl From<WireHaltReason> for HaltReason {
+        fn from(value: WireHaltReason) -> Self {
+            match value {
+                WireHaltReason::Multiple => HaltReason::Multiple,
+                WireHaltReason::Breakpoint(cause) => HaltReason::Breakpoint(cause.into()),
+                WireHaltReason::Exception => HaltReason::Exception,
+                WireHaltReason::Watchpoint => HaltReason::Watchpoint,
+                WireHaltReason::Step => HaltReason::Step,
+                WireHaltReason::Request => HaltReason::Request,
+                WireHaltReason::External => HaltReason::External,
+                WireHaltReason::Unknown => HaltReason::Unknown,
+            }
+        }
+    }
+
+    impl From<WireCoreStatus> for CoreStatus {
+        fn from(value: WireCoreStatus) -> Self {
+            match value {
+                WireCoreStatus::Running => CoreStatus::Running,
+                WireCoreStatus::Halted(reason) => CoreStatus::Halted(reason.into()),
+                WireCoreStatus::LockedUp => CoreStatus::LockedUp,
+                WireCoreStatus::Sleeping => CoreStatus::Sleeping,
+                WireCoreStatus::Unknown => CoreStatus::Unknown,
+            }
+        }
+    }
+
+    impl From<VectorCatchCondition> for WireVectorCatchCondition {
+        fn from(value: VectorCatchCondition) -> Self {
+            match value {
+                VectorCatchCondition::HardFault => WireVectorCatchCondition::HardFault,
+                VectorCatchCondition::CoreReset => WireVectorCatchCondition::CoreReset,
+                VectorCatchCondition::SecureFault => WireVectorCatchCondition::SecureFault,
+                VectorCatchCondition::All => WireVectorCatchCondition::All,
+                VectorCatchCondition::Svc => WireVectorCatchCondition::Svc,
+                VectorCatchCondition::Hlt => WireVectorCatchCondition::Hlt,
+            }
+        }
+    }
+
+    impl From<WireVectorCatchCondition> for VectorCatchCondition {
+        fn from(value: WireVectorCatchCondition) -> Self {
+            match value {
+                WireVectorCatchCondition::HardFault => VectorCatchCondition::HardFault,
+                WireVectorCatchCondition::CoreReset => VectorCatchCondition::CoreReset,
+                WireVectorCatchCondition::SecureFault => VectorCatchCondition::SecureFault,
+                WireVectorCatchCondition::All => VectorCatchCondition::All,
+                WireVectorCatchCondition::Svc => VectorCatchCondition::Svc,
+                WireVectorCatchCondition::Hlt => VectorCatchCondition::Hlt,
+            }
+        }
+    }
+
+    impl From<InstructionSet> for WireInstructionSet {
+        fn from(value: InstructionSet) -> Self {
+            match value {
+                InstructionSet::Thumb2 => WireInstructionSet::Thumb2,
+                InstructionSet::A32 => WireInstructionSet::A32,
+                InstructionSet::A64 => WireInstructionSet::A64,
+                InstructionSet::RV32 => WireInstructionSet::RV32,
+                InstructionSet::RV32C => WireInstructionSet::RV32C,
+                InstructionSet::RV64 => WireInstructionSet::RV64,
+                InstructionSet::RV64C => WireInstructionSet::RV64C,
+                InstructionSet::Xtensa => WireInstructionSet::Xtensa,
+            }
+        }
+    }
+
+    impl From<WireInstructionSet> for InstructionSet {
+        fn from(value: WireInstructionSet) -> Self {
+            match value {
+                WireInstructionSet::Thumb2 => InstructionSet::Thumb2,
+                WireInstructionSet::A32 => InstructionSet::A32,
+                WireInstructionSet::A64 => InstructionSet::A64,
+                WireInstructionSet::RV32 => InstructionSet::RV32,
+                WireInstructionSet::RV32C => InstructionSet::RV32C,
+                WireInstructionSet::RV64 => InstructionSet::RV64,
+                WireInstructionSet::RV64C => InstructionSet::RV64C,
+                WireInstructionSet::Xtensa => InstructionSet::Xtensa,
+            }
+        }
+    }
+
+    impl From<WireSteppingMode> for SteppingMode {
+        fn from(mode: WireSteppingMode) -> Self {
+            match mode {
+                WireSteppingMode::StepInstruction => SteppingMode::StepInstruction,
+                WireSteppingMode::OverStatement => SteppingMode::OverStatement,
+                WireSteppingMode::IntoStatement => SteppingMode::IntoStatement,
+                WireSteppingMode::OutOfStatement => SteppingMode::OutOfStatement,
+            }
+        }
+    }
+
+    impl From<probe_rs::CoreType> for WireCoreType {
+        fn from(value: probe_rs::CoreType) -> Self {
+            match value {
+                probe_rs::CoreType::Armv6m => WireCoreType::Armv6m,
+                probe_rs::CoreType::Armv7a => WireCoreType::Armv7a,
+                probe_rs::CoreType::Armv7r => WireCoreType::Armv7r,
+                probe_rs::CoreType::Armv7m => WireCoreType::Armv7m,
+                probe_rs::CoreType::Armv7em => WireCoreType::Armv7em,
+                probe_rs::CoreType::Armv8a => WireCoreType::Armv8a,
+                probe_rs::CoreType::Armv8m => WireCoreType::Armv8m,
+                probe_rs::CoreType::Riscv => WireCoreType::Riscv,
+                probe_rs::CoreType::Riscv64 => WireCoreType::Riscv64,
+                probe_rs::CoreType::Xtensa => WireCoreType::Xtensa,
+            }
+        }
+    }
+
+    impl From<WireCoreType> for probe_rs::CoreType {
+        fn from(value: WireCoreType) -> Self {
+            match value {
+                WireCoreType::Armv6m => probe_rs::CoreType::Armv6m,
+                WireCoreType::Armv7a => probe_rs::CoreType::Armv7a,
+                WireCoreType::Armv7r => probe_rs::CoreType::Armv7r,
+                WireCoreType::Armv7m => probe_rs::CoreType::Armv7m,
+                WireCoreType::Armv7em => probe_rs::CoreType::Armv7em,
+                WireCoreType::Armv8a => probe_rs::CoreType::Armv8a,
+                WireCoreType::Armv8m => probe_rs::CoreType::Armv8m,
+                WireCoreType::Riscv => probe_rs::CoreType::Riscv,
+                WireCoreType::Riscv64 => probe_rs::CoreType::Riscv64,
+                WireCoreType::Xtensa => probe_rs::CoreType::Xtensa,
+            }
+        }
+    }
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/core_ops.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/core_ops.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use crate::util::rtt::DataFormat;
 
 use crate::rpc::{
-    Key,
+    Key, Session,
     functions::{NoResponse, RpcContext, RpcError, RpcResult},
 };
 
@@ -280,7 +280,7 @@ pub type HandleSemihostingResponse = RpcResult<HandleSemihostingResult>;
 // -- handlers -----------------------------------------------------------------
 
 use probe_rs::{
-    BreakpointCause, CoreDump, CoreStatus, HaltReason, RegisterId, RegisterValue, Session,
+    BreakpointCause, CoreDump, CoreStatus, HaltReason, RegisterId, RegisterValue,
     VectorCatchCondition, semihosting::SemihostingCommand,
 };
 use probe_rs_debug::{DebugError, SteppingMode};

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/debug_vars.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/debug_vars.rs
@@ -1,10 +1,9 @@
 use crate::rpc::{
-    Key,
+    Key, Session,
     functions::{RpcContext, RpcResult},
 };
 use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;
-use probe_rs::Session;
 use probe_rs_debug::{
     DebugInfo, DebugRegisters, ObjectRef, StackFrameInfo, Variable, VariableCache, VariableName,
 };

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/disassemble.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/disassemble.rs
@@ -1,13 +1,10 @@
-use crate::cmd::dap_server::debug_adapter::dap::dap_types::{DisassembledInstruction, Source};
-use crate::cmd::dap_server::debug_adapter::dap::request_helpers::disassemble_target_memory;
+use postcard_schema::Schema;
+use serde::{Deserialize, Serialize};
+
 use crate::rpc::{
     Key,
     functions::{RpcContext, RpcResult},
 };
-use postcard_rpc::header::VarHeader;
-use postcard_schema::Schema;
-use probe_rs::Session;
-use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Schema)]
 pub struct DisassembleRequest {
@@ -36,6 +33,10 @@ pub struct WireDisassembledInstruction {
 }
 
 pub type DisassembleResponse = RpcResult<Vec<WireDisassembledInstruction>>;
+
+use crate::cmd::dap_server::debug_adapter::dap::request_helpers::disassemble_target_memory;
+use postcard_rpc::header::VarHeader;
+use probe_rs::Session;
 
 /// Disassemble target memory server-side, running the capstone disassembly
 /// (shared with the local path via `disassemble_target_memory`) against the
@@ -71,24 +72,29 @@ pub async fn disassemble(
         .collect())
 }
 
-impl From<Source> for WireSource {
-    fn from(s: Source) -> Self {
-        WireSource {
-            name: s.name,
-            path: s.path,
+pub(crate) mod convert {
+    use super::{WireDisassembledInstruction, WireSource};
+    use crate::cmd::dap_server::debug_adapter::dap::dap_types::{DisassembledInstruction, Source};
+
+    impl From<Source> for WireSource {
+        fn from(s: Source) -> Self {
+            WireSource {
+                name: s.name,
+                path: s.path,
+            }
         }
     }
-}
 
-impl From<DisassembledInstruction> for WireDisassembledInstruction {
-    fn from(i: DisassembledInstruction) -> Self {
-        WireDisassembledInstruction {
-            address: i.address,
-            column: i.column,
-            instruction: i.instruction,
-            instruction_bytes: i.instruction_bytes,
-            line: i.line,
-            location: i.location.map(WireSource::from),
+    impl From<DisassembledInstruction> for WireDisassembledInstruction {
+        fn from(i: DisassembledInstruction) -> Self {
+            WireDisassembledInstruction {
+                address: i.address,
+                column: i.column,
+                instruction: i.instruction,
+                instruction_bytes: i.instruction_bytes,
+                line: i.line,
+                location: i.location.map(WireSource::from),
+            }
         }
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/disassemble.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/disassemble.rs
@@ -2,7 +2,7 @@ use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
 
 use crate::rpc::{
-    Key,
+    Key, Session,
     functions::{RpcContext, RpcResult},
 };
 
@@ -36,7 +36,6 @@ pub type DisassembleResponse = RpcResult<Vec<WireDisassembledInstruction>>;
 
 use crate::cmd::dap_server::debug_adapter::dap::request_helpers::disassemble_target_memory;
 use postcard_rpc::header::VarHeader;
-use probe_rs::Session;
 
 /// Disassemble target memory server-side, running the capstone disassembly
 /// (shared with the local path via `disassemble_target_memory`) against the

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/file.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/file.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 #[cfg(feature = "remote")]
 use anyhow::Context as _;
 use postcard_rpc::header::VarHeader;
@@ -7,7 +5,7 @@ use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
 
 use crate::rpc::{
-    Key,
+    Key, TempFileHandle,
     functions::{NoResponse, RpcContext, RpcResult},
 };
 
@@ -17,7 +15,7 @@ use tempfile::NamedTempFile;
 #[derive(Serialize, Deserialize, Schema)]
 pub struct TempFile {
     pub path: String,
-    pub key: Key<PathBuf>,
+    pub key: Key<TempFileHandle>,
 }
 
 pub type CreateFileResponse = RpcResult<TempFile>;
@@ -25,7 +23,7 @@ pub type CreateFileResponse = RpcResult<TempFile>;
 #[derive(Serialize, Deserialize, Schema)]
 pub struct AppendFileRequest {
     pub data: Vec<u8>,
-    pub key: Key<PathBuf>,
+    pub key: Key<TempFileHandle>,
 }
 
 #[cfg(feature = "remote")]
@@ -40,10 +38,7 @@ pub async fn create_temp_file(
     tracing::info!("Created temporary file {}", path);
     let key = ctx.store_object(file).await;
 
-    Ok(TempFile {
-        path,
-        key: unsafe { key.cast() },
-    })
+    Ok(TempFile { path, key })
 }
 
 #[cfg(not(feature = "remote"))]
@@ -63,9 +58,7 @@ pub async fn append_temp_file(
 ) -> NoResponse {
     use std::io::Write as _;
 
-    let mut file = ctx
-        .object_mut::<NamedTempFile>(unsafe { request.key.cast::<NamedTempFile>() })
-        .await;
+    let mut file = ctx.object_mut(request.key).await;
 
     file.as_file_mut()
         .write_all(&request.data)

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     FormatOptions,
-    rpc::{Key, functions::RpcResult},
+    rpc::{FlashLoader, Key, RttClient, Session, functions::RpcResult},
 };
 
 #[derive(Serialize, Deserialize, Default, Schema)]
@@ -228,14 +228,14 @@ use std::time::Duration;
 
 use postcard_rpc::header::VarHeader;
 use probe_rs::{
-    InstructionSet, Session,
-    flashing::{self, FileDownloadError, FlashLoader, FlashProgress},
+    InstructionSet,
+    flashing::{self, FileDownloadError, FlashProgress},
 };
 use tokio::sync::mpsc::Sender;
 
 use crate::{
     rpc::functions::{NoResponse, ProgressEventTopic, RpcContext, RpcSpawnContext},
-    util::{flash::build_loader, rtt::client::RttClient},
+    util::flash::build_loader,
 };
 
 impl FlashRequest {
@@ -255,7 +255,7 @@ impl FlashRequest {
 }
 
 impl BootInfo {
-    pub fn prepare(&self, session: &mut Session, core_id: usize) -> anyhow::Result<()> {
+    pub fn prepare(&self, session: &mut probe_rs::Session, core_id: usize) -> anyhow::Result<()> {
         match self {
             BootInfo::FromRam {
                 vector_table_addr, ..

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
@@ -1,21 +1,9 @@
-use std::time::Duration;
-
-use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;
-use probe_rs::{
-    InstructionSet, Session,
-    flashing::{self, FileDownloadError, FlashLoader, FlashProgress},
-};
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc::Sender;
 
 use crate::{
     FormatOptions,
-    rpc::{
-        Key,
-        functions::{NoResponse, ProgressEventTopic, RpcContext, RpcResult, RpcSpawnContext},
-    },
-    util::{flash::build_loader, rtt::client::RttClient},
+    rpc::{Key, functions::RpcResult},
 };
 
 #[derive(Serialize, Deserialize, Default, Schema)]
@@ -79,52 +67,12 @@ pub struct BuildResult {
 
 pub type BuildResponse = RpcResult<BuildResult>;
 
-pub async fn build(
-    ctx: &mut RpcContext,
-    _header: VarHeader,
-    request: BuildRequest,
-) -> BuildResponse {
-    // build loader
-    let mut session = ctx.session(request.sessid).await;
-    let mut loader = build_loader(
-        &mut session,
-        &request.path,
-        request.format,
-        request
-            .image_target
-            .as_deref()
-            .and_then(InstructionSet::from_target_triple),
-    )?;
-
-    loader.read_rtt_output(request.read_flasher_rtt);
-
-    Ok(BuildResult {
-        boot_info: loader.boot_info().into(),
-        loader: ctx.store_object(loader).await,
-    })
-}
-
 #[derive(Serialize, Deserialize, Schema)]
 pub struct FlashRequest {
     pub sessid: Key<Session>,
     pub loader: Key<FlashLoader>,
     pub options: DownloadOptions,
     pub rtt_client: Option<Key<RttClient>>,
-}
-impl FlashRequest {
-    fn download_options<'a>(&self) -> flashing::DownloadOptions<'a> {
-        let mut options = probe_rs::flashing::DownloadOptions::default();
-
-        options.keep_unwritten_bytes = self.options.keep_unwritten_bytes;
-        options.do_chip_erase = self.options.do_chip_erase;
-        options.skip_erase = self.options.skip_erase;
-        options.preverify = false;
-        options.verify = self.options.verify;
-        options.disable_double_buffering = self.options.disable_double_buffering;
-        options.preferred_algos = self.options.preferred_algos.clone();
-
-        options
-    }
 }
 
 #[derive(Default, Clone, Serialize, Deserialize, Schema)]
@@ -140,46 +88,6 @@ impl FlashLayout {
         self.pages.extend(layout.pages);
         self.fills.extend(layout.fills);
         self.data_blocks.extend(layout.data_blocks);
-    }
-}
-
-impl From<&probe_rs::flashing::FlashLayout> for FlashLayout {
-    fn from(layout: &probe_rs::flashing::FlashLayout) -> Self {
-        FlashLayout {
-            sectors: layout
-                .sectors()
-                .iter()
-                .map(|sector| FlashSector {
-                    address: sector.address(),
-                    size: sector.size(),
-                })
-                .collect(),
-            pages: layout
-                .pages()
-                .iter()
-                .map(|page| FlashPage {
-                    address: page.address(),
-                    data_len: page.data().len() as u64,
-                })
-                .collect(),
-            fills: layout
-                .fills()
-                .iter()
-                .map(|fill| FlashFill {
-                    address: fill.address(),
-                    size: fill.size(),
-                    page_index: fill.page_index() as u64,
-                })
-                .collect(),
-            data_blocks: layout
-                .data_blocks()
-                .iter()
-                .map(|block| FlashDataBlockSpan {
-                    address: block.address(),
-                    size: block.size(),
-                })
-                .collect(),
-        }
     }
 }
 
@@ -228,17 +136,6 @@ pub enum Operation {
     Verify,
 }
 
-impl From<flashing::ProgressOperation> for Operation {
-    fn from(operation: flashing::ProgressOperation) -> Self {
-        match operation {
-            flashing::ProgressOperation::Fill => Operation::Fill,
-            flashing::ProgressOperation::Erase => Operation::Erase,
-            flashing::ProgressOperation::Program => Operation::Program,
-            flashing::ProgressOperation::Verify => Operation::Verify,
-        }
-    }
-}
-
 #[derive(Clone, Serialize, Deserialize, Schema)]
 pub enum ProgressEvent {
     FlashLayoutReady {
@@ -274,6 +171,111 @@ pub enum ProgressEvent {
     },
 }
 impl ProgressEvent {
+    pub fn is_operation(&self, operation: Operation) -> bool {
+        matches!(
+            self,
+            ProgressEvent::Started(op)
+            | ProgressEvent::Progress { operation: op, .. }
+            | ProgressEvent::Failed(op)
+            | ProgressEvent::Finished(op)
+            | ProgressEvent::AddProgressBar { operation: op, .. }
+            if *op == operation
+        )
+    }
+}
+
+/// Current boot information
+#[derive(Clone, Debug, Serialize, Deserialize, Schema)]
+pub enum BootInfo {
+    /// Loaded executable has a vector table in RAM
+    FromRam {
+        /// Address of the vector table in memory
+        vector_table_addr: u64,
+        /// All cores that should be reset and halted before any RAM access
+        cores_to_reset: Vec<String>,
+    },
+    /// Executable is either not loaded yet or will be booted conventionally (from flash etc.)
+    Other,
+}
+
+#[derive(Serialize, Deserialize, Schema)]
+pub struct EraseRequest {
+    pub sessid: Key<Session>,
+    pub command: EraseCommand,
+    pub read_flasher_rtt: bool,
+}
+
+#[derive(Serialize, Deserialize, Schema)]
+pub enum EraseCommand {
+    All,
+}
+
+#[derive(Serialize, Deserialize, Schema)]
+pub struct VerifyRequest {
+    pub sessid: Key<Session>,
+    pub loader: Key<FlashLoader>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Schema)]
+pub enum VerifyResult {
+    Ok,
+    Mismatch,
+}
+
+pub type VerifyResponse = RpcResult<VerifyResult>;
+
+use std::time::Duration;
+
+use postcard_rpc::header::VarHeader;
+use probe_rs::{
+    InstructionSet, Session,
+    flashing::{self, FileDownloadError, FlashLoader, FlashProgress},
+};
+use tokio::sync::mpsc::Sender;
+
+use crate::{
+    rpc::functions::{NoResponse, ProgressEventTopic, RpcContext, RpcSpawnContext},
+    util::{flash::build_loader, rtt::client::RttClient},
+};
+
+impl FlashRequest {
+    fn download_options<'a>(&self) -> flashing::DownloadOptions<'a> {
+        let mut options = probe_rs::flashing::DownloadOptions::default();
+
+        options.keep_unwritten_bytes = self.options.keep_unwritten_bytes;
+        options.do_chip_erase = self.options.do_chip_erase;
+        options.skip_erase = self.options.skip_erase;
+        options.preverify = false;
+        options.verify = self.options.verify;
+        options.disable_double_buffering = self.options.disable_double_buffering;
+        options.preferred_algos = self.options.preferred_algos.clone();
+
+        options
+    }
+}
+
+impl BootInfo {
+    pub fn prepare(&self, session: &mut Session, core_id: usize) -> anyhow::Result<()> {
+        match self {
+            BootInfo::FromRam {
+                vector_table_addr, ..
+            } => {
+                // core should be already reset and halt by this point.
+                session.prepare_running_on_ram(*vector_table_addr, core_id)?;
+            }
+            BootInfo::Other => {
+                // reset the core to leave it in a consistent state after flashing
+                session
+                    .core(core_id)?
+                    .reset_and_halt(Duration::from_millis(100))?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl ProgressEvent {
     pub fn from_library_event(event: flashing::ProgressEvent, mut cb: impl FnMut(ProgressEvent)) {
         let event = match event {
             flashing::ProgressEvent::FlashLayoutReady { flash_layout } => {
@@ -305,53 +307,31 @@ impl ProgressEvent {
 
         cb(event);
     }
-
-    pub fn is_operation(&self, operation: Operation) -> bool {
-        matches!(
-            self,
-            ProgressEvent::Started(op)
-            | ProgressEvent::Progress { operation: op, .. }
-            | ProgressEvent::Failed(op)
-            | ProgressEvent::Finished(op)
-            | ProgressEvent::AddProgressBar { operation: op, .. }
-            if *op == operation
-        )
-    }
 }
 
-/// Current boot information
-#[derive(Clone, Debug, Serialize, Deserialize, Schema)]
-pub enum BootInfo {
-    /// Loaded executable has a vector table in RAM
-    FromRam {
-        /// Address of the vector table in memory
-        vector_table_addr: u64,
-        /// All cores that should be reset and halted before any RAM access
-        cores_to_reset: Vec<String>,
-    },
-    /// Executable is either not loaded yet or will be booted conventionally (from flash etc.)
-    Other,
-}
+pub async fn build(
+    ctx: &mut RpcContext,
+    _header: VarHeader,
+    request: BuildRequest,
+) -> BuildResponse {
+    // build loader
+    let mut session = ctx.session(request.sessid).await;
+    let mut loader = build_loader(
+        &mut session,
+        &request.path,
+        request.format,
+        request
+            .image_target
+            .as_deref()
+            .and_then(InstructionSet::from_target_triple),
+    )?;
 
-impl BootInfo {
-    pub fn prepare(&self, session: &mut Session, core_id: usize) -> anyhow::Result<()> {
-        match self {
-            BootInfo::FromRam {
-                vector_table_addr, ..
-            } => {
-                // core should be already reset and halt by this point.
-                session.prepare_running_on_ram(*vector_table_addr, core_id)?;
-            }
-            BootInfo::Other => {
-                // reset the core to leave it in a consistent state after flashing
-                session
-                    .core(core_id)?
-                    .reset_and_halt(Duration::from_millis(100))?;
-            }
-        }
+    loader.read_rtt_output(request.read_flasher_rtt);
 
-        Ok(())
-    }
+    Ok(BuildResult {
+        boot_info: loader.boot_info().into(),
+        loader: ctx.store_object(loader).await,
+    })
 }
 
 #[derive(Serialize, Deserialize, Schema)]
@@ -371,21 +351,6 @@ pub async fn boot(ctx: &mut RpcContext, _header: VarHeader, request: BootRequest
     session.resume_all_cores()?;
 
     Ok(())
-}
-
-impl From<probe_rs::flashing::BootInfo> for BootInfo {
-    fn from(boot_info: probe_rs::flashing::BootInfo) -> Self {
-        match boot_info {
-            probe_rs::flashing::BootInfo::FromRam {
-                vector_table_addr,
-                cores_to_reset,
-            } => BootInfo::FromRam {
-                vector_table_addr,
-                cores_to_reset,
-            },
-            probe_rs::flashing::BootInfo::Other => BootInfo::Other,
-        }
-    }
 }
 
 pub async fn flash(ctx: &mut RpcContext, _header: VarHeader, request: FlashRequest) -> NoResponse {
@@ -426,18 +391,6 @@ fn flash_impl(
     Ok(())
 }
 
-#[derive(Serialize, Deserialize, Schema)]
-pub struct EraseRequest {
-    pub sessid: Key<Session>,
-    pub command: EraseCommand,
-    pub read_flasher_rtt: bool,
-}
-
-#[derive(Serialize, Deserialize, Schema)]
-pub enum EraseCommand {
-    All,
-}
-
 pub async fn erase(ctx: &mut RpcContext, _header: VarHeader, request: EraseRequest) -> NoResponse {
     ctx.run_blocking::<ProgressEventTopic, _, _, _>(request, erase_impl)
         .await
@@ -467,20 +420,6 @@ fn erase_impl(
 
     Ok(())
 }
-
-#[derive(Serialize, Deserialize, Schema)]
-pub struct VerifyRequest {
-    pub sessid: Key<Session>,
-    pub loader: Key<FlashLoader>,
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Eq, Schema)]
-pub enum VerifyResult {
-    Ok,
-    Mismatch,
-}
-
-pub type VerifyResponse = RpcResult<VerifyResult>;
 
 pub async fn verify(
     ctx: &mut RpcContext,
@@ -514,5 +453,78 @@ fn verify_impl(
         Ok(()) => Ok(VerifyResult::Ok),
         Err(flashing::FlashError::Verify) => Ok(VerifyResult::Mismatch),
         Err(other) => Err(other.into()),
+    }
+}
+
+pub(crate) mod convert {
+    use super::{
+        BootInfo, FlashDataBlockSpan, FlashFill, FlashLayout, FlashPage, FlashSector, Operation,
+    };
+    use probe_rs::flashing;
+
+    impl From<&probe_rs::flashing::FlashLayout> for FlashLayout {
+        fn from(layout: &probe_rs::flashing::FlashLayout) -> Self {
+            FlashLayout {
+                sectors: layout
+                    .sectors()
+                    .iter()
+                    .map(|sector| FlashSector {
+                        address: sector.address(),
+                        size: sector.size(),
+                    })
+                    .collect(),
+                pages: layout
+                    .pages()
+                    .iter()
+                    .map(|page| FlashPage {
+                        address: page.address(),
+                        data_len: page.data().len() as u64,
+                    })
+                    .collect(),
+                fills: layout
+                    .fills()
+                    .iter()
+                    .map(|fill| FlashFill {
+                        address: fill.address(),
+                        size: fill.size(),
+                        page_index: fill.page_index() as u64,
+                    })
+                    .collect(),
+                data_blocks: layout
+                    .data_blocks()
+                    .iter()
+                    .map(|block| FlashDataBlockSpan {
+                        address: block.address(),
+                        size: block.size(),
+                    })
+                    .collect(),
+            }
+        }
+    }
+
+    impl From<flashing::ProgressOperation> for Operation {
+        fn from(operation: flashing::ProgressOperation) -> Self {
+            match operation {
+                flashing::ProgressOperation::Fill => Operation::Fill,
+                flashing::ProgressOperation::Erase => Operation::Erase,
+                flashing::ProgressOperation::Program => Operation::Program,
+                flashing::ProgressOperation::Verify => Operation::Verify,
+            }
+        }
+    }
+
+    impl From<probe_rs::flashing::BootInfo> for BootInfo {
+        fn from(boot_info: probe_rs::flashing::BootInfo) -> Self {
+            match boot_info {
+                probe_rs::flashing::BootInfo::FromRam {
+                    vector_table_addr,
+                    cores_to_reset,
+                } => BootInfo::FromRam {
+                    vector_table_addr,
+                    cores_to_reset,
+                },
+                probe_rs::flashing::BootInfo::Other => BootInfo::Other,
+            }
+        }
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -2,43 +2,18 @@
 //!
 //! The information is passed as a stream of messages to the provided emitter.
 
-use anyhow::anyhow;
 use postcard_rpc::header::{VarHeader, VarSeq};
 use postcard_schema::{Schema, schema};
-use probe_rs::{
-    Session,
-    architecture::{
-        arm::{
-            self, ApAddress, ApV2Address, ArmDebugInterface,
-            ap::{ApClass, ApRegister, IDR},
-            component::Scs,
-            dp::{self, Ctrl, DLPIDR, DPIDR, DpRegister, TARGETID},
-            memory::{
-                ArmMemoryInterface, Component, ComponentId, CoresightComponent, PeripheralType,
-                romtable::{PeripheralID, RomTable},
-            },
-            sequences::DefaultArmSequence,
-        },
-        xtensa::communication_interface::{
-            XtensaCommunicationInterface, XtensaDebugInterfaceState,
-        },
-    },
-    probe::{Probe, WireProtocol as ProbeRsWireProtocol, wlink::WchLink},
-};
-use probe_rs_target::ScanChainElement;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    rpc::{
-        Key,
-        functions::{
-            NoResponse, RpcContext, TargetInfoDataTopic, TargetMetadataResponse,
-            chip::JEP106Code,
-            core_ops::WireCoreType,
-            probe::{DebugProbeEntry, WireProtocol},
-        },
+use crate::rpc::{
+    Key,
+    functions::{
+        NoResponse, RpcContext, TargetInfoDataTopic, TargetMetadataResponse,
+        chip::JEP106Code,
+        core_ops::WireCoreType,
+        probe::{DebugProbeEntry, WireProtocol},
     },
-    util::common_options::ProbeOptions,
 };
 
 /// Session-scoped target description fields the DAP RPC client needs without
@@ -61,27 +36,6 @@ pub struct TargetMetadataRequest {
     pub sessid: Key<Session>,
 }
 
-pub async fn target_metadata(
-    ctx: &mut RpcContext,
-    _hdr: VarHeader,
-    request: TargetMetadataRequest,
-) -> TargetMetadataResponse {
-    let session = ctx.session(request.sessid).await;
-    let target = session.target();
-    Ok(WireSessionTargetMetadata {
-        target_name: target.name.clone(),
-        default_format: target.default_format.clone(),
-        cores: session
-            .list_cores()
-            .into_iter()
-            .map(|(index, core_type)| WireSessionCore {
-                index: index as u32,
-                core_type: core_type.into(),
-            })
-            .collect(),
-    })
-}
-
 #[derive(Serialize, Deserialize, Schema)]
 pub struct TargetInfoRequest {
     pub probe: DebugProbeEntry,
@@ -96,59 +50,6 @@ pub struct TargetInfoRequest {
     /// directly. For example, `[5]` specifies a single-TAP chain with IR length 5.
     #[serde(default)]
     pub scan_chain: Vec<u8>,
-}
-
-impl From<&TargetInfoRequest> for ProbeOptions {
-    fn from(request: &TargetInfoRequest) -> Self {
-        ProbeOptions {
-            chip: None,
-            chip_description_path: None,
-            protocol: match request.protocol {
-                WireProtocol::Jtag => Some(ProbeRsWireProtocol::Jtag),
-                WireProtocol::Swd => Some(ProbeRsWireProtocol::Swd),
-            },
-            non_interactive: true,
-            probe: Some(request.probe.selector().into()),
-            speed: request.speed,
-            connect_under_reset: request.connect_under_reset,
-            cycle_power: false,
-            dry_run: request.dry_run,
-            allow_erase_all: false,
-        }
-    }
-}
-
-pub async fn target_info(
-    ctx: &mut RpcContext,
-    _hdr: VarHeader,
-    request: TargetInfoRequest,
-) -> NoResponse {
-    let mut registry = ctx.registry().await;
-    let probe_options = ProbeOptions::from(&request).load(&mut registry)?;
-
-    let probe = probe_options.attach_probe(&ctx.lister())?;
-
-    if let Err(e) = try_show_info(
-        ctx,
-        probe,
-        request.scan_chain.clone(),
-        request.protocol,
-        probe_options.connect_under_reset(),
-        request.target_sel,
-    )
-    .await
-    {
-        ctx.publish::<TargetInfoDataTopic>(
-            VarSeq::Seq2(0),
-            &InfoEvent::Message(format!(
-                "Failed to identify target using protocol {}: {e:?}",
-                request.protocol
-            )),
-        )
-        .await?;
-    }
-
-    Ok(())
 }
 
 #[derive(Clone, Serialize, Deserialize, Schema)]
@@ -187,15 +88,6 @@ pub enum DpAddress {
     Multidrop(u32),
 }
 
-impl From<dp::DpAddress> for DpAddress {
-    fn from(address: dp::DpAddress) -> Self {
-        match address {
-            dp::DpAddress::Default => DpAddress::Default,
-            dp::DpAddress::Multidrop(target_sel) => DpAddress::Multidrop(target_sel),
-        }
-    }
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize, Schema)]
 pub struct DebugPortInfoNode {
     pub dp_info: DebugPortId,
@@ -218,21 +110,6 @@ pub struct DebugPortId {
     pub designer: JEP106Code,
 }
 
-impl From<&dp::DebugPortId> for DebugPortId {
-    fn from(id: &dp::DebugPortId) -> Self {
-        Self {
-            revision: id.revision,
-            part_no: id.part_no,
-            version: id.version.into(),
-            min_dp_support: match id.min_dp_support {
-                dp::MinDpSupport::NotImplemented => MinDpSupport::NotImplemented,
-                dp::MinDpSupport::Implemented => MinDpSupport::Implemented,
-            },
-            designer: id.designer.into(),
-        }
-    }
-}
-
 /// The version of the debug port.
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize, Schema)]
 pub enum DebugPortVersion {
@@ -246,18 +123,6 @@ pub enum DebugPortVersion {
     DPv3,
     /// Some unsupported value was encountered!
     Unsupported(u8),
-}
-
-impl From<dp::DebugPortVersion> for DebugPortVersion {
-    fn from(version: dp::DebugPortVersion) -> Self {
-        match version {
-            dp::DebugPortVersion::DPv0 => DebugPortVersion::DPv0,
-            dp::DebugPortVersion::DPv1 => DebugPortVersion::DPv1,
-            dp::DebugPortVersion::DPv2 => DebugPortVersion::DPv2,
-            dp::DebugPortVersion::DPv3 => DebugPortVersion::DPv3,
-            dp::DebugPortVersion::Unsupported(v) => DebugPortVersion::Unsupported(v),
-        }
-    }
 }
 
 /// Specifies if pushed-find operations are implemented or not.
@@ -338,6 +203,85 @@ impl ComponentTreeNode {
     fn push(&mut self, child: impl Into<ComponentTreeNode>) {
         self.children.push(child.into());
     }
+}
+
+use anyhow::anyhow;
+use probe_rs::{
+    Session,
+    architecture::{
+        arm::{
+            self, ApAddress, ApV2Address, ArmDebugInterface,
+            ap::{ApClass, ApRegister, IDR},
+            component::Scs,
+            dp::{self, Ctrl, DLPIDR, DPIDR, DpRegister, TARGETID},
+            memory::{
+                ArmMemoryInterface, Component, ComponentId, CoresightComponent, PeripheralType,
+                romtable::{PeripheralID, RomTable},
+            },
+            sequences::DefaultArmSequence,
+        },
+        xtensa::communication_interface::{
+            XtensaCommunicationInterface, XtensaDebugInterfaceState,
+        },
+    },
+    probe::{Probe, WireProtocol as ProbeRsWireProtocol, wlink::WchLink},
+};
+use probe_rs_target::ScanChainElement;
+
+use crate::util::common_options::ProbeOptions;
+
+pub async fn target_metadata(
+    ctx: &mut RpcContext,
+    _hdr: VarHeader,
+    request: TargetMetadataRequest,
+) -> TargetMetadataResponse {
+    let session = ctx.session(request.sessid).await;
+    let target = session.target();
+    Ok(WireSessionTargetMetadata {
+        target_name: target.name.clone(),
+        default_format: target.default_format.clone(),
+        cores: session
+            .list_cores()
+            .into_iter()
+            .map(|(index, core_type)| WireSessionCore {
+                index: index as u32,
+                core_type: core_type.into(),
+            })
+            .collect(),
+    })
+}
+
+pub async fn target_info(
+    ctx: &mut RpcContext,
+    _hdr: VarHeader,
+    request: TargetInfoRequest,
+) -> NoResponse {
+    let mut registry = ctx.registry().await;
+    let probe_options = ProbeOptions::from(&request).load(&mut registry)?;
+
+    let probe = probe_options.attach_probe(&ctx.lister())?;
+
+    if let Err(e) = try_show_info(
+        ctx,
+        probe,
+        request.scan_chain.clone(),
+        request.protocol,
+        probe_options.connect_under_reset(),
+        request.target_sel,
+    )
+    .await
+    {
+        ctx.publish::<TargetInfoDataTopic>(
+            VarSeq::Seq2(0),
+            &InfoEvent::Message(format!(
+                "Failed to identify target using protocol {}: {e:?}",
+                request.protocol
+            )),
+        )
+        .await?;
+    }
+
+    Ok(())
 }
 
 async fn try_show_info(
@@ -924,6 +868,70 @@ async fn show_xtensa_info(
         },
     )
     .await
+}
+
+pub(crate) mod convert {
+    use super::{
+        DebugPortId, DebugPortVersion, DpAddress, MinDpSupport, TargetInfoRequest, WireProtocol,
+    };
+    use crate::util::common_options::ProbeOptions;
+    use probe_rs::{architecture::arm::dp, probe::WireProtocol as ProbeRsWireProtocol};
+
+    impl From<&TargetInfoRequest> for ProbeOptions {
+        fn from(request: &TargetInfoRequest) -> Self {
+            ProbeOptions {
+                chip: None,
+                chip_description_path: None,
+                protocol: match request.protocol {
+                    WireProtocol::Jtag => Some(ProbeRsWireProtocol::Jtag),
+                    WireProtocol::Swd => Some(ProbeRsWireProtocol::Swd),
+                },
+                non_interactive: true,
+                probe: Some(request.probe.selector().into()),
+                speed: request.speed,
+                connect_under_reset: request.connect_under_reset,
+                cycle_power: false,
+                dry_run: request.dry_run,
+                allow_erase_all: false,
+            }
+        }
+    }
+
+    impl From<dp::DpAddress> for DpAddress {
+        fn from(address: dp::DpAddress) -> Self {
+            match address {
+                dp::DpAddress::Default => DpAddress::Default,
+                dp::DpAddress::Multidrop(target_sel) => DpAddress::Multidrop(target_sel),
+            }
+        }
+    }
+
+    impl From<&dp::DebugPortId> for DebugPortId {
+        fn from(id: &dp::DebugPortId) -> Self {
+            Self {
+                revision: id.revision,
+                part_no: id.part_no,
+                version: id.version.into(),
+                min_dp_support: match id.min_dp_support {
+                    dp::MinDpSupport::NotImplemented => MinDpSupport::NotImplemented,
+                    dp::MinDpSupport::Implemented => MinDpSupport::Implemented,
+                },
+                designer: id.designer.into(),
+            }
+        }
+    }
+
+    impl From<dp::DebugPortVersion> for DebugPortVersion {
+        fn from(version: dp::DebugPortVersion) -> Self {
+            match version {
+                dp::DebugPortVersion::DPv0 => DebugPortVersion::DPv0,
+                dp::DebugPortVersion::DPv1 => DebugPortVersion::DPv1,
+                dp::DebugPortVersion::DPv2 => DebugPortVersion::DPv2,
+                dp::DebugPortVersion::DPv3 => DebugPortVersion::DPv3,
+                dp::DebugPortVersion::Unsupported(v) => DebugPortVersion::Unsupported(v),
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -7,7 +7,7 @@ use postcard_schema::{Schema, schema};
 use serde::{Deserialize, Serialize};
 
 use crate::rpc::{
-    Key,
+    Key, Session,
     functions::{
         NoResponse, RpcContext, TargetInfoDataTopic, TargetMetadataResponse,
         chip::JEP106Code,
@@ -207,7 +207,6 @@ impl ComponentTreeNode {
 
 use anyhow::anyhow;
 use probe_rs::{
-    Session,
     architecture::{
         arm::{
             self, ApAddress, ApV2Address, ArmDebugInterface,

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/memory.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/memory.rs
@@ -1,10 +1,10 @@
 use crate::rpc::{
-    Key,
+    Key, Session,
     functions::{NoResponse, RpcContext, RpcResult},
 };
 use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;
-use probe_rs::{MemoryInterface, Session};
+use probe_rs::MemoryInterface;
 use serde::{Deserialize, Serialize};
 
 pub trait Word: Copy + Default + Send + Schema {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
@@ -1,23 +1,20 @@
 use std::time::Duration;
 
-use crate::{
-    rpc::{
-        Key, ObjectStorageSlot,
-        functions::{
-            MonitorEndpoint, MultiTopicPublisher, MultiTopicWriter, RpcResult, RpcSpawnContext,
-            RttTopic, SemihostingTopic, WireTxImpl, flash::BootInfo,
-        },
-        utils::{
-            run_loop::{ReturnReason, RunLoop, RunLoopPoller, VectorCatchConfig},
-            semihosting::{SemihostingFileManager, SemihostingOptions},
-        },
+use crate::rpc::{
+    Key, ObjectStorageSlot, RttClient, Session,
+    functions::{
+        MonitorEndpoint, MultiTopicPublisher, MultiTopicWriter, RpcResult, RpcSpawnContext,
+        RttTopic, SemihostingTopic, WireTxImpl, flash::BootInfo,
     },
-    util::rtt::client::RttClient,
+    utils::{
+        run_loop::{ReturnReason, RunLoop, RunLoopPoller, VectorCatchConfig},
+        semihosting::{SemihostingFileManager, SemihostingOptions},
+    },
 };
 use anyhow::Context;
 use postcard_rpc::{header::VarHeader, server::Sender};
 use postcard_schema::Schema;
-use probe_rs::{BreakpointCause, Core, HaltReason, Session, semihosting::SemihostingCommand};
+use probe_rs::{BreakpointCause, Core, HaltReason, semihosting::SemihostingCommand};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{self, error::SendError};
 use tokio_util::sync::CancellationToken;
@@ -37,7 +34,7 @@ impl MonitorMode {
         }
     }
 
-    pub fn prepare(&self, session: &mut Session, core_id: usize) -> anyhow::Result<()> {
+    pub fn prepare(&self, session: &mut probe_rs::Session, core_id: usize) -> anyhow::Result<()> {
         match self {
             MonitorMode::Run(boot_info) => boot_info.prepare(session, core_id),
             MonitorMode::AttachToRunning => Ok(()),
@@ -245,7 +242,7 @@ pub struct RttPoller<S>
 where
     S: FnMut(RttEvent) -> anyhow::Result<()>,
 {
-    pub rtt_client: ObjectStorageSlot<RttClient>,
+    pub rtt_client: ObjectStorageSlot<crate::util::rtt::client::RttClient>,
     pub clear_control_block: bool,
     pub sender: S,
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/probe.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/probe.rs
@@ -1,20 +1,9 @@
-use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;
-use probe_rs::{
-    Session,
-    probe::list::{Accessibility, ProbeListItem},
-};
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    rpc::{
-        Key,
-        functions::{RpcContext, RpcResult},
-    },
-    util::common_options::{OperationError, ProbeOptions},
-};
-
 use std::fmt::Display;
+
+use crate::rpc::{Key, functions::RpcResult};
 
 // Separate from DebugProbeInfo because we can't serialize a &dyn ProbeFactory
 #[derive(Debug, Serialize, Deserialize, Clone, Schema)]
@@ -55,22 +44,6 @@ impl Display for DebugProbeEntry {
     }
 }
 
-impl From<ProbeListItem> for DebugProbeEntry {
-    fn from(item: ProbeListItem) -> DebugProbeEntry {
-        let inaccessible = item.accessibility == Accessibility::PermissionDenied;
-        let probe = item.info;
-        DebugProbeEntry {
-            probe_type: probe.probe_type(),
-            inaccessible,
-            identifier: probe.identifier,
-            vendor_id: probe.vendor_id,
-            product_id: probe.product_id,
-            serial_number: probe.serial_number.unwrap_or_default(),
-            interface: probe.interface,
-        }
-    }
-}
-
 impl DebugProbeEntry {
     pub fn selector(&self) -> DebugProbeSelector {
         DebugProbeSelector {
@@ -84,16 +57,6 @@ impl DebugProbeEntry {
 
 pub type ListProbesResponse = RpcResult<Vec<DebugProbeEntry>>;
 
-pub fn list_probes(ctx: &mut RpcContext, _header: VarHeader, _request: ()) -> ListProbesResponse {
-    let lister = ctx.lister();
-    let probes = lister.list_all_with_access();
-
-    Ok(probes
-        .into_iter()
-        .map(DebugProbeEntry::from)
-        .collect::<Vec<_>>())
-}
-
 #[derive(Serialize, Deserialize, Schema)]
 pub struct SelectProbeRequest {
     pub probe: Option<DebugProbeSelector>,
@@ -106,6 +69,64 @@ pub enum SelectProbeResult {
 }
 
 pub type SelectProbeResponse = RpcResult<SelectProbeResult>;
+
+#[derive(Serialize, Deserialize, Schema)]
+pub enum AttachResult {
+    Success(Key<Session>),
+    ProbeNotFound,
+    FailedToOpenProbe(String),
+    ProbeInUse,
+}
+
+#[derive(Debug, docsplay::Display, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Schema)]
+pub enum WireProtocol {
+    /// JTAG
+    Jtag,
+    /// SWD
+    Swd,
+}
+
+#[derive(Clone, Serialize, Deserialize, Schema)]
+pub struct DebugProbeSelector {
+    /// The the USB vendor id of the debug probe to be used.
+    pub vendor_id: u16,
+    /// The the USB product id of the debug probe to be used.
+    pub product_id: u16,
+    /// The the interface of the debug probe to be used.
+    pub interface: Option<u8>,
+    /// The the serial number of the debug probe to be used.
+    pub serial_number: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Schema)]
+pub struct AttachRequest {
+    pub chip: Option<String>,
+    pub protocol: Option<WireProtocol>,
+    pub probe: DebugProbeEntry,
+    pub speed: Option<u32>,
+    pub connect_under_reset: bool,
+    pub dry_run: bool,
+    pub allow_erase_all: bool,
+    pub resume_target: bool,
+}
+
+pub type AttachResponse = RpcResult<AttachResult>;
+
+use postcard_rpc::header::VarHeader;
+use probe_rs::Session;
+
+use crate::rpc::functions::RpcContext;
+use crate::util::common_options::{OperationError, ProbeOptions};
+
+pub fn list_probes(ctx: &mut RpcContext, _header: VarHeader, _request: ()) -> ListProbesResponse {
+    let lister = ctx.lister();
+    let probes = lister.list_all_with_access();
+
+    Ok(probes
+        .into_iter()
+        .map(DebugProbeEntry::from)
+        .collect::<Vec<_>>())
+}
 
 pub async fn select_probe(
     ctx: &mut RpcContext,
@@ -146,105 +167,6 @@ pub async fn select_probe(
     }
 }
 
-#[derive(Serialize, Deserialize, Schema)]
-pub enum AttachResult {
-    Success(Key<Session>),
-    ProbeNotFound,
-    FailedToOpenProbe(String),
-    ProbeInUse,
-}
-
-#[derive(Debug, docsplay::Display, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Schema)]
-pub enum WireProtocol {
-    /// JTAG
-    Jtag,
-    /// SWD
-    Swd,
-}
-
-impl From<WireProtocol> for probe_rs::probe::WireProtocol {
-    fn from(protocol: WireProtocol) -> Self {
-        match protocol {
-            WireProtocol::Jtag => probe_rs::probe::WireProtocol::Jtag,
-            WireProtocol::Swd => probe_rs::probe::WireProtocol::Swd,
-        }
-    }
-}
-
-impl From<probe_rs::probe::WireProtocol> for WireProtocol {
-    fn from(protocol: probe_rs::probe::WireProtocol) -> Self {
-        match protocol {
-            probe_rs::probe::WireProtocol::Jtag => WireProtocol::Jtag,
-            probe_rs::probe::WireProtocol::Swd => WireProtocol::Swd,
-        }
-    }
-}
-
-#[derive(Clone, Serialize, Deserialize, Schema)]
-pub struct DebugProbeSelector {
-    /// The the USB vendor id of the debug probe to be used.
-    pub vendor_id: u16,
-    /// The the USB product id of the debug probe to be used.
-    pub product_id: u16,
-    /// The the interface of the debug probe to be used.
-    pub interface: Option<u8>,
-    /// The the serial number of the debug probe to be used.
-    pub serial_number: Option<String>,
-}
-
-impl From<probe_rs::probe::DebugProbeSelector> for DebugProbeSelector {
-    fn from(selector: probe_rs::probe::DebugProbeSelector) -> Self {
-        Self {
-            vendor_id: selector.vendor_id,
-            product_id: selector.product_id,
-            serial_number: selector.serial_number,
-            interface: selector.interface,
-        }
-    }
-}
-
-impl From<DebugProbeSelector> for probe_rs::probe::DebugProbeSelector {
-    fn from(selector: DebugProbeSelector) -> Self {
-        Self {
-            vendor_id: selector.vendor_id,
-            product_id: selector.product_id,
-            serial_number: selector.serial_number,
-            interface: selector.interface,
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Schema)]
-pub struct AttachRequest {
-    pub chip: Option<String>,
-    pub protocol: Option<WireProtocol>,
-    pub probe: DebugProbeEntry,
-    pub speed: Option<u32>,
-    pub connect_under_reset: bool,
-    pub dry_run: bool,
-    pub allow_erase_all: bool,
-    pub resume_target: bool,
-}
-
-impl From<&AttachRequest> for ProbeOptions {
-    fn from(request: &AttachRequest) -> Self {
-        ProbeOptions {
-            chip: request.chip.clone(),
-            chip_description_path: None,
-            protocol: request.protocol.map(Into::into),
-            non_interactive: true,
-            probe: Some(request.probe.selector().into()),
-            speed: request.speed,
-            connect_under_reset: request.connect_under_reset,
-            cycle_power: false,
-            dry_run: request.dry_run,
-            allow_erase_all: request.allow_erase_all,
-        }
-    }
-}
-
-pub type AttachResponse = RpcResult<AttachResult>;
-
 pub async fn attach(
     ctx: &mut RpcContext,
     _header: VarHeader,
@@ -274,4 +196,83 @@ pub async fn attach(
     }
     let session_id = ctx.set_session(session, common_options.dry_run()).await;
     Ok(AttachResult::Success(session_id))
+}
+
+pub(crate) mod convert {
+    use super::{AttachRequest, DebugProbeEntry, DebugProbeSelector, WireProtocol};
+    use crate::util::common_options::ProbeOptions;
+    use probe_rs::probe::list::{Accessibility, ProbeListItem};
+
+    impl From<ProbeListItem> for DebugProbeEntry {
+        fn from(item: ProbeListItem) -> DebugProbeEntry {
+            let inaccessible = item.accessibility == Accessibility::PermissionDenied;
+            let probe = item.info;
+            DebugProbeEntry {
+                probe_type: probe.probe_type(),
+                inaccessible,
+                identifier: probe.identifier,
+                vendor_id: probe.vendor_id,
+                product_id: probe.product_id,
+                serial_number: probe.serial_number.unwrap_or_default(),
+                interface: probe.interface,
+            }
+        }
+    }
+
+    impl From<WireProtocol> for probe_rs::probe::WireProtocol {
+        fn from(protocol: WireProtocol) -> Self {
+            match protocol {
+                WireProtocol::Jtag => probe_rs::probe::WireProtocol::Jtag,
+                WireProtocol::Swd => probe_rs::probe::WireProtocol::Swd,
+            }
+        }
+    }
+
+    impl From<probe_rs::probe::WireProtocol> for WireProtocol {
+        fn from(protocol: probe_rs::probe::WireProtocol) -> Self {
+            match protocol {
+                probe_rs::probe::WireProtocol::Jtag => WireProtocol::Jtag,
+                probe_rs::probe::WireProtocol::Swd => WireProtocol::Swd,
+            }
+        }
+    }
+
+    impl From<probe_rs::probe::DebugProbeSelector> for DebugProbeSelector {
+        fn from(selector: probe_rs::probe::DebugProbeSelector) -> Self {
+            Self {
+                vendor_id: selector.vendor_id,
+                product_id: selector.product_id,
+                serial_number: selector.serial_number,
+                interface: selector.interface,
+            }
+        }
+    }
+
+    impl From<DebugProbeSelector> for probe_rs::probe::DebugProbeSelector {
+        fn from(selector: DebugProbeSelector) -> Self {
+            Self {
+                vendor_id: selector.vendor_id,
+                product_id: selector.product_id,
+                serial_number: selector.serial_number,
+                interface: selector.interface,
+            }
+        }
+    }
+
+    impl From<&AttachRequest> for ProbeOptions {
+        fn from(request: &AttachRequest) -> Self {
+            ProbeOptions {
+                chip: request.chip.clone(),
+                chip_description_path: None,
+                protocol: request.protocol.map(Into::into),
+                non_interactive: true,
+                probe: Some(request.probe.selector().into()),
+                speed: request.speed,
+                connect_under_reset: request.connect_under_reset,
+                cycle_power: false,
+                dry_run: request.dry_run,
+                allow_erase_all: request.allow_erase_all,
+            }
+        }
+    }
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/probe.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/probe.rs
@@ -3,7 +3,10 @@ use serde::{Deserialize, Serialize};
 
 use std::fmt::Display;
 
-use crate::rpc::{Key, functions::RpcResult};
+use crate::rpc::{
+    Key, Session,
+    functions::{RpcContext, RpcResult},
+};
 
 // Separate from DebugProbeInfo because we can't serialize a &dyn ProbeFactory
 #[derive(Debug, Serialize, Deserialize, Clone, Schema)]
@@ -113,9 +116,7 @@ pub struct AttachRequest {
 pub type AttachResponse = RpcResult<AttachResult>;
 
 use postcard_rpc::header::VarHeader;
-use probe_rs::Session;
 
-use crate::rpc::functions::RpcContext;
 use crate::util::common_options::{OperationError, ProbeOptions};
 
 pub fn list_probes(ctx: &mut RpcContext, _header: VarHeader, _request: ()) -> ListProbesResponse {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/reset.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/reset.rs
@@ -2,12 +2,11 @@ use std::time::Duration;
 
 use crate::rpc::functions::core_ops::WireCoreInformation;
 use crate::rpc::{
-    Key,
+    Key, Session,
     functions::{NoResponse, RpcContext, RpcResult},
 };
 use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;
-use probe_rs::Session;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Schema)]

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/resume.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/resume.rs
@@ -1,10 +1,9 @@
 use crate::rpc::{
-    Key,
+    Key, Session,
     functions::{NoResponse, RpcContext},
 };
 use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;
-use probe_rs::Session;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Schema)]

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/rtt_client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/rtt_client.rs
@@ -1,13 +1,13 @@
 use crate::{
     rpc::{
-        Key,
+        Key, RttClient, Session,
         functions::{NoResponse, RpcContext, RpcError, RpcResult},
     },
-    util::rtt::{RttChannelConfig, RttConfig, client::RttClient},
+    util::rtt::{RttChannelConfig, RttConfig},
 };
 use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;
-use probe_rs::{Session, rtt};
+use probe_rs::rtt;
 use serde::{Deserialize, Serialize};
 
 /// Used to specify which memory regions to scan for the RTT control block.
@@ -64,7 +64,7 @@ pub async fn create_rtt_client(
         ScanRegion::Exact(addr) => rtt::ScanRegion::Exact(addr),
     };
 
-    let client = RttClient::new(
+    let client = crate::util::rtt::client::RttClient::new(
         RttConfig {
             enabled: true,
             channels: request.config,

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/stack_trace.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/stack_trace.rs
@@ -1,19 +1,13 @@
 use std::fmt::{self, Display, Write as _};
-use std::sync::Arc;
 
 use crate::rpc::{
     Key,
     functions::{
-        NoResponse, RpcContext, RpcResult,
+        NoResponse, RpcResult,
         core_ops::{WireRegisterId, WireRegisterValue},
     },
 };
-use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;
-use probe_rs::{CoreInterface, Error, Session};
-use probe_rs_debug::{
-    DebugInfo, DebugRegister, DebugRegisters, StackFrame, VariableCache, exception_handler_for_core,
-};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Schema)]
@@ -33,36 +27,6 @@ pub struct StackTraceFrame {
     pub program_counter: u64,
     pub is_inlined: bool,
     pub location: Option<SourceLocation>,
-}
-
-impl From<&probe_rs_debug::SourceLocation> for SourceLocation {
-    fn from(location: &probe_rs_debug::SourceLocation) -> Self {
-        SourceLocation {
-            file: location.path.to_path().display().to_string(),
-            line: location.line,
-            column: location.column.map(|col| match col {
-                probe_rs_debug::ColumnType::LeftEdge => 1,
-                probe_rs_debug::ColumnType::Column(c) => c,
-            }),
-        }
-    }
-}
-
-impl From<StackFrame> for StackTraceFrame {
-    fn from(frame: StackFrame) -> Self {
-        StackTraceFrame::from(&frame)
-    }
-}
-
-impl From<&StackFrame> for StackTraceFrame {
-    fn from(frame: &StackFrame) -> Self {
-        StackTraceFrame {
-            function_name: frame.function_name.clone(),
-            program_counter: frame.pc.try_into().unwrap_or(0),
-            is_inlined: frame.is_inlined,
-            location: frame.source_location.as_ref().map(SourceLocation::from),
-        }
-    }
 }
 
 impl Display for StackTraceFrame {
@@ -133,6 +97,56 @@ pub struct LoadDebugInfoRequest {
 }
 
 pub type LoadDebugInfoResponse = NoResponse;
+
+/// A single register, in the wire format used by the rich stack trace.
+#[derive(Serialize, Deserialize, Schema, Clone, PartialEq)]
+pub struct WireDebugRegister {
+    pub id: WireRegisterId,
+    pub dwarf_id: Option<u16>,
+    pub value: Option<WireRegisterValue>,
+}
+
+/// A stack frame carrying the full per-frame register state plus frame
+/// metadata. The server owns the `local_variables`/`static_variables`
+/// `VariableCache` trees (keyed by `sessid` + core); the client relays the
+/// server-assigned `id` handles
+/// verbatim so subsequent `scopes`/`variables` requests resolve server-side.
+#[derive(Serialize, Deserialize, Schema, Clone)]
+pub struct RichStackTraceFrame {
+    pub function_name: String,
+    pub program_counter: WireRegisterValue,
+    pub is_inlined: bool,
+    pub location: Option<SourceLocation>,
+    pub frame_base: Option<u64>,
+    pub canonical_frame_address: Option<u64>,
+    pub registers: Vec<WireDebugRegister>,
+    /// Server-assigned frame id (also the DAP `frameId` and the registers
+    /// scope `variablesReference`).
+    pub id: u32,
+}
+
+#[derive(Serialize, Deserialize, Schema, Clone)]
+pub struct RichStackTrace {
+    pub core: u32,
+    pub frames: Vec<RichStackTraceFrame>,
+}
+
+#[derive(Serialize, Deserialize, Schema, Clone)]
+pub struct RichStackTraces {
+    pub cores: Vec<RichStackTrace>,
+}
+
+pub type TakeRichStackTraceResponse = RpcResult<RichStackTraces>;
+
+use std::sync::Arc;
+
+use postcard_rpc::header::VarHeader;
+use probe_rs::{CoreInterface, Error, Session};
+use probe_rs_debug::{
+    DebugInfo, DebugRegisters, StackFrame, VariableCache, exception_handler_for_core,
+};
+
+use crate::rpc::functions::RpcContext;
 
 /// Eagerly load and cache the authoritative server-side [`DebugInfo`] for a
 /// session, keyed by `sessid`, so consumers can resolve source locations
@@ -212,56 +226,6 @@ pub async fn take_stack_trace(
             .collect(),
     })
 }
-
-/// A single register, in the wire format used by the rich stack trace.
-#[derive(Serialize, Deserialize, Schema, Clone, PartialEq)]
-pub struct WireDebugRegister {
-    pub id: WireRegisterId,
-    pub dwarf_id: Option<u16>,
-    pub value: Option<WireRegisterValue>,
-}
-
-impl From<&DebugRegister> for WireDebugRegister {
-    fn from(r: &DebugRegister) -> Self {
-        WireDebugRegister {
-            id: r.core_register.id.into(),
-            dwarf_id: r.dwarf_id,
-            value: r.value.map(WireRegisterValue::from),
-        }
-    }
-}
-
-/// A stack frame carrying the full per-frame register state plus frame
-/// metadata. The server owns the `local_variables`/`static_variables`
-/// `VariableCache` trees (keyed by `sessid` + core); the client relays the
-/// server-assigned `id` handles
-/// verbatim so subsequent `scopes`/`variables` requests resolve server-side.
-#[derive(Serialize, Deserialize, Schema, Clone)]
-pub struct RichStackTraceFrame {
-    pub function_name: String,
-    pub program_counter: WireRegisterValue,
-    pub is_inlined: bool,
-    pub location: Option<SourceLocation>,
-    pub frame_base: Option<u64>,
-    pub canonical_frame_address: Option<u64>,
-    pub registers: Vec<WireDebugRegister>,
-    /// Server-assigned frame id (also the DAP `frameId` and the registers
-    /// scope `variablesReference`).
-    pub id: u32,
-}
-
-#[derive(Serialize, Deserialize, Schema, Clone)]
-pub struct RichStackTrace {
-    pub core: u32,
-    pub frames: Vec<RichStackTraceFrame>,
-}
-
-#[derive(Serialize, Deserialize, Schema, Clone)]
-pub struct RichStackTraces {
-    pub cores: Vec<RichStackTrace>,
-}
-
-pub type TakeRichStackTraceResponse = RpcResult<RichStackTraces>;
 
 /// Like [`take_stack_trace`], but the server owns the per-core
 /// `local_variables`/`static_variables` `VariableCache` trees (cached in
@@ -409,5 +373,50 @@ mod tests {
         let decoded: TakeRichStackTraceRequest = postcard::from_bytes(&encoded).unwrap();
         assert_eq!(decoded.core, Some(0));
         assert_eq!(decoded.stack_frame_limit, 64);
+    }
+}
+
+pub(crate) mod convert {
+    use super::{SourceLocation, StackTraceFrame, WireDebugRegister, WireRegisterValue};
+    use probe_rs_debug::{DebugRegister, StackFrame};
+
+    impl From<&probe_rs_debug::SourceLocation> for SourceLocation {
+        fn from(location: &probe_rs_debug::SourceLocation) -> Self {
+            SourceLocation {
+                file: location.path.to_path().display().to_string(),
+                line: location.line,
+                column: location.column.map(|col| match col {
+                    probe_rs_debug::ColumnType::LeftEdge => 1,
+                    probe_rs_debug::ColumnType::Column(c) => c,
+                }),
+            }
+        }
+    }
+
+    impl From<StackFrame> for StackTraceFrame {
+        fn from(frame: StackFrame) -> Self {
+            StackTraceFrame::from(&frame)
+        }
+    }
+
+    impl From<&StackFrame> for StackTraceFrame {
+        fn from(frame: &StackFrame) -> Self {
+            StackTraceFrame {
+                function_name: frame.function_name.clone(),
+                program_counter: frame.pc.try_into().unwrap_or(0),
+                is_inlined: frame.is_inlined,
+                location: frame.source_location.as_ref().map(SourceLocation::from),
+            }
+        }
+    }
+
+    impl From<&DebugRegister> for WireDebugRegister {
+        fn from(r: &DebugRegister) -> Self {
+            WireDebugRegister {
+                id: r.core_register.id.into(),
+                dwarf_id: r.dwarf_id,
+                value: r.value.map(WireRegisterValue::from),
+            }
+        }
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/stack_trace.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/stack_trace.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display, Write as _};
 
 use crate::rpc::{
-    Key,
+    Key, Session,
     functions::{
         NoResponse, RpcResult,
         core_ops::{WireRegisterId, WireRegisterValue},
@@ -141,7 +141,7 @@ pub type TakeRichStackTraceResponse = RpcResult<RichStackTraces>;
 use std::sync::Arc;
 
 use postcard_rpc::header::VarHeader;
-use probe_rs::{CoreInterface, Error, Session};
+use probe_rs::{CoreInterface, Error};
 use probe_rs_debug::{
     DebugInfo, DebugRegisters, StackFrame, VariableCache, exception_handler_for_core,
 };

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
@@ -2,7 +2,7 @@ use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
 
 use crate::rpc::{
-    Key,
+    Key, RttClient, Session,
     functions::{RpcResult, flash::BootInfo},
     utils::semihosting::SemihostingOptions,
 };
@@ -121,20 +121,17 @@ use std::time::Duration;
 
 use anyhow::Context;
 use postcard_rpc::{header::VarHeader, server::Sender};
-use probe_rs::{BreakpointCause, Core, HaltReason, Session, semihosting::SemihostingCommand};
+use probe_rs::{BreakpointCause, Core, HaltReason, semihosting::SemihostingCommand};
 
-use crate::{
-    rpc::{
-        functions::{
-            ListTestsEndpoint, RpcContext, RpcSpawnContext, RunTestEndpoint, WireTxImpl,
-            monitor::{MonitorSender, RttPoller, SemihostingEvent},
-        },
-        utils::{
-            run_loop::{ReturnReason, RunLoop, VectorCatchConfig},
-            semihosting::SemihostingFileManager,
-        },
+use crate::rpc::{
+    functions::{
+        ListTestsEndpoint, RpcContext, RpcSpawnContext, RunTestEndpoint, WireTxImpl,
+        monitor::{MonitorSender, RttPoller, SemihostingEvent},
     },
-    util::rtt::client::RttClient,
+    utils::{
+        run_loop::{ReturnReason, RunLoop, VectorCatchConfig},
+        semihosting::SemihostingFileManager,
+    },
 };
 
 pub async fn list_tests(

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
@@ -1,25 +1,10 @@
-use std::time::Duration;
-
-use anyhow::Context;
-use postcard_rpc::{header::VarHeader, server::Sender};
 use postcard_schema::Schema;
-use probe_rs::{BreakpointCause, Core, HaltReason, Session, semihosting::SemihostingCommand};
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    rpc::{
-        Key,
-        functions::{
-            ListTestsEndpoint, RpcContext, RpcResult, RpcSpawnContext, RunTestEndpoint, WireTxImpl,
-            flash::BootInfo,
-            monitor::{MonitorSender, RttPoller, SemihostingEvent},
-        },
-        utils::{
-            run_loop::{ReturnReason, RunLoop, VectorCatchConfig},
-            semihosting::{SemihostingFileManager, SemihostingOptions},
-        },
-    },
-    util::rtt::client::RttClient,
+use crate::rpc::{
+    Key,
+    functions::{RpcResult, flash::BootInfo},
+    utils::semihosting::SemihostingOptions,
 };
 
 #[derive(Debug, Serialize, Deserialize, Schema)]
@@ -112,6 +97,46 @@ pub struct ListTestsRequest {
 
 pub type ListTestsResponse = RpcResult<Tests>;
 
+#[derive(Serialize, Deserialize, Schema)]
+pub struct RunTestRequest {
+    pub sessid: Key<Session>,
+    pub test: Test,
+    /// RTT client if used.
+    pub rtt_client: Option<Key<RttClient>>,
+    pub semihosting_options: SemihostingOptions,
+}
+
+pub type RunTestResponse = RpcResult<TestResult>;
+
+#[derive(Serialize, Deserialize, Schema)]
+pub struct TestKickoffRequest {
+    pub sessid: Key<Session>,
+    pub core: u32,
+    pub address: u64,
+}
+
+pub type TestKickoffResponse = RpcResult<()>;
+
+use std::time::Duration;
+
+use anyhow::Context;
+use postcard_rpc::{header::VarHeader, server::Sender};
+use probe_rs::{BreakpointCause, Core, HaltReason, Session, semihosting::SemihostingCommand};
+
+use crate::{
+    rpc::{
+        functions::{
+            ListTestsEndpoint, RpcContext, RpcSpawnContext, RunTestEndpoint, WireTxImpl,
+            monitor::{MonitorSender, RttPoller, SemihostingEvent},
+        },
+        utils::{
+            run_loop::{ReturnReason, RunLoop, VectorCatchConfig},
+            semihosting::SemihostingFileManager,
+        },
+    },
+    util::rtt::client::RttClient,
+};
+
 pub async fn list_tests(
     mut ctx: RpcSpawnContext,
     header: VarHeader,
@@ -189,17 +214,6 @@ fn list_tests_impl(
         }
     }
 }
-
-#[derive(Serialize, Deserialize, Schema)]
-pub struct RunTestRequest {
-    pub sessid: Key<Session>,
-    pub test: Test,
-    /// RTT client if used.
-    pub rtt_client: Option<Key<RttClient>>,
-    pub semihosting_options: SemihostingOptions,
-}
-
-pub type RunTestResponse = RpcResult<TestResult>;
 
 pub async fn run_test(
     mut ctx: RpcSpawnContext,
@@ -289,15 +303,6 @@ fn run_test_impl(
 }
 
 // -- test kickoff (DAP REPL `test run`) --------------------------------------
-
-#[derive(Serialize, Deserialize, Schema)]
-pub struct TestKickoffRequest {
-    pub sessid: Key<Session>,
-    pub core: u32,
-    pub address: u64,
-}
-
-pub type TestKickoffResponse = RpcResult<()>;
 
 /// Kick off a single embedded-test case from the DAP REPL: run the core until
 /// it halts on the `GetCommandLine` semihosting call, write the test address

--- a/probe-rs-tools/src/bin/probe-rs/rpc/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/mod.rs
@@ -14,10 +14,35 @@ use postcard_schema::{
     Schema,
     schema::{DataModelType, NamedType, NamedValue},
 };
-use probe_rs::{Session, config::Registry};
+use probe_rs::config::Registry;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
+
+pub struct Session;
+pub struct FlashLoader;
+pub struct RttClient;
+pub struct TempFileHandle;
+
+pub trait ObjectMarker: 'static {
+    type Object: Any + Send;
+}
+
+impl ObjectMarker for Session {
+    type Object = probe_rs::Session;
+}
+
+impl ObjectMarker for FlashLoader {
+    type Object = probe_rs::flashing::FlashLoader;
+}
+
+impl ObjectMarker for RttClient {
+    type Object = crate::util::rtt::client::RttClient;
+}
+
+impl ObjectMarker for TempFileHandle {
+    type Object = tempfile::NamedTempFile;
+}
 
 pub mod client;
 pub mod debug_state;
@@ -86,14 +111,6 @@ impl<T> Key<T> {
             marker: PhantomData,
         }
     }
-
-    #[cfg(feature = "remote")]
-    pub unsafe fn cast<U>(&self) -> Key<U> {
-        Key {
-            key: self.key,
-            marker: PhantomData,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -139,14 +156,14 @@ impl ObjectStorage {
         }
     }
 
-    pub fn store_object<T: Any + Send>(&mut self, obj: T) -> Key<T> {
+    pub fn store_object<M: ObjectMarker>(&mut self, obj: M::Object) -> Key<M> {
         let key = Key::new();
         self.storage.insert(key.key, Arc::new(Mutex::new(obj)));
         key
     }
 
     /// Ensures locks on `ObjectStorage` are held for as short a time as possible.
-    pub fn cell<T: Any + Send>(&self, key: Key<T>) -> ObjectStorageSlot<T> {
+    pub fn cell<M: ObjectMarker>(&self, key: Key<M>) -> ObjectStorageSlot<M::Object> {
         let obj = self.storage.get(&key.key).unwrap();
         ObjectStorageSlot {
             obj: obj.clone(),
@@ -180,29 +197,29 @@ impl ConnectionState {
         }
     }
 
-    pub async fn store_object<T: Any + Send>(&mut self, obj: T) -> Key<T> {
+    pub async fn store_object<M: ObjectMarker>(&mut self, obj: M::Object) -> Key<M> {
         self.object_storage.lock().await.store_object(obj)
     }
 
-    pub async fn object_mut<T: Any + Send>(
+    pub async fn object_mut<M: ObjectMarker>(
         &self,
-        key: Key<T>,
-    ) -> impl DerefMut<Target = T> + Send + use<T> {
+        key: Key<M>,
+    ) -> impl DerefMut<Target = M::Object> + Send + use<M> {
         // MUST be two separate statements so that the lock is released.
         let locked_cell = self.object_storage.lock().await.cell(key);
         locked_cell.get().await
     }
 
-    pub fn object_mut_blocking<T: Any + Send>(
+    pub fn object_mut_blocking<M: ObjectMarker>(
         &self,
-        key: Key<T>,
-    ) -> impl DerefMut<Target = T> + Send + use<T> {
+        key: Key<M>,
+    ) -> impl DerefMut<Target = M::Object> + Send + use<M> {
         // MUST be two separate statements so that the lock is released.
         let locked_cell = self.object_storage.blocking_lock().cell(key);
         locked_cell.get_blocking()
     }
 
-    pub async fn set_session(&mut self, session: Session, dry_run: bool) -> Key<Session> {
+    pub async fn set_session(&mut self, session: probe_rs::Session, dry_run: bool) -> Key<Session> {
         let key = self.store_object(session).await;
         if dry_run {
             self.dry_run_sessions.insert(key);
@@ -234,7 +251,7 @@ impl SessionState<'_> {
     }
 
     /// Blocks while other users hold the session.
-    pub fn session_blocking(&self) -> impl DerefMut<Target = Session> + Send + use<> {
+    pub fn session_blocking(&self) -> impl DerefMut<Target = probe_rs::Session> + Send + use<> {
         // MUST be two separate statements so that the lock is released.
         let obj_cell = self.object_storage().cell(self.session);
         obj_cell.get_blocking()

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -25,6 +25,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::cmd::run::{EmbeddedTestElfInfo, MonitoringOptions};
 use crate::rpc::Key;
+use crate::rpc::RttClient;
 use crate::rpc::functions::monitor::{ChannelInfo, MonitorExitReason};
 use crate::rpc::functions::stack_trace::StackTraceFrame;
 use crate::rpc::utils::run_loop::VectorCatchConfig;
@@ -50,7 +51,7 @@ use crate::{
         common_options::{BinaryDownloadOptions, ProbeOptions},
         flash::CliProgressBars,
         logging,
-        rtt::{DefmtProcessor, DefmtState, RttChannelConfig, RttDecoder, client::RttClient},
+        rtt::{DefmtProcessor, DefmtState, RttChannelConfig, RttDecoder},
     },
 };
 


### PR DESCRIPTION
## Summary

This is the first of six stacked pull requests that split the RPC interface out of the `probe-rs` binary into two reusable crates, so that other programs can build specialised clients.

This pull request changes no behaviour. It moves every conversion between a `probe-rs` domain type and an RPC wire type out of the wire type modules and into a `convert` submodule beside the handlers. The wire types themselves do not move yet.

The conversions have to move first. A wire type and a conversion for a foreign type cannot live in the same crate once the wire types leave the binary, because of the orphan rule. Doing this separately keeps the later move commits small and readable.

## The stack

Review in order. Each pull request targets the one before it.

1. **This pull request** — move the domain conversions
2. Separate the CLI wire types
3. Remove the target registry from the client
4. Return a typed error from the client
5. Add the `probe-rs-rpc` crate
6. Add the `probe-rs-rpc-client` crate and prepare both for publication

## Test plan

- [x] `just all`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo +1.89 check --all-features`

No changelog fragment: this pull request changes no user visible behaviour.
