### PR TITLE
Add generic IP components to the Coresight tree.

### DIFF
--- a/changelog/added-generic-ip-to-tree.md
+++ b/changelog/added-generic-ip-to-tree.md
@@ -1,0 +1,1 @@
+Add detected generic IP components to the info tree output.

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -581,6 +581,7 @@ fn coresight_component_tree(
 
             let mut tree = ComponentTreeNode::new(desc);
             process_component_entry(&mut tree, interface, peripheral_id, &component, access_port)?;
+            parent.push(tree);
         }
 
         Component::CoreLinkOrPrimeCellOrSystemComponent(id) => {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -574,7 +574,11 @@ fn coresight_component_tree(
             let peripheral_id = id.peripheral_id();
 
             let desc = if let Some(part_desc) = peripheral_id.determine_part() {
-                format!("{: <15} (Generic IP component)", part_desc.name())
+                format!(
+                    "{:#06x} {: <15} (Generic IP component)",
+                    id.component_address(),
+                    part_desc.name()
+                )
             } else {
                 "Generic IP component".to_string()
             };


### PR DESCRIPTION
Tested with an Arduino Due (ATSAM3X8E) this adds a couple more detected components to the tree.

`probe-rs` 0.32:

```
Probing target via SWD
----------------------

ARM Chip with debug port Default:

Debug Port: DPv1, Designer: ARM Ltd
└── V1(0) MemoryAP
    └── 0 MemoryAP (AmbaAhb3)
        ├── 0xe00ff000 ROM Table (Class 1)
        ├── 0xe0001000 Generic
        ├── 0xe0000000 Generic
        └── 0xe0040000 Generic


Debug port version DPv1 does not support SWD multidrop. Stopping here.
```

`0bdf855`:

```
Probing target via SWD
----------------------

ARM Chip with debug port Default:

Debug Port: DPv1, Designer: ARM Ltd
└── V1(0) MemoryAP
    └── 0 MemoryAP (AmbaAhb3)
        ├── 0xe00ff000 ROM Table (Class 1)
        ├── 0xe000e000 Cortex-M3 SCS   (Generic IP component)
        │   └── CPUID
        │       ├── IMPLEMENTER: ARM Ltd
        │       ├── VARIANT: 2
        │       ├── PARTNO: Cortex-M3
        │       └── REVISION: 0
        ├── 0xe0001000 Generic
        ├── 0xe0002000 Cortex-M3 FBP   (Generic IP component)
        ├── 0xe0000000 Generic
        └── 0xe0040000 Generic


Debug port version DPv1 does not support SWD multidrop. Stopping here.
```