### PR TITLE
Add the probe-rs-rpc-client crate and prepare both crates for publication

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Bump versions
         run: |
           # mi and rpc follow a separate versioning scheme
-          cargo release version ${{ inputs.version }} --exclude probe-rs-mi --exclude probe-rs-rpc --execute --verbose --no-confirm --allow-branch ${BRANCH_NAME}
+          cargo release version ${{ inputs.version }} --exclude probe-rs-mi --exclude probe-rs-rpc --exclude probe-rs-rpc-client --execute --verbose --no-confirm --allow-branch ${BRANCH_NAME}
           cargo release replace --execute --verbose --no-confirm
           cargo release hook --execute --verbose --no-confirm
           cargo release commit --execute --verbose --no-confirm --sign-commit
@@ -100,6 +100,7 @@ jobs:
           - probe-rs-tools
           - probe-rs-mi
           - probe-rs-rpc
+          - probe-rs-rpc-client
           - probe-rs-debug"
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,6 +3184,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "probe-rs-rpc-client"
+version = "0.1.0"
+dependencies = [
+ "docsplay",
+ "futures-util",
+ "http",
+ "postcard",
+ "postcard-rpc",
+ "postcard-schema",
+ "probe-rs-rpc",
+ "rustls",
+ "serde",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-tungstenite 0.30.0",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "probe-rs-target"
 version = "0.32.0"
 dependencies = [
@@ -3248,11 +3269,11 @@ dependencies = [
  "probe-rs-linux",
  "probe-rs-mi",
  "probe-rs-rpc",
+ "probe-rs-rpc-client",
  "probe-rs-target",
  "ratatui",
  "regex",
  "rustix",
- "rustls",
  "rustyline-async",
  "sanitize-filename",
  "scroll",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,7 +3167,6 @@ dependencies = [
 name = "probe-rs-rpc"
 version = "0.1.0"
 dependencies = [
- "axum",
  "clap",
  "docsplay",
  "futures-util",
@@ -3235,7 +3234,6 @@ dependencies = [
  "debugid",
  "defmt-decoder",
  "directories",
- "docsplay",
  "dunce",
  "espflash",
  "fastrand",
@@ -3259,7 +3257,6 @@ dependencies = [
  "object 0.39.1",
  "parking_lot",
  "parse_int",
- "postcard",
  "postcard-rpc",
  "postcard-schema",
  "pretty_assertions",
@@ -3289,7 +3286,6 @@ dependencies = [
  "thiserror 2.0.19",
  "time",
  "tokio",
- "tokio-tungstenite 0.30.0",
  "tokio-util",
  "toml 1.1.3+spec-1.1.0",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "probe-rs-tools",
     "probe-rs-mi",
     "probe-rs-rpc",
+    "probe-rs-rpc-client",
     "probe-rs-debug",
     "probe-rs-espressif",
     "probe-rs-linux",
@@ -37,6 +38,7 @@ probe-rs-mi = { path = "probe-rs-mi", version = "0.2.0" }
 probe-rs-espressif = { path = "probe-rs-espressif", version = "0.32.0" }
 probe-rs-linux = { path = "probe-rs-linux", version = "0.32.0" }
 probe-rs-rpc = { path = "probe-rs-rpc", version = "0.1.0" }
+probe-rs-rpc-client = { path = "probe-rs-rpc-client", version = "0.1.0" }
 
 docsplay = "0.1.1"
 thiserror = "2.0.11"

--- a/changelog/added-rpc-client-crate.md
+++ b/changelog/added-rpc-client-crate.md
@@ -1,1 +1,0 @@
-The RPC client is available as the `probe-rs-rpc-client` crate

--- a/changelog/added-rpc-client-crate.md
+++ b/changelog/added-rpc-client-crate.md
@@ -1,0 +1,1 @@
+The RPC client is available as the `probe-rs-rpc-client` crate

--- a/changelog/added-rpc-crates.md
+++ b/changelog/added-rpc-crates.md
@@ -1,0 +1,1 @@
+The RPC protocol and the RPC client are now separate crates.

--- a/probe-rs-rpc-client/Cargo.toml
+++ b/probe-rs-rpc-client/Cargo.toml
@@ -6,9 +6,15 @@ edition.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 license.workspace = true
 rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+[package.metadata.release]
+shared-version = false
 
 [features]
 default = []

--- a/probe-rs-rpc-client/Cargo.toml
+++ b/probe-rs-rpc-client/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "probe-rs-rpc-client"
+version = "0.1.0"
+description = "A client for the probe-rs RPC interface"
+edition.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+remote = [
+    "probe-rs-rpc/remote",
+    "dep:rustls",
+    "dep:tokio-tungstenite",
+    "dep:http",
+    "dep:futures-util",
+    "dep:tokio-util",
+]
+
+[dependencies]
+probe-rs-rpc = { workspace = true }
+postcard = { version = "1.0", features = ["use-std"] }
+postcard-rpc = { version = "0.12.0", features = ["use-std"] }
+postcard-schema = { version = "0.2.0", features = ["use-std", "derive"] }
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1.0", features = ["fs", "macros", "net", "sync", "time"] }
+sha2 = "0.11"
+docsplay = { workspace = true }
+thiserror = { workspace = true }
+tracing = "0.1"
+futures-util = { version = "0.3", optional = true }
+tokio-util = { version = "0.7", optional = true }
+http = { version = "1.4", optional = true }
+rustls = { version = "0.23", default-features = false, features = [
+    "std",
+    "ring",
+], optional = true }
+tokio-tungstenite = { version = "0.30", features = [
+    "rustls-tls-webpki-roots",
+], optional = true }
+
+[lints]
+workspace = true

--- a/probe-rs-rpc-client/README.md
+++ b/probe-rs-rpc-client/README.md
@@ -1,0 +1,16 @@
+# probe-rs-rpc-client
+
+This crate holds the client for the probe-rs RPC interface. Programs that
+talk to a `probe-rs serve` server depend on it.
+
+## Usage
+
+Add the crate as a dependency in your `Cargo.toml` file:
+
+```toml
+[dependencies]
+probe-rs-rpc-client = { version = "0.1", features = ["remote"] }
+```
+
+Use `connect` to open a remote session, then call methods on
+`SessionInterface` and `CoreInterface`.

--- a/probe-rs-rpc-client/src/lib.rs
+++ b/probe-rs-rpc-client/src/lib.rs
@@ -1,10 +1,7 @@
-//! Remote client
+//! A client for the probe-rs RPC interface.
 //!
-//! The client opens a websocket connection to the host, sends a token to authenticate and
-//! then sends commands to the server. The commands are handled by the server (by the same
-//! handlers that are used for the local commands) and the output is streamed back to the client.
-//!
-//! The command output may be a result and/or a stream of messages encoded as `ServerMessage`.
+//! Programs that talk to a `probe-rs serve` server depend on this crate.
+//! Enable the `remote` feature for websocket and unix socket transport.
 
 use postcard_rpc::{
     Topic,

--- a/probe-rs-rpc-client/src/lib.rs
+++ b/probe-rs-rpc-client/src/lib.rs
@@ -25,10 +25,11 @@ use std::{
     time::Duration,
 };
 
-use crate::rpc::{
-    FlashLoader, Key, RttClient, Session,
-    upload_cache::{ContentHash, ResolvedUpload, UploadCache},
-};
+mod upload_cache;
+
+use upload_cache::UploadCache;
+pub use upload_cache::{ContentHash, ResolvedUpload};
+
 use probe_rs_rpc::breakpoints::{
     BreakpointResolution, ResolveSourceBreakpointsRequest, ResolveSourceLocationsRequest,
     SourceBreakpointLocation, WireSourceLocation,
@@ -98,10 +99,11 @@ use probe_rs_rpc::{
     VariablesEndpoint, VerifyEndpoint, WriteMemory8Endpoint, WriteMemory16Endpoint,
     WriteMemory32Endpoint, WriteMemory64Endpoint,
 };
+use probe_rs_rpc::{FlashLoader, Key, RttClient, Session};
 
 /// Host and optional authentication token identifying a remote probe-rs RPC
 /// server. `None` selects a local, in-process server.
-pub(crate) type RemoteParams = Option<(String, Option<String>)>;
+pub type RemoteParams = Option<(String, Option<String>)>;
 
 #[derive(Debug, docsplay::Display, thiserror::Error)]
 pub enum TransportError {
@@ -129,10 +131,6 @@ pub enum ClientError {
     #[display("{0}")]
     Remote(RpcError),
     /// Failed to parse server URI.
-    #[cfg_attr(
-        not(feature = "remote"),
-        expect(dead_code, reason = "only constructed by the remote connect path")
-    )]
     InvalidRemoteHost,
     /// Failed to read {0}.
     FileRead(PathBuf, #[source] std::io::Error),
@@ -153,9 +151,13 @@ fn from_io_closed(_: IoClosed) -> ClientError {
 }
 
 #[cfg(feature = "remote")]
-pub async fn connect(host: &str, token: Option<&str>) -> Result<RpcClient, ClientError> {
-    use axum::http::Uri;
+pub async fn connect(
+    host: &str,
+    token: Option<&str>,
+    user_agent: &str,
+) -> Result<RpcClient, ClientError> {
     use futures_util::StreamExt as _;
+    use http::Uri;
     use probe_rs_rpc::transport::websocket::{WebsocketRx, WebsocketTx};
     use rustls::ClientConfig;
     use sha2::{Digest, Sha512};
@@ -180,10 +182,7 @@ pub async fn connect(host: &str, token: Option<&str>) -> Result<RpcClient, Clien
     // there are setups where the user uses port forwarding and the file actually needs to be
     // uploaded for correct behavior. Therefore, this check is not performed.
 
-    let req = ClientRequestBuilder::new(uri).with_header(
-        "User-Agent",
-        format!("probe-rs-tools {}", env!("PROBE_RS_LONG_VERSION")),
-    );
+    let req = ClientRequestBuilder::new(uri).with_header("User-Agent", user_agent);
 
     // TODO: implement something more secure
     let rustls_connector = ClientConfig::builder()
@@ -856,7 +855,7 @@ impl SessionInterface {
 
     /// Path-based stack trace for generic CLI callers. Uploads and parses
     /// DWARF from `path` on each request; does not use session
-    /// `crate::rpc::debug_state::ServerDebugState`. DAP stack refresh uses
+    /// `ServerDebugState`. DAP stack refresh uses
     /// [`Self::take_rich_stack_trace`] instead.
     pub async fn stack_trace(
         &self,
@@ -1091,7 +1090,7 @@ impl SessionInterface {
             .await
     }
 
-    pub(crate) async fn verify(
+    pub async fn verify(
         &self,
         loader: Key<FlashLoader>,
         on_msg: impl AsyncFnMut(ProgressEvent),
@@ -1120,7 +1119,7 @@ impl CoreInterface {
     ///
     /// Used by the RPC-backed DAP backend, which needs to synthesize a core
     /// client on every access.
-    pub(crate) fn new_for_backend(client: RpcClient, sessid: Key<Session>, core: u32) -> Self {
+    pub fn new_for_backend(client: RpcClient, sessid: Key<Session>, core: u32) -> Self {
         Self {
             sessid,
             core,
@@ -1517,7 +1516,7 @@ pub(crate) trait MultiSubscription {
     }
 }
 
-pub(crate) enum MonitorEvent {
+pub enum MonitorEvent {
     Rtt(RttEvent),
     Semihosting(SemihostingEvent),
 }
@@ -1564,30 +1563,5 @@ where
 
     async fn next(&mut self) -> Option<Self::Message> {
         self.recv().await
-    }
-}
-
-#[cfg(test)]
-mod resolve_upload_tests {
-    use super::*;
-    use crate::rpc::functions::{ProbeAccess, RpcApp};
-    use std::io::Write;
-    use tempfile::NamedTempFile;
-
-    #[tokio::test]
-    async fn local_resolve_upload_tracks_content_changes() {
-        let (_server, tx, rx) = RpcApp::create_server(16, ProbeAccess::All);
-        let client = RpcClient::new_local_from_wire(tx, rx);
-
-        let mut file = NamedTempFile::new().unwrap();
-        write!(file, "v1").unwrap();
-        let path = file.path().to_path_buf();
-
-        let first = client.resolve_upload(&path).await.unwrap();
-        write!(file, "v2").unwrap();
-        let second = client.resolve_upload(&path).await.unwrap();
-
-        assert_ne!(first.content_hash, second.content_hash);
-        assert_eq!(first.remote_path, second.remote_path);
     }
 }

--- a/probe-rs-rpc-client/src/upload_cache.rs
+++ b/probe-rs-rpc-client/src/upload_cache.rs
@@ -14,10 +14,10 @@ use std::{
 
 /// SHA-256 digest of a local file's contents.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct ContentHash([u8; 32]);
+pub struct ContentHash([u8; 32]);
 
 impl ContentHash {
-    pub(crate) fn from_bytes(data: &[u8]) -> Self {
+    pub fn from_bytes(data: &[u8]) -> Self {
         let digest = Sha256::digest(data);
         Self(digest.into())
     }
@@ -26,14 +26,14 @@ impl ContentHash {
 /// A resolved local upload: canonical path, content identity, and the path
 /// the RPC server should read (remote temp path, or the local path in-process).
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ResolvedUpload {
-    pub(crate) canonical_path: PathBuf,
-    pub(crate) content_hash: ContentHash,
-    pub(crate) remote_path: PathBuf,
+pub struct ResolvedUpload {
+    pub canonical_path: PathBuf,
+    pub content_hash: ContentHash,
+    pub remote_path: PathBuf,
 }
 
 impl ResolvedUpload {
-    pub(crate) fn server_path(&self) -> &Path {
+    pub fn server_path(&self) -> &Path {
         &self.remote_path
     }
 }

--- a/probe-rs-rpc/Cargo.toml
+++ b/probe-rs-rpc/Cargo.toml
@@ -6,9 +6,15 @@ edition.workspace = true
 documentation.workspace = true
 homepage.workspace = true
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 license.workspace = true
 rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+[package.metadata.release]
+shared-version = false
 
 [features]
 default = []

--- a/probe-rs-rpc/Cargo.toml
+++ b/probe-rs-rpc/Cargo.toml
@@ -20,7 +20,6 @@ shared-version = false
 default = []
 clap = ["dep:clap", "dep:parse_int"]
 remote = ["dep:tokio-tungstenite", "dep:futures-util"]
-axum = ["dep:axum", "remote"]
 
 [dependencies]
 serde = { workspace = true }
@@ -38,7 +37,6 @@ tokio-tungstenite = { version = "0.30", features = [
     "rustls-tls-webpki-roots",
 ], optional = true }
 futures-util = { version = "0.3", optional = true }
-axum = { version = "0.8", features = ["ws"], optional = true }
 
 [lints]
 workspace = true

--- a/probe-rs-rpc/Cargo.toml
+++ b/probe-rs-rpc/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 default = []
 clap = ["dep:clap", "dep:parse_int"]
 remote = ["dep:tokio-tungstenite", "dep:futures-util"]
+axum = ["dep:axum", "remote"]
 
 [dependencies]
 serde = { workspace = true }

--- a/probe-rs-rpc/README.md
+++ b/probe-rs-rpc/README.md
@@ -1,0 +1,24 @@
+# probe-rs-rpc
+
+This crate holds the wire types, endpoint tables, and transport for the
+probe-rs RPC protocol. The `probe-rs-rpc-client` crate and the
+`probe-rs serve` server depend on it.
+
+## Version compatibility
+
+The protocol is not stable between releases. postcard-rpc keys each endpoint
+by a hash of its path and its schemas. A client that talks to a server of
+a different version gets an unknown endpoint error, not corrupt data. See
+`ClientError::UnknownEndpoint` in the `probe-rs-rpc-client` crate.
+
+## Usage
+
+Add the crate as a dependency in your `Cargo.toml` file:
+
+```toml
+[dependencies]
+probe-rs-rpc = "0.1"
+```
+
+Enable the `remote` feature when you need the unix socket or websocket
+transport. Enable the `clap` feature when you need CLI option types.

--- a/probe-rs-rpc/src/lib.rs
+++ b/probe-rs-rpc/src/lib.rs
@@ -1,3 +1,8 @@
+//! Wire types, endpoint tables, and transport for the probe-rs RPC protocol.
+//!
+//! Programs that implement or speak the protocol depend on this crate.
+//! The client crate is `probe-rs-rpc-client`.
+
 use std::{
     hash::{Hash, Hasher},
     marker::PhantomData,

--- a/probe-rs-rpc/src/transport/websocket.rs
+++ b/probe-rs-rpc/src/transport/websocket.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "axum")]
-use axum::extract::ws;
 use futures_util::{FutureExt, Sink, SinkExt, Stream, StreamExt};
 use postcard_rpc::server::{WireRxErrorKind, WireTxErrorKind};
 use std::{
@@ -105,43 +103,5 @@ where
             .send(Message::Binary(frame(&msg).freeze()))
             .await
             .map_err(|_| WireTxErrorKind::Other)
-    }
-}
-
-#[cfg(feature = "axum")]
-// Sends length-prefixed binary messages to a websocket stream
-#[cfg(feature = "axum")]
-pub struct AxumWebsocketTx<S> {
-    writer: S,
-}
-#[cfg(feature = "axum")]
-impl<S> AxumWebsocketTx<S> {
-    pub fn new(writer: S) -> Self {
-        Self { writer }
-    }
-}
-
-#[cfg(feature = "axum")]
-impl<S> Sink<Vec<u8>> for AxumWebsocketTx<S>
-where
-    S: Sink<ws::Message> + Unpin,
-{
-    type Error = S::Error;
-
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.writer.poll_ready_unpin(cx)
-    }
-
-    fn start_send(mut self: Pin<&mut Self>, msg: Vec<u8>) -> Result<(), Self::Error> {
-        self.writer
-            .start_send_unpin(ws::Message::Binary(frame(&msg).freeze()))
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.writer.poll_flush_unpin(cx)
-    }
-
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.writer.poll_close_unpin(cx)
     }
 }

--- a/probe-rs-rpc/src/transport/websocket.rs
+++ b/probe-rs-rpc/src/transport/websocket.rs
@@ -108,6 +108,7 @@ where
     }
 }
 
+#[cfg(feature = "axum")]
 // Sends length-prefixed binary messages to a websocket stream
 #[cfg(feature = "axum")]
 pub struct AxumWebsocketTx<S> {

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -18,12 +18,11 @@ default-run = "probe-rs"
 [features]
 default = []
 # Include server/client functionality
-remote = ["dep:tokio-tungstenite", "dep:axum", "probe-rs-rpc/remote", "probe-rs-rpc/axum", "probe-rs-rpc-client/remote"]
+remote = ["dep:axum", "probe-rs-rpc/remote", "probe-rs-rpc-client/remote"]
 
 [dependencies]
 anyhow = { workspace = true }
 base64 = "0.23"
-docsplay = { workspace = true }
 jep106 = "0.3"
 num-traits = "0.2"
 scroll = "0.13"
@@ -113,12 +112,8 @@ probe-rs-rpc-client = { workspace = true }
 tokio = { version = "1.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 futures-util = { version = "0.3" }
-tokio-tungstenite = { version = "0.30", features = [
-    "rustls-tls-webpki-roots",
-], optional = true }
 axum = { version = "0.8", features = ["ws"], optional = true }
 tempfile = "3.0"
-postcard = { version = "1.0", features = ["use-std"] }
 postcard-rpc = { version = "0.12.0", features = ["use-std"] }
 postcard-schema = { version = "0.2.0", features = ["use-std", "derive"] }
 sha2 = "0.11"

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -18,7 +18,7 @@ default-run = "probe-rs"
 [features]
 default = []
 # Include server/client functionality
-remote = ["dep:tokio-tungstenite", "dep:axum", "dep:rustls", "probe-rs-rpc/remote", "probe-rs-rpc/axum"]
+remote = ["dep:tokio-tungstenite", "dep:axum", "probe-rs-rpc/remote", "probe-rs-rpc/axum", "probe-rs-rpc-client/remote"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -107,15 +107,12 @@ probe-rs-mi.workspace = true
 probe-rs-target.workspace = true
 probe-rs-espressif.workspace = true
 probe-rs-rpc = { workspace = true, features = ["clap"] }
+probe-rs-rpc-client = { workspace = true }
 
 # Server-only
 tokio = { version = "1.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 futures-util = { version = "0.3" }
-rustls = { version = "0.23", default-features = false, features = [
-    "std",
-    "ring",
-], optional = true }
 tokio-tungstenite = { version = "0.30", features = [
     "rustls-tls-webpki-roots",
 ], optional = true }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/attach.rs
@@ -3,12 +3,12 @@ use std::path::PathBuf;
 use time::UtcOffset;
 
 use crate::cmd::run::{MonitoringOptions, NormalRunOptions};
-use crate::rpc::client::RpcClient;
 use crate::rpc::utils::run_loop::VectorCatchConfig;
 use crate::util::cli::{self, FileMetadata, parse_metadata, rtt_client};
 use crate::util::common_options::ProbeOptions;
 use probe_rs_rpc::format::FormatOptions;
 use probe_rs_rpc::monitor::MonitorMode;
+use probe_rs_rpc_client::RpcClient;
 
 #[derive(clap::Parser)]
 #[group(skip)]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -10,7 +10,6 @@ use std::{
     process,
 };
 
-use crate::rpc::client::RpcClient;
 use crate::util::cargo::build_artifact;
 use crate::util::cargo::cargo_target;
 use crate::util::common_options::{
@@ -19,6 +18,7 @@ use crate::util::common_options::{
 use crate::util::logging::{LevelFilter, setup_logging};
 use crate::util::{cli, logging};
 use crate::{Config, parse_and_resolve_cli_args, run_app};
+use probe_rs_rpc_client::RpcClient;
 
 /// Common options when flashing a target device.
 #[derive(Debug, clap::Parser)]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/chip.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/chip.rs
@@ -2,8 +2,8 @@ use std::io::Write;
 
 use bytesize::ByteSize;
 
-use crate::rpc::client::RpcClient;
 use probe_rs_rpc::chip::MemoryRegion;
+use probe_rs_rpc_client::RpcClient;
 
 #[derive(clap::Parser)]
 pub struct Cmd {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/common/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/common/info.rs
@@ -1,6 +1,7 @@
 use probe_rs_mi::info::BasicDeviceInfo;
 
-use crate::{rpc::client::RpcClient, util::cli, util::common_options::ProbeOptions};
+use crate::{util::cli, util::common_options::ProbeOptions};
+use probe_rs_rpc_client::RpcClient;
 
 /// Attach to a probe and return the auto-detected chip name.
 ///

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/backend/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/backend/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! The DAP server drives the target exclusively through [`rpc::RpcBackend`],
 //! which forwards every operation to a probe-rs RPC server via
-//! [`crate::rpc::client::RpcClient`] — including the in-process RPC server
+//! [`probe_rs_rpc_client::RpcClient`] — including the in-process RPC server
 //! used for local sessions, so the debugger never touches a
 //! [`probe_rs::Session`] directly.
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/backend/rpc.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/backend/rpc.rs
@@ -1,7 +1,7 @@
 //! RPC backend for the DAP server.
 //!
 //! [`RpcBackend`] proxies all session/core operations to a probe-rs RPC
-//! server through [`crate::rpc::client::RpcClient`]. The DAP session loop is
+//! server through [`probe_rs_rpc_client::RpcClient`]. The DAP session loop is
 //! driven from a [`tokio::task::spawn_blocking`] task on a multi-threaded
 //! runtime, so async round trips can be `.await`ed directly — no
 //! `block_on`/`block_in_place` bridge is required.
@@ -16,7 +16,6 @@ use crate::cmd::dap_server::debug_adapter::dap::dap_types::{
 use crate::cmd::dap_server::server::configuration::FlashingConfig;
 use crate::rpc::{
     Key, Session,
-    client::{CoreInterface as RpcCoreClient, RpcClient, SessionInterface},
     functions::{
         breakpoints::convert::from_wire_source_location,
         core_ops::convert::{
@@ -46,6 +45,9 @@ use probe_rs_rpc::flash::{
 use probe_rs_rpc::info::WireSessionTargetMetadata;
 use probe_rs_rpc::stack_trace::{
     RichStackTraces, SourceLocation as WireSourceLocation, WireDebugRegister,
+};
+use probe_rs_rpc_client::{
+    CoreInterface as RpcCoreClient, ResolvedUpload, RpcClient, SessionInterface,
 };
 
 /// Convert an [`anyhow::Error`] coming out of the RPC client into the
@@ -800,7 +802,7 @@ impl RpcBackend {
 
     pub(crate) async fn flash_binary_resolved(
         &mut self,
-        upload: &crate::rpc::upload_cache::ResolvedUpload,
+        upload: &ResolvedUpload,
         config: &FlashingConfig,
         progress: &mut dyn FnMut(WireProgressEvent),
     ) -> Result<(), DebuggerError> {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/mod.rs
@@ -23,8 +23,8 @@ use std::{
 };
 use time::UtcOffset;
 
-use crate::rpc::client::RpcClient;
 use crate::util::common_options::OperationError;
+use probe_rs_rpc_client::RpcClient;
 
 #[derive(Debug, thiserror::Error)]
 pub enum DebuggerError {
@@ -103,7 +103,7 @@ impl Cmd {
 pub async fn run(
     cmd: Cmd,
     stdio_client: Option<RpcClient>,
-    remote: crate::rpc::client::RemoteParams,
+    remote: probe_rs_rpc_client::RemoteParams,
     time_offset: UtcOffset,
     log_file: Option<&Path>,
 ) -> Result<()> {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
@@ -1,10 +1,11 @@
 use crate::{
     cmd::dap_server::{DebuggerError, debug_adapter::dap::adapter::*},
-    rpc::{Key, RttClient, client::SessionInterface},
+    rpc::{Key, RttClient},
     util::rtt::RttDecoder,
 };
 use anyhow::anyhow;
 use probe_rs::rtt::Error as RttError;
+use probe_rs_rpc_client::SessionInterface;
 
 /// Per-channel result of a batched [`RemoteRttClient::poll_channels_remote`]
 /// call.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -5,24 +5,22 @@ use super::{
     startup::{TargetSessionType, get_file_timestamp},
     uploaded_files::UploadedFiles,
 };
-use crate::{
-    cmd::dap_server::{
-        DebuggerError,
-        debug_adapter::dap::{
-            adapter::{DebugAdapter, get_arguments},
-            dap_types::{
-                Capabilities, DisconnectResponse, Event, ExitedEventBody,
-                InitializeRequestArguments, MessageSeverity, Request, TerminatedEventBody,
-            },
+use crate::cmd::dap_server::{
+    DebuggerError,
+    debug_adapter::dap::{
+        adapter::{DebugAdapter, get_arguments},
+        dap_types::{
+            Capabilities, DisconnectResponse, Event, ExitedEventBody, InitializeRequestArguments,
+            MessageSeverity, Request, TerminatedEventBody,
         },
-        server::configuration::SessionConfig,
     },
-    rpc::{client::RpcClient, upload_cache::ResolvedUpload},
+    server::configuration::SessionConfig,
 };
 use anyhow::{Context, anyhow};
 use probe_rs::CoreStatus;
 use probe_rs_debug::DebugInfo;
 use probe_rs_rpc::flash::{Operation, ProgressEvent as WireProgressEvent};
+use probe_rs_rpc_client::{ResolvedUpload, RpcClient};
 use std::{collections::HashMap, path::Path, time::Duration};
 use time::UtcOffset;
 
@@ -1023,12 +1021,12 @@ mod test {
         server::configuration::{ConsoleLog, CoreConfig, FlashingConfig, SessionConfig},
         test::TestLister,
     };
-    use crate::rpc::client::RpcClient;
     use probe_rs::{
         architecture::arm::FullyQualifiedApAddress,
         integration::{FakeProbe, Operation},
         probe::{DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeFactory},
     };
+    use probe_rs_rpc_client::RpcClient;
     use serde_json::json;
     use std::{
         collections::{BTreeMap, HashMap, VecDeque},

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/rpc_lifetime.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/rpc_lifetime.rs
@@ -10,10 +10,10 @@ use anyhow::Context;
 use anyhow::Result;
 use tokio::task::JoinHandle;
 
-use crate::rpc::{
-    client::{RemoteParams, RpcClient},
-    functions::{ProbeAccess, RpcApp},
-};
+use crate::rpc::functions::{ProbeAccess, RpcApp};
+#[cfg(feature = "remote")]
+use probe_rs_rpc_client::connect;
+use probe_rs_rpc_client::{RemoteParams, RpcClient};
 
 /// Owns one RPC client and, for local mode, the in-process server task backing
 /// it. Drop or [`close`](Self::close) to release connection-scoped state.
@@ -29,7 +29,7 @@ impl DapRpcConnection {
     ) -> Result<Self> {
         #[cfg(feature = "remote")]
         if let Some((host, token)) = remote {
-            let client = crate::rpc::client::connect(host, token.as_deref())
+            let client = connect(host, token.as_deref(), &crate::util::meta::rpc_user_agent())
                 .await
                 .context("Failed to connect to remote probe-rs server")?;
             return Ok(Self {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -17,7 +17,7 @@ use crate::cmd::{
     },
     run::EmbeddedTestElfInfo,
 };
-use crate::rpc::{Key, RttClient, client::RpcClient};
+use crate::rpc::{Key, RttClient};
 use crate::util::cli::attach_probe as attach_probe_rpc;
 use crate::util::rtt::{DefmtProcessor, DefmtState, RttDecoder};
 use anyhow::{Result, anyhow};
@@ -26,6 +26,7 @@ use probe_rs_debug::SourceLocation;
 use probe_rs_rpc::breakpoints::SourceBreakpointLocation;
 use probe_rs_rpc::format::FormatKind;
 use probe_rs_rpc::rtt_client::ScanRegion as WireScanRegion;
+use probe_rs_rpc_client::{ResolvedUpload, RpcClient};
 use std::{any::Any, env::set_current_dir, path::Path};
 use time::UtcOffset;
 
@@ -403,11 +404,11 @@ impl SessionData {
         Ok(())
     }
 
-    /// Publish server-owned debug info from a prior [`crate::rpc::upload_cache::ResolvedUpload`].
+    /// Publish server-owned debug info from a prior [`ResolvedUpload`].
     pub(crate) async fn reload_debug_info_resolved(
         &mut self,
         core_configuration: &CoreConfig,
-        upload: &crate::rpc::upload_cache::ResolvedUpload,
+        upload: &ResolvedUpload,
     ) -> Result<(), DebuggerError> {
         let Some(core_data_index) = self
             .core_data

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/startup.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/startup.rs
@@ -1,7 +1,7 @@
 use super::{debugger::Debugger, rpc_lifetime::with_dap_rpc_connection};
 use crate::cmd::dap_server::debug_adapter::{dap::adapter::*, protocol::DapAdapter};
-use crate::rpc::client::{RemoteParams, RpcClient};
 use anyhow::{Context, Result};
+use probe_rs_rpc_client::{RemoteParams, RpcClient};
 use serde::Deserialize;
 use std::{
     fs,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
@@ -30,10 +30,10 @@ use crate::cmd::dap_server::server::configuration::CoreConfig;
 use crate::cmd::dap_server::server::configuration::FlashingConfig;
 use crate::cmd::dap_server::server::configuration::SessionConfig;
 use crate::cmd::dap_server::server::debugger::Debugger;
-use crate::rpc::client::RpcClient;
 use crate::util::cli::{Prompt, probe_rs_color_enabled};
 use crate::util::rtt::RttConfig;
 use crate::{CoreOptions, util::common_options::ProbeOptions};
+use probe_rs_rpc_client::RpcClient;
 
 use super::dap_server::debug_adapter::dap::dap_types::Request;
 use super::dap_server::debug_adapter::dap::dap_types::Response;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/download.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/download.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::rpc::client::RpcClient;
+use probe_rs_rpc_client::RpcClient;
 
 use crate::util::cli;
 use crate::util::common_options::BinaryDownloadOptions;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/erase.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/erase.rs
@@ -1,8 +1,6 @@
-use crate::{
-    rpc::client::RpcClient,
-    util::{cli, common_options::ProbeOptions, flash::CliProgressBars},
-};
+use crate::util::{cli, common_options::ProbeOptions, flash::CliProgressBars};
 use probe_rs_rpc::flash::EraseCommand;
+use probe_rs_rpc_client::RpcClient;
 
 #[derive(clap::Parser)]
 pub struct Cmd {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -13,14 +13,12 @@ use termtree::Tree;
 
 use crate::rpc::functions::chip::convert::from_wire_jep106_code;
 use crate::rpc::functions::probe::convert::{to_wire_debug_probe_selector, to_wire_protocol};
-use crate::{
-    rpc::client::RpcClient,
-    util::{cli::select_probe, common_options::ProbeOptions},
-};
+use crate::util::{cli::select_probe, common_options::ProbeOptions};
 use probe_rs_rpc::info::{
     ApInfo, ComponentTreeNode, DebugPortInfo, DebugPortInfoNode, DebugPortVersion, InfoEvent,
     MinDpSupport, TargetInfoRequest,
 };
+use probe_rs_rpc_client::RpcClient;
 
 const JEP_ARM: JEP106Code = JEP106Code::new(4, 0x3b);
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/list.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/list.rs
@@ -1,4 +1,4 @@
-use crate::rpc::client::RpcClient;
+use probe_rs_rpc_client::RpcClient;
 
 #[derive(clap::Parser)]
 pub struct Cmd {}

--- a/probe-rs-tools/src/bin/probe-rs/cmd/mi.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/mi.rs
@@ -1,7 +1,7 @@
 mod info;
 mod meta;
 
-use crate::rpc::client::RpcClient;
+use probe_rs_rpc_client::RpcClient;
 
 #[derive(clap::Parser)]
 #[group(skip)]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/mi/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/mi/info.rs
@@ -1,6 +1,5 @@
-use crate::{
-    cmd::common::info::basic_info, rpc::client::RpcClient, util::common_options::ProbeOptions,
-};
+use crate::{cmd::common::info::basic_info, util::common_options::ProbeOptions};
+use probe_rs_rpc_client::RpcClient;
 
 #[derive(clap::Parser)]
 #[group(skip)]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/read.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/read.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use ihex::Record;
 use itertools::Itertools;
 
-use crate::rpc::client::{CoreInterface, RpcClient};
+use probe_rs_rpc_client::{CoreInterface, RpcClient};
 
 use crate::CoreOptions;
 use crate::util::cli;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/reset.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/reset.rs
@@ -1,8 +1,8 @@
 use crate::{
     CoreOptions,
-    rpc::client::RpcClient,
     util::{cli, common_options::ProbeOptions},
 };
+use probe_rs_rpc_client::RpcClient;
 
 #[derive(clap::Parser)]
 pub struct Cmd {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run.rs
@@ -1,10 +1,10 @@
 use std::path::{Path, PathBuf};
 
-use crate::rpc::client::RpcClient;
 use crate::rpc::utils::run_loop::VectorCatchConfig;
 use probe_rs_rpc::monitor::MonitorMode;
 use probe_rs_rpc::rtt_client::ScanRegion;
 use probe_rs_rpc::test::{Test, TestDefinition};
+use probe_rs_rpc_client::RpcClient;
 
 use crate::util::cli::{self, parse_metadata, rtt_client};
 use crate::util::common_options::{BinaryDownloadOptions, ProbeOptions};

--- a/probe-rs-tools/src/bin/probe-rs/cmd/serve.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/serve.rs
@@ -14,9 +14,10 @@ use axum::{
     routing::{any, get},
 };
 use base64::{Engine, engine::general_purpose::STANDARD};
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{Sink, SinkExt, StreamExt};
 use postcard_rpc::server::WireRxErrorKind;
 use probe_rs::probe::list::Lister;
+use probe_rs_rpc::transport::{frame, websocket::WebsocketRx};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha512};
 use tokio::task::LocalSet;
@@ -25,13 +26,49 @@ use tokio_util::bytes::Bytes;
 #[cfg(unix)]
 use std::path::PathBuf;
 use std::{fmt::Write, sync::Arc};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use crate::{
     rpc::functions::{ProbeAccess, RpcApp},
     util::pwr,
 };
-#[cfg(feature = "remote")]
-use probe_rs_rpc::transport::websocket::{AxumWebsocketTx, WebsocketRx};
+
+// Sends length-prefixed binary messages to a websocket stream
+pub struct AxumWebsocketTx<S> {
+    writer: S,
+}
+impl<S> AxumWebsocketTx<S> {
+    pub fn new(writer: S) -> Self {
+        Self { writer }
+    }
+}
+
+impl<S> Sink<Vec<u8>> for AxumWebsocketTx<S>
+where
+    S: Sink<ws::Message> + Unpin,
+{
+    type Error = S::Error;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.writer.poll_ready_unpin(cx)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, msg: Vec<u8>) -> Result<(), Self::Error> {
+        self.writer
+            .start_send_unpin(ws::Message::Binary(frame(&msg).freeze()))
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.writer.poll_flush_unpin(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.writer.poll_close_unpin(cx)
+    }
+}
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/verify.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/verify.rs
@@ -1,11 +1,11 @@
 use std::path::PathBuf;
 
-use crate::rpc::client::RpcClient;
 use crate::util::cli;
 use crate::util::common_options::ProbeOptions;
 use crate::util::flash::CliProgressBars;
 use probe_rs_rpc::flash::VerifyResult;
 use probe_rs_rpc::format::FormatOptions;
+use probe_rs_rpc_client::RpcClient;
 
 #[derive(clap::Parser)]
 pub struct Cmd {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/write.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/write.rs
@@ -1,4 +1,4 @@
-use crate::rpc::client::RpcClient;
+use probe_rs_rpc_client::RpcClient;
 
 use crate::CoreOptions;
 use crate::util::common_options::{ProbeOptions, ReadWriteBitWidth, ReadWriteOptions};

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -22,9 +22,9 @@ use report::Report;
 use serde::{Deserialize, Serialize};
 use time::{OffsetDateTime, UtcOffset};
 
-use crate::rpc::client::{RemoteParams, RpcClient};
 use crate::rpc::functions::RpcApp;
 use crate::util::logging::setup_logging;
+use probe_rs_rpc_client::{RemoteParams, RpcClient};
 
 const MAX_LOG_FILES: usize = 20;
 
@@ -394,7 +394,12 @@ async fn run_app<R>(
     #[cfg(feature = "remote")]
     if let Some((host, token)) = connection_params {
         // Run the command remotely.
-        let client = rpc::client::connect(&host, token.as_deref()).await?;
+        let client = probe_rs_rpc_client::connect(
+            &host,
+            token.as_deref(),
+            &crate::util::meta::rpc_user_agent(),
+        )
+        .await?;
 
         return cb(client).await;
     }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client_tests.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client_tests.rs
@@ -1,0 +1,23 @@
+use std::io::Write;
+
+use probe_rs_rpc_client::RpcClient;
+use tempfile::NamedTempFile;
+
+use crate::rpc::functions::{ProbeAccess, RpcApp};
+
+#[tokio::test]
+async fn local_resolve_upload_tracks_content_changes() {
+    let (_server, tx, rx) = RpcApp::create_server(16, ProbeAccess::All);
+    let client = RpcClient::new_local_from_wire(tx, rx);
+
+    let mut file = NamedTempFile::new().unwrap();
+    write!(file, "v1").unwrap();
+    let path = file.path().to_path_buf();
+
+    let first = client.resolve_upload(&path).await.unwrap();
+    write!(file, "v2").unwrap();
+    let second = client.resolve_upload(&path).await.unwrap();
+
+    assert_ne!(first.content_hash, second.content_hash);
+    assert_eq!(first.remote_path, second.remote_path);
+}

--- a/probe-rs-tools/src/bin/probe-rs/rpc/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/mod.rs
@@ -32,12 +32,13 @@ impl ObjectMarker for TempFileHandle {
     type Object = tempfile::NamedTempFile;
 }
 
-pub mod client;
 pub mod debug_state;
 pub mod functions;
 pub mod svd;
-pub(crate) mod upload_cache;
 pub mod utils;
+
+#[cfg(test)]
+mod client_tests;
 
 pub(crate) struct ObjectStorage {
     storage: HashMap<u64, Arc<Mutex<dyn Any + Send>>>,

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -23,7 +23,6 @@ use tokio_util::sync::CancellationToken;
 use crate::cmd::run::{EmbeddedTestElfInfo, MonitoringOptions};
 use crate::rpc::Key;
 use crate::rpc::RttClient;
-use crate::rpc::client::{MonitorEvent, RpcClient, SessionInterface};
 use crate::rpc::functions::probe::convert::{
     from_wire_debug_probe_selector, to_wire_debug_probe_selector, to_wire_protocol,
 };
@@ -49,6 +48,7 @@ use probe_rs_rpc::semihosting_options::SemihostingOptions;
 use probe_rs_rpc::stack_trace::StackTrace;
 use probe_rs_rpc::stack_trace::StackTraceFrame;
 use probe_rs_rpc::test::{Test, TestResult};
+use probe_rs_rpc_client::{MonitorEvent, RpcClient, SessionInterface};
 
 type TargetOutputFiles = std::collections::HashMap<ChannelIdentifier, tokio::fs::File>;
 

--- a/probe-rs-tools/src/bin/probe-rs/util/meta.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/meta.rs
@@ -1,6 +1,12 @@
 use anyhow::{Context, Result};
 use probe_rs_mi::meta::Meta;
 
+#[cfg(feature = "remote")]
+#[cfg(feature = "remote")]
+pub fn rpc_user_agent() -> String {
+    format!("probe-rs-tools {}", env!("PROBE_RS_LONG_VERSION"))
+}
+
 pub fn current_meta() -> Result<Meta> {
     Ok(Meta {
         version: env!("PROBE_RS_VERSION")


### PR DESCRIPTION
## Summary

Part 6 of 6 of the RPC crate split. Based on #4210. Closes #3327 

This pull request adds the `probe-rs-rpc-client` crate, moves the client and the upload cache into it, and prepares both new crates for crates.io.

After the earlier pull requests the client names no `probe-rs` type, holds no registry, and returns a typed error, so this is close to a file move.

## Dependency check

Neither crate depends on `probe-rs`. This was the goal of the whole stack.

```
$ cargo tree -p probe-rs-rpc -e normal --all-features | grep "probe-rs v"
$ cargo tree -p probe-rs-rpc-client -e normal --all-features | grep "probe-rs v"
```

Both are empty. `axum` also does not reach the client, since the server side websocket adapter sits behind its own feature.

## Notes for the reviewer

**The user agent is now a parameter.** The client used to build `probe-rs-tools {PROBE_RS_LONG_VERSION}` from its own crate version. A library should not hardcode the name of one program that uses it, and the version would have been the library's rather than the tool's. `probe-rs-tools` passes the same string it sent before, so the wire behaviour does not change.

**One test stayed behind.** The test module in the old `client.rs` builds an `RpcApp`, which is server side and stays in the binary. It now lives in `probe-rs-tools/src/bin/probe-rs/rpc/client_tests.rs`.

**Publication.** Publish `probe-rs-rpc` first, then `probe-rs-rpc-client`, which names it by version. `cargo publish --dry-run -p probe-rs-rpc` passes; `cargo package -p probe-rs-rpc-client` cannot pass until the first crate is on crates.io.

Both crates carry `shared-version = false`, so `cargo-release` keeps them at `0.1.0` rather than moving them to the workspace's `0.32.0`. `deny.toml` and `dist-workspace.toml` needed no change: neither lists workspace members by name, and cargo-dist builds only the root binary package.

## Test plan

- [x] `just all`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo clippy -p probe-rs-tools --no-default-features --all-targets -- -D warnings`
- [x] `cargo build -p probe-rs-rpc-client` with and without `remote`
- [x] `cargo doc` for both crates with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo package -p probe-rs-rpc`
- [x] `cargo +1.89 check --all-features`
- [x] `typos`
- [x] CLI checked by hand: `probe-rs --version`, `probe-rs chip list`, `probe-rs --help`
