### PR TITLE
fix(debug): match Windows source paths case-insensitively

### DIFF
--- a/changelog/fixed-dap-breakpoint-path-case.md
+++ b/changelog/fixed-dap-breakpoint-path-case.md
@@ -1,0 +1,4 @@
+Fixed DAP source breakpoints failing on Windows when the drive letter case differs between the client and DWARF.
+
+Author: RawNuke
+Copyright (c) 2026 RawNuke. All rights reserved.

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -1,3 +1,6 @@
+// Author: RawNuke
+// Copyright (c) 2026 RawNuke. All rights reserved.
+
 use super::{
     DebugError, DebugRegisters, StackFrame, VariableCache,
     exception_handling::ExceptionInterface,
@@ -1087,8 +1090,20 @@ impl DebugInfo {
 }
 
 /// Uses the [`TypedPathBuf::normalize`] function to normalize both paths before comparing them
+///
+/// When either path is Windows-typed, the comparison is case-insensitive, because Windows
+/// file systems are case-insensitive and the drive letter case may differ between the client
+/// and the DWARF info. Otherwise the comparison is byte-for-byte.
 pub(crate) fn canonical_path_eq(primary_path: TypedPath, secondary_path: TypedPath) -> bool {
-    primary_path.normalize() == secondary_path.normalize()
+    let primary_buf = primary_path.normalize();
+    let secondary_buf = secondary_path.normalize();
+    if primary_path.is_windows() || secondary_path.is_windows() {
+        primary_buf
+            .to_string_lossy()
+            .eq_ignore_ascii_case(&secondary_buf.to_string_lossy())
+    } else {
+        primary_buf == secondary_buf
+    }
 }
 
 /// Returns `true` if `full_path` matches `partial_path`.
@@ -1109,6 +1124,14 @@ pub(crate) fn path_matches(full_path: TypedPath, partial_path: TypedPath) -> boo
         let full_str = full_buf.to_string_lossy().replace('\\', "/");
         let partial_buf = partial_path.normalize();
         let partial_str = partial_buf.to_string_lossy().replace('\\', "/");
+        let (full_str, partial_str) = if full_path.is_windows() || partial_path.is_windows() {
+            (
+                full_str.to_ascii_lowercase(),
+                partial_str.to_ascii_lowercase(),
+            )
+        } else {
+            (full_str, partial_str)
+        };
         full_str.ends_with(&*partial_str)
             && (full_str.len() == partial_str.len()
                 || full_str[..full_str.len() - partial_str.len()].ends_with('/'))
@@ -1486,8 +1509,9 @@ mod test {
     };
     use std::path::{Path, PathBuf};
     use test_case::test_case;
+    use typed_path::TypedPath;
 
-    use super::unwind_register_using_rule;
+    use super::{canonical_path_eq, path_matches, unwind_register_using_rule};
 
     /// Get the full path to a file in the `tests` directory.
     fn get_path_for_test_files(relative_file: &str) -> PathBuf {
@@ -2240,5 +2264,32 @@ mod test {
         // forward, NOT the canonical frame address. Overwriting it with the CFA
         // would corrupt the frame pointer when unwinding handlers that don't save R7.
         assert_eq!(value, Some(RegisterValue::U32(0x100)));
+    }
+
+    #[test]
+    fn windows_absolute_paths_case_insensitive() {
+        let primary = TypedPath::derive(r"C:\src\main.rs");
+        let secondary = TypedPath::derive(r"c:\src\main.rs");
+
+        assert!(primary.is_windows());
+        assert!(canonical_path_eq(primary, secondary));
+        assert!(path_matches(primary, secondary));
+    }
+
+    #[test]
+    fn windows_relative_suffix_case_insensitive() {
+        let full_path = TypedPath::derive(r"C:\probe-rs\src\main.rs");
+        let partial_path = TypedPath::derive(r"src\MAIN.RS");
+
+        assert!(path_matches(full_path, partial_path));
+    }
+
+    #[test]
+    fn unix_paths_case_sensitive() {
+        let primary = TypedPath::derive("/src/main.rs");
+        let secondary = TypedPath::derive("/src/Main.rs");
+
+        assert!(!canonical_path_eq(primary, secondary));
+        assert!(!path_matches(primary, secondary));
     }
 }

--- a/probe-rs-debug/tests/source_location.rs
+++ b/probe-rs-debug/tests/source_location.rs
@@ -1,3 +1,6 @@
+// Author: RawNuke
+// Copyright (c) 2026 RawNuke. All rights reserved.
+
 use probe_rs_debug::{ColumnType, SourceLocation, debug_info::DebugInfo};
 use std::path::PathBuf;
 use typed_path::{TypedPath, UnixPathBuf};
@@ -116,6 +119,18 @@ fn find_non_existing_unit_by_path() {
 #[test]
 fn regression_pr2324() {
     let path = "C:\\_Hobby\\probe-rs-test-c-firmware/Atmel/hpl/core/hpl_init.c";
+
+    let di = DebugInfo::from_file("tests/debug-unwind-tests/atsamd51p19a.elf").unwrap();
+    let path = TypedPath::derive(path);
+
+    let addr = di.get_breakpoint_location(path, 58, None).unwrap();
+
+    assert_eq!(addr.address, 0x2e4);
+}
+
+#[test]
+fn regression_pr4244_drive_letter_case() {
+    let path = "c:\\_hobby\\probe-rs-test-c-firmware/Atmel/hpl/core/hpl_init.c";
 
     let di = DebugInfo::from_file("tests/debug-unwind-tests/atsamd51p19a.elf").unwrap();
     let path = TypedPath::derive(path);


### PR DESCRIPTION
## Summary

Fixes #4244

The VS Code DAP gutter sends breakpoint source paths with a lowercase
drive letter (`c:\...`) while DWARF embeds an uppercase drive letter
(`C:\...`). Source path comparison was case-sensitive, so source
breakpoints could not be set from the UI on Windows. The REPL
`break file:line` form worked because relative-path suffix matching was
added in 0.32, but absolute Windows paths from the UI still failed.

This change makes path comparison case-insensitive when either path is
Windows-typed. Windows file systems are case-insensitive, so `c:\` and
`C:\` refer to the same file. Unix paths remain case-sensitive.

## Changes

- `probe-rs-debug/src/debug_info.rs`: `canonical_path_eq()` and
  `path_matches()` compare case-insensitively for Windows-typed paths.
- `probe-rs-debug/tests/source_location.rs`: regression test resolving a
  breakpoint on a real ELF with a lowercase drive letter.
- Unit tests for drive-letter case, Windows suffix matching, and Unix
  case-sensitivity.
- `changelog/fixed-dap-breakpoint-path-case.md`

## Testing

- `cargo test -p probe-rs-debug`: 40 lib + 6 integration tests pass.
- `cargo fmt --check -p probe-rs-debug`: clean.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo fmt` was run.
- [x] Add a changelog fragment describing your changes in `changelogs/`. See https://github.com/probe-rs/probe-rs/blob/master/CONTRIBUTING.md#changelog-entries. 

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your newly added features and code.

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke
