### PR TITLE
Revert "probe-rs info coresight component fix (#4246)"

### DIFF
--- a/changelog/fixed-coresight-info-reporting.md
+++ b/changelog/fixed-coresight-info-reporting.md
@@ -1,1 +1,0 @@
-Fixed coresight `probe-rs info` reporting. Debug components are once again discovered and displayed correctly after a fresh power cycle.

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -5,12 +5,10 @@
 use anyhow::anyhow;
 use postcard_rpc::header::{VarHeader, VarSeq};
 use probe_rs::{
-    MemoryMappedRegister,
     architecture::{
         arm::{
             self, ApAddress, ApV2Address, ArmDebugInterface,
             ap::{ApClass, ApRegister, IDR},
-            armv6m::Demcr,
             component::Scs,
             dp::{self, Ctrl, DLPIDR, DPIDR, DpRegister, TARGETID},
             memory::{
@@ -491,10 +489,6 @@ fn handle_memory_ap(
         }
 
         let base_address = memory.base_address()?;
-        // Enable dwt here otherwise DWT/ITM/ETM/TPIU won't be visible in component table
-        let mut demcr = Demcr(memory.read_word_32(Demcr::get_mmio_address())?);
-        demcr.set_dwtena(true);
-        memory.write_word_32(Demcr::get_mmio_address(), demcr.into())?;
         Component::try_parse(&mut *memory, base_address)?
     };
     coresight_component_tree(interface, component, access_port, parent)


### PR DESCRIPTION
This reverts commit 01ec374b55f73688737784350e8ff5cc3218d08e.

Setting demcr.dwtena for all APs was very naive.
I assumed that if it would break AP probing, it would only be for APs we don't care about.
We'll want better detection mechanism before attempting this again.