### PR TITLE
Update ARM info output

### DIFF
--- a/changelog/changed-info-output.md
+++ b/changelog/changed-info-output.md
@@ -1,0 +1,1 @@
+Update the info tree for ARM cores so that the ROM table entries are shown as children of the ROM table.  Also identify more components and unify formatting of unknown components.

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -532,13 +532,13 @@ fn coresight_component_tree(
             let mut tree =
                 ComponentTreeNode::new(format!("{:#06x} {}", id.component_address(), root));
             process_vendor_rom_tables(interface, id, table, access_port, &mut tree)?;
-            parent.push(tree);
 
             for entry in table.entries() {
                 let component = entry.component().clone();
 
-                coresight_component_tree(interface, component, access_port, parent)?;
+                coresight_component_tree(interface, component, access_port, &mut tree)?;
             }
+            parent.push(tree);
         }
         Component::CoresightComponent(id) => {
             let peripheral_id = id.peripheral_id();

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -519,10 +519,14 @@ fn coresight_component_tree(
             let root = if let Some(part) = peripheral_id.determine_part() {
                 format!("{} (ROM Table, Class 1)", part.name())
             } else {
-                match peripheral_id.designer() {
-                    Some(designer) => format!("ROM Table (Class 1), Designer: {designer}"),
-                    None => "ROM Table (Class 1)".to_string(),
-                }
+                let designer = peripheral_id.designer().unwrap_or("<unknown>");
+                format!(
+                    "ROM Table (Class 1), Designer: {}, Part: {:#06x}, Devtype: {:#04x}, Archid: {:#06x}",
+                    designer,
+                    peripheral_id.part(),
+                    peripheral_id.dev_type(),
+                    peripheral_id.arch_id(),
+                )
             };
 
             let mut tree =
@@ -581,12 +585,12 @@ fn coresight_component_tree(
 
             let desc = if let Some(part_desc) = peripheral_id.determine_part() {
                 format!(
-                    "{:#06x} {: <15} (Generic IP component)",
+                    "{:#06x} {: <15} (Generic IP Component)",
                     id.component_address(),
                     part_desc.name()
                 )
             } else {
-                "Generic IP component".to_string()
+                "Generic IP Component".to_string()
             };
 
             let mut tree = ComponentTreeNode::new(desc);
@@ -595,17 +599,27 @@ fn coresight_component_tree(
         }
 
         Component::CoreLinkOrPrimeCellOrSystemComponent(id) => {
-            let desc = "Core Link / Prime Cell / System component";
-            let desc = if let Some(part_desc) = id.peripheral_id().determine_part() {
-                format!("{: <15} ({})", part_desc.name(), desc)
+            let desc = "Core Link / Prime Cell / System Component";
+            let peripheral_id = id.peripheral_id();
+            let part_info = peripheral_id.determine_part();
+
+            let component_description = if let Some(part_info) = part_info {
+                format!("{: <15} ({})", part_info.name(), desc)
             } else {
-                desc.to_string()
+                format!(
+                    "{}, Part: {:#06x}, Devtype: {:#04x}, Archid: {:#06x}, Designer: {}",
+                    desc,
+                    peripheral_id.part(),
+                    peripheral_id.dev_type(),
+                    peripheral_id.arch_id(),
+                    peripheral_id.designer().unwrap_or("<unknown>"),
+                )
             };
 
             parent.push(ComponentTreeNode::new(format!(
                 "{:#06x} {}",
                 id.component_address(),
-                desc
+                component_description
             )));
         }
     };

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -769,6 +769,8 @@ impl PeripheralID {
             ("ARM Ltd", 0xD21, 0x11, 0x0000) => Some(PartInfo::new("Cortex-M33 TPIU", PeripheralType::Tpiu)),
             // From Arm Cortex-M55 Processor Technical Reference Manual
             ("ARM Ltd", 0xD22, 0x11, 0x0000) => Some(PartInfo::new("Cortex-M55 TPIU", PeripheralType::Tpiu)),
+            // From Arm Cortex-M85 Processor Technical Reference Manual B.2
+            ("ARM Ltd", 0xD23, 0x11, 0x0000) => Some(PartInfo::new("Cortex-M85 TPIU", PeripheralType::Tpiu)),
             // From IHI0029F: Coresight v3.0 architecture Specification
             ("ARM Ltd", _, _, 0x0A06) => Some(PartInfo::new("PMU architecture", PeripheralType::Pmu)),
             ("ARM Ltd", _, _, 0x1A01) => Some(PartInfo::new("ITM architecture", PeripheralType::Itm)),
@@ -781,13 +783,23 @@ impl PeripheralID {
             ("ARM Ltd", _, _, 0x0AF7) => Some(PartInfo::new("ROM architecture", PeripheralType::Rom)),
             // From Arm CoreSight System-on-Chip SoC-600 Technical Reference Manual
             ("ARM Ltd", 0x193, _, _) => Some(PartInfo::new("SoC-600 Timestamp Generator", PeripheralType::Tsgen)),
+            // Verified empirically
+            ("ARM Ltd", 0x4C9, 0x01, 0x0000) => Some(PartInfo::new("Cortex-M33 Core", PeripheralType::Rom)),
+            ("ARM Ltd", 0x4D4, 0x01, 0x0000) => Some(PartInfo::new("Cortex-M85 Core", PeripheralType::Rom)),
+            // From Arm CoreSight System-on-Chip SoC-400 Technical Reference Manual
+            ("ARM Ltd", 0x906, 0x14, 0x0000) => Some(PartInfo::new("SoC-400 CTI", PeripheralType::Cti)),
+            // From Arm CoreSight System-on-Chip SoC-600 Technical Reference Manual
             ("ARM Ltd", 0x9E7, 0x11, 0x0000) => Some(PartInfo::new("SoC-600 TPIU", PeripheralType::Tpiu)),
             ("ARM Ltd", 0x9EB, 0x12, 0x0000) => Some(PartInfo::new("SoC-600 ATB Funnel", PeripheralType::TraceFunnel)),
             // From Arm CoreSight TPIU-M Technical Reference Manual
-            ("ARM Ltd", 0x9F1, 0x11, _) => Some(PartInfo::new("Coresigth TPIU-M", PeripheralType::Tpiu)),
+            ("ARM Ltd", 0x9F1, 0x11, _) => Some(PartInfo::new("Coresight TPIU-M", PeripheralType::Tpiu)),
             // vendors
             ("Atmel", 0xCD0, 1, 0) => Some(PartInfo::new("Atmel DSU", PeripheralType::Custom)),
             ("Raspberry Pi Trading Ltd", _, _, 0x0AF7) => Some(PartInfo::new("RP235x CoreSight ROM", PeripheralType::Rom)),
+            ("Renesas Electronics", 0x004, 0x00, 0x0000) => Some(PartInfo::new("Renesas OCDREG", PeripheralType::Custom)),
+            ("Renesas Electronics", 0x050, 0x01, 0x0000) => Some(PartInfo::new("Renesas EPPB", PeripheralType::Rom)),
+            ("Renesas Electronics", 0x050, 0x00, 0x0000) => Some(PartInfo::new("Renesas Debug System", PeripheralType::Rom)),
+            ("STMicroelectronics", 0x000, _, _) => Some(PartInfo::new("STMicroelectronics DBGMCU", PeripheralType::Custom)),
 
             _ => None,
         }


### PR DESCRIPTION
This PR does a few things (and can easily be split if any are particularly controversial). 

* Makes ROM table entries children of the ROM table instead of siblings
* Adds some known components from ARM, Rensas, and STM
* Updates formatting of unknown components to include designer, devtype, etc. fields for all types


### This PR + #4252:

Arduino Due:

```
Debug Port: DPv1, Designer: ARM Ltd
└── V1(0) MemoryAP
    └── 0 MemoryAP (AmbaAhb3)
        └── 0xe00ff000 ROM Table (Class 1), Designer: <unknown>, Part: 0x0000, Devtype: 0x01, Archid: 0x0000
            ├── 0xe000e000 Cortex-M3 SCS   (Generic IP Component)
            │   └── CPUID
            │       ├── IMPLEMENTER: ARM Ltd
            │       ├── VARIANT: 2
            │       ├── PARTNO: Cortex-M3
            │       └── REVISION: 0
            ├── 0xe0001000 Cortex-M3 DWT   (Generic IP Component)
            ├── 0xe0002000 Cortex-M3/M4 FPB (Generic IP Component)
            ├── 0xe0000000 Cortex-M3 ITM   (Generic IP Component)
            └── 0xe0040000 Cortex-M3 TPIU  (Coresight Component)
```

RA8P1-EK:

Note the TPIUs here need a vendor specific sequence to enable that's out of scope for this PR.

```
Debug Port: DPv2, Designer: Renesas Electronics, Part: 0x500, Revision: 0x0, Instance: 0x00
├── V1(0) MemoryAP
│   └── 0 MemoryAP (AmbaAhb3)
│       └── 0xe00fe000 Renesas EPPB (ROM Table, Class 1)
│           ├── 0xe00ff000 Cortex-M85 Core (ROM Table, Class 1)
│           │   ├── 0xe000e000 Processor debug architecture (ARMv8-M) (Coresight Component)
│           │   │   └── CPUID
│           │   │       ├── IMPLEMENTER: ARM Ltd
│           │   │       ├── VARIANT: 1
│           │   │       ├── PARTNO: Cortex-M85
│           │   │       └── REVISION: 1
│           │   ├── 0xe0001000 DWT architecture (Coresight Component)
│           │   ├── 0xe0002000 FPB architecture (Coresight Component)
│           │   ├── 0xe0000000 ITM architecture (Coresight Component)
│           │   ├── 0xe0041000 ETM architecture (Coresight Component)
│           │   ├── 0xe0003000 PMU architecture (Coresight Component)
│           │   └── 0xe0042000 CTI architecture (Coresight Component)
│           └── 0xe0040000 Cortex-M85 TPIU (Coresight Component)
└── V1(1) MemoryAP
    └── 1 MemoryAP (AmbaApb2Apb3)
        └── 0x80010000 Renesas Debug System (ROM Table, Class 1)
            ├── 0x80011000 Renesas OCDREG  (Core Link / Prime Cell / System Component)
            ├── 0x80012000 SoC-400 CTI     (Coresight Component)
            ├── 0x80013000 CoreSight TraceFunnel (Coresight Component)
            ├── 0x80014000 CoreSight TMC   (Coresight Component)
            ├── 0x80015000 System TSGEN    (Core Link / Prime Cell / System Component)
            └── 0x80016000 CoreSight TPIU  (Coresight Component)
```

### master

Arduino Due:

```
Debug Port: DPv1, Designer: ARM Ltd
└── V1(0) MemoryAP
    └── 0 MemoryAP (AmbaAhb3)
        ├── 0xe00ff000 ROM Table (Class 1)
        ├── 0xe000e000 Cortex-M3 SCS   (Generic IP component)
        │   └── CPUID
        │       ├── IMPLEMENTER: ARM Ltd
        │       ├── VARIANT: 2
        │       ├── PARTNO: Cortex-M3
        │       └── REVISION: 0
        ├── 0xe0001000 Cortex-M3 DWT   (Generic IP component)
        ├── 0xe0002000 Cortex-M3/M4 FPB (Generic IP component)
        ├── 0xe0000000 Cortex-M3 ITM   (Generic IP component)
        └── 0xe0040000 Cortex-M3 TPIU  (Coresight Component)
```

RA8P1-EK:

```
Debug Port: DPv2, Designer: Renesas Electronics, Part: 0x500, Revision: 0x0, Instance: 0x00
├── V1(0) MemoryAP
│   └── 0 MemoryAP (AmbaAhb3)
│       ├── 0xe00fe000 ROM Table (Class 1), Designer: Renesas Electronics
│       ├── 0xe00ff000 ROM Table (Class 1), Designer: ARM Ltd
│       ├── 0xe000e000 Processor debug architecture (ARMv8-M) (Coresight Component)
│       │   └── CPUID
│       │       ├── IMPLEMENTER: ARM Ltd
│       │       ├── VARIANT: 1
│       │       ├── PARTNO: Cortex-M85
│       │       └── REVISION: 1
│       ├── 0xe0001000 DWT architecture (Coresight Component)
│       ├── 0xe0002000 FPB architecture (Coresight Component)
│       ├── 0xe0000000 ITM architecture (Coresight Component)
│       ├── 0xe0041000 ETM architecture (Coresight Component)
│       ├── 0xe0003000 PMU architecture (Coresight Component)
│       ├── 0xe0042000 CTI architecture (Coresight Component)
│       └── 0xe0040000 Generic
└── V1(1) MemoryAP
    └── 1 MemoryAP (AmbaApb2Apb3)
        ├── 0x80010000 ROM Table (Class 1), Designer: Renesas Electronics
        ├── 0x80011000 Core Link / Prime Cell / System component
        ├── 0x80012000 Coresight Component, Part: 0x0906, Devtype: 0x14, Archid: 0x0000, Designer: ARM Ltd
        ├── 0x80013000 CoreSight TraceFunnel (Coresight Component)
        ├── 0x80014000 CoreSight TMC   (Coresight Component)
        ├── 0x80015000 System TSGEN    (Core Link / Prime Cell / System component)
        └── 0x80016000 Generic
```