### PR TITLE
fix - rtt down channel silently discarding bytes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,21 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
+{
+      "type": "lldb",
+      "request": "launch",
+      "name": "cargo-embed",
+      "cargo": {
+        "args": ["build", "--package", "probe-rs-tools"],
+        "filter": {
+          "name": "cargo-embed",
+          "kind": "bin"
+        }
+      },
+      "stopOnEntry": false,
+      "args": ["--bin", "proxy-main" ],
+      "cwd": "/Users/sean/Projects/crypto-seq/app/rp-app",
+    },    
     {
       "type": "lldb",
       "request": "launch",

--- a/changelog/fixed-rtt-down-channel-short-writes.md
+++ b/changelog/fixed-rtt-down-channel-short-writes.md
@@ -1,0 +1,1 @@
+Writing to an RTT down channel no longer silently discards the bytes the target could not accept. The `rtt/down` RPC endpoint now returns the number of bytes written, and takes a `timeout_ms` for how long the server should retry a channel that is full (`0` means a single attempt).

--- a/probe-rs-rpc-client/src/lib.rs
+++ b/probe-rs-rpc-client/src/lib.rs
@@ -722,18 +722,22 @@ impl SessionInterface {
             .await
     }
 
+    /// Write to an RTT down channel, returning how many bytes the target
+    /// accepted until finish or Timeout. Timeout = 0 -> single attempt
     pub async fn send_to_rtt(
         &self,
         rtt_client: Key<RttClient>,
         channel: u32,
         data: Vec<u8>,
-    ) -> Result<(), ClientError> {
+        timeout_ms: u32,
+    ) -> Result<u64, ClientError> {
         self.client
             .send_resp::<RttDownEndpoint, _>(&RttDownRequest {
                 sessid: self.sessid,
                 rtt_client,
                 channel,
                 data,
+                timeout_ms,
             })
             .await
     }

--- a/probe-rs-rpc/src/endpoints.rs
+++ b/probe-rs-rpc/src/endpoints.rs
@@ -32,7 +32,7 @@ use crate::reset::{ResetCoreAndHaltRequest, ResetCoreRequest};
 use crate::resume::ResumeAllCoresRequest;
 use crate::rtt_client::{
     CreateRttClientRequest, CreateRttClientResponse, PollRttUpRequest, PollRttUpResponse,
-    RttChannelRequest, RttChannelsResponse, RttDownRequest,
+    RttChannelRequest, RttChannelsResponse, RttDownRequest, RttDownResponse,
 };
 use crate::stack_trace::{
     LoadDebugInfoRequest, LoadDebugInfoResponse, TakeRichStackTraceRequest,
@@ -95,7 +95,7 @@ endpoints! {
     | LoadSvdEndpoint                  | LoadSvdRequest                  | LoadSvdResponse                  | "debug_state/load_svd"                   |
 
     | CreateRttClientEndpoint      | CreateRttClientRequest | CreateRttClientResponse | "create_rtt"              |
-    | RttDownEndpoint              | RttDownRequest         | NoResponse              | "rtt/down"                |
+    | RttDownEndpoint              | RttDownRequest         | RttDownResponse         | "rtt/down"                |
     | GetRttChannelsEndpoint       | RttChannelRequest      | RttChannelsResponse     | "rtt/channels"            |
     | PollRttUpEndpoint            | PollRttUpRequest       | PollRttUpResponse       | "rtt/poll_up"             |
     | CleanUpRttEndpoint           | RttChannelRequest      | NoResponse              | "rtt/clean_up"            |

--- a/probe-rs-rpc/src/rtt_client.rs
+++ b/probe-rs-rpc/src/rtt_client.rs
@@ -33,7 +33,14 @@ pub struct RttDownRequest {
     pub rtt_client: Key<RttClient>,
     pub channel: u32,
     pub data: Vec<u8>,
+    /// How long to keep retrying while the target's channel buffer is full.
+    /// `0` means a single attempt. The server caps this.
+    pub timeout_ms: u32,
 }
+
+/// The number of bytes the target accepted. A down channel write is not
+/// blocking, so this may be less than the request's data length.
+pub type RttDownResponse = RpcResult<u64>;
 
 #[derive(Serialize, Deserialize, Schema, Clone)]
 pub struct RttChannelMeta {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
@@ -56,14 +56,19 @@ impl RemoteRttClient {
     }
 
     /// Write data to a down channel.
+    ///
+    /// Single attempt, and the accepted count is discarded: this signature
+    /// cannot report a short write, so a full target buffer still loses the
+    /// tail here. Kept as it was rather than fixed blind -- see the callers.
     pub(crate) async fn write_down_async(
         &mut self,
         channel: u32,
         data: Vec<u8>,
     ) -> Result<(), RttError> {
         self.session
-            .send_to_rtt(self.rtt_client, channel, data)
+            .send_to_rtt(self.rtt_client, channel, data, 0)
             .await
+            .map(|_| ())
             .map_err(|e| RttError::Other(e.into()))
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/rtt_client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/rtt_client.rs
@@ -4,12 +4,13 @@ use crate::{
 };
 use postcard_rpc::header::VarHeader;
 use probe_rs::rtt;
-use probe_rs_rpc::NoResponse;
 use probe_rs_rpc::rtt_client::{
     CreateRttClientRequest, CreateRttClientResponse, PollRttUpRequest, PollRttUpResponse,
     RttChannelMeta, RttChannelRequest, RttChannels, RttChannelsResponse, RttClientData,
-    RttDownRequest, RttPollResult, ScanRegion,
+    RttDownRequest, RttDownResponse, RttPollResult, ScanRegion,
 };
+use probe_rs_rpc::{NoResponse, RpcError};
+use std::time::{Duration, Instant};
 
 pub async fn create_rtt_client(
     ctx: &mut RpcContext,
@@ -41,19 +42,61 @@ pub async fn create_rtt_client(
     })
 }
 
+/// Upper bound on `RttDownRequest::timeout_ms`.
+const MAX_DOWN_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How long to wait before retrying a full channel. The target drains on its own
+/// schedule, so this only has to be short relative to that.
+const DOWN_WRITE_RETRY_INTERVAL: Duration = Duration::from_millis(1);
+
 pub async fn write_rtt_down(
     ctx: &mut RpcContext,
     _header: VarHeader,
     request: RttDownRequest,
-) -> NoResponse {
-    let mut session = ctx.session(request.sessid).await;
-    let mut rtt_client = ctx.object_mut(request.rtt_client).await;
+) -> RttDownResponse {
+    // Nothing to write
+    if request.data.is_empty() {
+        return Ok(0);
+    }
 
-    let core_id = rtt_client.core_id();
-    let mut core = lift(session.core(core_id))?;
-    lift(rtt_client.write_down_channel(&mut core, request.channel, &request.data))?;
+    let timeout = Duration::from_millis(request.timeout_ms as u64).min(MAX_DOWN_WRITE_TIMEOUT);
+    let deadline = Instant::now() + timeout;
+    let mut written = 0;
 
-    Ok(())
+    loop {
+        let attached;
+
+        // Scoped so the session and RTT client guards drop before we sleep
+        {
+            let mut session = ctx.session(request.sessid).await;
+            let mut rtt_client = ctx.object_mut(request.rtt_client).await;
+
+            let core_id = rtt_client.core_id();
+            let mut core = lift(session.core(core_id))?;
+            written += lift(rtt_client.write_down_channel(
+                &mut core,
+                request.channel,
+                &request.data[written..],
+            ))?;
+            attached = rtt_client.is_attached();
+        }
+
+        // Nothing was written and nothing can be: report that rather than a
+        // zero-byte write, which the caller cannot tell from a full channel.
+        if !attached && written == 0 {
+            return Err(RpcError::from("RTT is not attached"));
+        }
+
+        // Only a full buffer is worth waiting on. Writing while unattached scans
+        // for the control block every time, so retrying that is far from free.
+        // A partial write still returns its count: erroring would leave the caller
+        // unable to tell what landed, and resending would duplicate it.
+        if written == request.data.len() || !attached || Instant::now() >= deadline {
+            return Ok(written as u64);
+        }
+
+        tokio::time::sleep(DOWN_WRITE_RETRY_INTERVAL).await;
+    }
 }
 
 pub async fn get_rtt_channels(

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -683,7 +683,7 @@ pub async fn monitor(
                     line.push('\n');
                     if let Some(client) = data.rtt_client
                         && let Err(error) = session
-                            .send_to_rtt(client, selected_channel, line.into_bytes())
+                            .send_to_rtt(client, selected_channel, line.into_bytes(), 0)
                             .await
                     {
                         eprintln!("Error sending data to RTT: {:?}", error);

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -144,8 +144,11 @@ impl RttActiveDownChannel {
         self.down_channel.number() as u32
     }
 
-    pub fn write(&mut self, core: &mut Core<'_>, data: impl AsRef<[u8]>) -> Result<(), Error> {
-        self.down_channel.write(core, data.as_ref()).map(|_| ())
+    /// Writes as much of `data` as the target's buffer accepts, returning how many
+    /// bytes were taken. This does not block: a caller that discards the count
+    /// cannot know what to retry, and silently loses the remainder.
+    pub fn write(&mut self, core: &mut Core<'_>, data: impl AsRef<[u8]>) -> Result<usize, Error> {
+        self.down_channel.write(core, data.as_ref())
     }
 }
 
@@ -202,13 +205,13 @@ impl RttConnection {
         }
     }
 
-    /// Send data to a down channel.
+    /// Send data to a down channel, returning how many bytes it accepted.
     pub fn write_down_channel(
         &mut self,
         core: &mut Core,
         channel_idx: u32,
         data: impl AsRef<[u8]>,
-    ) -> Result<(), Error> {
+    ) -> Result<usize, Error> {
         let channel_idx = channel_idx as usize;
         if let Some(channel) = self.active_down_channels.get_mut(channel_idx) {
             channel.write(core, data)

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt/client.rs
@@ -176,16 +176,18 @@ impl RttClient {
         Ok(&[])
     }
 
+    /// Writes as much of `input` as the target accepts, returning that count.
+    /// Returns 0 if RTT is not attached yet, in which case nothing was sent.
     pub(crate) fn write_down_channel(
         &mut self,
         core: &mut Core,
         channel: u32,
         input: impl AsRef<[u8]>,
-    ) -> Result<(), Error> {
+    ) -> Result<usize, Error> {
         self.try_attach(core)?;
 
         let Some(target) = self.target.as_mut() else {
-            return Ok(());
+            return Ok(0);
         };
 
         target.write_down_channel(core, channel, input)


### PR DESCRIPTION
Fix to RTT down channels silently discarding bytes that target didn't receive due to buffer overflow or too slow draining. 

Added timeout param to low-level transport, which now also returns number of bytes actually written to channel. RPC client altered and tested.

Did not update all consumers (dap_server, cargo-embed tab, repl) .. since they already suffered from this problem, and each case needs separate analysis, so maintained current behaviour.

