### PR TITLE
fix(dap): respond to the restart request when the reset fails

### DIFF
--- a/changelog/fixed-dap-restart-error-response.md
+++ b/changelog/fixed-dap-restart-error-response.md
@@ -1,0 +1,1 @@
+Fixed the DAP server hanging when a debug session restart fails: the server now sends an error response to the restart request instead of leaving the client waiting.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1470,7 +1470,11 @@ impl DebugAdapter {
         {
             Ok(core_info) => core_info,
             Err(error) => {
-                return self.show_error_message(&DebuggerError::Other(anyhow!("{error}")));
+                let error = DebuggerError::Other(anyhow!("{error}"));
+                if let Some(request) = request {
+                    return self.send_response::<()>(request, Err(&error));
+                }
+                return self.show_error_message(&error);
             }
         };
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -1449,6 +1449,14 @@ mod test {
         protocol_adapter: MockProtocolAdapter,
         with_probe: bool,
     ) -> Result<(), DebuggerError> {
+        execute_test_with_probe_config(protocol_adapter, with_probe, |_| {}).await
+    }
+
+    async fn execute_test_with_probe_config(
+        protocol_adapter: MockProtocolAdapter,
+        with_probe: bool,
+        probe_config: impl FnOnce(&mut FakeProbe),
+    ) -> Result<(), DebuggerError> {
         use crate::rpc::functions::RpcApp;
         use std::sync::Arc;
 
@@ -1456,7 +1464,9 @@ mod test {
 
         let lister = TestLister::new();
         if with_probe {
-            lister.probes.lock().unwrap().push(fake_probe());
+            let (info, mut fake_probe) = fake_probe();
+            probe_config(&mut fake_probe);
+            lister.probes.lock().unwrap().push((info, fake_probe));
         }
         let lister = Arc::new(lister) as Arc<dyn probe_rs::integration::ProbeLister + Send + Sync>;
 
@@ -1550,6 +1560,37 @@ mod test {
         disconnect_protocol_adapter(&mut protocol_adapter);
 
         execute_test(protocol_adapter, true).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn restart_failure_responds_with_error() {
+        let mut protocol_adapter = initialized_protocol_adapter();
+
+        let attach_args = valid_session_config();
+        protocol_adapter
+            .add_request("attach")
+            .with_arguments(attach_args)
+            .and_successful_response();
+
+        protocol_adapter.expect_event("initialized", None::<u32>);
+
+        // The restart request must receive an error response. The reset
+        // fails on the target (the system reset request register write
+        // times out, as when the debug connection drops on reset), so the
+        // server must not leave the client waiting for a response.
+        protocol_adapter.expect_output_event("A timeout occurred.\n");
+        protocol_adapter
+            .add_request("restart")
+            .and_error_response()
+            .with_body(error_response_body("A timeout occurred."));
+
+        disconnect_protocol_adapter(&mut protocol_adapter);
+
+        execute_test_with_probe_config(protocol_adapter, true, |probe| {
+            probe.set_system_reset_write_failure(true);
+        })
+        .await
+        .unwrap();
     }
 
     #[tokio::test]

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -95,6 +95,12 @@ struct MockCore {
     program_binary: Option<Vec<u8>>,
     loadable_segments: Vec<LoadableSegment>,
     endianness: Endianness,
+
+    /// When set, a write to the system reset request register (AIRCR) fails.
+    ///
+    /// Use this to simulate a target whose debug connection drops when it
+    /// resets, which is what the DAP restart flow must handle.
+    fail_system_reset_write: bool,
 }
 
 impl MockCore {
@@ -105,6 +111,7 @@ impl MockCore {
             program_binary: None,
             loadable_segments: Vec::new(),
             endianness: Endianness::Little,
+            fail_system_reset_write: false,
         }
     }
 }
@@ -234,6 +241,12 @@ impl MemoryInterface<ArmError> for &mut MockCore {
     }
 
     fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), ArmError> {
+        use crate::architecture::arm::core::armv7m::Aircr;
+
+        if self.fail_system_reset_write && address == Aircr::ADDRESS_OFFSET {
+            return Err(ArmError::Timeout);
+        }
+
         for (i, word) in data.iter().enumerate() {
             let address = address + (i as u64 * 4);
 
@@ -391,6 +404,17 @@ impl FakeProbe {
         handler: Box<dyn Fn(RegisterAddress, u32) -> Result<(), ArmError> + Send>,
     ) {
         self.dap_register_write_handler = Some(handler);
+    }
+
+    /// When `fail` is true, the next write to the system reset request
+    /// register (AIRCR) fails with a timeout.
+    ///
+    /// Use this to simulate a target whose debug connection drops when it
+    /// resets. This is only honored for a core-mocked memory AP.
+    pub fn set_system_reset_write_failure(&mut self, fail: bool) {
+        if let MockedAp::Core(core) = &mut self.memory_ap {
+            core.fail_system_reset_write = fail;
+        }
     }
 
     /// Makes a generic probe out of the [`FakeProbe`]


### PR DESCRIPTION
## What

The DAP server did not respond to a `restart` request when `reset_and_halt` failed. It only showed an error message and returned, so the client (VS Code) waited for the response forever. This is what surfaces as a hang when a restart resets a target whose debug link drops, for example USB-JTAG on an ESP32-S3 (see #4245).

With this change the server sends a proper DAP error response to the request when one exists. The launch and REPL paths, which call `restart_async` without a request, keep the existing error-message behavior.

## Verification

- New full-session regression test `restart_failure_responds_with_error` runs the DAP session against an in-process RPC server with a `FakeProbe` whose system-reset register write fails (simulating the dropped debug link), and asserts the restart request receives an error response.
- The test fails without the fix (no response is ever sent) and passes with it.
- `cargo test -p probe-rs-tools --bin probe-rs -- dap_server`: 72 passed.
- `cargo test -p probe-rs --lib`: 183 passed.
- `cargo clippy --all-features --all-targets -- -D warnings`: clean on both crates.
- `cargo fmt --check`: clean.

## Notes

The remaining ~60s wait reported in #4245 happens in the host USB driver reclamation after the target re-enumerates, which is outside the DAP server. The hardware-level recovery (re-attaching the probe after the link drops) still needs testing on an actual ESP32-S3; this change removes the protocol-level hang so the client always gets an answer.

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke
