### PR TITLE
fix(nrf53): restore network access across app resets

### DIFF
--- a/changelog/fixed-nrf5340-network-core-lifecycle.md
+++ b/changelog/fixed-nrf5340-network-core-lifecycle.md
@@ -1,0 +1,1 @@
+Restored nRF5340 network-core debug access before AP1 inspection and after application resets, including the silicon-gated Erratum 161 FORCEOFF release sequence.

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf.rs
@@ -2,17 +2,23 @@
 
 use crate::{
     architecture::arm::{
-        ArmDebugInterface, ArmError, FullyQualifiedApAddress,
+        ApAddress, ArmDebugInterface, ArmError, FullyQualifiedApAddress,
+        core::armv7m::Dhcsr,
         dp::DpAddress,
         memory::ArmMemoryInterface,
         sequences::{
-            ArmDebugSequence, ArmDebugSequenceError, DebugEraseSequence, cortex_m_wait_for_reset,
+            ArmDebugSequence, ArmDebugSequenceError, DebugEraseSequence, cortex_m_reset_system,
+            cortex_m_wait_for_reset,
         },
     },
+    core::MemoryMappedRegister,
     session::MissingPermissions,
 };
-use std::fmt::Debug;
-use std::sync::Arc;
+use std::{
+    fmt::Debug,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 pub trait Nrf: Sync + Send + Debug {
     /// Returns the ahb_ap and ctrl_ap of every core
@@ -40,6 +46,33 @@ pub trait Nrf: Sync + Send + Debug {
         Ok(None)
     }
 
+    /// Reset the selected core. Implementors can override this while retaining
+    /// the shared nRF pre- and post-reset orchestration.
+    fn reset_core(
+        &self,
+        interface: &mut dyn ArmMemoryInterface,
+        _core_type: crate::CoreType,
+        _debug_base: Option<u64>,
+    ) -> Result<(), ArmError> {
+        let core_ap = interface.fully_qualified_address();
+        let Some(ctrl_ap) = self.ctrl_ap_for_core(&core_ap)? else {
+            return cortex_m_reset_system(interface);
+        };
+
+        let arm_interface = interface.get_arm_debug_interface()?;
+        tracing::debug!(?core_ap, ?ctrl_ap, "Asserting core reset through CTRL-AP");
+        arm_interface.write_raw_ap_register(&ctrl_ap, RESET, 1)?;
+        arm_interface.write_raw_ap_register(&ctrl_ap, RESET, 0)?;
+        arm_interface.flush()?;
+
+        cortex_m_wait_for_reset(interface)
+    }
+
+    /// Restore target-specific debug access after resetting the selected core.
+    fn post_reset(&self, _interface: &mut dyn ArmMemoryInterface) -> Result<(), ArmError> {
+        Ok(())
+    }
+
     /// Returns true if the chip must be soft-reset after an erase-all operation (ie to unlock APPROTECT).
     ///
     /// Defaults to false. For implementors, make sure to override this method if a reset is required.
@@ -57,7 +90,48 @@ const APPLICATION_SPU_PERIPH_PERM: u64 = 0x50003800;
 const APPLICATION_RESET_PERIPH_ID: u64 = 5;
 const APPLICATION_RESET_S_NETWORK_FORCEOFF_REGISTER: u32 = 0x50005614;
 const APPLICATION_RESET_NS_NETWORK_FORCEOFF_REGISTER: u32 = 0x40005614;
+// Nordic's current nrfx uses these hidden FICR words to gate nRF5340 Erratum 161:
+// https://github.com/NordicSemiconductor/nrfx/blob/master/bsp/stable/mdk/nrf53/nrf53_erratas.h
+const APPLICATION_FICR_ERRATA_VAR1_REGISTER: u64 = 0x00ff0130;
+const APPLICATION_FICR_ERRATA_VAR2_REGISTER: u64 = 0x00ff0134;
+const NETWORK_FORCEOFF_WORKAROUND_OFFSET: u32 = 4;
 const RELEASE_FORCEOFF: u32 = 0;
+const HOLD_FORCEOFF: u32 = 1;
+const ERRATUM_161_RELEASE_DELAY: Duration = Duration::from_micros(5);
+const ERRATUM_161_HOLD_DELAY: Duration = Duration::from_micros(1);
+// This is a conservative host-side deadline, not a Nordic-specified startup maximum.
+const NETWORK_CORE_ACCESS_TIMEOUT: Duration = Duration::from_millis(300);
+
+pub(super) trait NetworkForceoffInterface {
+    fn read_forceoff_word(&mut self, address: u64) -> Result<u32, ArmError>;
+    fn write_forceoff_word(&mut self, address: u64, value: u32) -> Result<(), ArmError>;
+    fn flush_forceoff(&mut self) -> Result<(), ArmError>;
+    fn sleep_forceoff(&mut self, duration: Duration);
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum NetworkCoreRelease {
+    AlreadyReleased,
+    Released,
+}
+
+impl<T: ArmMemoryInterface + ?Sized> NetworkForceoffInterface for T {
+    fn read_forceoff_word(&mut self, address: u64) -> Result<u32, ArmError> {
+        self.read_word_32(address)
+    }
+
+    fn write_forceoff_word(&mut self, address: u64, value: u32) -> Result<(), ArmError> {
+        self.write_word_32(address, value)
+    }
+
+    fn flush_forceoff(&mut self) -> Result<(), ArmError> {
+        self.flush()
+    }
+
+    fn sleep_forceoff(&mut self, duration: Duration) {
+        std::thread::sleep(duration);
+    }
+}
 
 /// Performs an erase all operation on the core.
 /// The `ap_address` must be of the ctrl ap of the core.
@@ -99,11 +173,67 @@ fn unlock_core(
     erase_all(arm_interface, ap_address, permissions, reset_after_erase)
 }
 
-/// Sets the network core to active running.
-fn set_network_core_running(interface: &mut dyn ArmMemoryInterface) -> Result<(), ArmError> {
+fn erratum_161_present(
+    interface: &mut (impl NetworkForceoffInterface + ?Sized),
+) -> Result<bool, ArmError> {
+    // This runs through application AP0, which is also used above to read the
+    // secure SPU attribution register. RESET's attribution does not change the
+    // application FICR address used by the debugger.
+    let var1 = interface.read_forceoff_word(APPLICATION_FICR_ERRATA_VAR1_REGISTER)?;
+    let var2 = interface.read_forceoff_word(APPLICATION_FICR_ERRATA_VAR2_REGISTER)?;
+
+    // nrf53_errata_161() marks variants 0x02 through 0x04 unaffected and
+    // variant 0x05 plus later/default encodings affected.
+    Ok(var1 == 0x07 && !matches!(var2, 0x02..=0x04))
+}
+
+fn clear_forceoff_workaround(
+    interface: &mut (impl NetworkForceoffInterface + ?Sized),
+    workaround_addr: u64,
+) -> Result<(), ArmError> {
+    interface.write_forceoff_word(workaround_addr, 0)?;
+    interface.flush_forceoff()
+}
+
+fn apply_erratum_161_release(
+    interface: &mut (impl NetworkForceoffInterface + ?Sized),
+    forceoff_addr: u64,
+) -> Result<(), ArmError> {
+    // Follow Nordic's release/hold/release sequence and explicit minimum delays:
+    // https://github.com/NordicSemiconductor/nrfx/blob/master/hal/nrf_reset.h
+    let workaround_addr = forceoff_addr + u64::from(NETWORK_FORCEOFF_WORKAROUND_OFFSET);
+    let sequence_result = (|| {
+        interface.write_forceoff_word(workaround_addr, 1)?;
+        interface.flush_forceoff()?;
+
+        interface.write_forceoff_word(forceoff_addr, RELEASE_FORCEOFF)?;
+        interface.flush_forceoff()?;
+        interface.sleep_forceoff(ERRATUM_161_RELEASE_DELAY);
+
+        interface.write_forceoff_word(forceoff_addr, HOLD_FORCEOFF)?;
+        interface.flush_forceoff()?;
+        interface.sleep_forceoff(ERRATUM_161_HOLD_DELAY);
+
+        interface.write_forceoff_word(forceoff_addr, RELEASE_FORCEOFF)?;
+        interface.flush_forceoff()
+    })();
+
+    if sequence_result.is_err() {
+        let _ = interface.write_forceoff_word(forceoff_addr, HOLD_FORCEOFF);
+        let _ = interface.flush_forceoff();
+    }
+
+    let cleanup_result = clear_forceoff_workaround(interface, workaround_addr);
+    sequence_result.and(cleanup_result)
+}
+
+/// Release network FORCEOFF without resetting an already-running network core.
+pub(super) fn set_network_core_running(
+    interface: &mut (impl NetworkForceoffInterface + ?Sized),
+) -> Result<NetworkCoreRelease, ArmError> {
     // Determine if the RESET peripheral is mapped to secure or non-secure address space.
     let periph_config_address = APPLICATION_SPU_PERIPH_PERM + 0x4 * APPLICATION_RESET_PERIPH_ID;
-    let periph_config = interface.read_word_32(periph_config_address)?;
+    let periph_config = interface.read_forceoff_word(periph_config_address)?;
     let is_secure = (periph_config >> 4) & 1 == 1;
 
     let forceoff_addr = if is_secure {
@@ -114,7 +244,246 @@ fn set_network_core_running(interface: &mut dyn ArmMemoryInterface) -> Result<()
         APPLICATION_RESET_NS_NETWORK_FORCEOFF_REGISTER
     };
 
-    interface.write_32(forceoff_addr as u64, &[RELEASE_FORCEOFF])?;
+    if interface.read_forceoff_word(forceoff_addr as u64)? == RELEASE_FORCEOFF {
+        tracing::debug!("Network core is already released from FORCEOFF");
+        return Ok(NetworkCoreRelease::AlreadyReleased);
+    }
+
+    if erratum_161_present(interface)? {
+        tracing::debug!("Applying nRF5340 Revision 1 Erratum 161 workaround");
+        apply_erratum_161_release(interface, forceoff_addr as u64)?;
+        return Ok(NetworkCoreRelease::Released);
+    }
+
+    interface.write_forceoff_word(forceoff_addr as u64, RELEASE_FORCEOFF)?;
+    interface.flush_forceoff()?;
+    Ok(NetworkCoreRelease::Released)
+}
+
+pub(super) fn reset_affects_network<T: Nrf + ?Sized>(
+    sequence: &T,
+    core_ap: &FullyQualifiedApAddress,
+) -> bool {
+    sequence.has_network_core() && core_ap.ap() == &ApAddress::V1(0)
+}
+
+fn wait_for_network_core_halted(interface: &mut dyn ArmMemoryInterface) -> Result<(), ArmError> {
+    let started = Instant::now();
+
+    loop {
+        if Dhcsr(interface.read_word_32(Dhcsr::get_mmio_address())?).s_halt() {
+            return Ok(());
+        }
+
+        if started.elapsed() >= NETWORK_CORE_ACCESS_TIMEOUT {
+            return Err(ArmError::Timeout);
+        }
+
+        std::thread::sleep(Duration::from_millis(1));
+    }
+}
+
+pub(super) fn halt_network_core(interface: &mut dyn ArmMemoryInterface) -> Result<(), ArmError> {
+    let mut dhcsr = Dhcsr(0);
+    dhcsr.set_c_debugen(true);
+    dhcsr.set_c_halt(true);
+    dhcsr.enable_write();
+    interface.write_word_32(Dhcsr::get_mmio_address(), dhcsr.into())?;
+    interface.flush()?;
+    wait_for_network_core_halted(interface)
+}
+
+pub(super) fn wait_for_core_accessible<T: Nrf + ?Sized>(
+    sequence: &T,
+    interface: &mut dyn ArmDebugInterface,
+    ahb_ap_address: &FullyQualifiedApAddress,
+    ctrl_ap_address: &FullyQualifiedApAddress,
+) -> Result<bool, ArmError> {
+    let started = Instant::now();
+
+    loop {
+        if sequence.is_core_unlocked(interface, ahb_ap_address, ctrl_ap_address)? {
+            return Ok(true);
+        }
+
+        if started.elapsed() >= NETWORK_CORE_ACCESS_TIMEOUT {
+            tracing::debug!(
+                "Network core remained inaccessible for {} ms",
+                NETWORK_CORE_ACCESS_TIMEOUT.as_millis()
+            );
+            return Ok(false);
+        }
+
+        std::thread::sleep(Duration::from_millis(1));
+    }
+}
+
+fn core_is_accessible<T: Nrf + ?Sized>(
+    sequence: &T,
+    interface: &mut dyn ArmDebugInterface,
+    ahb_ap_address: &FullyQualifiedApAddress,
+    ctrl_ap_address: &FullyQualifiedApAddress,
+    wait_for_network_core: bool,
+) -> Result<bool, ArmError> {
+    if wait_for_network_core {
+        wait_for_core_accessible(sequence, interface, ahb_ap_address, ctrl_ap_address)
+    } else {
+        sequence.is_core_unlocked(interface, ahb_ap_address, ctrl_ap_address)
+    }
+}
+
+trait CoreUnlockOperations {
+    fn prepare_network_core(
+        &mut self,
+        default_ap: &FullyQualifiedApAddress,
+    ) -> Result<NetworkCoreRelease, ArmError>;
+    fn is_core_accessible<T: Nrf + ?Sized>(
+        &mut self,
+        sequence: &T,
+        ahb_ap_address: &FullyQualifiedApAddress,
+        ctrl_ap_address: &FullyQualifiedApAddress,
+        wait_for_network_core: bool,
+    ) -> Result<bool, ArmError>;
+    fn recover_core(
+        &mut self,
+        ctrl_ap_address: &FullyQualifiedApAddress,
+        permissions: &crate::Permissions,
+        reset_after_erase: bool,
+    ) -> Result<(), ArmError>;
+    fn halt_core(&mut self, ahb_ap_address: &FullyQualifiedApAddress) -> Result<(), ArmError>;
+}
+
+struct ArmCoreUnlockOperations<'a> {
+    interface: &'a mut dyn ArmDebugInterface,
+}
+
+impl CoreUnlockOperations for ArmCoreUnlockOperations<'_> {
+    fn prepare_network_core(
+        &mut self,
+        default_ap: &FullyQualifiedApAddress,
+    ) -> Result<NetworkCoreRelease, ArmError> {
+        let mut memory_interface = self.interface.memory_interface(default_ap)?;
+        set_network_core_running(&mut *memory_interface)
+    }
+
+    fn is_core_accessible<T: Nrf + ?Sized>(
+        &mut self,
+        sequence: &T,
+        ahb_ap_address: &FullyQualifiedApAddress,
+        ctrl_ap_address: &FullyQualifiedApAddress,
+        wait_for_network_core: bool,
+    ) -> Result<bool, ArmError> {
+        core_is_accessible(
+            sequence,
+            self.interface,
+            ahb_ap_address,
+            ctrl_ap_address,
+            wait_for_network_core,
+        )
+    }
+
+    fn recover_core(
+        &mut self,
+        ctrl_ap_address: &FullyQualifiedApAddress,
+        permissions: &crate::Permissions,
+        reset_after_erase: bool,
+    ) -> Result<(), ArmError> {
+        unlock_core(
+            self.interface,
+            ctrl_ap_address,
+            permissions,
+            reset_after_erase,
+        )
+    }
+
+    fn halt_core(&mut self, ahb_ap_address: &FullyQualifiedApAddress) -> Result<(), ArmError> {
+        let mut network_interface = self.interface.memory_interface(ahb_ap_address)?;
+        halt_network_core(&mut *network_interface)
+    }
+}
+
+fn initialize_core_access<T: Nrf + ?Sized>(
+    sequence: &T,
+    operations: &mut impl CoreUnlockOperations,
+    default_ap: &FullyQualifiedApAddress,
+    permissions: &crate::Permissions,
+) -> Result<(), ArmError> {
+    let aps = sequence.core_aps(&default_ap.dp());
+
+    if aps.is_empty() {
+        return Err(ArmDebugSequenceError::custom(
+            "Target does not declare a supported Nordic core access port",
+        )
+        .into());
+    }
+
+    for (core_index, (core_ahb_ap_address, core_ctrl_ap_address)) in aps.iter().enumerate() {
+        let is_network_core =
+            sequence.has_network_core() && core_ahb_ap_address.ap() == &ApAddress::V1(1);
+        let mut quiesce_network_core = false;
+        if is_network_core {
+            tracing::debug!("Releasing network core before accessing its AHB-AP");
+            quiesce_network_core =
+                operations.prepare_network_core(default_ap)? == NetworkCoreRelease::Released;
+        }
+
+        tracing::info!("Checking if core {} is accessible", core_index);
+        let is_accessible = operations.is_core_accessible(
+            sequence,
+            core_ahb_ap_address,
+            core_ctrl_ap_address,
+            is_network_core,
+        )?;
+
+        if is_accessible {
+            tracing::info!("Core {} is already accessible", core_index);
+        } else {
+            tracing::warn!(
+                "Core {} is not accessible. Erase procedure will be started to recover access.",
+                core_index
+            );
+
+            operations.recover_core(
+                core_ctrl_ap_address,
+                permissions,
+                sequence.requires_soft_reset_after_erase(),
+            )?;
+            quiesce_network_core |= is_network_core;
+
+            if !operations.is_core_accessible(
+                sequence,
+                core_ahb_ap_address,
+                core_ctrl_ap_address,
+                is_network_core,
+            )? {
+                tracing::warn!("Core is still not accessible after erase operation. Retrying");
+
+                operations.recover_core(
+                    core_ctrl_ap_address,
+                    permissions,
+                    sequence.requires_soft_reset_after_erase(),
+                )?;
+
+                if !operations.is_core_accessible(
+                    sequence,
+                    core_ahb_ap_address,
+                    core_ctrl_ap_address,
+                    is_network_core,
+                )? {
+                    return Err(ArmDebugSequenceError::custom(format!(
+                        "Could not access core {core_index}"
+                    ))
+                    .into());
+                }
+            }
+        }
+
+        if quiesce_network_core {
+            tracing::debug!("Halting newly released network core");
+            operations.halt_core(core_ahb_ap_address)?;
+        }
+    }
+
     Ok(())
 }
 
@@ -122,23 +491,20 @@ impl<T: Nrf> ArmDebugSequence for T {
     fn reset_system(
         &self,
         interface: &mut dyn ArmMemoryInterface,
-        _core_type: crate::CoreType,
-        _debug_base: Option<u64>,
+        core_type: crate::CoreType,
+        debug_base: Option<u64>,
     ) -> Result<(), ArmError> {
-        // Every current `Nrf` implementor is Cortex-M. A target without a
-        // CTRL-AP override therefore retains the existing Cortex-M reset path.
-        let core_ap = interface.fully_qualified_address();
-        let Some(ctrl_ap) = self.ctrl_ap_for_core(&core_ap)? else {
-            return crate::architecture::arm::sequences::cortex_m_reset_system(interface);
-        };
-
-        let arm_interface = interface.get_arm_debug_interface()?;
-        tracing::debug!(?core_ap, ?ctrl_ap, "Asserting core reset through CTRL-AP");
-        arm_interface.write_raw_ap_register(&ctrl_ap, RESET, 1)?;
-        arm_interface.write_raw_ap_register(&ctrl_ap, RESET, 0)?;
-        arm_interface.flush()?;
-
-        cortex_m_wait_for_reset(interface)
+        let reset_result = self.reset_core(interface, core_type, debug_base);
+        if let Err(post_reset_error) = self.post_reset(interface) {
+            if reset_result.is_ok() {
+                return Err(post_reset_error);
+            }
+            tracing::warn!(
+                ?post_reset_error,
+                "Network post-reset preparation also failed"
+            );
+        }
+        reset_result
     }
 
     fn debug_device_unlock(
@@ -147,65 +513,15 @@ impl<T: Nrf> ArmDebugSequence for T {
         default_ap: &FullyQualifiedApAddress,
         permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
-        let aps = self.core_aps(&default_ap.dp());
-
-        if aps.is_empty() {
-            return Err(ArmDebugSequenceError::custom(
-                "Target does not declare a supported Nordic core access port",
-            )
-            .into());
-        }
-
         // TODO: Eraseprotect is not considered. If enabled, the debugger must set up the same keys as the firmware does
         // TODO: Approtect and Secure Approtect are not considered. If enabled, the debugger must set up the same keys as the firmware does
         // These keys should be queried from the user if required and once that mechanism is implemented
-
-        for (core_index, (core_ahb_ap_address, core_ctrl_ap_address)) in aps.iter().enumerate() {
-            tracing::info!("Checking if core {} is unlocked", core_index);
-            if self.is_core_unlocked(interface, core_ahb_ap_address, core_ctrl_ap_address)? {
-                tracing::info!("Core {} is already unlocked", core_index);
-                continue;
-            }
-
-            tracing::warn!(
-                "Core {} is locked. Erase procedure will be started to unlock it.",
-                core_index
-            );
-            unlock_core(
-                interface,
-                core_ctrl_ap_address,
-                permissions,
-                self.requires_soft_reset_after_erase(),
-            )?;
-
-            if !self.is_core_unlocked(interface, core_ahb_ap_address, core_ctrl_ap_address)? {
-                tracing::warn!("Core is still locked after erase operation. Retrying");
-
-                unlock_core(
-                    interface,
-                    core_ctrl_ap_address,
-                    permissions,
-                    self.requires_soft_reset_after_erase(),
-                )?;
-
-                if !self.is_core_unlocked(interface, core_ahb_ap_address, core_ctrl_ap_address)? {
-                    return Err(ArmDebugSequenceError::custom(format!(
-                        "Could not unlock core {core_index}"
-                    ))
-                    .into());
-                }
-            }
-        }
-
-        if self.has_network_core() {
-            let mut memory_interface = interface.memory_interface(default_ap)?;
-            tracing::debug!("Setting network core to running");
-            set_network_core_running(&mut *memory_interface)?;
-
-            memory_interface.flush()?;
-        }
-
-        Ok(())
+        initialize_core_access(
+            self,
+            &mut ArmCoreUnlockOperations { interface },
+            default_ap,
+            permissions,
+        )
     }
 
     fn debug_erase_sequence(&self) -> Option<Arc<dyn DebugEraseSequence>> {
@@ -245,5 +561,381 @@ impl DebugEraseSequence for NrfDebugEraseSequence {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestNrf {
+        core_aps: Vec<(u8, u8)>,
+    }
+
+    impl Nrf for TestNrf {
+        fn core_aps(
+            &self,
+            dp_address: &DpAddress,
+        ) -> Vec<(FullyQualifiedApAddress, FullyQualifiedApAddress)> {
+            self.core_aps
+                .iter()
+                .map(|&(ahb_ap, ctrl_ap)| {
+                    (
+                        FullyQualifiedApAddress::v1_with_dp(*dp_address, ahb_ap),
+                        FullyQualifiedApAddress::v1_with_dp(*dp_address, ctrl_ap),
+                    )
+                })
+                .collect()
+        }
+
+        fn is_core_unlocked(
+            &self,
+            _interface: &mut dyn ArmDebugInterface,
+            _ahb_ap_address: &FullyQualifiedApAddress,
+            _ctrl_ap_address: &FullyQualifiedApAddress,
+        ) -> Result<bool, ArmError> {
+            unreachable!("mock operations provide accessibility results")
+        }
+
+        fn has_network_core(&self) -> bool {
+            self.core_aps.iter().any(|&(ahb_ap, _)| ahb_ap == 1)
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    enum UnlockOperation {
+        PrepareNetwork,
+        Check(ApAddress),
+        Recover(ApAddress),
+        Halt(ApAddress),
+    }
+
+    struct MockCoreUnlockOperations {
+        network_release: NetworkCoreRelease,
+        accessibility: std::collections::VecDeque<bool>,
+        operations: Vec<UnlockOperation>,
+    }
+
+    impl CoreUnlockOperations for MockCoreUnlockOperations {
+        fn prepare_network_core(
+            &mut self,
+            _default_ap: &FullyQualifiedApAddress,
+        ) -> Result<NetworkCoreRelease, ArmError> {
+            self.operations.push(UnlockOperation::PrepareNetwork);
+            Ok(self.network_release)
+        }
+
+        fn is_core_accessible<T: Nrf + ?Sized>(
+            &mut self,
+            _sequence: &T,
+            ahb_ap_address: &FullyQualifiedApAddress,
+            _ctrl_ap_address: &FullyQualifiedApAddress,
+            _wait_for_network_core: bool,
+        ) -> Result<bool, ArmError> {
+            self.operations
+                .push(UnlockOperation::Check(ahb_ap_address.ap().clone()));
+            Ok(self.accessibility.pop_front().unwrap_or(true))
+        }
+
+        fn recover_core(
+            &mut self,
+            ctrl_ap_address: &FullyQualifiedApAddress,
+            _permissions: &crate::Permissions,
+            _reset_after_erase: bool,
+        ) -> Result<(), ArmError> {
+            self.operations
+                .push(UnlockOperation::Recover(ctrl_ap_address.ap().clone()));
+            Ok(())
+        }
+
+        fn halt_core(&mut self, ahb_ap_address: &FullyQualifiedApAddress) -> Result<(), ArmError> {
+            self.operations
+                .push(UnlockOperation::Halt(ahb_ap_address.ap().clone()));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn dual_core_unlock_prepares_network_before_ap1_and_only_halts_new_release() {
+        let sequence = TestNrf {
+            core_aps: vec![(0, 2), (1, 3)],
+        };
+
+        for (network_release, expected) in [
+            (
+                NetworkCoreRelease::Released,
+                vec![
+                    UnlockOperation::Check(ApAddress::V1(0)),
+                    UnlockOperation::PrepareNetwork,
+                    UnlockOperation::Check(ApAddress::V1(1)),
+                    UnlockOperation::Halt(ApAddress::V1(1)),
+                ],
+            ),
+            (
+                NetworkCoreRelease::AlreadyReleased,
+                vec![
+                    UnlockOperation::Check(ApAddress::V1(0)),
+                    UnlockOperation::PrepareNetwork,
+                    UnlockOperation::Check(ApAddress::V1(1)),
+                ],
+            ),
+        ] {
+            let mut operations = MockCoreUnlockOperations {
+                network_release,
+                accessibility: [true, true].into(),
+                operations: Vec::new(),
+            };
+
+            initialize_core_access(
+                &sequence,
+                &mut operations,
+                &FullyQualifiedApAddress::v1_with_default_dp(0),
+                &crate::Permissions::new(),
+            )
+            .unwrap();
+
+            assert_eq!(operations.operations, expected);
+        }
+    }
+
+    #[test]
+    fn application_only_unlock_never_prepares_network_core() {
+        let sequence = TestNrf {
+            core_aps: vec![(0, 2)],
+        };
+        let mut operations = MockCoreUnlockOperations {
+            network_release: NetworkCoreRelease::Released,
+            accessibility: [true].into(),
+            operations: Vec::new(),
+        };
+
+        initialize_core_access(
+            &sequence,
+            &mut operations,
+            &FullyQualifiedApAddress::v1_with_default_dp(0),
+            &crate::Permissions::new(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            operations.operations,
+            [UnlockOperation::Check(ApAddress::V1(0))]
+        );
+    }
+
+    #[derive(Debug, PartialEq)]
+    enum ForceoffOperation {
+        Read(u64),
+        Write(u64, u32),
+        Flush,
+        Sleep(Duration),
+    }
+
+    struct MockNetworkForceoffInterface {
+        periph_config: u32,
+        forceoff: u32,
+        errata_var1: u32,
+        errata_var2: u32,
+        fail_write_address: Option<u64>,
+        operations: Vec<ForceoffOperation>,
+    }
+
+    impl MockNetworkForceoffInterface {
+        fn new(periph_config: u32, forceoff: u32, errata_var1: u32, errata_var2: u32) -> Self {
+            Self {
+                periph_config,
+                forceoff,
+                errata_var1,
+                errata_var2,
+                fail_write_address: None,
+                operations: Vec::new(),
+            }
+        }
+    }
+
+    impl NetworkForceoffInterface for MockNetworkForceoffInterface {
+        fn read_forceoff_word(&mut self, address: u64) -> Result<u32, ArmError> {
+            self.operations.push(ForceoffOperation::Read(address));
+            if address == APPLICATION_SPU_PERIPH_PERM + 0x4 * APPLICATION_RESET_PERIPH_ID {
+                Ok(self.periph_config)
+            } else if address == APPLICATION_FICR_ERRATA_VAR1_REGISTER {
+                Ok(self.errata_var1)
+            } else if address == APPLICATION_FICR_ERRATA_VAR2_REGISTER {
+                Ok(self.errata_var2)
+            } else {
+                Ok(self.forceoff)
+            }
+        }
+
+        fn write_forceoff_word(&mut self, address: u64, value: u32) -> Result<(), ArmError> {
+            self.operations
+                .push(ForceoffOperation::Write(address, value));
+            if self.fail_write_address == Some(address) {
+                self.fail_write_address = None;
+                return Err(ArmError::Timeout);
+            }
+            if address == u64::from(APPLICATION_RESET_S_NETWORK_FORCEOFF_REGISTER)
+                || address == u64::from(APPLICATION_RESET_NS_NETWORK_FORCEOFF_REGISTER)
+            {
+                self.forceoff = value;
+            }
+            Ok(())
+        }
+
+        fn flush_forceoff(&mut self) -> Result<(), ArmError> {
+            self.operations.push(ForceoffOperation::Flush);
+            Ok(())
+        }
+
+        fn sleep_forceoff(&mut self, duration: Duration) {
+            self.operations.push(ForceoffOperation::Sleep(duration));
+        }
+    }
+
+    #[test]
+    fn held_secure_forceoff_is_released_and_flushed() {
+        let mut interface = MockNetworkForceoffInterface::new(1 << 4, 1, 0, 0);
+
+        let release = set_network_core_running(&mut interface).unwrap();
+
+        assert_eq!(release, NetworkCoreRelease::Released);
+
+        assert_eq!(
+            interface.operations,
+            [
+                ForceoffOperation::Read(0x50003814),
+                ForceoffOperation::Read(0x50005614),
+                ForceoffOperation::Read(0x00ff0130),
+                ForceoffOperation::Read(0x00ff0134),
+                ForceoffOperation::Write(0x50005614, RELEASE_FORCEOFF),
+                ForceoffOperation::Flush,
+            ]
+        );
+    }
+
+    #[test]
+    fn held_non_secure_forceoff_uses_the_non_secure_alias() {
+        let mut interface = MockNetworkForceoffInterface::new(0, 1, 0, 0);
+
+        let release = set_network_core_running(&mut interface).unwrap();
+
+        assert_eq!(release, NetworkCoreRelease::Released);
+
+        assert_eq!(
+            interface.operations,
+            [
+                ForceoffOperation::Read(0x50003814),
+                ForceoffOperation::Read(0x40005614),
+                ForceoffOperation::Read(0x00ff0130),
+                ForceoffOperation::Read(0x00ff0134),
+                ForceoffOperation::Write(0x40005614, RELEASE_FORCEOFF),
+                ForceoffOperation::Flush,
+            ]
+        );
+    }
+
+    #[test]
+    fn released_network_core_is_not_reset_or_rewritten() {
+        let mut interface = MockNetworkForceoffInterface::new(1 << 4, RELEASE_FORCEOFF, 0x07, 0x05);
+
+        let release = set_network_core_running(&mut interface).unwrap();
+
+        assert_eq!(release, NetworkCoreRelease::AlreadyReleased);
+
+        assert_eq!(
+            interface.operations,
+            [
+                ForceoffOperation::Read(0x50003814),
+                ForceoffOperation::Read(0x50005614),
+            ]
+        );
+    }
+
+    #[test]
+    fn affected_secure_revision_uses_erratum_161_sequence() {
+        let mut interface = MockNetworkForceoffInterface::new(1 << 4, HOLD_FORCEOFF, 0x07, 0x05);
+
+        let release = set_network_core_running(&mut interface).unwrap();
+
+        assert_eq!(release, NetworkCoreRelease::Released);
+
+        assert_eq!(
+            interface.operations,
+            [
+                ForceoffOperation::Read(0x50003814),
+                ForceoffOperation::Read(0x50005614),
+                ForceoffOperation::Read(0x00ff0130),
+                ForceoffOperation::Read(0x00ff0134),
+                ForceoffOperation::Write(0x50005618, 1),
+                ForceoffOperation::Flush,
+                ForceoffOperation::Write(0x50005614, RELEASE_FORCEOFF),
+                ForceoffOperation::Flush,
+                ForceoffOperation::Sleep(ERRATUM_161_RELEASE_DELAY),
+                ForceoffOperation::Write(0x50005614, HOLD_FORCEOFF),
+                ForceoffOperation::Flush,
+                ForceoffOperation::Sleep(ERRATUM_161_HOLD_DELAY),
+                ForceoffOperation::Write(0x50005614, RELEASE_FORCEOFF),
+                ForceoffOperation::Flush,
+                ForceoffOperation::Write(0x50005618, 0),
+                ForceoffOperation::Flush,
+            ]
+        );
+    }
+
+    #[test]
+    fn affected_non_secure_revision_uses_matching_aliases() {
+        let mut interface = MockNetworkForceoffInterface::new(0, HOLD_FORCEOFF, 0x07, 0x05);
+
+        let release = set_network_core_running(&mut interface).unwrap();
+
+        assert_eq!(release, NetworkCoreRelease::Released);
+
+        assert!(
+            interface
+                .operations
+                .contains(&ForceoffOperation::Write(0x40005618, 1))
+        );
+        assert!(
+            interface
+                .operations
+                .contains(&ForceoffOperation::Write(0x40005614, RELEASE_FORCEOFF))
+        );
+        assert!(!interface.operations.iter().any(|operation| matches!(
+            operation,
+            ForceoffOperation::Write(address, _) if *address >= 0x50005614
+        )));
+    }
+
+    #[test]
+    fn erratum_failure_attempts_to_hold_core_and_clear_workaround() {
+        let mut interface = MockNetworkForceoffInterface::new(1 << 4, HOLD_FORCEOFF, 0x07, 0x05);
+        interface.fail_write_address = Some(0x50005614);
+
+        assert!(set_network_core_running(&mut interface).is_err());
+
+        assert!(
+            interface
+                .operations
+                .contains(&ForceoffOperation::Write(0x50005614, HOLD_FORCEOFF))
+        );
+        assert!(
+            interface
+                .operations
+                .contains(&ForceoffOperation::Write(0x50005618, 0))
+        );
+    }
+
+    #[test]
+    fn unaffected_revision_one_variant_uses_plain_release() {
+        let mut interface = MockNetworkForceoffInterface::new(1 << 4, HOLD_FORCEOFF, 0x07, 0x04);
+
+        let release = set_network_core_running(&mut interface).unwrap();
+
+        assert_eq!(release, NetworkCoreRelease::Released);
+        assert!(!interface.operations.iter().any(|operation| matches!(
+            operation,
+            ForceoffOperation::Write(address, _) if *address == 0x50005618
+        )));
     }
 }

--- a/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
+++ b/probe-rs/src/vendor/nordicsemi/sequences/nrf53.rs
@@ -2,11 +2,11 @@
 
 use std::sync::Arc;
 
-use super::nrf::Nrf;
+use super::nrf::{Nrf, reset_affects_network, set_network_core_running, wait_for_core_accessible};
 use crate::architecture::arm::sequences::ArmDebugSequenceError;
 use crate::architecture::arm::{
     ApAddress as ArmApAddress, ArmDebugInterface, ArmError, FullyQualifiedApAddress, ap::CSW,
-    dp::DpAddress, sequences::ArmDebugSequence,
+    dp::DpAddress, memory::ArmMemoryInterface, sequences::ArmDebugSequence,
 };
 use probe_rs_target::{ApAddress as TargetApAddress, Chip, CoreAccessOptions};
 
@@ -119,6 +119,39 @@ impl Nrf for Nrf5340 {
             Ok(None)
         }
     }
+
+    fn post_reset(&self, interface: &mut dyn ArmMemoryInterface) -> Result<(), ArmError> {
+        let core_ap = interface.fully_qualified_address();
+        if !reset_affects_network(self, &core_ap) {
+            return Ok(());
+        }
+
+        // An application reset asserts NETWORK.FORCEOFF. A session using the
+        // stock dual-core target owns AP1 as well as AP0, so restore AP1 before
+        // returning. Run-control remains core-specific; AP0 reset state does not
+        // imply that AP1 should be halted. The application-only target never
+        // enters this path.
+        let (network_ahb_ap, network_ctrl_ap) = self
+            .core_aps(&core_ap.dp())
+            .into_iter()
+            .find(|(ahb_ap, _)| ahb_ap.ap() == &ArmApAddress::V1(1))
+            .ok_or_else(|| {
+                ArmError::from(ArmDebugSequenceError::custom(
+                    "Dual-core nRF5340 target has no network AP mapping",
+                ))
+            })?;
+
+        let _ = set_network_core_running(interface)?;
+        let arm_interface = interface.get_arm_debug_interface()?;
+        if !wait_for_core_accessible(self, arm_interface, &network_ahb_ap, &network_ctrl_ap)? {
+            return Err(ArmDebugSequenceError::custom(
+                "Network core did not become accessible after application reset",
+            )
+            .into());
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -226,6 +259,22 @@ mod tests {
                 .iter()
                 .all(|region| region.cores() == ["application"])
         );
+    }
+
+    #[test]
+    fn only_dual_target_application_reset_affects_network() {
+        let dual = Nrf5340 {
+            core_aps: vec![(0, 2), (1, 3)],
+        };
+        let app_only = Nrf5340 {
+            core_aps: vec![(0, 2)],
+        };
+        let application_ap = FullyQualifiedApAddress::v1_with_default_dp(0);
+        let network_ap = FullyQualifiedApAddress::v1_with_default_dp(1);
+
+        assert!(reset_affects_network(&dual, &application_ap));
+        assert!(!reset_affects_network(&dual, &network_ap));
+        assert!(!reset_affects_network(&app_only, &application_ap));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Keep the stock dual-core `nRF5340_xxAA` target usable across initial attach,
application reset, and combined application-plus-network flashing.

The sequence now:

1. completes AP0 initialization before inspecting AP1;
2. releases `RESET.NETWORK.FORCEOFF` before the first AP1 check;
3. preserves a network core that was already running;
4. applies the FICR-gated Revision 1 Erratum 161 release sequence when needed;
5. restores AP1 after AP0 reset.

During initial attach, AP1 is halted only when probe-rs had to release it. An
already-running network core is left untouched. Post-reset handling restores
AP1 accessibility but does not infer network-core halt intent from AP0 state.

The opt-in application-only target never enters the AP1, CTRL-AP3, or FORCEOFF
paths.

Fixes #3053.

## Motivation

Application reset forces the nRF5340 network domain off. probe-rs previously
checked AP1 before releasing that state, and only prepared the network domain
during initial session unlock. Combined flashing can reset AP0 before loading
the network flash algorithm, making AP1 unavailable again inside the same
session.

Nordic's production-programming documentation requires AP0 initialization and
network release before connecting to AP1. Nordic's current `nrfx` gates
Erratum 161 by FICR revision/build and uses a release/hold/release sequence.
OpenOCD independently restores the network domain from the application reset
event before examining AP1.

- [nRF5340 production programming](https://docs.nordicsemi.com/r/bundle/nan_042/)
- [nRF5340 reset behavior](https://docs.nordicsemi.com/r/bundle/ps_nrf5340/page/chapters/reset/doc/reset.html)
- [Nordic nrfx Erratum 161 implementation](https://github.com/NordicSemiconductor/nrfx/blob/master/hal/nrf_reset.h)
- [OpenOCD nRF53 target configuration](https://github.com/openocd-org/openocd/blob/master/tcl/target/nordic/nrf53.cfg)

This is based on the CTRL-AP2 application-reset support from #4168 and leaves
the shared Nordic debug-erase sequence from #4226 unchanged.

## Safety properties

- AP1 is not inspected until AP0 is accessible and FORCEOFF is prepared.
- An already-running network core receives no FORCEOFF write, reset, or halt
  during initial attach.
- Erratum 161 is applied only to affected FICR revision/build values.
- Secure and non-secure RESET/workaround aliases remain paired.
- Partial Erratum 161 failures attempt to hold the network core and clear the
  workaround register.
- AP1 readiness uses a conservative, bounded 300 ms host-side deadline.
- Transport errors abort rather than being classified as protection.
- Failure to restore AP1 for the stock dual-core target is reported instead of
  leaving a session whose declared network core is inaccessible.
- Application-only sessions remain AP0/CTRL-AP2-only.
- Destructive recovery remains separately permission-gated.

## Tests

Tests cover:

- complete `AP0 check -> FORCEOFF preparation -> AP1 check` ordering, including
  halt only when initial attach newly releases AP1;
- application-only isolation from network preparation;
- already-running versus newly released AP1 behavior;
- secure and non-secure aliases;
- affected and unaffected Revision 1 builds;
- exact Erratum 161 writes, flushes, delays, and failure cleanup;
- AP0 post-reset AP1 restoration and target-scope behavior;
- actual built-in stock and application-only target scope.

Validation completed on the final commit:

- `cargo test --workspace --all-features --exclude smoke_tester`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

## Hardware evidence

Test setup:

- affected Revision 1 nRF5340 (`FICR 0x00ff0130/134 = 0x07/0x05`);
- Raspberry Pi Debug Probe, CMSIS-DAP firmware v0230;
- SWD at 100 kHz;
- minimal application and network images with distinct identifiers;
- no erase permission during the lifecycle matrix.

After physical power-on reset:

| Operation | Result |
|---|---|
| Stock-target attach | AP0 and AP1 accessible; newly released AP1 halted |
| Application verify | Passed |
| Network verify | Passed |
| AP0 reset through CTRL-AP2 | Passed; AP1 restored |
| Fresh stock-target attach | AP0 and AP1 accessible |
| Combined app+network download | Passed |
| Combined verify | Passed |
| AP0 reset and second combined verify | Passed |

The combined image intentionally excluded the network-UICR record because the
independent `nrf53xx_network_uicr` algorithm failed at `0x01ff8000`. Normal
application and network flash algorithms are the behavior validated here; the
UICR failure is tracked separately.

## Checklist

- [x] The code compiles without errors or warnings
- [x] All workspace tests pass, with focused regression coverage added
- [x] `cargo fmt` was run
- [x] A changelog fragment describes the change
- [x] Physical POR, combined download, reset, fresh attach, and verification pass
