### PR TITLE
Add probe group configuration

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/benchmark.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/benchmark.rs
@@ -85,7 +85,7 @@ struct TestData {
 impl Cmd {
     pub fn run(self, registry: &mut Registry, lister: &Lister) -> anyhow::Result<()> {
         let speed = self.common.speed;
-        let common_options = self.common.load(registry)?;
+        let common_options = self.common.load(registry, lister)?;
         let mut max_speed = self.max_speed;
         let mut speeds = vec![];
         // if no max-speed specified, assume the user just wants to use a single speed (as per other cli cmds)

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -222,7 +222,7 @@ async fn main_try(args: Vec<OsString>, config: Config, offset: UtcOffset) -> Res
         chip_description_path: None,
         protocol: config.probe.protocol,
         non_interactive: false,
-        probe: selector,
+        probe: selector.map(|s| s.to_string()),
         cycle_power: false,
         speed: config.probe.speed,
         connect_under_reset: config.general.connect_under_reset,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/configuration.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/configuration.rs
@@ -262,7 +262,7 @@ impl SessionConfig {
             chip_description_path: self.chip_description_path.clone(),
             protocol: self.wire_protocol,
             non_interactive: true,
-            probe: self.probe.clone(),
+            probe: self.probe.clone().map(|s| s.to_string()),
             speed: self.speed,
             connect_under_reset: self.connect_under_reset,
             cycle_power: false,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/rpc_lifetime.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/rpc_lifetime.rs
@@ -140,7 +140,7 @@ mod tests {
             probe: probes
                 .into_iter()
                 .find(|p| p.serial_number == serial)
-                .map(|p| from_wire_debug_probe_selector(p.selector())),
+                .map(|p| from_wire_debug_probe_selector(p.selector()).to_string()),
             speed: None,
             connect_under_reset: false,
             dry_run: false,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
@@ -270,7 +270,7 @@ impl Cmd {
                 arguments: serde_json::to_value(&SessionConfig {
                     console_log_level: None,
                     cwd: None,
-                    probe: self.common.probe,
+                    probe: self.common.probe.as_deref().and_then(|s| s.parse().ok()),
                     chip: self.common.chip,
                     chip_description_path: self.common.chip_description_path,
                     chip_description_data: None,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -68,8 +68,11 @@ impl Cmd {
                 vec![WireProtocol::Jtag, WireProtocol::Swd]
             };
 
-            let probe =
-                select_probe(&client, self.common.probe.map(to_wire_debug_probe_selector)).await?;
+            let probe = self.common.probe
+                .as_deref()
+                .and_then(|s| s.parse().ok())
+                .map(to_wire_debug_probe_selector);
+            let probe = select_probe(&client, probe).await?;
 
             let mut any_success = false;
 

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -51,6 +51,15 @@ pub(crate) struct Config {
 
     /// A named set of `--key=value` pairs.
     pub presets: HashMap<String, ConfigPreset>,
+
+    /// Named groups of probes.
+    ///
+    /// Each group maps a name to a list of probe selector strings
+    /// (format: `VID:PID`, `VID:PID:SERIAL`, or `VID:PID-INTERFACE:SERIAL`).
+    /// When the user passes `--probe <group_name>`, probe-rs picks one
+    /// free probe from the group.
+    #[serde(default)]
+    pub probe_groups: HashMap<String, Vec<String>>,
 }
 
 #[derive(clap::Parser)]
@@ -337,6 +346,9 @@ async fn main() -> Result<()> {
     }
 
     let mut cli = parse_and_resolve_cli_args::<Cli>(args, &config)?;
+
+    // Store probe group definitions for use during probe resolution.
+    crate::util::common_options::set_probe_groups(config.probe_groups.clone());
 
     // If the user has not specified a log file, we will try to create one in the default location.
     if cli.log_file.is_none() && (cli.log_to_folder || cli.report.is_some()) {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -65,7 +65,7 @@ pub async fn target_info(
     request: TargetInfoRequest,
 ) -> NoResponse {
     let mut registry = ctx.registry().await;
-    let probe_options = ProbeOptions::from(&request).load(&mut registry)?;
+    let probe_options = ProbeOptions::from(&request).load(&mut registry, &ctx.lister())?;
 
     let probe = probe_options.attach_probe(&ctx.lister())?;
 
@@ -690,6 +690,8 @@ pub(crate) mod convert {
 
     impl From<&TargetInfoRequest> for ProbeOptions {
         fn from(request: &TargetInfoRequest) -> Self {
+            let selector: probe_rs::probe::DebugProbeSelector =
+                from_wire_debug_probe_selector(request.probe.selector());
             ProbeOptions {
                 chip: None,
                 chip_description_path: None,
@@ -698,7 +700,7 @@ pub(crate) mod convert {
                     WireProtocol::Swd => Some(ProbeRsWireProtocol::Swd),
                 },
                 non_interactive: true,
-                probe: Some(from_wire_debug_probe_selector(request.probe.selector())),
+                probe: Some(selector.to_string()),
                 speed: request.speed,
                 connect_under_reset: request.connect_under_reset,
                 cycle_power: false,

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/probe.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/probe.rs
@@ -163,7 +163,7 @@ fn attach_once(
 
     let lister = ctx.lister();
     let mut registry = ctx.registry_blocking();
-    let loaded = probe_options.load(&mut registry)?;
+    let loaded = probe_options.load(&mut registry, &lister)?;
     let target = loaded.get_target_selector()?;
 
     let probe = match loaded.attach_probe(&lister) {
@@ -453,12 +453,14 @@ pub(crate) mod convert {
 
     impl From<&AttachRequest> for ProbeOptions {
         fn from(request: &AttachRequest) -> Self {
+            let selector: probe_rs::probe::DebugProbeSelector =
+                from_wire_debug_probe_selector(request.probe.selector());
             ProbeOptions {
                 chip: request.chip.clone(),
                 chip_description_path: None,
                 protocol: request.protocol.map(from_wire_protocol),
                 non_interactive: true,
-                probe: Some(from_wire_debug_probe_selector(request.probe.selector())),
+                probe: Some(selector.to_string()),
                 speed: request.speed,
                 connect_under_reset: request.connect_under_reset,
                 cycle_power: false,

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -52,6 +52,69 @@ use probe_rs_rpc_client::{MonitorEvent, RpcClient, SessionInterface};
 
 type TargetOutputFiles = std::collections::HashMap<ChannelIdentifier, tokio::fs::File>;
 
+async fn resolve_probe_from_client(
+    client: &RpcClient,
+    probe_options: &ProbeOptions,
+) -> anyhow::Result<Option<DebugProbeSelector>> {
+    let Some(probe_arg) = &probe_options.probe else {
+        return Ok(None);
+    };
+
+    // Try group resolution via RPC client
+    if let Some(selectors) = crate::util::common_options::get_probe_groups().get(probe_arg) {
+        let probes = client.list_probes().await?;
+        for selector_str in selectors {
+            if let Ok(selector) = selector_str
+                .parse::<probe_rs::probe::DebugProbeSelector>()
+            {
+                for entry in &probes {
+                    if selector.vendor_id == entry.vendor_id
+                        && selector.product_id == entry.product_id
+                        && selector
+                            .interface
+                            .map(|iface| entry.interface == Some(iface))
+                            .unwrap_or(true)
+                        && selector
+                            .serial_number
+                            .as_ref()
+                            .map(|s| {
+                                if entry.serial_number.is_empty() {
+                                    s.is_empty()
+                                } else {
+                                    entry.serial_number == *s
+                                }
+                            })
+                            .unwrap_or(true)
+                    {
+                        return Ok(Some(to_wire_debug_probe_selector(
+                            probe_rs::probe::DebugProbeSelector {
+                                vendor_id: entry.vendor_id,
+                                product_id: entry.product_id,
+                                interface: entry.interface,
+                                serial_number: if entry.serial_number.is_empty() {
+                                    None
+                                } else {
+                                    Some(entry.serial_number.clone())
+                                },
+                            },
+                        )));
+                    }
+                }
+            }
+        }
+        anyhow::bail!(
+            "No free probe found in group '{}'. Check that a matching probe is connected.",
+            probe_arg
+        );
+    }
+
+    // Try direct selector format: parse as core DebugProbeSelector and convert
+    let core_selector: probe_rs::probe::DebugProbeSelector = probe_arg
+        .parse()
+        .context(format!("Invalid probe selector or group name: '{}'", probe_arg))?;
+    Ok(Some(to_wire_debug_probe_selector(core_selector)))
+}
+
 pub async fn attach_probe(
     client: &RpcClient,
     mut probe_options: ProbeOptions,
@@ -81,9 +144,11 @@ pub async fn attach_probe(
         client.load_chip_family(file).await?;
     }
 
+    let probe_selector = resolve_probe_from_client(client, &probe_options).await?;
+
     let probe = match select_probe(
         client,
-        probe_options.probe.map(to_wire_debug_probe_selector),
+        probe_selector,
     )
     .await
     {

--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -1,6 +1,8 @@
 use std::{
+    collections::HashMap,
     io::Write,
     path::PathBuf,
+    sync::OnceLock,
     time::{Duration, Instant},
 };
 
@@ -21,6 +23,22 @@ use serde::{Deserialize, Serialize};
 /// How long to wait before another attempt at a probe that another process
 /// holds.
 pub const OPEN_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Global probe group definitions, set once during startup.
+static PROBE_GROUPS: OnceLock<HashMap<String, Vec<String>>> = OnceLock::new();
+
+/// Store probe group definitions loaded from the config file.
+///
+/// Call this once during startup before any probe resolution.
+pub fn set_probe_groups(groups: HashMap<String, Vec<String>>) {
+    let _ = PROBE_GROUPS.set(groups);
+}
+
+/// Read the probe group definitions, or an empty map if none were set.
+pub fn get_probe_groups() -> &'static HashMap<String, Vec<String>> {
+    static EMPTY: OnceLock<HashMap<String, Vec<String>>> = OnceLock::new();
+    PROBE_GROUPS.get().unwrap_or_else(|| EMPTY.get_or_init(HashMap::new))
+}
 
 /// Common options when flashing a target device.
 #[derive(Debug, clap::Parser)]
@@ -92,7 +110,6 @@ pub struct ReadWriteOptions {
     #[clap(value_parser = parse_u64)]
     pub address: u64,
 }
-
 /// Common options and logic when interfacing with a [Probe].
 #[derive(clap::Parser, Clone, Debug, Serialize, Deserialize)]
 pub struct ProbeOptions {
@@ -126,14 +143,19 @@ pub struct ProbeOptions {
     )]
     pub non_interactive: bool,
 
-    /// Use this flag to select a specific probe in the list.
+    /// Use this flag to select a specific probe in the list, or a named probe group
+    /// defined in the config file.
+    ///
+    /// When the value is a group name (see `[probe_groups]` in `.probe-rs.toml`),
+    /// probe-rs picks one free probe from the group.
     ///
     /// Use '--probe VID:PID' or '--probe VID:PID:Serial' if you have more than one
     /// probe with the same VID:PID. For multi-channel FTDI probes (e.g. FT2232H),
     /// use '--probe VID:PID-INTERFACE' to select the channel (0=A, 1=B, 2=C, 3=D).
     /// Example: '--probe 0403:6010-1' selects Channel B.
     #[arg(long, env = "PROBE_RS_PROBE", help_heading = "PROBE CONFIGURATION")]
-    pub probe: Option<DebugProbeSelector>,
+    pub probe: Option<String>,
+
     /// The protocol speed in kHz.
     #[arg(long, env = "PROBE_RS_SPEED", help_heading = "PROBE CONFIGURATION")]
     pub speed: Option<u32>,
@@ -173,9 +195,44 @@ pub struct ProbeOptions {
     pub attach_timeout: Option<Duration>,
 }
 
+/// Resolve a probe argument to a concrete [DebugProbeSelector].
+///
+/// If the argument matches a group name in the config, it selects one free
+/// probe from the group. Otherwise, it parses the argument as a `VID:PID`
+/// selector string.
+pub fn resolve_probe_selector(
+    probe_arg: &str,
+    lister: &Lister,
+) -> Option<DebugProbeSelector> {
+    if let Some(groups) = PROBE_GROUPS.get() {
+        if let Some(selectors) = groups.get(probe_arg) {
+            let probes = lister.list_all();
+            for selector_str in selectors {
+                if let Ok(selector) = selector_str.parse::<DebugProbeSelector>() {
+                    for probe in &probes {
+                        if selector.matches_probe(probe) {
+                            return Some(probe.into());
+                        }
+                    }
+                }
+            }
+            return None;
+        }
+    }
+    probe_arg.parse().ok()
+}
+
 impl ProbeOptions {
-    pub fn load(self, registry: &mut Registry) -> Result<LoadedProbeOptions<'_>, OperationError> {
-        LoadedProbeOptions::new(self, registry)
+    pub fn load<'r>(
+        self,
+        registry: &'r mut Registry,
+        lister: &Lister,
+    ) -> Result<LoadedProbeOptions<'r>, OperationError> {
+        let resolved = self
+            .probe
+            .as_deref()
+            .and_then(|arg| resolve_probe_selector(arg, lister));
+        LoadedProbeOptions::new(self, registry, resolved)
     }
 
     /// Convenience method that attaches to the specified probe, target,
@@ -185,7 +242,7 @@ impl ProbeOptions {
         registry: &'r mut Registry,
         lister: &Lister,
     ) -> Result<(Session, LoadedProbeOptions<'r>), OperationError> {
-        let common_options = self.load(registry)?;
+        let common_options = self.load(registry, lister)?;
 
         let target = common_options.get_target_selector()?;
         let probe = common_options.attach_probe(lister)?;
@@ -196,7 +253,11 @@ impl ProbeOptions {
 }
 
 /// Common options and logic when interfacing with a [Probe] which already did all pre operation preparation.
-pub struct LoadedProbeOptions<'r>(ProbeOptions, &'r mut Registry);
+pub struct LoadedProbeOptions<'r> {
+    options: ProbeOptions,
+    registry: &'r mut Registry,
+    pub(crate) probe_selector: Option<DebugProbeSelector>,
+}
 
 impl<'r> LoadedProbeOptions<'r> {
     /// Performs necessary init calls such as loading all chip descriptions
@@ -204,8 +265,13 @@ impl<'r> LoadedProbeOptions<'r> {
     pub(crate) fn new(
         probe_options: ProbeOptions,
         registry: &'r mut Registry,
+        resolved_probe: Option<DebugProbeSelector>,
     ) -> Result<Self, OperationError> {
-        let mut options = Self(probe_options, registry);
+        let mut options = Self {
+            options: probe_options,
+            registry,
+            probe_selector: resolved_probe,
+        };
         // Load the target description, if given in the cli parameters.
         options.maybe_load_chip_desc()?;
         Ok(options)
@@ -216,7 +282,7 @@ impl<'r> LoadedProbeOptions<'r> {
     ///
     /// Note: should be called before any functions in [ProbeOptions].
     fn maybe_load_chip_desc(&mut self) -> Result<(), OperationError> {
-        if let Some(ref cdp) = self.0.chip_description_path {
+        if let Some(ref cdp) = self.options.chip_description_path {
             let yaml = std::fs::read_to_string(cdp).map_err(|error| {
                 OperationError::ChipDescriptionNotFound {
                     source: error,
@@ -224,12 +290,12 @@ impl<'r> LoadedProbeOptions<'r> {
                 }
             })?;
 
-            self.1.add_target_family_from_yaml(&yaml).map_err(|error| {
-                OperationError::FailedChipDescriptionParsing {
+            self.registry
+                .add_target_family_from_yaml(&yaml)
+                .map_err(|error| OperationError::FailedChipDescriptionParsing {
                     source: error,
                     path: cdp.clone(),
-                }
-            })?;
+                })?;
         }
 
         Ok(())
@@ -237,13 +303,14 @@ impl<'r> LoadedProbeOptions<'r> {
 
     /// Resolves a resultant target selector from passed [ProbeOptions].
     pub fn get_target_selector(&self) -> Result<TargetSelector, OperationError> {
-        let target = if let Some(chip_name) = &self.0.chip {
-            let target = self.1.get_target_by_name(chip_name).map_err(|error| {
-                OperationError::ChipNotFound {
+        let target = if let Some(chip_name) = &self.options.chip {
+            let target = self
+                .registry
+                .get_target_by_name(chip_name)
+                .map_err(|error| OperationError::ChipNotFound {
                     source: error,
                     name: chip_name.clone(),
-                }
-            })?;
+                })?;
 
             TargetSelector::Specified(target)
         } else {
@@ -299,15 +366,15 @@ impl<'r> LoadedProbeOptions<'r> {
     /// Another process can hold the probe, in which case opening it fails, or
     /// the probe drops out of the probe list altogether.
     fn open_probe(&self, lister: &Lister) -> Result<Probe, OperationError> {
-        let wait_for_probe = self.0.attach_timeout.unwrap_or(Duration::ZERO);
+        let wait_for_probe = self.options.attach_timeout.unwrap_or(Duration::ZERO);
         let start = Instant::now();
 
         loop {
             // If we got a probe selector as an argument, open the probe
             // matching the selector if possible.
-            let error = match &self.0.probe {
+            let error = match &self.probe_selector {
                 Some(selector) => lister.open(selector.clone()).map_err(OperationError::from),
-                None => Self::select_probe(lister, self.0.non_interactive),
+                None => Self::select_probe(lister, self.options.non_interactive),
             };
 
             let error = match error {
@@ -329,13 +396,13 @@ impl<'r> LoadedProbeOptions<'r> {
 
     /// Attaches to specified probe and configures it.
     pub fn attach_probe(&self, lister: &Lister) -> Result<Probe, OperationError> {
-        let mut probe = if self.0.dry_run {
+        let mut probe = if self.options.dry_run {
             Probe::from_specific_probe(Box::new(FakeProbe::with_mocked_core()))
         } else {
             self.open_probe(lister)?
         };
 
-        if let Some(protocol) = self.0.protocol {
+        if let Some(protocol) = self.options.protocol {
             // Select protocol and speed
             probe.select_protocol(protocol).map_err(|error| {
                 OperationError::FailedToSelectProtocol {
@@ -345,7 +412,7 @@ impl<'r> LoadedProbeOptions<'r> {
             })?;
         }
 
-        if let Some(speed) = self.0.speed {
+        if let Some(speed) = self.options.speed {
             let _actual_speed = probe.set_speed(speed).map_err(|error| {
                 OperationError::FailedToSelectProtocolSpeed {
                     source: error,
@@ -356,7 +423,7 @@ impl<'r> LoadedProbeOptions<'r> {
             // Warn the user if they specified a speed the debug probe does not support
             // and a fitting speed was automatically selected.
             let protocol_speed = probe.speed_khz();
-            if let Some(speed) = self.0.speed
+            if let Some(speed) = self.options.speed
                 && protocol_speed < speed
             {
                 tracing::warn!(
@@ -380,39 +447,39 @@ impl<'r> LoadedProbeOptions<'r> {
         target: TargetSelector,
     ) -> Result<Session, OperationError> {
         let mut permissions = Permissions::new();
-        if self.0.allow_erase_all {
+        if self.options.allow_erase_all {
             permissions = permissions.allow_erase_all();
         }
 
-        let session = if self.0.connect_under_reset {
-            probe.attach_under_reset_with_registry(target, permissions, self.1)
+        let session = if self.options.connect_under_reset {
+            probe.attach_under_reset_with_registry(target, permissions, self.registry)
         } else {
-            probe.attach_with_registry(target, permissions, self.1)
+            probe.attach_with_registry(target, permissions, self.registry)
         }
         .map_err(|error| OperationError::AttachingFailed {
             source: error,
-            connect_under_reset: self.0.connect_under_reset,
+            connect_under_reset: self.options.connect_under_reset,
         })?;
 
         Ok(session)
     }
 
     pub(crate) fn connect_under_reset(&self) -> bool {
-        self.0.connect_under_reset
+        self.options.connect_under_reset
     }
 
     pub(crate) fn dry_run(&self) -> bool {
-        self.0.dry_run
+        self.options.dry_run
     }
 
     pub(crate) fn chip(&self) -> Option<String> {
-        self.0.chip.clone()
+        self.options.chip.clone()
     }
 }
 
 impl AsRef<ProbeOptions> for LoadedProbeOptions<'_> {
     fn as_ref(&self) -> &ProbeOptions {
-        &self.0
+        &self.options
     }
 }
 
@@ -777,7 +844,7 @@ mod tests {
         let (lister, handle) = busy_lister(2);
         let mut registry = Registry::from_builtin_families();
         let options = probe_options(Some(Duration::from_secs(30)))
-            .load(&mut registry)
+            .load(&mut registry, &handle)
             .unwrap();
 
         assert!(options.attach_probe(&handle).is_ok());
@@ -788,7 +855,7 @@ mod tests {
     fn busy_probe_is_tried_once_without_an_attach_timeout() {
         let (lister, handle) = busy_lister(usize::MAX);
         let mut registry = Registry::from_builtin_families();
-        let options = probe_options(None).load(&mut registry).unwrap();
+        let options = probe_options(None).load(&mut registry, &handle).unwrap();
 
         assert!(options.attach_probe(&handle).is_err());
         assert_eq!(lister.attempts.load(Ordering::SeqCst), 1);


### PR DESCRIPTION
Let the config file contain named groups. Each group can contain any number of probes. When --probe is used with a group name, probe-rs picks one free probe from the group. A probe can belong to multiple groups.

This enables specifying by metadata in firmware which probe group can run a particular firmware, while load-balancing across multiple MCUs in a shared setup.

Closes #4222
/claim #4222