### PR TITLE
Remove the target registry from the RPC client

### DIFF
--- a/changelog/changed-chip-description-validation.md
+++ b/changelog/changed-chip-description-validation.md
@@ -1,0 +1,1 @@
+Invalid `--chip-description-path` files are now rejected by the server instead of the client.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -3,6 +3,7 @@ mod diagnostics;
 use anyhow::Context;
 use colored::Colorize;
 use diagnostics::render_diagnostics;
+use probe_rs::config::Registry;
 use std::ffi::OsString;
 use std::{path::PathBuf, process};
 
@@ -106,17 +107,16 @@ pub async fn main(args: Vec<OsString>, config: Config) -> anyhow::Result<()> {
     let terminate = run_app(connection_params, async |mut client| {
         let main_result = main_try(&mut client, opt).await;
 
-        let r = client.registry().await;
-
         match main_result {
             Ok(()) => Ok(false),
             Err(e) => {
+                let registry = Registry::from_builtin_families();
                 // Ensure stderr is flushed before calling process::exit,
                 // otherwise the process might panic, because it tries
                 // to access stderr during shutdown.
                 //
                 // We ignore the errors, not much we can do anyway.
-                render_diagnostics(&r, e);
+                render_diagnostics(&registry, e);
 
                 Ok(true)
             }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -5,7 +5,10 @@ use colored::Colorize;
 use diagnostics::render_diagnostics;
 use probe_rs::config::Registry;
 use std::ffi::OsString;
-use std::{path::PathBuf, process};
+use std::{
+    path::{Path, PathBuf},
+    process,
+};
 
 use crate::rpc::client::RpcClient;
 use crate::util::cargo::build_artifact;
@@ -88,6 +91,20 @@ struct CliOptions {
     preset: Option<String>,
 }
 
+/// Creates a registry that holds the builtin targets and the targets of the
+/// chip description file, if the caller names one.
+pub fn registry_with_chip_description(chip_description: Option<&Path>) -> Registry {
+    let mut registry = Registry::from_builtin_families();
+
+    if let Some(path) = chip_description
+        && let Ok(yaml) = std::fs::read_to_string(path)
+    {
+        _ = registry.add_target_family_from_yaml(&yaml);
+    }
+
+    registry
+}
+
 pub async fn main(args: Vec<OsString>, config: Config) -> anyhow::Result<()> {
     // Parse the commandline options.
     let opt = parse_and_resolve_cli_args::<CliOptions>(args, &config)?;
@@ -104,13 +121,17 @@ pub async fn main(args: Vec<OsString>, config: Config) -> anyhow::Result<()> {
     #[cfg(not(feature = "remote"))]
     let connection_params = None;
 
+    // The server owns the target state, but it offers no chip name search, so
+    // the diagnostics keep a local copy of the same targets.
+    let registry =
+        registry_with_chip_description(opt.probe_options.chip_description_path.as_deref());
+
     let terminate = run_app(connection_params, async |mut client| {
         let main_result = main_try(&mut client, opt).await;
 
         match main_result {
             Ok(()) => Ok(false),
             Err(e) => {
-                let registry = Registry::from_builtin_families();
                 // Ensure stderr is flushed before calling process::exit,
                 // otherwise the process might panic, because it tries
                 // to access stderr during shutdown.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -382,8 +382,8 @@ impl Debugger {
 
     /// RPC entry point for the DAP server. Drives the session against an
     /// [`RpcBackend`] wired up around the provided [`RpcClient`] (and its
-    /// ambient tokio runtime). The local chip registry on `client` supplies
-    /// `Target` descriptions.
+    /// ambient tokio runtime). The chip registry of the server that `client`
+    /// talks to supplies the target descriptions.
     pub(crate) async fn debug_session_rpc(
         &mut self,
         client: &RpcClient,

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -16,6 +16,7 @@ use figment::Figment;
 use figment::providers::{Data, Format as _, Json, Toml, Yaml};
 use figment::value::Value;
 use itertools::Itertools;
+use probe_rs::config::Registry;
 use probe_rs::probe::list::Lister;
 use report::Report;
 use serde::{Deserialize, Serialize};
@@ -104,6 +105,7 @@ struct Cli {
 impl Cli {
     async fn run(self, client: RpcClient, _config: Config, utc_offset: UtcOffset) -> Result<()> {
         let lister = Lister::new();
+        let mut registry = Registry::from_builtin_families();
         match self.subcommand {
             Subcommand::DapServer(cmd) => {
                 let log_path = self.log_file.as_deref();
@@ -113,7 +115,7 @@ impl Cli {
             Subcommand::Serve(cmd) => cmd.run(_config.server).await,
             Subcommand::List(cmd) => cmd.run(client).await,
             Subcommand::Info(cmd) => cmd.run(client).await,
-            Subcommand::Gdb(cmd) => cmd.run(&mut *client.registry().await, &lister),
+            Subcommand::Gdb(cmd) => cmd.run(&mut registry, &lister),
             Subcommand::Reset(cmd) => cmd.run(client).await,
             Subcommand::Debug(cmd) => cmd.run(client, utc_offset).await,
             Subcommand::Download(cmd) => cmd.run(client).await,
@@ -121,11 +123,11 @@ impl Cli {
             Subcommand::Attach(cmd) => cmd.run(client, utc_offset).await,
             Subcommand::Verify(cmd) => cmd.run(client).await,
             Subcommand::Erase(cmd) => cmd.run(client).await,
-            Subcommand::Trace(cmd) => cmd.run(&mut *client.registry().await, &lister),
-            Subcommand::Itm(cmd) => cmd.run(&mut *client.registry().await, &lister),
+            Subcommand::Trace(cmd) => cmd.run(&mut registry, &lister),
+            Subcommand::Itm(cmd) => cmd.run(&mut registry, &lister),
             Subcommand::Chip(cmd) => cmd.run(client).await,
-            Subcommand::Benchmark(cmd) => cmd.run(&mut *client.registry().await, &lister),
-            Subcommand::Profile(cmd) => cmd.run(&mut *client.registry().await, &lister),
+            Subcommand::Benchmark(cmd) => cmd.run(&mut registry, &lister),
+            Subcommand::Profile(cmd) => cmd.run(&mut registry, &lister),
             Subcommand::Read(cmd) => cmd.run(client).await,
             Subcommand::Write(cmd) => cmd.run(client).await,
             Subcommand::Complete(cmd) => cmd.run(&lister),

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client.rs
@@ -12,10 +12,9 @@ use postcard_rpc::{
     host_client::{HostClient, HostClientConfig, HostErr, IoClosed, SubscribeError, Subscription},
 };
 use postcard_schema::Schema;
-use probe_rs::config::Registry;
 use serde::{Serialize, de::DeserializeOwned};
 use tokio::{
-    sync::{Mutex, MutexGuard, Notify},
+    sync::{Mutex, Notify},
     time::timeout,
 };
 
@@ -269,7 +268,6 @@ mod tls {
 pub struct RpcClient {
     client: HostClient<String>,
     upload_cache: Arc<Mutex<UploadCache>>,
-    registry: Arc<Mutex<Registry>>,
     is_localhost: bool,
 }
 
@@ -300,7 +298,6 @@ impl RpcClient {
                 },
             ),
             upload_cache: Arc::new(Mutex::new(UploadCache::default())),
-            registry: Arc::new(Mutex::new(Registry::from_builtin_families())),
             is_localhost: false,
         }
     }
@@ -518,10 +515,6 @@ impl RpcClient {
     pub async fn chip_info(&self, name: &str) -> anyhow::Result<ChipData> {
         self.send_resp::<ChipInfoEndpoint, _>(&ChipInfoRequest { name: name.into() })
             .await
-    }
-
-    pub(crate) async fn registry(&self) -> MutexGuard<'_, Registry> {
-        self.registry.lock().await
     }
 }
 

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -79,10 +79,6 @@ pub async fn attach_probe(
                 )
             })?;
 
-        // Parse the YAML locally to validate it and register chip metadata for
-        // client-side transport setup; target state remains server-owned after attach.
-        client.registry().await.add_target_family_from_yaml(&file)?;
-
         client.load_chip_family(file).await?;
     }
 


### PR DESCRIPTION
## Summary

Part 3 of 6 of the RPC crate split. Based on #4207.

The RPC client carried its own `probe_rs::config::Registry`. That makes the client depend on the whole target description database, which a remote client should not need: the server already has one, and the server is the authority on what it can flash.

This pull request removes the registry from the client. The commands that need a registry locally now make their own:

- the local command path in `main.rs`
- the `cargo-flash` diagnostics

Chip description files are no longer parsed on the client. The client sends the file and the server validates it, which also means a malformed file now produces one error from one place instead of two different errors depending on where you ran the command.

## Behaviour change

If you pass a broken chip description file, the error now comes from the server. The message is the server's message. This is the one user visible change in this pull request, and it has a changelog fragment.

## Test plan

- [x] `just all`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] Checked by hand that a malformed `--chip-description-path` file is rejected with a clear error
