### PR TITLE
nRF53/nRF91: implement `debug_erase_sequence` via CTRL-AP ERASEALL so `--chip-erase` always clears UICR

### DIFF
--- a/changelog/fixed-nrf-chip-erase-uicr.md
+++ b/changelog/fixed-nrf-chip-erase-uicr.md
@@ -1,0 +1,1 @@
+Chip erase on nRF53 and nRF91 targets now uses the CTRL-AP ERASEALL sequence, which also erases the UICR. Previously, `--chip-erase` ran the CMSIS-Pack flash algorithm's erase routine, which does not erase the UICR on these chips, so downloading an image with UICR contents failed with `program_page` error code 104 unless the UICR was already blank.

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
@@ -5,11 +5,12 @@ use crate::{
         ArmDebugInterface, ArmError, FullyQualifiedApAddress,
         dp::DpAddress,
         memory::ArmMemoryInterface,
-        sequences::{ArmDebugSequence, ArmDebugSequenceError},
+        sequences::{ArmDebugSequence, ArmDebugSequenceError, DebugEraseSequence},
     },
     session::MissingPermissions,
 };
 use std::fmt::Debug;
+use std::sync::Arc;
 
 pub trait Nrf: Sync + Send + Debug {
     /// Returns the ahb_ap and ctrl_ap of every core
@@ -170,6 +171,45 @@ impl<T: Nrf> ArmDebugSequence for T {
             set_network_core_running(&mut *memory_interface)?;
 
             memory_interface.flush()?;
+        }
+
+        Ok(())
+    }
+
+    fn debug_erase_sequence(&self) -> Option<Arc<dyn DebugEraseSequence>> {
+        Some(Arc::new(NrfDebugEraseSequence {
+            ctrl_aps: self
+                .core_aps(&DpAddress::Default)
+                .into_iter()
+                .map(|(_ahb_ap, ctrl_ap)| ctrl_ap)
+                .collect(),
+            reset_after_erase: self.requires_soft_reset_after_erase(),
+        }))
+    }
+}
+
+/// Chip erase via the ERASEALL register of each core's CTRL-AP.
+///
+/// Unlike the flash algorithms from the vendor's CMSIS-Pack, this erases *all* nonvolatile
+/// memory, including the UICR, which some of the pack algorithms cannot erase at all
+/// (the UICR of nRF53 and nRF91 chips can only be erased by an ERASEALL operation).
+///
+/// TODO: Eraseprotect is not considered, same as in `debug_device_unlock` above. If enabled,
+/// the hardware ignores the ERASEALL request and this sequence reports success anyway.
+#[derive(Debug)]
+struct NrfDebugEraseSequence {
+    ctrl_aps: Vec<FullyQualifiedApAddress>,
+    reset_after_erase: bool,
+}
+
+impl DebugEraseSequence for NrfDebugEraseSequence {
+    fn erase_all(&self, interface: &mut dyn ArmDebugInterface) -> Result<(), ArmError> {
+        // Chip erase is only requested by an explicit user action (`--chip-erase` or an erase
+        // command), which stands in for the `erase_all` permission here.
+        let permissions = crate::Permissions::new().allow_erase_all();
+
+        for ctrl_ap in &self.ctrl_aps {
+            erase_all(interface, ctrl_ap, &permissions, self.reset_after_erase)?;
         }
 
         Ok(())


### PR DESCRIPTION
PARTIALLY addresses #4225 and #4112 (same failure mode on nRF5340 network UICR).

## Problem

On nRF53 and nRF91, downloading an image with UICR contents fails with `program_page` error code 104 unless the UICR happens to be blank. The vendor's CMSIS-Pack UICR flash algorithms cannot erase the UICR — these chips have no per-page UICR erase, only ERASEALL — and their EraseSector routine *silently reports success* on a non-blank UICR (the "erase UICR" helper in the blob is a stub returning code 105, which the wrapper maps back to 0). The failure only surfaces later in ProgramPage, which refuses to write non-blank words.

`--chip-erase` doesn't help for combined firmware+UICR images: the loader runs EraseChip once via the first flasher, which in a full program is the main-flash algorithm, whose EraseChip is a page-by-page loop over main flash only — it never touches UICR.

Note that for secure images (eg. the nordic-serial-modem out of the box), Nordic's toolchain emits a `merged.hex` that includes bootloader+firmware+UICR, so this is nontheoretical.

## Change

This change doesn't fix the big picture, but does at least make `--chip-erase` consistently use ERASEALL.

It implements `debug_erase_sequence()` in the blanket `impl<T: Nrf> ArmDebugSequence for T` (`vendor/nordicsemi/sequences/nrf.rs`), backed by the existing CTRL-AP `erase_all` helper that was previously only used for APPROTECT unlock. The sequence issues ERASEALL through each core's CTRL-AP (both cores on nRF5340), honoring `requires_soft_reset_after_erase()` for nRF91x1.

With a sequence available, `Flasher::run_erase_all` prefers it over the flash algorithm's EraseChip, so `probe-rs download --chip-erase` and `probe-rs erase` now perform the vendor's canonical full-chip erase, which erases the UICR as well. Downloading firmware+UICR images with `--chip-erase` then works: everything is erased once up front, and all subsequent programming (including UICR) proceeds onto blank flash.

Scope: the `Nrf` trait is implemented only by the nRF53 and nRF91 sequences, so nRF52 (whose UICR erase works via its `ERASEUICR` register, and where an ERASEALL side effect on UICR could surprise users, e.g. resetting `REGOUT0`) and nRF54L are unaffected.

Permissions: following the `AtSAM` precedent, the erase sequence authorizes itself with `Permissions::new().allow_erase_all()` — chip erase only runs on an explicit user request (`--chip-erase` or an erase command), which stands in for the `erase_all` permission. `--allow-erase-all` remains the gate for *implicit* erases such as unlock-on-attach.

Not addressed here (possible follow-ups):

- Sector-erase of a non-blank UICR without `--chip-erase` still silently no-ops and then fails in ProgramPage with code 104; the blob comes from Nordic's pack, so probe-rs could at best detect the situation and produce a better error suggesting `--chip-erase`.
- `probe-rs erase` runs the erase sequence once per flasher, so on these chips the ERASEALL now runs twice (harmless, but redundant).
- ERASEPROTECT is not considered, matching the existing TODO in `debug_device_unlock`: if it is enabled, the hardware ignores the ERASEALL request (ERASEALLSTATUS never reads busy) and the sequence reports success anyway. Detecting that would be a follow-up affecting the unlock path too.

## Testing

- `cargo check` / `cargo clippy` clean.
- Tested on nRF9151 with CMSIS-DAP probe (https://docs.circuitdojo.com/nrf9151-feather/overview.html)
- `probe-rs download --chip-erase --binary-format=hex <uicr-only hex> --verify` (repeatedly): completed

Repeated downloads of bootloader+app+UICR work with `--chip-erase`:
```
% ./target/release/probe-rs download --chip=nRF9151_xxAA --chip-erase --binary-format=hex ~/source/blub/dev.tmp/nordic/workspace/circuitdojo-ncs-serial-modem/app/build/merged.hex
      Erasing ✔ 0s                                                              
  Programming ✔ 100% [####################] 416.00 KiB @  39.92 KiB/s (took 10s)
     Finished in 11.31s
% ./target/release/probe-rs download --chip=nRF9151_xxAA --chip-erase --binary-format=hex ~/source/blub/dev.tmp/nordic/workspace/circuitdojo-ncs-serial-modem/app/build/merged.hex
      Erasing ✔ 0s                                                              
  Programming ✔ 100% [####################] 416.00 KiB @  40.52 KiB/s (took 10s)
  Programming 2 ✔ 100% [####################]      120 B @      244 B/s (took 0s)
     Finished in 11.14s
% ./target/release/probe-rs download --chip=nRF9151_xxAA --chip-erase --binary-format=hex ~/source/blub/dev.tmp/nordic/workspace/circuitdojo-ncs-serial-modem/app/build/merged.hex
      Erasing ✔ 0s                                                              
  Programming ✔ 100% [####################] 416.00 KiB @  40.47 KiB/s (took 10s)
     Finished in 11.15s
```

With stock `probe-rs`, the same command fails:

```
% probe-rs download --chip=nRF9151_xxAA --chip-erase --binary-format=hex ~/source/blub/dev.tmp/nordic/workspace/circuitdojo-ncs-serial-modem/app/build/merged.hex
      Erasing ✔ 22s                                                             
  Programming ✔ 100% [####################] 416.00 KiB @  40.74 KiB/s (took 10s)
  Programming 2 ✔   3% [#-------------------]        4 B @       42 B/s (ETA 0s)
Error: An error with the flashing procedure has occurred.

Caused by:
    0: The page write of the page at address 0x00ff8130 failed.
    1: The execution of 'program_page' failed with code 104. This might indicate a problem with the flash algorithm.
```