### PR TITLE
RISC-V: add support for memory access via abstract commands

### DIFF
--- a/changelog/added-riscv-abstractcmd-memory-support.md
+++ b/changelog/added-riscv-abstractcmd-memory-support.md
@@ -1,0 +1,1 @@
+Added support for memory access via abstract commands in RISC-V.

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -32,6 +32,9 @@ pub enum RiscvError {
     /// An error occurred during the execution of an abstract command.
     #[error("Error occurred during execution of an abstract command: {0:?}")]
     AbstractCommand(AbstractCommandErrorKind),
+    /// Value does not fit into the abstract command argument width
+    #[error("Abstract command argument value {0:#x} does not fit in 32 bits")]
+    AbstractArgumentOutOfRange(u64),
     /// The request for reset, resume or halt was not acknowledged.
     #[error("The core did not acknowledge a request for reset, resume or halt")]
     RequestNotAcknowledged,
@@ -1897,6 +1900,104 @@ impl<'state> RiscvCommunicationInterface<'state> {
         })
     }
 
+    /// https://github.com/riscv/riscv-debug-spec/issues/1148
+    fn check_abstract_cmd_memory_support<V: RiscvValue>(&self) -> Result<(), RiscvError> {
+        let maximum_aamsize = if self.state.xlen_64 {
+            RiscvBusAccess::A64
+        } else {
+            RiscvBusAccess::A32
+        };
+
+        if V::WIDTH > maximum_aamsize {
+            return Err(RiscvError::AbstractCommand(
+                AbstractCommandErrorKind::NotSupported,
+            ));
+        }
+
+        // Using arg0 and arg1 consumes twice as much Abstract Data.
+        if self.state.data_register_count < if self.state.xlen_64 { 4 } else { 2 } {
+            return Err(RiscvError::AbstractCommand(
+                AbstractCommandErrorKind::NotSupported,
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn schedule_write_abstract_cmd_arg1(&mut self, arg1: u64) -> Result<(), RiscvError> {
+        if self.state.xlen_64 {
+            self.schedule_write_dm_register(Data3((arg1 >> 32) as u32))?;
+            self.schedule_write_dm_register(Data2(arg1 as u32))?;
+        } else {
+            if arg1 > u32::MAX as u64 {
+                return Err(RiscvError::AbstractArgumentOutOfRange(arg1));
+            }
+
+            self.schedule_write_dm_register(Data1(arg1 as u32))?;
+        }
+
+        Ok(())
+    }
+
+    /// Perform a single read from a memory location, using abstract commands.
+    fn perform_memory_read_abstract_cmd<V: RiscvValue>(
+        &mut self,
+        address: u64,
+        aamvirtual: bool,
+    ) -> Result<V, RiscvError> {
+        self.check_abstract_cmd_memory_support::<V>()?;
+
+        let mut command = AccessMemoryCommand(0);
+        command.set_cmd_type(2);
+        command.set_aamvirtual(aamvirtual);
+        command.set_aamsize(V::WIDTH);
+
+        self.schedule_write_abstract_cmd_arg1(address)?;
+        self.execute_abstract_command(command.0)?;
+
+        let mut results = vec![];
+        self.schedule_read_large_dtm_register::<V, Arg0>(&mut results)?;
+
+        Ok(V::read_scheduled_result(self, &mut results)?)
+    }
+
+    /// Perform multiple reads from consecutive memory locations
+    /// using abstract commands.
+    ///
+    /// `aampostincrement` is not currently supported.
+    fn perform_memory_read_multiple_abstract_cmd<V: RiscvValue>(
+        &mut self,
+        address: u64,
+        data: &mut [V],
+        aamvirtual: bool,
+    ) -> Result<(), RiscvError> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        self.check_abstract_cmd_memory_support::<V>()?;
+
+        let mut command = AccessMemoryCommand(0);
+        command.set_cmd_type(2);
+        command.set_aamvirtual(aamvirtual);
+        command.set_aamsize(V::WIDTH);
+
+        let mut address = address;
+        for out in data {
+            self.schedule_write_abstract_cmd_arg1(address)?;
+            self.execute_abstract_command(command.0)?;
+
+            let mut results = vec![];
+            self.schedule_read_large_dtm_register::<V, Arg0>(&mut results)?;
+
+            *out = V::read_scheduled_result(self, &mut results)?;
+
+            address = address.wrapping_add(V::WIDTH.byte_width() as u64);
+        }
+
+        Ok(())
+    }
+
     /// Memory write using system bus
     fn perform_memory_write_sysbus<V: RiscvValue>(
         &mut self,
@@ -1996,6 +2097,40 @@ impl<'state> RiscvCommunicationInterface<'state> {
 
             Ok(())
         })
+    }
+
+    /// Memory write using abstract commands.
+    ///
+    /// `aampostincrement` is not currently supported.
+    fn perform_memory_write_abstract_cmd<V: RiscvValue>(
+        &mut self,
+        address: u64,
+        data: &[V],
+        aamvirtual: bool,
+    ) -> Result<(), RiscvError> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        self.check_abstract_cmd_memory_support::<V>()?;
+
+        let mut command = AccessMemoryCommand(0);
+        command.set_cmd_type(2);
+        command.set_aamvirtual(aamvirtual);
+        command.set_aamsize(V::WIDTH);
+
+        command.set_write(true);
+
+        let mut address = address;
+        for value in data {
+            self.schedule_write_large_dtm_register::<V, Arg0>(*value)?;
+            self.schedule_write_abstract_cmd_arg1(address)?;
+            self.execute_abstract_command(command.0)?;
+
+            address = address.wrapping_add(V::WIDTH.byte_width() as u64);
+        }
+
+        Ok(())
     }
 
     /// The abstract command that transfers DATA0 into S1 and then executes the program buffer.
@@ -2456,9 +2591,7 @@ impl<'state> RiscvCommunicationInterface<'state> {
             }
             MemoryAccessMethod::SystemBus => self.perform_memory_read_sysbus(address)?,
             MemoryAccessMethod::AbstractCommand => {
-                return Err(crate::Error::NotImplemented(
-                    "Memory access using abstract commands is not implemented",
-                ));
+                self.perform_memory_read_abstract_cmd(address, false)?
             }
         };
 
@@ -2495,9 +2628,7 @@ impl<'state> RiscvCommunicationInterface<'state> {
                 self.perform_memory_read_multiple_sysbus(address, data)?;
             }
             MemoryAccessMethod::AbstractCommand => {
-                return Err(crate::Error::NotImplemented(
-                    "Memory access using abstract commands is not implemented",
-                ));
+                self.perform_memory_read_multiple_abstract_cmd(address, data, false)?;
             }
         };
 
@@ -2517,9 +2648,7 @@ impl<'state> RiscvCommunicationInterface<'state> {
             }
             MemoryAccessMethod::SystemBus => self.perform_memory_write_sysbus(address, &[data])?,
             MemoryAccessMethod::AbstractCommand => {
-                return Err(crate::Error::NotImplemented(
-                    "Memory access using abstract commands is not implemented",
-                ));
+                self.perform_memory_write_abstract_cmd(address, &[data], false)?
             }
         };
 
@@ -2547,9 +2676,7 @@ impl<'state> RiscvCommunicationInterface<'state> {
                 self.perform_memory_write_multiple_progbuf(address, data, true)?
             }
             MemoryAccessMethod::AbstractCommand => {
-                return Err(crate::Error::NotImplemented(
-                    "Memory access using abstract commands is not implemented",
-                ));
+                self.perform_memory_write_abstract_cmd(address, data, false)?
             }
         }
 
@@ -3227,8 +3354,6 @@ impl From<RiscvBusAccess> for u8 {
 
 /// Different methods of memory access,
 /// which can be supported by a debug module.
-///
-/// The `AbstractCommand` method for memory access is not implemented.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MemoryAccessMethod {
     /// Memory access using an abstract command is supported

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -2014,7 +2014,11 @@ impl<'state> RiscvCommunicationInterface<'state> {
         command.set_aamvirtual(aamvirtual);
         command.set_aamsize(V::WIDTH);
 
-        self.schedule_write_abstract_cmd_arg1(address)?;
+        if self.state.xlen_64 {
+            self.schedule_write_abstract_cmd_arg1(address)?;
+        } else {
+            self.schedule_write_abstract_cmd_arg1((address as u32) as u64)?;
+        }
 
         match self.execute_abstract_command(command.0) {
             Ok(_) => (),
@@ -2057,7 +2061,11 @@ impl<'state> RiscvCommunicationInterface<'state> {
 
         let mut address = address;
         for out in data {
-            self.schedule_write_abstract_cmd_arg1(address)?;
+            if self.state.xlen_64 {
+                self.schedule_write_abstract_cmd_arg1(address)?;
+            } else {
+                self.schedule_write_abstract_cmd_arg1((address as u32) as u64)?;
+            }
 
             match self.execute_abstract_command(command.0) {
                 Ok(_) => (),
@@ -2211,7 +2219,11 @@ impl<'state> RiscvCommunicationInterface<'state> {
         let mut address = address;
         for value in data {
             self.schedule_write_large_dtm_register::<V, Arg0>(*value)?;
-            self.schedule_write_abstract_cmd_arg1(address)?;
+            if self.state.xlen_64 {
+                self.schedule_write_abstract_cmd_arg1(address)?;
+            } else {
+                self.schedule_write_abstract_cmd_arg1((address as u32) as u64)?;
+            }
 
             match self.execute_abstract_command(command.0) {
                 Ok(_) => (),

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -3394,7 +3394,7 @@ memory_mapped_bitfield_register! {
     /// 2: Access the lowest 32 bits of the memory location.\
     /// 3: Access the lowest 64 bits of the memory location.\
     /// 4: Access the lowest 128 bits of the memory location.
-    pub _, set_aamsize: 22,20;
+    pub u8, from into RiscvBusAccess, _, set_aamsize: 22,20;
     /// After a memory access has completed, if this bit
     /// is 1, increment arg1 (which contains the address
     /// used) by the number of bytes encoded in `aamsize`.

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -201,6 +201,23 @@ impl CoreRegisterAbstractCmdSupport {
     }
 }
 
+#[derive(Copy, Clone, Debug)]
+struct MemoryAbstractCmdSupport(u8);
+
+impl MemoryAbstractCmdSupport {
+    const READ: Self = Self(1 << 0);
+    const WRITE: Self = Self(1 << 1);
+    const BOTH: Self = Self(Self::READ.0 | Self::WRITE.0);
+
+    fn supports(&self, o: Self) -> bool {
+        self.0 & o.0 == o.0
+    }
+
+    fn unset(&mut self, o: Self) {
+        self.0 &= !(o.0);
+    }
+}
+
 /// Save stack of a scratch register.
 // TODO: we probably only need an Option, we don't seem to use scratch registers in nested situations.
 #[derive(Debug, Default)]
@@ -227,6 +244,10 @@ pub struct MemoryAccessConfig {
     default_method: HashMap<RiscvBusAccess, MemoryAccessMethod>,
 
     region_override: HashMap<(Range<u64>, RiscvBusAccess), MemoryAccessMethod>,
+
+    /// Describes if the abstract command supports read or write access
+    /// at the given `aamsize`.
+    aamsize_info: HashMap<RiscvBusAccess, MemoryAbstractCmdSupport>,
 }
 
 impl MemoryAccessConfig {
@@ -287,6 +308,34 @@ impl MemoryAccessConfig {
         }
 
         max
+    }
+
+    /// Check if an `aamsize` is supported
+    fn check_abstract_cmd_aamsize_support(
+        &self,
+        aamsize: RiscvBusAccess,
+        rw: MemoryAbstractCmdSupport,
+    ) -> bool {
+        if let Some(status) = self.aamsize_info.get(&aamsize) {
+            status.supports(rw)
+        } else {
+            // If not cached yet, assume the aamsize supported
+            true
+        }
+    }
+
+    /// Remember that the given `aamsize` is not supported.
+    fn set_abstract_cmd_aamsize_unsupported(
+        &mut self,
+        aamsize: RiscvBusAccess,
+        rw: MemoryAbstractCmdSupport,
+    ) {
+        let entry = self
+            .aamsize_info
+            .entry(aamsize)
+            .or_insert(MemoryAbstractCmdSupport::BOTH);
+
+        entry.unset(rw);
     }
 }
 
@@ -1900,8 +1949,11 @@ impl<'state> RiscvCommunicationInterface<'state> {
         })
     }
 
-    /// https://github.com/riscv/riscv-debug-spec/issues/1148
-    fn check_abstract_cmd_memory_support<V: RiscvValue>(&self) -> Result<(), RiscvError> {
+    /// [About DXLEN, aamsize, and Argument Width](https://github.com/riscv/riscv-debug-spec/issues/1148)
+    fn check_abstract_cmd_memory_support<V: RiscvValue>(
+        &self,
+        rw: MemoryAbstractCmdSupport,
+    ) -> Result<(), RiscvError> {
         let maximum_aamsize = if self.state.xlen_64 {
             RiscvBusAccess::A64
         } else {
@@ -1916,6 +1968,16 @@ impl<'state> RiscvCommunicationInterface<'state> {
 
         // Using arg0 and arg1 consumes twice as much Abstract Data.
         if self.state.data_register_count < if self.state.xlen_64 { 4 } else { 2 } {
+            return Err(RiscvError::AbstractCommand(
+                AbstractCommandErrorKind::NotSupported,
+            ));
+        }
+
+        if !self
+            .state
+            .memory_access_config
+            .check_abstract_cmd_aamsize_support(V::WIDTH, rw)
+        {
             return Err(RiscvError::AbstractCommand(
                 AbstractCommandErrorKind::NotSupported,
             ));
@@ -1945,7 +2007,7 @@ impl<'state> RiscvCommunicationInterface<'state> {
         address: u64,
         aamvirtual: bool,
     ) -> Result<V, RiscvError> {
-        self.check_abstract_cmd_memory_support::<V>()?;
+        self.check_abstract_cmd_memory_support::<V>(MemoryAbstractCmdSupport::READ)?;
 
         let mut command = AccessMemoryCommand(0);
         command.set_cmd_type(2);
@@ -1953,7 +2015,18 @@ impl<'state> RiscvCommunicationInterface<'state> {
         command.set_aamsize(V::WIDTH);
 
         self.schedule_write_abstract_cmd_arg1(address)?;
-        self.execute_abstract_command(command.0)?;
+
+        match self.execute_abstract_command(command.0) {
+            Ok(_) => (),
+            err @ Err(RiscvError::AbstractCommand(AbstractCommandErrorKind::NotSupported)) => {
+                // Remember, that this aamsize is unsupported
+                self.state
+                    .memory_access_config
+                    .set_abstract_cmd_aamsize_unsupported(V::WIDTH, MemoryAbstractCmdSupport::READ);
+                err?;
+            }
+            Err(e) => return Err(e),
+        }
 
         let mut results = vec![];
         self.schedule_read_large_dtm_register::<V, Arg0>(&mut results)?;
@@ -1975,7 +2048,7 @@ impl<'state> RiscvCommunicationInterface<'state> {
             return Ok(());
         }
 
-        self.check_abstract_cmd_memory_support::<V>()?;
+        self.check_abstract_cmd_memory_support::<V>(MemoryAbstractCmdSupport::READ)?;
 
         let mut command = AccessMemoryCommand(0);
         command.set_cmd_type(2);
@@ -1985,7 +2058,21 @@ impl<'state> RiscvCommunicationInterface<'state> {
         let mut address = address;
         for out in data {
             self.schedule_write_abstract_cmd_arg1(address)?;
-            self.execute_abstract_command(command.0)?;
+
+            match self.execute_abstract_command(command.0) {
+                Ok(_) => (),
+                err @ Err(RiscvError::AbstractCommand(AbstractCommandErrorKind::NotSupported)) => {
+                    // Remember, that this aamsize is unsupported
+                    self.state
+                        .memory_access_config
+                        .set_abstract_cmd_aamsize_unsupported(
+                            V::WIDTH,
+                            MemoryAbstractCmdSupport::READ,
+                        );
+                    err?;
+                }
+                Err(e) => return Err(e),
+            }
 
             let mut results = vec![];
             self.schedule_read_large_dtm_register::<V, Arg0>(&mut results)?;
@@ -2112,7 +2199,7 @@ impl<'state> RiscvCommunicationInterface<'state> {
             return Ok(());
         }
 
-        self.check_abstract_cmd_memory_support::<V>()?;
+        self.check_abstract_cmd_memory_support::<V>(MemoryAbstractCmdSupport::WRITE)?;
 
         let mut command = AccessMemoryCommand(0);
         command.set_cmd_type(2);
@@ -2125,7 +2212,21 @@ impl<'state> RiscvCommunicationInterface<'state> {
         for value in data {
             self.schedule_write_large_dtm_register::<V, Arg0>(*value)?;
             self.schedule_write_abstract_cmd_arg1(address)?;
-            self.execute_abstract_command(command.0)?;
+
+            match self.execute_abstract_command(command.0) {
+                Ok(_) => (),
+                err @ Err(RiscvError::AbstractCommand(AbstractCommandErrorKind::NotSupported)) => {
+                    // Remember, that this aamsize is unsupported
+                    self.state
+                        .memory_access_config
+                        .set_abstract_cmd_aamsize_unsupported(
+                            V::WIDTH,
+                            MemoryAbstractCmdSupport::WRITE,
+                        );
+                    err?;
+                }
+                Err(e) => return Err(e),
+            }
 
             address = address.wrapping_add(V::WIDTH.byte_width() as u64);
         }

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -1958,7 +1958,7 @@ impl<'state> RiscvCommunicationInterface<'state> {
         let mut results = vec![];
         self.schedule_read_large_dtm_register::<V, Arg0>(&mut results)?;
 
-        Ok(V::read_scheduled_result(self, &mut results)?)
+        V::read_scheduled_result(self, &mut results)
     }
 
     /// Perform multiple reads from consecutive memory locations


### PR DESCRIPTION
The feature still needs to be tested on more devices.

Currently, I have only completed testing on an FPGA, where it works as expected.

The `aampostincrement` feature has not yet been implemented.

Closes #4034 