### PR TITLE
Move the CLI oriented wire types into the RPC module

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
@@ -2,9 +2,9 @@ use std::path::PathBuf;
 
 use time::UtcOffset;
 
-use crate::FormatOptions;
 use crate::cmd::run::{MonitoringOptions, NormalRunOptions};
 use crate::rpc::client::RpcClient;
+use crate::rpc::functions::format::FormatOptions;
 use crate::rpc::functions::monitor::MonitorMode;
 use crate::rpc::utils::run_loop::VectorCatchConfig;
 use crate::util::cli::{self, FileMetadata, parse_metadata, rtt_client};

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -7,10 +7,8 @@ use probe_rs::probe::WireProtocol;
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
-use crate::util::{
-    logging::LevelFilter,
-    rtt::{ChannelMode, DataFormat},
-};
+use crate::rpc::functions::rtt_config::{ChannelMode, DataFormat};
+use crate::util::logging::LevelFilter;
 
 use super::rttui::tab::TabConfig;
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -23,6 +23,7 @@ use std::{
 };
 use time::{OffsetDateTime, UtcOffset};
 
+use crate::rpc::functions::format::{FormatKind, FormatOptions};
 use crate::util::cargo::target_instruction_set;
 use crate::util::common_options::{BinaryDownloadOptions, OperationError, ProbeOptions};
 use crate::util::flash::{build_loader, run_flash_download};
@@ -30,7 +31,7 @@ use crate::util::logging::setup_logging;
 use crate::util::rtt::client::RttClient;
 use crate::util::rtt::{RttChannelConfig, RttConfig};
 use crate::util::{cargo::build_artifact, common_options::CargoOptions, logging};
-use crate::{Config, FormatKind, FormatOptions, parse_and_resolve_cli_args};
+use crate::{Config, parse_and_resolve_cli_args};
 
 #[derive(Debug, clap::Parser)]
 #[clap(

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -24,12 +24,12 @@ use std::{
 use time::{OffsetDateTime, UtcOffset};
 
 use crate::rpc::functions::format::{FormatKind, FormatOptions};
+use crate::rpc::functions::rtt_config::RttChannelConfig;
 use crate::util::cargo::target_instruction_set;
 use crate::util::common_options::{BinaryDownloadOptions, OperationError, ProbeOptions};
 use crate::util::flash::{build_loader, run_flash_download};
 use crate::util::logging::setup_logging;
-use crate::util::rtt::client::RttClient;
-use crate::util::rtt::{RttChannelConfig, RttConfig};
+use crate::util::rtt::{RttConfig, client::RttClient};
 use crate::util::{cargo::build_artifact, common_options::CargoOptions, logging};
 use crate::{Config, parse_and_resolve_cli_args};
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -18,9 +18,8 @@ use time::UtcOffset;
 
 use crate::{
     cmd::cargo_embed::rttui::{channel::ChannelData, tab::TabConfig},
-    util::rtt::{
-        DataFormat, DefmtProcessor, DefmtState, RttChannelConfig, RttDecoder, client::RttClient,
-    },
+    rpc::functions::rtt_config::{DataFormat, RttChannelConfig},
+    util::rtt::{DefmtProcessor, DefmtState, RttDecoder, client::RttClient},
 };
 
 use super::super::config;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -53,7 +53,7 @@ struct CliOptions {
     pub download_options: BinaryDownloadOptions,
 
     #[command(flatten)]
-    pub format_options: crate::FormatOptions,
+    pub format_options: crate::rpc::functions::format::FormatOptions,
 
     /// Remote host to connect to
     #[cfg(feature = "remote")]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/backend/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/backend/mod.rs
@@ -10,7 +10,7 @@ pub mod rpc;
 
 use probe_rs::CoreStatus;
 
-use crate::util::rtt::DataFormat;
+use crate::rpc::functions::rtt_config::DataFormat;
 
 /// UI event produced by semihosting handling, to be replayed on the DAP
 /// adapter (RTT window open, console/RTT output). Backend-agnostic mirror of

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -18,7 +18,7 @@ use crate::cmd::dap_server::{
     },
 };
 use crate::rpc::functions::breakpoints::SourceBreakpointLocation;
-use crate::util::rtt;
+use crate::rpc::functions::rtt_config::DataFormat;
 use anyhow::{Context, Result, anyhow};
 use base64::{Engine as _, engine::general_purpose as base64_engine};
 use dap_types::*;
@@ -1611,7 +1611,7 @@ impl DebugAdapter {
         &mut self,
         channel_number: u32,
         channel_name: String,
-        data_format: rtt::DataFormat,
+        data_format: DataFormat,
     ) -> bool {
         let Ok(event_body) = serde_json::to_value(RttChannelEventBody {
             channel_number,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/dap_types.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/dap_types.rs
@@ -1,6 +1,6 @@
 // use crate::dap_types2 as debugserver_types;
 use crate::cmd::dap_server::DebuggerError;
-use crate::util::rtt;
+use crate::rpc::functions::rtt_config::DataFormat;
 use num_traits::Num;
 use parse_int::parse;
 use serde::{Deserialize, Serialize};
@@ -43,7 +43,7 @@ pub struct RttWindowOpenedArguments {
 pub struct RttChannelEventBody {
     pub channel_number: u32,
     pub channel_name: String,
-    pub data_format: rtt::DataFormat,
+    pub data_format: DataFormat,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/configuration.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/configuration.rs
@@ -1,6 +1,7 @@
+use crate::cmd::dap_server::DebuggerError;
+use crate::rpc::functions::format::FormatOptions;
 use crate::util::common_options::ProbeOptions;
 use crate::util::rtt;
-use crate::{FormatOptions, cmd::dap_server::DebuggerError};
 use anyhow::{Result, anyhow};
 use probe_rs::probe::{DebugProbeSelector, WireProtocol};
 use serde::{Deserialize, Serialize};

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -31,7 +31,8 @@ use probe_rs_debug::SourceLocation;
 use std::{any::Any, env::set_current_dir, path::Path};
 use time::UtcOffset;
 
-use crate::util::rtt::{self, DataFormat};
+use crate::rpc::functions::rtt_config::DataFormat;
+use crate::util::rtt::RttConfig;
 
 /// The supported breakpoint types
 #[derive(Clone, Debug, PartialEq)]
@@ -255,7 +256,7 @@ impl SessionData {
     async fn ensure_rtt_client(
         &mut self,
         cd_idx: usize,
-        rtt_config: &rtt::RttConfig,
+        rtt_config: &RttConfig,
     ) -> Result<Key<RttClient>> {
         if let Some(handle) = self.core_data[cd_idx].rtt_remote_handle {
             return Ok(handle);
@@ -509,7 +510,7 @@ impl SessionData {
         debug_adapter: &mut DebugAdapter,
         cd_idx: usize,
         program_binary: Option<&Path>,
-        rtt_config: &rtt::RttConfig,
+        rtt_config: &RttConfig,
         timestamp_offset: UtcOffset,
     ) -> Result<()> {
         if self.core_data[cd_idx].rtt_connection.is_some() {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -4,31 +4,27 @@ use super::{
 };
 use crate::cmd::dap_server::debug_adapter::dap::dap_types::PromptKind;
 use crate::cmd::dap_server::server::debug_rtt;
-use crate::util::rtt::{DefmtProcessor, DefmtState, RttDecoder};
-use crate::{
-    FormatKind,
-    cmd::{
-        dap_server::{
-            DebuggerError,
-            backend::rpc::{CorePerAttachInfo, RpcBackend, SessionTargetMetadata, rpc_err},
-            debug_adapter::dap::{
-                adapter::DebugAdapter,
-                core_status::DapStatus,
-                dap_types::{ContinuedEventBody, MessageSeverity, Source, StoppedEventBody},
-                repl_commands::{REPL_COMMANDS, embedded_test::EMBEDDED_TEST},
-            },
-        },
-        run::EmbeddedTestElfInfo,
-    },
-    rpc::{
-        Key, RttClient,
-        client::RpcClient,
-        functions::{
-            breakpoints::SourceBreakpointLocation, rtt_client::ScanRegion as WireScanRegion,
+use crate::cmd::{
+    dap_server::{
+        DebuggerError,
+        backend::rpc::{CorePerAttachInfo, RpcBackend, SessionTargetMetadata, rpc_err},
+        debug_adapter::dap::{
+            adapter::DebugAdapter,
+            core_status::DapStatus,
+            dap_types::{ContinuedEventBody, MessageSeverity, Source, StoppedEventBody},
+            repl_commands::{REPL_COMMANDS, embedded_test::EMBEDDED_TEST},
         },
     },
-    util::cli::attach_probe as attach_probe_rpc,
+    run::EmbeddedTestElfInfo,
 };
+use crate::rpc::functions::format::FormatKind;
+use crate::rpc::{
+    Key, RttClient,
+    client::RpcClient,
+    functions::{breakpoints::SourceBreakpointLocation, rtt_client::ScanRegion as WireScanRegion},
+};
+use crate::util::cli::attach_probe as attach_probe_rpc;
+use crate::util::rtt::{DefmtProcessor, DefmtState, RttDecoder};
 use anyhow::{Result, anyhow};
 use probe_rs::{BreakpointCause, CoreStatus, HaltReason, rtt::find_rtt_control_block_in_raw_file};
 use probe_rs_debug::SourceLocation;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/download.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/download.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::rpc::client::RpcClient;
 
-use crate::FormatOptions;
+use crate::rpc::functions::format::FormatOptions;
 use crate::util::cli;
 use crate::util::common_options::BinaryDownloadOptions;
 use crate::util::common_options::ProbeOptions;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -6,7 +6,7 @@ use crate::rpc::functions::rtt_client::ScanRegion;
 use crate::rpc::functions::test::{Test, TestDefinition};
 use crate::rpc::utils::run_loop::VectorCatchConfig;
 
-use crate::FormatOptions;
+use crate::rpc::functions::format::FormatOptions;
 use crate::util::cli::{self, parse_metadata, rtt_client};
 use crate::util::common_options::{BinaryDownloadOptions, ProbeOptions};
 use crate::util::rtt::ChannelMode;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -7,9 +7,9 @@ use crate::rpc::functions::test::{Test, TestDefinition};
 use crate::rpc::utils::run_loop::VectorCatchConfig;
 
 use crate::rpc::functions::format::FormatOptions;
+use crate::rpc::functions::rtt_config::ChannelMode;
 use crate::util::cli::{self, parse_metadata, rtt_client};
 use crate::util::common_options::{BinaryDownloadOptions, ProbeOptions};
-use crate::util::rtt::ChannelMode;
 
 use anyhow::{Context, anyhow};
 use libtest_mimic::{Arguments, FormatSetting};

--- a/probe-rs-tools/src/bin/probe-rs/cmd/verify.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/verify.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
-use crate::FormatOptions;
 use crate::rpc::client::RpcClient;
 use crate::rpc::functions::flash::VerifyResult;
+use crate::rpc::functions::format::FormatOptions;
 use crate::util::cli;
 use crate::util::common_options::ProbeOptions;
 use crate::util::flash::CliProgressBars;

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -10,18 +10,13 @@ use std::path::Path;
 use std::{ffi::OsString, path::PathBuf};
 
 use anyhow::{Context, Result};
-use clap::{ArgMatches, CommandFactory, FromArgMatches, ValueEnum};
+use clap::{ArgMatches, CommandFactory, FromArgMatches};
 use colored::Colorize;
 use figment::Figment;
 use figment::providers::{Data, Format as _, Json, Toml, Yaml};
 use figment::value::Value;
 use itertools::Itertools;
-use postcard_schema::Schema;
-use probe_rs::flashing::{
-    BinLoader, BinOptions, ElfLoader, ElfOptions, HexLoader, ImageLoader, Uf2Loader,
-};
-use probe_rs::{Target, probe::list::Lister};
-use probe_rs_espressif::image_format::IdfLoader;
+use probe_rs::probe::list::Lister;
 use report::Report;
 use serde::{Deserialize, Serialize};
 use time::{OffsetDateTime, UtcOffset};
@@ -29,8 +24,6 @@ use time::{OffsetDateTime, UtcOffset};
 use crate::rpc::client::{RemoteParams, RpcClient};
 use crate::rpc::functions::RpcApp;
 use crate::util::logging::setup_logging;
-use crate::util::parse_u32;
-use crate::util::parse_u64;
 
 const MAX_LOG_FILES: usize = 20;
 
@@ -226,245 +219,6 @@ impl Subcommand {
 pub(crate) struct CoreOptions {
     #[clap(long, default_value = "0")]
     core: usize,
-}
-
-#[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default, Schema)]
-#[serde(default)]
-pub struct BinaryCliOptions {
-    /// The address in memory where the binary will be put at. This is only considered when `bin` is selected as the format.
-    #[clap(long, value_parser = parse_u64, help_heading = "DOWNLOAD CONFIGURATION / BIN IMAGE")]
-    base_address: Option<u64>,
-    /// The number of bytes to skip at the start of the binary file. This is only considered when `bin` is selected as the format.
-    #[clap(long, value_parser = parse_u32, default_value = "0", help_heading = "DOWNLOAD CONFIGURATION / BIN IMAGE")]
-    skip: u32,
-}
-
-/// Supported flash frequencies
-///
-/// Note that not all frequencies are supported by each target device.
-#[derive(
-    Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ValueEnum, Schema,
-)]
-#[serde(rename_all = "lowercase")]
-pub enum EspFlashFrequency {
-    /// 12 MHz
-    #[serde(rename = "12MHz")]
-    _12Mhz,
-    /// 15 MHz
-    #[serde(rename = "15MHz")]
-    _15Mhz,
-    /// 16 MHz
-    #[serde(rename = "16MHz")]
-    _16Mhz,
-    /// 20 MHz
-    #[serde(rename = "20MHz")]
-    _20Mhz,
-    /// 24 MHz
-    #[serde(rename = "24MHz")]
-    _24Mhz,
-    /// 26 MHz
-    #[serde(rename = "26MHz")]
-    _26Mhz,
-    /// 30 MHz
-    #[serde(rename = "30MHz")]
-    _30Mhz,
-    /// 40 MHz
-    #[serde(rename = "40MHz")]
-    #[default]
-    _40Mhz,
-    /// 48 MHz
-    #[serde(rename = "48MHz")]
-    _48Mhz,
-    /// 60 MHz
-    #[serde(rename = "60MHz")]
-    _60Mhz,
-    /// 80 MHz
-    #[serde(rename = "80MHz")]
-    _80Mhz,
-}
-
-impl From<EspFlashFrequency> for espflash::flasher::FlashFrequency {
-    fn from(freq: EspFlashFrequency) -> Self {
-        match freq {
-            EspFlashFrequency::_12Mhz => espflash::flasher::FlashFrequency::_12Mhz,
-            EspFlashFrequency::_15Mhz => espflash::flasher::FlashFrequency::_15Mhz,
-            EspFlashFrequency::_16Mhz => espflash::flasher::FlashFrequency::_16Mhz,
-            EspFlashFrequency::_20Mhz => espflash::flasher::FlashFrequency::_20Mhz,
-            EspFlashFrequency::_24Mhz => espflash::flasher::FlashFrequency::_24Mhz,
-            EspFlashFrequency::_26Mhz => espflash::flasher::FlashFrequency::_26Mhz,
-            EspFlashFrequency::_30Mhz => espflash::flasher::FlashFrequency::_30Mhz,
-            EspFlashFrequency::_40Mhz => espflash::flasher::FlashFrequency::_40Mhz,
-            EspFlashFrequency::_48Mhz => espflash::flasher::FlashFrequency::_48Mhz,
-            EspFlashFrequency::_60Mhz => espflash::flasher::FlashFrequency::_60Mhz,
-            EspFlashFrequency::_80Mhz => espflash::flasher::FlashFrequency::_80Mhz,
-        }
-    }
-}
-
-/// Supported flash modes
-#[derive(
-    Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ValueEnum, Schema,
-)]
-#[serde(rename_all = "lowercase")]
-pub enum EspFlashMode {
-    /// Quad I/O (4 pins used for address & data)
-    Qio,
-    /// Quad Output (4 pins used for data)
-    Qout,
-    /// Dual I/O (2 pins used for address & data)
-    #[default]
-    Dio,
-    /// Dual Output (2 pins used for data)
-    Dout,
-}
-
-impl From<EspFlashMode> for espflash::flasher::FlashMode {
-    fn from(mode: EspFlashMode) -> Self {
-        match mode {
-            EspFlashMode::Qio => espflash::flasher::FlashMode::Qio,
-            EspFlashMode::Qout => espflash::flasher::FlashMode::Qout,
-            EspFlashMode::Dio => espflash::flasher::FlashMode::Dio,
-            EspFlashMode::Dout => espflash::flasher::FlashMode::Dout,
-        }
-    }
-}
-
-#[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default, Schema)]
-#[serde(default)]
-pub struct IdfCliOptions {
-    /// The idf bootloader path
-    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION / ESP-IDF IMAGE")]
-    idf_bootloader: Option<String>,
-    /// The idf partition table path
-    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION / ESP-IDF IMAGE")]
-    idf_partition_table: Option<String>,
-    /// The idf target app partition
-    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION / ESP-IDF IMAGE")]
-    idf_target_app_partition: Option<String>,
-    /// Flash SPI mode
-    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION / ESP-IDF IMAGE")]
-    idf_flash_mode: Option<EspFlashMode>,
-    /// Flash SPI frequency
-    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION / ESP-IDF IMAGE")]
-    idf_flash_freq: Option<EspFlashFrequency>,
-}
-
-#[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default, Schema)]
-#[serde(default)]
-pub struct ElfCliOptions {
-    /// Section name to skip flashing. This option may be specified multiple times, and is only
-    /// considered when `elf` is selected as the format.
-    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION / ELF IMAGE")]
-    skip_section: Vec<String>,
-}
-
-#[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default, Schema)]
-#[serde(default)]
-pub struct FormatOptions {
-    /// The format of the firmware image.
-    #[clap(
-        value_enum,
-        ignore_case = true,
-        default_value_t = FormatKind::Target,
-        long,
-        help_heading = "DOWNLOAD CONFIGURATION"
-    )]
-    pub binary_format: FormatKind,
-
-    #[clap(flatten)]
-    pub bin_options: BinaryCliOptions,
-
-    #[clap(flatten)]
-    pub idf_options: IdfCliOptions,
-
-    #[clap(flatten)]
-    pub elf_options: ElfCliOptions,
-}
-
-/// A finite list of all the available binary formats probe-rs understands.
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, ValueEnum, Schema)]
-pub enum FormatKind {
-    /// The image format is determined by the target chip's preference, which is usually ELF.
-    #[default]
-    Target,
-
-    /// The image is in binary format. This means that the file contains the contents of the flash 1:1.
-    #[value(alias("binary"))]
-    Bin,
-
-    /// The image is in Intel HEX format. For more information, see https://en.wikipedia.org/wiki/Intel_HEX
-    #[value(aliases(["ihex", "intelhex"]))]
-    Hex,
-
-    /// The image is in the Executable and Linkable Format (ELF). For more information, see https://en.wikipedia.org/wiki/Executable_and_Linkable_Format
-    Elf,
-
-    /// The image is an ELF file containing an ESP-IDF bootloader compatible application. For more information, see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/app_image_format.html#app-image-structures
-    #[value(aliases(["esp-idf", "espidf"]))]
-    Idf,
-
-    /// The image is in the Universal Flash Storage (UF2) format. For more information, see https://github.com/microsoft/uf2
-    Uf2,
-}
-
-impl FormatKind {
-    /// Creates a new Format from an optional string.
-    ///
-    /// If the string is `None`, the default format is returned.
-    pub fn from_optional(s: Option<&str>) -> Result<Self, String> {
-        match s {
-            Some(format) => Self::from_str(format, true),
-            None => Ok(Self::Elf),
-        }
-    }
-
-    /// Replaces `FormatKind::Target` with a default format based on the target.
-    pub fn resolve(self, target: &Target) -> FormatKind {
-        self.resolve_default_format(target.default_format.as_deref())
-    }
-
-    /// Replaces `FormatKind::Target` using a server-provided default format string.
-    pub fn resolve_default_format(self, default_format: Option<&str>) -> FormatKind {
-        if self == FormatKind::Target {
-            FormatKind::from_optional(default_format)
-                .expect("Failed to parse a default binary format. This shouldn't happen.")
-        } else {
-            self
-        }
-    }
-}
-
-impl FormatOptions {
-    /// If a format is provided, use it.
-    /// If a target has a preferred format, we use that.
-    /// Finally, if neither of the above cases are true, we default to [`FormatKind::default()`].
-    fn image_loader(&self, target: &Target) -> Box<dyn ImageLoader> {
-        match self.binary_format.resolve(target) {
-            FormatKind::Target => unreachable!(),
-            FormatKind::Bin => Box::new(BinLoader(BinOptions {
-                base_address: self.bin_options.base_address,
-                skip: self.bin_options.skip,
-            })),
-
-            FormatKind::Hex => Box::new(HexLoader),
-            FormatKind::Elf => Box::new(ElfLoader(ElfOptions {
-                skip_sections: self.elf_options.skip_section.clone(),
-            })),
-            FormatKind::Uf2 => Box::new(Uf2Loader),
-
-            FormatKind::Idf => Box::new(IdfLoader {
-                bootloader: self.idf_options.idf_bootloader.as_ref().map(PathBuf::from),
-                partition_table: self
-                    .idf_options
-                    .idf_partition_table
-                    .as_ref()
-                    .map(PathBuf::from),
-                target_app_partition: self.idf_options.idf_target_app_partition.clone(),
-                flash_frequency: self.idf_options.idf_flash_freq.map(From::from),
-                flash_mode: self.idf_options.idf_flash_mode.map(From::from),
-            }),
-        }
-    }
 }
 
 /// Determine the default location for the logfile
@@ -811,7 +565,6 @@ fn load_config() -> anyhow::Result<Config> {
 #[cfg(test)]
 mod test {
     use crate::Cli;
-    use crate::FormatKind;
     use crate::multicall_check;
 
     /// clap finds duplicate argument names only in a debug build, and only when it
@@ -844,22 +597,6 @@ mod test {
             )
             .unwrap(),
             os_strs(&["cargo-flash", "--chip", "esp32c2"])
-        );
-    }
-
-    #[test]
-    fn format_kind_resolve_default_format_uses_server_hint() {
-        assert_eq!(
-            FormatKind::Target.resolve_default_format(Some("idf")),
-            FormatKind::Idf
-        );
-        assert_eq!(
-            FormatKind::Target.resolve_default_format(None),
-            FormatKind::Elf
-        );
-        assert_eq!(
-            FormatKind::Bin.resolve_default_format(Some("elf")),
-            FormatKind::Bin
         );
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -41,10 +41,10 @@ use crate::rpc::{
         ReadMemory8Endpoint, ReadMemory16Endpoint, ReadMemory32Endpoint, ReadMemory64Endpoint,
         ResetCoreAndHaltEndpoint, ResetCoreEndpoint, ResolveSourceBreakpointsEndpoint,
         ResolveSourceLocationsEndpoint, ResumeAllCoresEndpoint, RpcError, RpcResult,
-        RttDownEndpoint, RunTestEndpoint, ScopesEndpoint, SelectProbeEndpoint, SetVariableEndpoint,
-        TakeRichStackTraceEndpoint, TakeStackTraceEndpoint, TargetInfoDataTopic,
-        TargetInfoEndpoint, TargetMetadataEndpoint, TempFileDataEndpoint, TestKickoffEndpoint,
-        TokioSpawner, VariablesEndpoint, VerifyEndpoint, WriteMemory8Endpoint,
+        RttDownEndpoint, RttTopic, RunTestEndpoint, ScopesEndpoint, SelectProbeEndpoint,
+        SemihostingTopic, SetVariableEndpoint, TakeRichStackTraceEndpoint, TakeStackTraceEndpoint,
+        TargetInfoDataTopic, TargetInfoEndpoint, TargetMetadataEndpoint, TempFileDataEndpoint,
+        TestKickoffEndpoint, TokioSpawner, VariablesEndpoint, VerifyEndpoint, WriteMemory8Endpoint,
         WriteMemory16Endpoint, WriteMemory32Endpoint, WriteMemory64Endpoint,
         breakpoints::{
             BreakpointResolution, ResolveSourceBreakpointsRequest, ResolveSourceLocationsRequest,
@@ -71,7 +71,10 @@ use crate::rpc::{
         },
         info::{InfoEvent, TargetInfoRequest, TargetMetadataRequest, WireSessionTargetMetadata},
         memory::{ReadBytesRequest, ReadMemoryRequest, WriteMemoryRequest},
-        monitor::{MonitorExitReason, MonitorMode, MonitorOptions, MonitorRequest},
+        monitor::{
+            MonitorExitReason, MonitorMode, MonitorOptions, MonitorRequest, RttEvent,
+            SemihostingEvent,
+        },
         probe::{
             AttachRequest, AttachResult, DebugProbeEntry, DebugProbeSelector, SelectProbeRequest,
             SelectProbeResult,
@@ -82,6 +85,8 @@ use crate::rpc::{
             CreateRttClientRequest, PollRttUpRequest, RttChannelRequest, RttChannels,
             RttClientData, RttDownRequest, RttPollResult, ScanRegion,
         },
+        rtt_config::RttChannelConfig,
+        semihosting_options::SemihostingOptions,
         stack_trace::{
             LoadDebugInfoRequest, RichStackTraces, StackTraces, TakeRichStackTraceRequest,
             TakeStackTraceRequest,
@@ -90,9 +95,7 @@ use crate::rpc::{
     },
     transport::memory::{PostcardReceiver, PostcardSender, WireRx, WireTx},
     upload_cache::{ContentHash, ResolvedUpload, UploadCache},
-    utils::semihosting::SemihostingOptions,
 };
-use crate::util::{cli::MonitorEvent, rtt::RttChannelConfig};
 
 /// Host and optional authentication token identifying a remote probe-rs RPC
 /// server. `None` selects a local, in-process server.
@@ -1452,6 +1455,45 @@ pub(crate) trait MultiSubscription {
                     }
                 }
             }
+        }
+    }
+}
+
+pub(crate) enum MonitorEvent {
+    Rtt(RttEvent),
+    Semihosting(SemihostingEvent),
+}
+
+impl MultiTopic for MonitorEvent {
+    type Message = Self;
+    type Subscription = MonitorSubscription;
+
+    async fn subscribe<E>(
+        client: &HostClient<E>,
+        depth: usize,
+    ) -> Result<Self::Subscription, MultiSubscribeError>
+    where
+        E: DeserializeOwned + Schema,
+    {
+        // TODO: remove MonitorEvent from the RPC interface, split this subscribe into two:
+        // one for RTT, one for semihosting, then introduce a MultiSubscription impl for them
+        let rtt = RttTopic::subscribe(client, depth).await?;
+        let semihosting = SemihostingTopic::subscribe(client, depth).await?;
+        Ok(MonitorSubscription { rtt, semihosting })
+    }
+}
+
+pub(crate) struct MonitorSubscription {
+    rtt: <RttTopic as MultiTopic>::Subscription,
+    semihosting: <SemihostingTopic as MultiTopic>::Subscription,
+}
+impl MultiSubscription for MonitorSubscription {
+    type Message = MonitorEvent;
+
+    async fn next(&mut self) -> Option<Self::Message> {
+        tokio::select! {
+            message = self.rtt.recv() => message.map(MonitorEvent::Rtt),
+            message = self.semihosting.recv() => message.map(MonitorEvent::Semihosting),
         }
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -25,81 +25,74 @@ use std::{
     time::Duration,
 };
 
-use crate::{
-    FormatOptions,
-    rpc::{
-        FlashLoader, Key, RttClient, Session,
-        functions::{
-            AttachEndpoint, BootEndpoint, BuildEndpoint, ChipInfoEndpoint, CleanUpRttEndpoint,
-            ClearCoreDebugStateEndpoint, ClearRttControlBlockEndpoint, CoreClearHwBpsEndpoint,
-            CoreDumpEndpoint, CoreEnableVcEndpoint, CoreHaltEndpoint, CoreMetadataEndpoint,
-            CoreReadRegistersEndpoint, CoreRunEndpoint, CoreSetHwBpsEndpoint, CoreStatusEndpoint,
-            CoreStepEndpoint, CoreWriteRegEndpoint, CreateRttClientEndpoint,
-            CreateTempFileEndpoint, DisassembleEndpoint, EraseEndpoint, EvaluateEndpoint,
-            FlashEndpoint, GetRttChannelsEndpoint, HandleSemihostingEndpoint,
-            ListChipFamiliesEndpoint, ListProbesEndpoint, ListTestsEndpoint,
-            LoadChipFamilyEndpoint, LoadDebugInfoEndpoint, LoadSvdEndpoint, MonitorEndpoint,
-            PollRttUpEndpoint, ProgressEventTopic, ReadBytesEndpoint, ReadMemory8Endpoint,
-            ReadMemory16Endpoint, ReadMemory32Endpoint, ReadMemory64Endpoint,
-            ResetCoreAndHaltEndpoint, ResetCoreEndpoint, ResolveSourceBreakpointsEndpoint,
-            ResolveSourceLocationsEndpoint, ResumeAllCoresEndpoint, RpcError, RpcResult,
-            RttDownEndpoint, RunTestEndpoint, ScopesEndpoint, SelectProbeEndpoint,
-            SetVariableEndpoint, TakeRichStackTraceEndpoint, TakeStackTraceEndpoint,
-            TargetInfoDataTopic, TargetInfoEndpoint, TargetMetadataEndpoint, TempFileDataEndpoint,
-            TestKickoffEndpoint, TokioSpawner, VariablesEndpoint, VerifyEndpoint,
-            WriteMemory8Endpoint, WriteMemory16Endpoint, WriteMemory32Endpoint,
-            WriteMemory64Endpoint,
-            breakpoints::{
-                BreakpointResolution, ResolveSourceBreakpointsRequest,
-                ResolveSourceLocationsRequest, SourceBreakpointLocation, WireSourceLocation,
-            },
-            chip::{ChipData, ChipFamily, ChipInfoRequest, LoadChipFamilyRequest},
-            core_ops::{
-                CoreAccessRequest, CoreBreakpointsRequest, CoreDumpRequest, CoreHaltRequest,
-                CoreReadRegistersRequest, CoreVectorCatchRequest, CoreWriteRegRequest,
-                HandleSemihostingRequest, HandleSemihostingResult, StepRequest, StepResponse,
-                WireCoreDump, WireCoreInformation, WireCoreMetadata, WireCoreStatus,
-                WireRegisterId, WireRegisterReadResult, WireRegisterValue, WireSteppingMode,
-                WireVectorCatchCondition,
-            },
-            debug_vars::{
-                ClearCoreDebugStateRequest, EvaluateRequest, LoadSvdRequest, ScopesRequest,
-                SetVariableRequest, VariablesRequest, WireEvaluateResponse, WireScope,
-                WireSetVariableResponse, WireVariable,
-            },
-            disassemble::{DisassembleRequest, WireDisassembledInstruction},
-            file::{AppendFileRequest, TempFile},
-            flash::{
-                BootInfo, BootRequest, BuildRequest, BuildResult, DownloadOptions, EraseCommand,
-                EraseRequest, FlashRequest, ProgressEvent, VerifyRequest, VerifyResult,
-            },
-            info::{
-                InfoEvent, TargetInfoRequest, TargetMetadataRequest, WireSessionTargetMetadata,
-            },
-            memory::{ReadBytesRequest, ReadMemoryRequest, WriteMemoryRequest},
-            monitor::{MonitorExitReason, MonitorMode, MonitorOptions, MonitorRequest},
-            probe::{
-                AttachRequest, AttachResult, DebugProbeEntry, DebugProbeSelector,
-                SelectProbeRequest, SelectProbeResult,
-            },
-            reset::{ResetCoreAndHaltRequest, ResetCoreRequest},
-            resume::ResumeAllCoresRequest,
-            rtt_client::{
-                CreateRttClientRequest, PollRttUpRequest, RttChannelRequest, RttChannels,
-                RttClientData, RttDownRequest, RttPollResult, ScanRegion,
-            },
-            stack_trace::{
-                LoadDebugInfoRequest, RichStackTraces, StackTraces, TakeRichStackTraceRequest,
-                TakeStackTraceRequest,
-            },
-            test::{ListTestsRequest, RunTestRequest, Test, TestKickoffRequest, TestResult, Tests},
+use crate::rpc::functions::format::FormatOptions;
+use crate::rpc::{
+    FlashLoader, Key, RttClient, Session,
+    functions::{
+        AttachEndpoint, BootEndpoint, BuildEndpoint, ChipInfoEndpoint, CleanUpRttEndpoint,
+        ClearCoreDebugStateEndpoint, ClearRttControlBlockEndpoint, CoreClearHwBpsEndpoint,
+        CoreDumpEndpoint, CoreEnableVcEndpoint, CoreHaltEndpoint, CoreMetadataEndpoint,
+        CoreReadRegistersEndpoint, CoreRunEndpoint, CoreSetHwBpsEndpoint, CoreStatusEndpoint,
+        CoreStepEndpoint, CoreWriteRegEndpoint, CreateRttClientEndpoint, CreateTempFileEndpoint,
+        DisassembleEndpoint, EraseEndpoint, EvaluateEndpoint, FlashEndpoint,
+        GetRttChannelsEndpoint, HandleSemihostingEndpoint, ListChipFamiliesEndpoint,
+        ListProbesEndpoint, ListTestsEndpoint, LoadChipFamilyEndpoint, LoadDebugInfoEndpoint,
+        LoadSvdEndpoint, MonitorEndpoint, PollRttUpEndpoint, ProgressEventTopic, ReadBytesEndpoint,
+        ReadMemory8Endpoint, ReadMemory16Endpoint, ReadMemory32Endpoint, ReadMemory64Endpoint,
+        ResetCoreAndHaltEndpoint, ResetCoreEndpoint, ResolveSourceBreakpointsEndpoint,
+        ResolveSourceLocationsEndpoint, ResumeAllCoresEndpoint, RpcError, RpcResult,
+        RttDownEndpoint, RunTestEndpoint, ScopesEndpoint, SelectProbeEndpoint, SetVariableEndpoint,
+        TakeRichStackTraceEndpoint, TakeStackTraceEndpoint, TargetInfoDataTopic,
+        TargetInfoEndpoint, TargetMetadataEndpoint, TempFileDataEndpoint, TestKickoffEndpoint,
+        TokioSpawner, VariablesEndpoint, VerifyEndpoint, WriteMemory8Endpoint,
+        WriteMemory16Endpoint, WriteMemory32Endpoint, WriteMemory64Endpoint,
+        breakpoints::{
+            BreakpointResolution, ResolveSourceBreakpointsRequest, ResolveSourceLocationsRequest,
+            SourceBreakpointLocation, WireSourceLocation,
         },
-        transport::memory::{PostcardReceiver, PostcardSender, WireRx, WireTx},
-        upload_cache::{ContentHash, ResolvedUpload, UploadCache},
-        utils::semihosting::SemihostingOptions,
+        chip::{ChipData, ChipFamily, ChipInfoRequest, LoadChipFamilyRequest},
+        core_ops::{
+            CoreAccessRequest, CoreBreakpointsRequest, CoreDumpRequest, CoreHaltRequest,
+            CoreReadRegistersRequest, CoreVectorCatchRequest, CoreWriteRegRequest,
+            HandleSemihostingRequest, HandleSemihostingResult, StepRequest, StepResponse,
+            WireCoreDump, WireCoreInformation, WireCoreMetadata, WireCoreStatus, WireRegisterId,
+            WireRegisterReadResult, WireRegisterValue, WireSteppingMode, WireVectorCatchCondition,
+        },
+        debug_vars::{
+            ClearCoreDebugStateRequest, EvaluateRequest, LoadSvdRequest, ScopesRequest,
+            SetVariableRequest, VariablesRequest, WireEvaluateResponse, WireScope,
+            WireSetVariableResponse, WireVariable,
+        },
+        disassemble::{DisassembleRequest, WireDisassembledInstruction},
+        file::{AppendFileRequest, TempFile},
+        flash::{
+            BootInfo, BootRequest, BuildRequest, BuildResult, DownloadOptions, EraseCommand,
+            EraseRequest, FlashRequest, ProgressEvent, VerifyRequest, VerifyResult,
+        },
+        info::{InfoEvent, TargetInfoRequest, TargetMetadataRequest, WireSessionTargetMetadata},
+        memory::{ReadBytesRequest, ReadMemoryRequest, WriteMemoryRequest},
+        monitor::{MonitorExitReason, MonitorMode, MonitorOptions, MonitorRequest},
+        probe::{
+            AttachRequest, AttachResult, DebugProbeEntry, DebugProbeSelector, SelectProbeRequest,
+            SelectProbeResult,
+        },
+        reset::{ResetCoreAndHaltRequest, ResetCoreRequest},
+        resume::ResumeAllCoresRequest,
+        rtt_client::{
+            CreateRttClientRequest, PollRttUpRequest, RttChannelRequest, RttChannels,
+            RttClientData, RttDownRequest, RttPollResult, ScanRegion,
+        },
+        stack_trace::{
+            LoadDebugInfoRequest, RichStackTraces, StackTraces, TakeRichStackTraceRequest,
+            TakeStackTraceRequest,
+        },
+        test::{ListTestsRequest, RunTestRequest, Test, TestKickoffRequest, TestResult, Tests},
     },
-    util::{cli::MonitorEvent, rtt::RttChannelConfig},
+    transport::memory::{PostcardReceiver, PostcardSender, WireRx, WireTx},
+    upload_cache::{ContentHash, ResolvedUpload, UploadCache},
+    utils::semihosting::SemihostingOptions,
 };
+use crate::util::{cli::MonitorEvent, rtt::RttChannelConfig};
 
 /// Host and optional authentication token identifying a remote probe-rs RPC
 /// server. `None` selects a local, in-process server.

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
@@ -100,6 +100,7 @@ pub mod probe;
 pub mod reset;
 pub mod resume;
 pub mod rtt_client;
+pub mod rtt_config;
 pub mod stack_trace;
 pub mod test;
 

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
@@ -92,6 +92,7 @@ pub mod debug_vars;
 pub mod disassemble;
 pub mod file;
 pub mod flash;
+pub mod format;
 pub mod info;
 pub mod memory;
 pub mod monitor;

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
@@ -101,6 +101,7 @@ pub mod reset;
 pub mod resume;
 pub mod rtt_client;
 pub mod rtt_config;
+pub mod semihosting_options;
 pub mod stack_trace;
 pub mod test;
 

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/core_ops.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/core_ops.rs
@@ -8,11 +8,9 @@ use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
 
-use crate::util::rtt::DataFormat;
-
 use crate::rpc::{
     Key, Session,
-    functions::{NoResponse, RpcContext, RpcError, RpcResult},
+    functions::{NoResponse, RpcContext, RpcError, RpcResult, rtt_config::DataFormat},
 };
 
 /// Common request fields for addressing a single core.

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
@@ -1,10 +1,8 @@
 use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    FormatOptions,
-    rpc::{FlashLoader, Key, RttClient, Session, functions::RpcResult},
-};
+use crate::rpc::functions::format::FormatOptions;
+use crate::rpc::{FlashLoader, Key, RttClient, Session, functions::RpcResult};
 
 #[derive(Serialize, Deserialize, Default, Schema)]
 pub struct DownloadOptions {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/format.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/format.rs
@@ -1,0 +1,207 @@
+﻿use clap::ValueEnum;
+use postcard_schema::Schema;
+use serde::{Deserialize, Serialize};
+
+use crate::util::{parse_u32, parse_u64};
+
+#[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default, Schema)]
+#[serde(default)]
+pub struct BinaryCliOptions {
+    /// The address in memory where the binary will be put at. This is only considered when `bin` is selected as the format.
+    #[clap(long, value_parser = parse_u64, help_heading = "DOWNLOAD CONFIGURATION / BIN IMAGE")]
+    pub base_address: Option<u64>,
+    /// The number of bytes to skip at the start of the binary file. This is only considered when `bin` is selected as the format.
+    #[clap(long, value_parser = parse_u32, default_value = "0", help_heading = "DOWNLOAD CONFIGURATION / BIN IMAGE")]
+    pub skip: u32,
+}
+
+/// Supported flash frequencies
+///
+/// Note that not all frequencies are supported by each target device.
+#[expect(clippy::enum_variant_names)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ValueEnum, Schema,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum EspFlashFrequency {
+    /// 12 MHz
+    #[serde(rename = "12MHz")]
+    _12Mhz,
+    /// 15 MHz
+    #[serde(rename = "15MHz")]
+    _15Mhz,
+    /// 16 MHz
+    #[serde(rename = "16MHz")]
+    _16Mhz,
+    /// 20 MHz
+    #[serde(rename = "20MHz")]
+    _20Mhz,
+    /// 24 MHz
+    #[serde(rename = "24MHz")]
+    _24Mhz,
+    /// 26 MHz
+    #[serde(rename = "26MHz")]
+    _26Mhz,
+    /// 30 MHz
+    #[serde(rename = "30MHz")]
+    _30Mhz,
+    /// 40 MHz
+    #[serde(rename = "40MHz")]
+    #[default]
+    _40Mhz,
+    /// 48 MHz
+    #[serde(rename = "48MHz")]
+    _48Mhz,
+    /// 60 MHz
+    #[serde(rename = "60MHz")]
+    _60Mhz,
+    /// 80 MHz
+    #[serde(rename = "80MHz")]
+    _80Mhz,
+}
+
+/// Supported flash modes
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ValueEnum, Schema,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum EspFlashMode {
+    /// Quad I/O (4 pins used for address & data)
+    Qio,
+    /// Quad Output (4 pins used for data)
+    Qout,
+    /// Dual I/O (2 pins used for address & data)
+    #[default]
+    Dio,
+    /// Dual Output (2 pins used for data)
+    Dout,
+}
+
+#[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default, Schema)]
+#[serde(default)]
+pub struct IdfCliOptions {
+    /// The idf bootloader path
+    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION / ESP-IDF IMAGE")]
+    pub idf_bootloader: Option<String>,
+    /// The idf partition table path
+    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION / ESP-IDF IMAGE")]
+    pub idf_partition_table: Option<String>,
+    /// The idf target app partition
+    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION / ESP-IDF IMAGE")]
+    pub idf_target_app_partition: Option<String>,
+    /// Flash SPI mode
+    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION / ESP-IDF IMAGE")]
+    pub idf_flash_mode: Option<EspFlashMode>,
+    /// Flash SPI frequency
+    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION / ESP-IDF IMAGE")]
+    pub idf_flash_freq: Option<EspFlashFrequency>,
+}
+
+#[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default, Schema)]
+#[serde(default)]
+pub struct ElfCliOptions {
+    /// Section name to skip flashing. This option may be specified multiple times, and is only
+    /// considered when `elf` is selected as the format.
+    #[clap(long, help_heading = "DOWNLOAD CONFIGURATION / ELF IMAGE")]
+    pub skip_section: Vec<String>,
+}
+
+#[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default, Schema)]
+#[serde(default)]
+pub struct FormatOptions {
+    /// The format of the firmware image.
+    #[clap(
+        value_enum,
+        ignore_case = true,
+        default_value_t = FormatKind::Target,
+        long,
+        help_heading = "DOWNLOAD CONFIGURATION"
+    )]
+    pub binary_format: FormatKind,
+
+    #[clap(flatten)]
+    pub bin_options: BinaryCliOptions,
+
+    #[clap(flatten)]
+    pub idf_options: IdfCliOptions,
+
+    #[clap(flatten)]
+    pub elf_options: ElfCliOptions,
+}
+
+/// A finite list of all the available binary formats probe-rs understands.
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, ValueEnum, Schema)]
+pub enum FormatKind {
+    /// The image format is determined by the target chip's preference, which is usually ELF.
+    #[default]
+    Target,
+
+    /// The image is in binary format. This means that the file contains the contents of the flash 1:1.
+    #[value(alias("binary"))]
+    Bin,
+
+    /// The image is in Intel HEX format. For more information, see https://en.wikipedia.org/wiki/Intel_HEX
+    #[value(aliases(["ihex", "intelhex"]))]
+    Hex,
+
+    /// The image is in the Executable and Linkable Format (ELF). For more information, see https://en.wikipedia.org/wiki/Executable_and_Linkable_Format
+    Elf,
+
+    /// The image is an ELF file containing an ESP-IDF bootloader compatible application. For more information, see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/app_image_format.html#app-image-structures
+    #[value(aliases(["esp-idf", "espidf"]))]
+    Idf,
+
+    /// The image is in the Universal Flash Storage (UF2) format. For more information, see https://github.com/microsoft/uf2
+    Uf2,
+}
+
+impl FormatKind {
+    /// Creates a new Format from an optional string.
+    ///
+    /// If the string is `None`, the default format is returned.
+    pub fn from_optional(s: Option<&str>) -> Result<Self, String> {
+        match s {
+            Some(format) => match format.to_ascii_lowercase().as_str() {
+                "target" => Ok(Self::Target),
+                "bin" | "binary" => Ok(Self::Bin),
+                "hex" | "ihex" | "intelhex" => Ok(Self::Hex),
+                "elf" => Ok(Self::Elf),
+                "idf" | "esp-idf" | "espidf" => Ok(Self::Idf),
+                "uf2" => Ok(Self::Uf2),
+                _ => Err(format!("invalid variant: {format}")),
+            },
+            None => Ok(Self::Elf),
+        }
+    }
+
+    /// Replaces `FormatKind::Target` using a server-provided default format string.
+    pub fn resolve_default_format(self, default_format: Option<&str>) -> FormatKind {
+        if self == FormatKind::Target {
+            FormatKind::from_optional(default_format)
+                .expect("Failed to parse a default binary format. This shouldn't happen.")
+        } else {
+            self
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FormatKind;
+
+    #[test]
+    fn format_kind_resolve_default_format_uses_server_hint() {
+        assert_eq!(
+            FormatKind::Target.resolve_default_format(Some("idf")),
+            FormatKind::Idf
+        );
+        assert_eq!(
+            FormatKind::Target.resolve_default_format(None),
+            FormatKind::Elf
+        );
+        assert_eq!(
+            FormatKind::Bin.resolve_default_format(Some("elf")),
+            FormatKind::Bin
+        );
+    }
+}

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/format.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/format.rs
@@ -1,8 +1,16 @@
-﻿use clap::ValueEnum;
+﻿use std::num::ParseIntError;
+
+use clap::ValueEnum;
 use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
 
-use crate::util::{parse_u32, parse_u64};
+fn parse_u32(input: &str) -> Result<u32, ParseIntError> {
+    parse_int::parse(input)
+}
+
+fn parse_u64(input: &str) -> Result<u64, ParseIntError> {
+    parse_int::parse(input)
+}
 
 #[derive(clap::Parser, Clone, Serialize, Deserialize, Debug, Default, Schema)]
 #[serde(default)]

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/monitor.rs
@@ -5,10 +5,11 @@ use crate::rpc::{
     functions::{
         MonitorEndpoint, MultiTopicPublisher, MultiTopicWriter, RpcResult, RpcSpawnContext,
         RttTopic, SemihostingTopic, WireTxImpl, flash::BootInfo,
+        semihosting_options::SemihostingOptions,
     },
     utils::{
         run_loop::{ReturnReason, RunLoop, RunLoopPoller, VectorCatchConfig},
-        semihosting::{SemihostingFileManager, SemihostingOptions},
+        semihosting::SemihostingFileManager,
     },
 };
 use anyhow::Context;

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/rtt_client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/rtt_client.rs
@@ -1,9 +1,9 @@
 use crate::{
     rpc::{
         Key, RttClient, Session,
-        functions::{NoResponse, RpcContext, RpcError, RpcResult},
+        functions::{NoResponse, RpcContext, RpcError, RpcResult, rtt_config::RttChannelConfig},
     },
-    util::rtt::{RttChannelConfig, RttConfig},
+    util::rtt::RttConfig,
 };
 use postcard_rpc::header::VarHeader;
 use postcard_schema::Schema;

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/rtt_config.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/rtt_config.rs
@@ -1,0 +1,76 @@
+use clap::ValueEnum;
+use postcard_schema::Schema;
+use serde::{Deserialize, Serialize};
+
+/// Used by serde to provide defaults for `RttChannelConfig::show_timestamps`
+fn default_show_timestamps() -> bool {
+    true
+}
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Default, docsplay::Display, Serialize, Deserialize, Schema,
+)]
+pub enum DataFormat {
+    #[default]
+    /// string
+    String,
+    /// binary
+    BinaryLE,
+    /// defmt
+    Defmt,
+}
+
+/// Specifies what to do when a channel doesn't have enough buffer space for a complete write on the
+/// target side.
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Serialize, Deserialize, Schema, ValueEnum)]
+#[repr(u32)]
+pub enum ChannelMode {
+    /// Skip writing the data completely if it doesn't fit in its entirety.
+    NoBlockSkip = 0,
+
+    /// Write as much as possible of the data and ignore the rest.
+    NoBlockTrim = 1,
+
+    /// Block (spin) if the buffer is full. Note that if the application writes within a critical
+    /// section, using this mode can cause the application to freeze if the buffer becomes full and
+    /// is not read by the host.
+    BlockIfFull = 2,
+}
+
+/// The User specified configuration for each active RTT Channel.
+#[derive(Debug, Clone, Serialize, Deserialize, Schema)]
+#[serde(rename_all = "camelCase")]
+pub struct RttChannelConfig {
+    pub channel_number: Option<u32>,
+    #[serde(default)]
+    pub data_format: DataFormat,
+
+    /// RTT channel operating mode. Defaults to the target's configuration.
+    #[serde(default)]
+    pub mode: Option<ChannelMode>,
+
+    #[serde(default = "default_show_timestamps")]
+    /// Controls the inclusion of timestamps for [`DataFormat::String`] and [`DataFormat::Defmt`].
+    pub show_timestamps: bool,
+
+    #[serde(default)]
+    /// Controls the inclusion of source location information for DataFormat::Defmt.
+    pub show_location: bool,
+
+    #[serde(default)]
+    /// Controls the output format for DataFormat::Defmt.
+    pub log_format: Option<String>,
+}
+
+impl Default for RttChannelConfig {
+    fn default() -> Self {
+        RttChannelConfig {
+            channel_number: Default::default(),
+            data_format: Default::default(),
+            mode: Default::default(),
+            show_timestamps: default_show_timestamps(),
+            show_location: Default::default(),
+            log_format: Default::default(),
+        }
+    }
+}

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/semihosting_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/semihosting_options.rs
@@ -1,0 +1,43 @@
+use std::convert::Infallible;
+
+use postcard_schema::Schema;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Schema, Clone)]
+pub enum Mapping {
+    Exact(String, String),
+    Prefix(String, String),
+    Regex(String, String),
+}
+
+#[derive(Serialize, Deserialize, Schema, Clone)]
+pub struct SemihostingOptions {
+    mappings: Vec<Mapping>,
+}
+
+impl SemihostingOptions {
+    pub fn new() -> Self {
+        Self { mappings: vec![] }
+    }
+
+    pub fn mappings(&self) -> &[Mapping] {
+        &self.mappings
+    }
+
+    pub fn add_file(&mut self, from: String, to: String) -> Result<(), Infallible> {
+        self.mappings.push(Mapping::Exact(from, to));
+        Ok(())
+    }
+
+    pub fn add_file_prefix(&mut self, from: String, to: String) -> Result<(), Infallible> {
+        self.mappings.push(Mapping::Prefix(from, to));
+        Ok(())
+    }
+
+    pub fn add_file_regex(&mut self, re: String, to: String) -> Result<(), regex::Error> {
+        let _ = Regex::new(&re)?; // Check if it's a valid regular expression
+        self.mappings.push(Mapping::Regex(re, to));
+        Ok(())
+    }
+}

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/test.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::rpc::{
     Key, RttClient, Session,
+    functions::semihosting_options::SemihostingOptions,
     functions::{RpcResult, flash::BootInfo},
-    utils::semihosting::SemihostingOptions,
 };
 
 #[derive(Debug, Serialize, Deserialize, Schema)]

--- a/probe-rs-tools/src/bin/probe-rs/rpc/utils/semihosting.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/utils/semihosting.rs
@@ -1,5 +1,5 @@
 use crate::rpc::functions::monitor::SemihostingEvent;
-pub use crate::rpc::functions::semihosting_options::{Mapping, SemihostingOptions};
+use crate::rpc::functions::semihosting_options::{Mapping, SemihostingOptions};
 use probe_rs::{
     Core,
     semihosting::{

--- a/probe-rs-tools/src/bin/probe-rs/rpc/utils/semihosting.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/utils/semihosting.rs
@@ -1,4 +1,5 @@
 use crate::rpc::functions::monitor::SemihostingEvent;
+pub use crate::rpc::functions::semihosting_options::{Mapping, SemihostingOptions};
 use probe_rs::{
     Core,
     semihosting::{
@@ -24,18 +25,7 @@ enum FileHandle {
     UnixStream(UnixStream),
 }
 
-use std::convert::Infallible;
-
-use postcard_schema::Schema;
 use regex::Regex;
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize, Schema, Clone)]
-enum Mapping {
-    Exact(String, String),
-    Prefix(String, String),
-    Regex(String, String),
-}
 
 enum FileVariant {
     File(String),
@@ -43,76 +33,49 @@ enum FileVariant {
     UnixStream(String),
 }
 
-#[derive(Serialize, Deserialize, Schema, Clone)]
-pub struct SemihostingOptions {
-    mappings: Vec<Mapping>,
-}
-
-impl SemihostingOptions {
-    pub fn new() -> Self {
-        Self { mappings: vec![] }
-    }
-
-    pub fn add_file(&mut self, from: String, to: String) -> Result<(), Infallible> {
-        self.mappings.push(Mapping::Exact(from, to));
-        Ok(())
-    }
-
-    pub fn add_file_prefix(&mut self, from: String, to: String) -> Result<(), Infallible> {
-        self.mappings.push(Mapping::Prefix(from, to));
-        Ok(())
-    }
-
-    pub fn add_file_regex(&mut self, re: String, to: String) -> Result<(), regex::Error> {
-        let _ = Regex::new(&re)?; // Check if it's a valid regular expression
-        self.mappings.push(Mapping::Regex(re, to));
-        Ok(())
-    }
-
-    fn map_file(&self, value: &str) -> Option<String> {
-        for item in &self.mappings {
-            match item {
-                Mapping::Exact(from, to) => {
-                    if value == from {
-                        return Some(to.clone());
-                    }
+fn map_file(options: &SemihostingOptions, value: &str) -> Option<String> {
+    for item in options.mappings() {
+        match item {
+            Mapping::Exact(from, to) => {
+                if value == from {
+                    return Some(to.clone());
                 }
-                Mapping::Prefix(prefix, to) => {
-                    if let Some(rest) = value.strip_prefix(prefix) {
-                        return Some(to.clone() + rest);
-                    }
+            }
+            Mapping::Prefix(prefix, to) => {
+                if let Some(rest) = value.strip_prefix(prefix) {
+                    return Some(to.clone() + rest);
                 }
-                Mapping::Regex(re, to) => {
-                    let re = Regex::new(re).expect("valid Regex");
-                    if let Some(captures) = re.captures(value) {
-                        let mut ret = String::new();
-                        captures.expand(to, &mut ret);
-                        return Some(ret);
-                    }
+            }
+            Mapping::Regex(re, to) => {
+                let re = Regex::new(re).expect("valid Regex");
+                if let Some(captures) = re.captures(value) {
+                    let mut ret = String::new();
+                    captures.expand(to, &mut ret);
+                    return Some(ret);
                 }
             }
         }
-
-        None
     }
 
-    fn find_file(&self, value: &str) -> Option<FileVariant> {
-        let v = self.map_file(value)?;
+    None
+}
 
-        if let Some(r) = v.strip_prefix("file:") {
-            return Some(FileVariant::File(r.into()));
-        }
+fn find_file(options: &SemihostingOptions, value: &str) -> Option<FileVariant> {
+    let v = map_file(options, value)?;
 
-        if let Some(r) = v.strip_prefix("tcp:") {
-            return Some(FileVariant::TcpStream(r.into()));
-        }
-
-        if let Some(r) = v.strip_prefix("unix:") {
-            return Some(FileVariant::UnixStream(r.into()));
-        }
-
-        Some(FileVariant::File(v))
+    if let Some(r) = v.strip_prefix("file:") {
+        return Some(FileVariant::File(r.into()));
     }
+
+    if let Some(r) = v.strip_prefix("tcp:") {
+        return Some(FileVariant::TcpStream(r.into()));
+    }
+
+    if let Some(r) = v.strip_prefix("unix:") {
+        return Some(FileVariant::UnixStream(r.into()));
+    }
+
+    Some(FileVariant::File(v))
 }
 
 pub struct SemihostingFileManager {
@@ -260,7 +223,7 @@ impl SemihostingFileManager {
 
         let f = if path == ":tt" {
             self.open_tt(request.mode())
-        } else if let Some(path) = self.semihosting_options.find_file(&path) {
+        } else if let Some(path) = find_file(&self.semihosting_options, &path) {
             match path {
                 FileVariant::File(path) => self.open_file(&path, request.mode()),
                 FileVariant::TcpStream(addr) => self.open_tcp_stream(&addr),

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -26,33 +26,31 @@ use tokio_util::sync::CancellationToken;
 use crate::cmd::run::{EmbeddedTestElfInfo, MonitoringOptions};
 use crate::rpc::Key;
 use crate::rpc::RttClient;
+use crate::rpc::functions::format::FormatOptions;
 use crate::rpc::functions::monitor::{ChannelInfo, MonitorExitReason};
 use crate::rpc::functions::stack_trace::StackTraceFrame;
 use crate::rpc::utils::run_loop::VectorCatchConfig;
 use crate::rpc::utils::semihosting::SemihostingOptions;
-use crate::util::pwr::power_reset;
-use crate::{
-    FormatOptions,
-    rpc::{
-        client::{MultiSubscribeError, MultiSubscription, MultiTopic, RpcClient, SessionInterface},
-        functions::{
-            CancelTopic, RttTopic, SemihostingTopic,
-            flash::{BootInfo, DownloadOptions, FlashLayout, ProgressEvent, VerifyResult},
-            monitor::{MonitorMode, MonitorOptions, RttEvent, SemihostingEvent},
-            probe::{
-                AttachRequest, AttachResult, DebugProbeEntry, DebugProbeSelector, SelectProbeResult,
-            },
-            rtt_client::ScanRegion,
-            stack_trace::StackTrace,
-            test::{Test, TestResult},
+use crate::rpc::{
+    client::{MultiSubscribeError, MultiSubscription, MultiTopic, RpcClient, SessionInterface},
+    functions::{
+        CancelTopic, RttTopic, SemihostingTopic,
+        flash::{BootInfo, DownloadOptions, FlashLayout, ProgressEvent, VerifyResult},
+        monitor::{MonitorMode, MonitorOptions, RttEvent, SemihostingEvent},
+        probe::{
+            AttachRequest, AttachResult, DebugProbeEntry, DebugProbeSelector, SelectProbeResult,
         },
+        rtt_client::ScanRegion,
+        stack_trace::StackTrace,
+        test::{Test, TestResult},
     },
-    util::{
-        common_options::{BinaryDownloadOptions, ProbeOptions},
-        flash::CliProgressBars,
-        logging,
-        rtt::{DefmtProcessor, DefmtState, RttChannelConfig, RttDecoder},
-    },
+};
+use crate::util::pwr::power_reset;
+use crate::util::{
+    common_options::{BinaryDownloadOptions, ProbeOptions},
+    flash::CliProgressBars,
+    logging,
+    rtt::{DefmtProcessor, DefmtState, RttChannelConfig, RttDecoder},
 };
 
 type TargetOutputFiles = std::collections::HashMap<ChannelIdentifier, tokio::fs::File>;

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -8,13 +8,10 @@ use std::{future::Future, ops::DerefMut, path::Path, time::Instant};
 
 use anyhow::Context;
 use libtest_mimic::{Failed, Trial};
-use postcard_rpc::host_client::HostClient;
-use postcard_schema::Schema;
 use probe_rs::meta::ElfMetadata;
 use probe_rs::rtt::find_rtt_control_block_and_metadata_in_raw_file;
 use ratatui::crossterm::style::Stylize;
 use rustyline_async::{Readline, ReadlineError, ReadlineEvent, SharedWriter};
-use serde::de::DeserializeOwned;
 use std::env::VarError;
 use time::UtcOffset;
 use tokio::io::AsyncWriteExt;
@@ -28,13 +25,14 @@ use crate::rpc::Key;
 use crate::rpc::RttClient;
 use crate::rpc::functions::format::FormatOptions;
 use crate::rpc::functions::monitor::{ChannelInfo, MonitorExitReason};
+use crate::rpc::functions::rtt_config::RttChannelConfig;
+use crate::rpc::functions::semihosting_options::SemihostingOptions;
 use crate::rpc::functions::stack_trace::StackTraceFrame;
 use crate::rpc::utils::run_loop::VectorCatchConfig;
-use crate::rpc::utils::semihosting::SemihostingOptions;
 use crate::rpc::{
-    client::{MultiSubscribeError, MultiSubscription, MultiTopic, RpcClient, SessionInterface},
+    client::{MonitorEvent, RpcClient, SessionInterface},
     functions::{
-        CancelTopic, RttTopic, SemihostingTopic,
+        CancelTopic,
         flash::{BootInfo, DownloadOptions, FlashLayout, ProgressEvent, VerifyResult},
         monitor::{MonitorMode, MonitorOptions, RttEvent, SemihostingEvent},
         probe::{
@@ -50,7 +48,7 @@ use crate::util::{
     common_options::{BinaryDownloadOptions, ProbeOptions},
     flash::CliProgressBars,
     logging,
-    rtt::{DefmtProcessor, DefmtState, RttChannelConfig, RttDecoder},
+    rtt::{DefmtProcessor, DefmtState, RttDecoder},
 };
 
 type TargetOutputFiles = std::collections::HashMap<ChannelIdentifier, tokio::fs::File>;
@@ -507,45 +505,6 @@ pub async fn flash(
     ));
 
     Ok(loader.boot_info)
-}
-
-pub enum MonitorEvent {
-    Rtt(RttEvent),
-    Semihosting(SemihostingEvent),
-}
-
-impl MultiTopic for MonitorEvent {
-    type Message = Self;
-    type Subscription = MonitorSubscription;
-
-    async fn subscribe<E>(
-        client: &HostClient<E>,
-        depth: usize,
-    ) -> Result<Self::Subscription, MultiSubscribeError>
-    where
-        E: DeserializeOwned + Schema,
-    {
-        // TODO: remove MonitorEvent from the RPC interface, split this subscribe into two:
-        // one for RTT, one for semihosting, then introduce a MultiSubscription impl for them
-        let rtt = RttTopic::subscribe(client, depth).await?;
-        let semihosting = SemihostingTopic::subscribe(client, depth).await?;
-        Ok(MonitorSubscription { rtt, semihosting })
-    }
-}
-
-pub struct MonitorSubscription {
-    rtt: <RttTopic as MultiTopic>::Subscription,
-    semihosting: <SemihostingTopic as MultiTopic>::Subscription,
-}
-impl MultiSubscription for MonitorSubscription {
-    type Message = MonitorEvent;
-
-    async fn next(&mut self) -> Option<Self::Message> {
-        tokio::select! {
-            message = self.rtt.recv() => message.map(MonitorEvent::Rtt),
-            message = self.semihosting.recv() => message.map(MonitorEvent::Semihosting),
-        }
-    }
 }
 
 // Monitor starts in read-only mode: it outputs logs, but has no prompt to type into.

--- a/probe-rs-tools/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/flash.rs
@@ -1,10 +1,11 @@
-use crate::FormatOptions;
 use crate::rpc::functions::flash::{FlashLayout, Operation, ProgressEvent};
+use crate::rpc::functions::format::{EspFlashFrequency, EspFlashMode, FormatKind, FormatOptions};
 
 use super::common_options::{BinaryDownloadOptions, LoadedProbeOptions, OperationError};
 use super::logging;
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::time::Duration;
 use std::{path::Path, time::Instant};
 
@@ -12,11 +13,15 @@ use colored::Colorize;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use parking_lot::Mutex;
 use probe_rs::InstructionSet;
-use probe_rs::flashing::{FlashError, FlashProgress};
+use probe_rs::flashing::{
+    BinLoader, BinOptions, ElfLoader, ElfOptions, FlashError, FlashProgress, HexLoader,
+    ImageLoader, Uf2Loader,
+};
 use probe_rs::{
-    Session,
+    Session, Target,
     flashing::{DownloadOptions, FileDownloadError, FlashLoader},
 };
+use probe_rs_espressif::image_format::IdfLoader;
 
 /// Performs the flash download with the given loader. Ensure that the loader has the data to load already stored.
 /// This function also manages the update and display of progress bars.
@@ -119,6 +124,75 @@ fn run_flash_download_inner(
     ));
 
     Ok(())
+}
+
+impl From<EspFlashFrequency> for espflash::flasher::FlashFrequency {
+    fn from(freq: EspFlashFrequency) -> Self {
+        match freq {
+            EspFlashFrequency::_12Mhz => espflash::flasher::FlashFrequency::_12Mhz,
+            EspFlashFrequency::_15Mhz => espflash::flasher::FlashFrequency::_15Mhz,
+            EspFlashFrequency::_16Mhz => espflash::flasher::FlashFrequency::_16Mhz,
+            EspFlashFrequency::_20Mhz => espflash::flasher::FlashFrequency::_20Mhz,
+            EspFlashFrequency::_24Mhz => espflash::flasher::FlashFrequency::_24Mhz,
+            EspFlashFrequency::_26Mhz => espflash::flasher::FlashFrequency::_26Mhz,
+            EspFlashFrequency::_30Mhz => espflash::flasher::FlashFrequency::_30Mhz,
+            EspFlashFrequency::_40Mhz => espflash::flasher::FlashFrequency::_40Mhz,
+            EspFlashFrequency::_48Mhz => espflash::flasher::FlashFrequency::_48Mhz,
+            EspFlashFrequency::_60Mhz => espflash::flasher::FlashFrequency::_60Mhz,
+            EspFlashFrequency::_80Mhz => espflash::flasher::FlashFrequency::_80Mhz,
+        }
+    }
+}
+
+impl From<EspFlashMode> for espflash::flasher::FlashMode {
+    fn from(mode: EspFlashMode) -> Self {
+        match mode {
+            EspFlashMode::Qio => espflash::flasher::FlashMode::Qio,
+            EspFlashMode::Qout => espflash::flasher::FlashMode::Qout,
+            EspFlashMode::Dio => espflash::flasher::FlashMode::Dio,
+            EspFlashMode::Dout => espflash::flasher::FlashMode::Dout,
+        }
+    }
+}
+
+impl FormatKind {
+    /// Replaces `FormatKind::Target` with a default format based on the target.
+    pub fn resolve(self, target: &Target) -> FormatKind {
+        self.resolve_default_format(target.default_format.as_deref())
+    }
+}
+
+impl FormatOptions {
+    /// If a format is provided, use it.
+    /// If a target has a preferred format, we use that.
+    /// Finally, if neither of the above cases are true, we default to [`FormatKind::default()`].
+    fn image_loader(&self, target: &Target) -> Box<dyn ImageLoader> {
+        match self.binary_format.resolve(target) {
+            FormatKind::Target => unreachable!(),
+            FormatKind::Bin => Box::new(BinLoader(BinOptions {
+                base_address: self.bin_options.base_address,
+                skip: self.bin_options.skip,
+            })),
+
+            FormatKind::Hex => Box::new(HexLoader),
+            FormatKind::Elf => Box::new(ElfLoader(ElfOptions {
+                skip_sections: self.elf_options.skip_section.clone(),
+            })),
+            FormatKind::Uf2 => Box::new(Uf2Loader),
+
+            FormatKind::Idf => Box::new(IdfLoader {
+                bootloader: self.idf_options.idf_bootloader.as_ref().map(PathBuf::from),
+                partition_table: self
+                    .idf_options
+                    .idf_partition_table
+                    .as_ref()
+                    .map(PathBuf::from),
+                target_app_partition: self.idf_options.idf_target_app_partition.clone(),
+                flash_frequency: self.idf_options.idf_flash_freq.map(From::from),
+                flash_mode: self.idf_options.idf_flash_mode.map(From::from),
+            }),
+        }
+    }
 }
 
 /// Builds a new flash loader for the given target and path. This

--- a/probe-rs-tools/src/bin/probe-rs/util/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/mod.rs
@@ -11,10 +11,6 @@ pub mod visualizer;
 
 use std::num::ParseIntError;
 
-pub fn parse_u32(input: &str) -> Result<u32, ParseIntError> {
-    parse_int::parse(input)
-}
-
 pub fn parse_u64(input: &str) -> Result<u64, ParseIntError> {
     parse_int::parse(input)
 }

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -1,4 +1,3 @@
-use clap::ValueEnum;
 use postcard_schema::Schema;
 use probe_rs::rtt::{self, DownChannel, Error, Rtt, UpChannel};
 use probe_rs::{Core, MemoryInterface};
@@ -7,42 +6,8 @@ use serde::{Deserialize, Serialize};
 pub(crate) mod client;
 pub(crate) mod processing;
 
+pub use crate::rpc::functions::rtt_config::{ChannelMode, DataFormat, RttChannelConfig};
 pub use processing::*;
-
-/// Used by serde to provide defaults for `RttChannelConfig::show_timestamps`
-fn default_show_timestamps() -> bool {
-    true
-}
-
-#[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Default, docsplay::Display, Serialize, Deserialize, Schema,
-)]
-pub enum DataFormat {
-    #[default]
-    /// string
-    String,
-    /// binary
-    BinaryLE,
-    /// defmt
-    Defmt,
-}
-
-/// Specifies what to do when a channel doesn't have enough buffer space for a complete write on the
-/// target side.
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Serialize, Deserialize, Schema, ValueEnum)]
-#[repr(u32)]
-pub enum ChannelMode {
-    /// Skip writing the data completely if it doesn't fit in its entirety.
-    NoBlockSkip = 0,
-
-    /// Write as much as possible of the data and ignore the rest.
-    NoBlockTrim = 1,
-
-    /// Block (spin) if the buffer is full. Note that if the application writes within a critical
-    /// section, using this mode can cause the application to freeze if the buffer becomes full and
-    /// is not read by the host.
-    BlockIfFull = 2,
-}
 
 impl From<ChannelMode> for rtt::ChannelMode {
     fn from(mode: ChannelMode) -> Self {
@@ -86,44 +51,6 @@ impl RttConfig {
             .iter()
             .find(|ch| ch.channel_number == Some(channel_number))
             .unwrap_or(&self.default_config)
-    }
-}
-
-/// The User specified configuration for each active RTT Channel.
-#[derive(Debug, Clone, Serialize, Deserialize, Schema)]
-#[serde(rename_all = "camelCase")]
-pub struct RttChannelConfig {
-    pub channel_number: Option<u32>,
-    #[serde(default)]
-    pub data_format: DataFormat,
-
-    /// RTT channel operating mode. Defaults to the target's configuration.
-    #[serde(default)]
-    pub mode: Option<ChannelMode>,
-
-    #[serde(default = "default_show_timestamps")]
-    /// Controls the inclusion of timestamps for [`DataFormat::String`] and [`DataFormat::Defmt`].
-    pub show_timestamps: bool,
-
-    #[serde(default)]
-    /// Controls the inclusion of source location information for DataFormat::Defmt.
-    pub show_location: bool,
-
-    #[serde(default)]
-    /// Controls the output format for DataFormat::Defmt.
-    pub log_format: Option<String>,
-}
-
-impl Default for RttChannelConfig {
-    fn default() -> Self {
-        RttChannelConfig {
-            channel_number: Default::default(),
-            data_format: Default::default(),
-            mode: Default::default(),
-            show_timestamps: default_show_timestamps(),
-            show_location: Default::default(),
-            log_format: Default::default(),
-        }
     }
 }
 

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 pub(crate) mod client;
 pub(crate) mod processing;
 
-pub use crate::rpc::functions::rtt_config::{ChannelMode, DataFormat, RttChannelConfig};
+use crate::rpc::functions::rtt_config::{ChannelMode, RttChannelConfig};
+
 pub use processing::*;
 
 impl From<ChannelMode> for rtt::ChannelMode {

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
@@ -1,6 +1,5 @@
-use crate::util::rtt::{
-    ChannelMode, RttActiveDownChannel, RttActiveUpChannel, RttConfig, RttConnection,
-};
+use crate::rpc::functions::rtt_config::ChannelMode;
+use crate::util::rtt::{RttActiveDownChannel, RttActiveUpChannel, RttConfig, RttConnection};
 use probe_rs::{
     Core, MemoryInterface, Target,
     flashing::FlashLoader,

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/processing.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/processing.rs
@@ -11,7 +11,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::util::rtt::DataFormat;
+use crate::rpc::functions::rtt_config::DataFormat;
 
 pub enum RttDecoder {
     String {


### PR DESCRIPTION
## Summary

Part 2 of 6 of the RPC crate split. Based on #4206.

This pull request changes no behaviour. Several wire types were declared beside the CLI code that uses them, which ties the protocol to the command line program. This moves them into the RPC module:

- the firmware format options, from `main.rs`
- the RTT channel configuration, from `util/rtt.rs`
- the semihosting options, from `util/semihosting.rs`

The `clap` derives stay on these types. They are both wire types and command line option types, and splitting them into two parallel type sets would be worse than carrying the derive. Pull request 5 puts the derives behind a `clap` feature so that a library user does not pay for them.

`FormatKind::from_optional` no longer goes through `clap::ValueEnum::from_str`. It uses a plain `match`, so that the type does not need `clap` to work.

## Test plan

- [x] `just all`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] CLI checked by hand: `probe-rs --help`, `probe-rs chip list`

No changelog fragment: this pull request changes no user visible behaviour.
