### PR TITLE
probe-rs info coresight component fix

### DIFF
--- a/changelog/fixed-coresight-info-reporting.md
+++ b/changelog/fixed-coresight-info-reporting.md
@@ -1,0 +1,1 @@
+Fixed coresight `probe-rs info` reporting. Debug components are once again discovered and displayed correctly after a fresh power cycle.

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -5,10 +5,12 @@
 use anyhow::anyhow;
 use postcard_rpc::header::{VarHeader, VarSeq};
 use probe_rs::{
+    MemoryMappedRegister,
     architecture::{
         arm::{
             self, ApAddress, ApV2Address, ArmDebugInterface,
             ap::{ApClass, ApRegister, IDR},
+            armv6m::Demcr,
             component::Scs,
             dp::{self, Ctrl, DLPIDR, DPIDR, DpRegister, TARGETID},
             memory::{
@@ -489,6 +491,10 @@ fn handle_memory_ap(
         }
 
         let base_address = memory.base_address()?;
+        // Enable dwt here otherwise DWT/ITM/ETM/TPIU won't be visible in component table
+        let mut demcr = Demcr(memory.read_word_32(Demcr::get_mmio_address())?);
+        demcr.set_dwtena(true);
+        memory.write_word_32(Demcr::get_mmio_address(), demcr.into())?;
         Component::try_parse(&mut *memory, base_address)?
     };
     coresight_component_tree(interface, component, access_port, parent)


### PR DESCRIPTION
### EDIT: I didn't see #4241 which already fixed the regression from #3003 Generic IP components not being print. This PR now only adds setting demcr.dwtena before probing the tree.

This fixes 2 regressions in `probe-rs info`.

https://github.com/probe-rs/probe-rs/pull/3005 stopped setting demcr.dwtena before ROM table parsing, which means we could no longer probe CoreSight Debug/Trace components.

https://github.com/probe-rs/probe-rs/pull/3003 stopped pushing generic IP components to our component tree, so they were no longer getting printed.

Before
```
probe-rs-32 info --verbose --protocol swd --chip rp2040
Probing target via SWD
----------------------

ARM Chip with debug port Default:

Debug Port: DPv2, MINDP, Designer: Raspberry Pi Trading Ltd, Part: 0x1002, Revision: 0x0, Instance: 0x0f
└── No access ports found on this chip.


ARM Chip with debug port Multidrop(1002927):

Debug Port: DPv2, MINDP, Designer: Raspberry Pi Trading Ltd, Part: 0x1002, Revision: 0x0, Instance: 0x00
└── V1(0) MemoryAP
    └── 0 MemoryAP (AmbaAhb3)
        └── 0xe00ff000 ROM Table (Class 1), Designer: ARM Ltd


ARM Chip with debug port Multidrop(11002927):

Debug Port: DPv2, MINDP, Designer: Raspberry Pi Trading Ltd, Part: 0x1002, Revision: 0x0, Instance: 0x01
└── V1(0) MemoryAP
    └── 0 MemoryAP (AmbaAhb3)
        └── 0xe00ff000 ROM Table (Class 1), Designer: ARM Ltd
```
After
```
cargo run -p probe-rs-tools --bin probe-rs -- info --verbose --protocol swd --chip rp2040
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/probe-rs info --verbose --protocol swd --chip rp2040`
Probing target via SWD
----------------------

ARM Chip with debug port Default:

Debug Port: DPv2, MINDP, Designer: Raspberry Pi Trading Ltd, Part: 0x1002, Revision: 0x0, Instance: 0x0f
└── No access ports found on this chip.


ARM Chip with debug port Multidrop(1002927):

Debug Port: DPv2, MINDP, Designer: Raspberry Pi Trading Ltd, Part: 0x1002, Revision: 0x0, Instance: 0x00
└── V1(0) MemoryAP
    └── 0 MemoryAP (AmbaAhb3)
        ├── 0xe00ff000 ROM Table (Class 1), Designer: ARM Ltd
        ├── 0xe000e000 Cortex-M0 SCS   (Generic IP component)
        │   └── CPUID
        │       ├── IMPLEMENTER: ARM Ltd
        │       ├── VARIANT: 0
        │       ├── PARTNO: Cortex-M0+
        │       └── REVISION: 1
        ├── 0xe0001000 Cortex-M0 DWT   (Generic IP component)
        └── 0xe0002000 Cortex-M0 BPU   (Generic IP component)


ARM Chip with debug port Multidrop(11002927):

Debug Port: DPv2, MINDP, Designer: Raspberry Pi Trading Ltd, Part: 0x1002, Revision: 0x0, Instance: 0x01
└── V1(0) MemoryAP
    └── 0 MemoryAP (AmbaAhb3)
        ├── 0xe00ff000 ROM Table (Class 1), Designer: ARM Ltd
        ├── 0xe000e000 Cortex-M0 SCS   (Generic IP component)
        │   └── CPUID
        │       ├── IMPLEMENTER: ARM Ltd
        │       ├── VARIANT: 0
        │       ├── PARTNO: Cortex-M0+
        │       └── REVISION: 1
        ├── 0xe0001000 Cortex-M0 DWT   (Generic IP component)
        └── 0xe0002000 Cortex-M0 BPU   (Generic IP component)

```

For the other regression to surface, you need to run an older probe-rs *first* to observe the problem (I have not diagnosed why):

```
$ probe-rs-32 info --verbose --protocol swd
Probing target via SWD
----------------------

ARM Chip with debug port Default:

Debug Port: DPv1, Designer: ARM Ltd
└── V1(0) MemoryAP
    └── 0 MemoryAP (AmbaAhb3)
        ├── 0xe00ff000 ROM Table (Class 1), Designer: ARM Ltd
        ├── 0xe0001000 Generic
        ├── 0xe0000000 Peripheral test block
        ├── 0xe0040000 Generic
        └── 0xe0041000 Cortex-M3 ETM   (Coresight Component)


Debug port version DPv1 does not support SWD multidrop. Stopping here.

$ probe-rs-26 info --protocol swd
Probing target via SWD

ARM Chip with debug port Default:
Debug Port: DPv1, DP Designer: ARM Ltd
└── 0 MemoryAP (AmbaAhb3)
    └── ROM Table (Class 1), Designer: ARM Ltd
        ├── Cortex-M3 SCS   (Generic IP component)
        │   └── CPUID
        │       ├── IMPLEMENTER: ARM Ltd
        │       ├── VARIANT: 2
        │       ├── PARTNO: Cortex-M3
        │       └── REVISION: 1
        ├── Cortex-M3 DWT   (Generic IP component)
        ├── Cortex-M3 FBP   (Generic IP component)
        ├── Cortex-M3 ITM   (Generic IP component)
        ├── Cortex-M3 TPIU  (Coresight Component)
        └── Cortex-M3 ETM   (Coresight Component)


Debugging RISC-V targets over SWD is not supported. For these targets, JTAG is the only supported protocol. RISC-V specific information cannot be printed.
Debugging Xtensa targets over SWD is not supported. For these targets, JTAG is the only supported protocol. Xtensa specific information cannot be printed.

$ probe-rs-32 info --verbose --protocol swd
Probing target via SWD
----------------------

ARM Chip with debug port Default:

Debug Port: DPv1, Designer: ARM Ltd
└── V1(0) MemoryAP
    └── 0 MemoryAP (AmbaAhb3)
        ├── 0xe00ff000 ROM Table (Class 1), Designer: ARM Ltd
        ├── 0xe0040000 Cortex-M3 TPIU  (Coresight Component)
        └── 0xe0041000 Cortex-M3 ETM   (Coresight Component)


Debug port version DPv1 does not support SWD multidrop. Stopping here.

$ cargo run -p probe-rs-tools --bin probe-rs -- info --verbose --protocol swd
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/probe-rs info --verbose --protocol swd`
Probing target via SWD
----------------------

ARM Chip with debug port Default:

Debug Port: DPv1, Designer: ARM Ltd
└── V1(0) MemoryAP
    └── 0 MemoryAP (AmbaAhb3)
        ├── 0xe00ff000 ROM Table (Class 1), Designer: ARM Ltd
        ├── 0xe000e000 Cortex-M3 SCS   (Generic IP component)
        │   └── CPUID
        │       ├── IMPLEMENTER: ARM Ltd
        │       ├── VARIANT: 2
        │       ├── PARTNO: Cortex-M3
        │       └── REVISION: 1
        ├── 0xe0001000 Cortex-M3 DWT   (Generic IP component)
        ├── 0xe0002000 Cortex-M3 FBP   (Generic IP component)
        ├── 0xe0000000 Cortex-M3 ITM   (Generic IP component)
        ├── 0xe0040000 Cortex-M3 TPIU  (Coresight Component)
        └── 0xe0041000 Cortex-M3 ETM   (Coresight Component)


Debug port version DPv1 does not support SWD multidrop. Stopping here.
```