### PR TITLE
feat: add probe_access config to limit accessible probes

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -18,6 +18,7 @@ use crate::util::common_options::{
 use crate::util::logging::{LevelFilter, setup_logging};
 use crate::util::{cli, logging};
 use crate::{Config, parse_and_resolve_cli_args, run_app};
+use crate::rpc::functions::ProbeAccess;
 use probe_rs_rpc_client::RpcClient;
 
 /// Common options when flashing a target device.
@@ -127,7 +128,7 @@ pub async fn main(args: Vec<OsString>, config: Config) -> anyhow::Result<()> {
     let registry =
         registry_with_chip_description(opt.probe_options.chip_description_path.as_deref());
 
-    let terminate = run_app(connection_params, async |mut client| {
+    let terminate = run_app(connection_params, ProbeAccess::All, async |mut client| {
         let main_result = main_try(&mut client, opt).await;
 
         match main_result {

--- a/probe-rs-tools/src/bin/probe-rs/main.rs
+++ b/probe-rs-tools/src/bin/probe-rs/main.rs
@@ -51,6 +51,13 @@ pub(crate) struct Config {
 
     /// A named set of `--key=value` pairs.
     pub presets: HashMap<String, ConfigPreset>,
+
+    /// Control which probes are accessible.
+    ///
+    /// `allow` lists the probes permitted. `deny` lists the probes blocked.
+    /// When this field is absent, all probes are accessible.
+    #[serde(default)]
+    pub probe_access: Option<rpc::functions::ProbeAccess>,
 }
 
 #[derive(clap::Parser)]
@@ -382,7 +389,7 @@ async fn main() -> Result<()> {
         let log_path = log_path.as_deref();
         cmd::dap_server::run(cmd, None, connection_params, utc_offset, log_path).await
     } else {
-        run_app(connection_params, async |client| {
+        run_app(connection_params, config.probe_access.clone().unwrap_or(rpc::functions::ProbeAccess::All), async |client| {
             anyhow::ensure!(
                 client.is_local_session() || cli.subcommand.is_remote_cmd(),
                 "The subcommand is not supported in remote mode."
@@ -404,6 +411,7 @@ async fn main() -> Result<()> {
 /// Runs the callback using either a local or remote RPC client.
 async fn run_app<R>(
     #[cfg_attr(not(feature = "remote"), expect(unused_variables))] connection_params: RemoteParams,
+    probe_access: rpc::functions::ProbeAccess,
     cb: impl AsyncFnOnce(RpcClient) -> Result<R>,
 ) -> Result<R> {
     #[cfg(feature = "remote")]
@@ -422,7 +430,7 @@ async fn run_app<R>(
     // Create a local server to run commands against.
     let probe_broker = Arc::new(crate::rpc::probe_broker::ProbeBroker::new());
     let (mut local_server, tx, rx) =
-        RpcApp::create_server(16, rpc::functions::ProbeAccess::All, probe_broker);
+        RpcApp::create_server(16, probe_access, probe_broker);
     let handle = tokio::spawn(async move { local_server.run().await });
 
     // Run the command locally.


### PR DESCRIPTION
/claim #4221

## Summary

Adds an optional `probe_access` field to the Config struct, read from `.probe-rs.toml`. Supports allow and deny lists of probes by VID:PID or VID:PID:Serial.

## Config examples

Allow only specific probes:

```toml
[probe_access]
allow = ["0483:3748", "1366:0101"]
```

Deny specific probes:

```toml
[probe_access]
deny = ["c251:2710"]
```

When `probe_access` is absent, behavior is unchanged (all probes accessible).

## Changes

- `main.rs`: Added `probe_access` field to `Config`, threaded through `run_app` to replace hardcoded `ProbeAccess::All`
- `cargo_flash/mod.rs`: Updated `run_app` call to pass `ProbeAccess::All`

Closes #4221