### PR TITLE
Add initial WCH CH570 and CH572 debugging support

### DIFF
--- a/changelog/added-ch570-ch572.md
+++ b/changelog/added-ch570-ch572.md
@@ -1,0 +1,1 @@
+Add initial debugging support for the WCH CH570 and CH572 via WCH-Link.

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -121,6 +121,8 @@ pub enum RiscvChip {
     CH32V00X = 0x4e,
     /// CH32V317 Qingke-V4F gigabit Ethernet series
     CH32V317 = 0x86,
+    /// CH570/CH572 Qingke-V3C series
+    CH570 = 0x8B,
     /// CH32H4 Qingke-V4F high-performance series (H415/H416/H417)
     CH32H4 = 0xC6,
 }
@@ -144,6 +146,7 @@ impl RiscvChip {
             0x49 => Some(RiscvChip::CH641),
             0x4E => Some(RiscvChip::CH32V00X),
             0x86 => Some(RiscvChip::CH32V317),
+            0x8B => Some(RiscvChip::CH570),
             0xC6 => Some(RiscvChip::CH32H4),
             _ => None,
         }
@@ -337,9 +340,13 @@ impl DebugProbe for WchLink {
 
         self.chip_family = resp.chip_family;
 
-        tracing::info!("attached riscv chip {:?}", self.chip_family);
-
         self.chip_id = resp.chip_id;
+
+        tracing::info!(
+            "attached riscv chip {:?} with chip id 0x{:08x}",
+            self.chip_family,
+            self.chip_id
+        );
 
         if self.chip_family.support_flash_protect() {
             self.device.send_command(commands::CheckFlashProtection)?;

--- a/probe-rs/targets/CH570_CH572_Series.yaml
+++ b/probe-rs/targets/CH570_CH572_Series.yaml
@@ -1,0 +1,53 @@
+name: CH570 / CH572 Series
+chip_detection:
+- !WchLink
+  mask: 0xff000000
+  variants:
+    0x70000000: CH570
+    0x72000000: CH572
+variants:
+- name: CH570
+  cores:
+  - name: main
+    type: riscv
+    core_access_options: !Riscv
+      hart_id: 0
+  memory_map:
+  - !Nvm
+    name: CodeFlash
+    range:
+      start: 0x0
+      end: 0x3c000
+    cores:
+    - main
+  - !Ram
+    name: RAM
+    range:
+      start: 0x20000000
+      end: 0x20003000
+    cores:
+    - main
+  flash_algorithms: []
+- name: CH572
+  cores:
+  - name: main
+    type: riscv
+    core_access_options: !Riscv
+      hart_id: 0
+  memory_map:
+  - !Nvm
+    name: CodeFlash
+    range:
+      start: 0x0
+      end: 0x3c000
+    cores:
+    - main
+  - !Ram
+    name: RAM
+    range:
+      start: 0x20000000
+      end: 0x20003000
+    cores:
+    - main
+  flash_algorithms: []
+flash_algorithms: []


### PR DESCRIPTION
## Summary

- recognize the WCH-Link family ID 0x8b used by CH570/CH572 (QingKe V3C)
- add CH570 and CH572 target definitions with 240 KiB CodeFlash and 12 KiB RAM
- auto-detect CH570/CH572 from WCH-Link chip IDs 0x70xxxxxx and 0x72xxxxxx
- include the reported chip ID in the WCH-Link attach log

This is initial debugging support only. No CH570/CH572 flash algorithm is included yet, so probe-rs can attach, inspect memory, debug, and reset the target but cannot program CodeFlash through this target definition.

## Verification

- cargo fmt --all --check
- cargo test -p probe-rs validate_builtin --features builtin-targets
- tested on a CH572D with WCH-LinkE firmware 2.18 at 400 kHz
- probe-rs info --protocol jtag --speed 400 reports Detected chip: CH572
- read access verified for peripheral registers and SRAM
- probe-rs reset --chip CH572 --protocol jtag --speed 400 succeeds