### PR TITLE
Flash RP235x RISC-V images with the Arm algorithm

### DIFF
--- a/changelog/changed-rp235x-riscv-flash-via-arm.md
+++ b/changelog/changed-rp235x-riscv-flash-via-arm.md
@@ -1,0 +1,1 @@
+Flashing `--chip RP235x_riscv` now programs QSPI with the existing Arm CMSIS-Pack algorithm, then IMAGE_DEF-binds Hazard3. `--chip RP235x` stays Arm. Live RISC-V is switched to Arm for the flash algorithm; live Arm is left on Arm until after program.

--- a/probe-rs-rpc/src/flash.rs
+++ b/probe-rs-rpc/src/flash.rs
@@ -165,6 +165,9 @@ pub enum BootInfo {
         cores_to_reset: Vec<String>,
     },
     Other,
+    BootArchitectureSwitch {
+        desired: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Schema)]

--- a/probe-rs-rpc/src/monitor.rs
+++ b/probe-rs-rpc/src/monitor.rs
@@ -16,6 +16,7 @@ impl MonitorMode {
         match self {
             MonitorMode::Run(BootInfo::FromRam { .. }) => true,
             MonitorMode::Run(BootInfo::Other) => true,
+            MonitorMode::Run(BootInfo::BootArchitectureSwitch { .. }) => true,
             MonitorMode::AttachToRunning => false,
         }
     }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -446,6 +446,9 @@ async fn prepare_halted_image(
             BootInfo::Other => {
                 core.reset_and_halt(Duration::from_millis(500)).await?;
             }
+            BootInfo::BootArchitectureSwitch { .. } => {
+                session.prepare_boot(boot_info.clone(), core_id).await?;
+            }
         }
     } else {
         core.reset_and_halt(Duration::from_millis(500)).await?;

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/flash.rs
@@ -49,6 +49,12 @@ pub fn prepare_boot_info(
                 .core(core_id)?
                 .reset_and_halt(Duration::from_millis(500))?;
         }
+        flashing::BootInfo::BootArchitectureSwitch { desired } => {
+            session.boot_switch_rebind(desired)?;
+            session
+                .core(core_id)?
+                .reset_and_halt(Duration::from_millis(500))?;
+        }
     }
 
     Ok(())
@@ -364,6 +370,11 @@ pub(crate) mod convert {
                 cores_to_reset,
             },
             probe_rs::flashing::BootInfo::Other => BootInfo::Other,
+            probe_rs::flashing::BootInfo::BootArchitectureSwitch { desired } => {
+                BootInfo::BootArchitectureSwitch {
+                    desired: format!("{desired:?}"),
+                }
+            }
         }
     }
 
@@ -377,6 +388,15 @@ pub(crate) mod convert {
                 cores_to_reset: cores_to_reset.clone(),
             },
             BootInfo::Other => probe_rs::flashing::BootInfo::Other,
+            BootInfo::BootArchitectureSwitch { desired } => {
+                probe_rs::flashing::BootInfo::BootArchitectureSwitch {
+                    desired: if desired.eq_ignore_ascii_case("riscv") {
+                        probe_rs::Architecture::Riscv
+                    } else {
+                        probe_rs::Architecture::Arm
+                    },
+                }
+            }
         }
     }
 }

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -536,11 +536,9 @@ impl<'state> RiscvCommunicationInterface<'state> {
             return Err(RiscvError::HartUnavailable);
         }
 
-        if self.state.last_selected_hart == hart {
-            return Ok(());
-        }
-
-        // Since we changed harts, we don't know the state of the Dmcontrol register anymore.
+        // Always write `hartsel`. ArmWithRiscv sessions keep a separate DM
+        // state per hart; the cache is stale after the other hart's interface
+        // changed the hardware selection.
         let mut control = self.read_dm_register::<Dmcontrol>()?;
         control.set_dmactive(true);
         control.set_hartsel(hart);
@@ -552,6 +550,17 @@ impl<'state> RiscvCommunicationInterface<'state> {
     /// Check if the given hart is enabled
     pub fn hart_enabled(&self, hart: u32) -> bool {
         self.state.enabled_harts & (1 << hart) != 0
+    }
+
+    /// Override the hart-present mask discovered in `enter_debug_mode`.
+    ///
+    /// If the number of harts found through autodetect is wrong, this
+    /// function allows you override it. Needs to be called any time
+    /// after autodetect happens, before something that accesses a hart
+    /// is called.
+    pub fn set_enabled_harts(&mut self, mask: u32) {
+        self.state.enabled_harts = mask;
+        self.state.num_harts = mask.count_ones();
     }
 
     /// Assert the target reset

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -13,6 +13,7 @@ use yaml_serde::Value;
 use super::builder::FlashBuilder;
 use super::{DownloadOptions, FileDownloadError, FlashError, Flasher};
 use crate::Target;
+use crate::core::Architecture;
 use crate::flashing::progress::ProgressOperation;
 use crate::flashing::{FlashLayout, FlashProgress};
 use crate::memory::MemoryInterface;
@@ -181,7 +182,7 @@ mod builtin {
         fn load(
             &self,
             flash_loader: &mut FlashLoader,
-            _session: &mut Session,
+            session: &mut Session,
             file: &mut dyn ImageReader,
         ) -> Result<(), FileDownloadError> {
             // Skip the specified bytes.
@@ -197,6 +198,7 @@ mod builtin {
                 &buf,
             )?;
 
+            flash_loader.prepare_rp235x_nvm_flash(session)?;
             Ok(())
         }
     }
@@ -209,7 +211,7 @@ mod builtin {
         fn load(
             &self,
             flash_loader: &mut FlashLoader,
-            _session: &mut Session,
+            session: &mut Session,
             file: &mut dyn ImageReader,
         ) -> Result<(), FileDownloadError> {
             const VECTOR_TABLE_SECTION_NAME: &str = ".vector_table";
@@ -246,6 +248,7 @@ mod builtin {
                 flash_loader.add_data(data.address.into(), data.data)?;
             }
 
+            flash_loader.prepare_rp235x_nvm_flash(session)?;
             Ok(())
         }
     }
@@ -390,7 +393,7 @@ mod builtin {
         fn load(
             &self,
             flash_loader: &mut FlashLoader,
-            _session: &mut Session,
+            session: &mut Session,
             file: &mut dyn ImageReader,
         ) -> Result<(), FileDownloadError> {
             let mut base_address = 0;
@@ -416,6 +419,7 @@ mod builtin {
                     | Record::StartLinearAddress(_) => {}
                 }
             }
+            flash_loader.prepare_rp235x_nvm_flash(session)?;
             Ok(())
         }
     }
@@ -428,7 +432,7 @@ mod builtin {
         fn load(
             &self,
             flash_loader: &mut FlashLoader,
-            _session: &mut Session,
+            session: &mut Session,
             file: &mut dyn ImageReader,
         ) -> Result<(), FileDownloadError> {
             let mut uf2_buffer = Vec::new();
@@ -444,6 +448,7 @@ mod builtin {
                     tracing::warn!("More than 1 section found in UF2 file.  Using first section.");
                 }
                 flash_loader.add_data(*target_address, &converted)?;
+                flash_loader.prepare_rp235x_nvm_flash(session)?;
 
                 Ok(())
             } else {
@@ -470,6 +475,11 @@ pub enum BootInfo {
     /// Executable is either not loaded yet or will be booted conventionally (from flash etc.)
     #[default]
     Other,
+    /// RP235x IMAGE_DEF is for the other processor architecture; rebind after reset.
+    BootArchitectureSwitch {
+        /// Architecture bootrom should select after IMAGE_DEF reset.
+        desired: Architecture,
+    },
 }
 
 /// `FlashLoader` is a struct which manages the flashing of any chunks of data onto any sections of flash.
@@ -488,6 +498,9 @@ pub struct FlashLoader {
     /// Relevant for manually configured RAM booted executables, available only if given loader supports it
     vector_table_addr: Option<u64>,
 
+    /// When set, flash was written for this RP235x architecture; after reset, rebind cores.
+    pending_boot_architecture: Option<Architecture>,
+
     read_flasher_rtt: bool,
 }
 
@@ -499,6 +512,7 @@ impl FlashLoader {
             builder: FlashBuilder::new(),
             source,
             vector_table_addr: None,
+            pending_boot_architecture: None,
             read_flasher_rtt: false,
         }
     }
@@ -524,19 +538,61 @@ impl FlashLoader {
         self.vector_table_addr = Some(vector_table_addr);
     }
 
-    /// Retrieve available boot information
-    pub fn boot_info(&self) -> BootInfo {
-        let Some(vector_table_addr) = self.vector_table_addr else {
-            return BootInfo::Other;
+    pub(crate) fn retarget(&mut self, target: &Target) {
+        self.memory_map = target.memory_map.clone();
+        self.source = target.source.clone();
+    }
+
+    /// Switch to Arm and record the IMAGE_DEF boot architecture when flashing RP235x NVM.
+    ///
+    /// ISA intent comes from `--chip` (`RP235x_riscv` vs `RP235x`), not ELF `e_machine`.
+    fn prepare_rp235x_nvm_flash(&mut self, session: &mut Session) -> Result<(), FileDownloadError> {
+        if !crate::vendor::raspberrypi::is_rp235x_chip(&session.target().name) {
+            return Ok(());
+        }
+
+        let has_nvm = self.builder.data.keys().any(|addr| {
+            matches!(
+                Self::get_region_for_address(&self.memory_map, *addr),
+                Some(MemoryRegion::Nvm(_))
+            )
+        });
+        if !has_nvm {
+            return Ok(());
+        }
+
+        session
+            .ensure_architecture(Architecture::Arm)
+            .map_err(FileDownloadError::Other)?;
+        self.retarget(session.target());
+
+        self.pending_boot_architecture = match session.rp235x_requested_arch() {
+            Some(crate::vendor::raspberrypi::Rp235xArch::Riscv) => Some(Architecture::Riscv),
+            _ => None,
         };
 
-        match Self::get_region_for_address(&self.memory_map, vector_table_addr) {
-            Some(MemoryRegion::Ram(region)) => BootInfo::FromRam {
+        Ok(())
+    }
+
+    /// Retrieve available boot information
+    pub fn boot_info(&self) -> BootInfo {
+        if let Some(vector_table_addr) = self.vector_table_addr
+            && let Some(MemoryRegion::Ram(region)) =
+                Self::get_region_for_address(&self.memory_map, vector_table_addr)
+        {
+            return BootInfo::FromRam {
                 vector_table_addr,
                 cores_to_reset: region.cores.clone(),
-            },
-            _ => BootInfo::Other,
+            };
         }
+
+        if let Some(desired) = self.pending_boot_architecture
+            && desired == Architecture::Riscv
+        {
+            return BootInfo::BootArchitectureSwitch { desired };
+        }
+
+        BootInfo::Other
     }
 
     /// Check the given address range is completely covered by the memory map,
@@ -610,10 +666,11 @@ impl FlashLoader {
                 }
             }
 
-            // Is the image compatible with any of the cores?
-            if !target_archs
-                .iter()
-                .any(|target| target.is_compatible(instr_set))
+            // RISC-V IMAGE_DEF is programmed with the Arm flash algorithm.
+            if !crate::vendor::raspberrypi::is_rp235x_chip(&session.target().name)
+                && !target_archs
+                    .iter()
+                    .any(|target| target.is_compatible(instr_set))
             {
                 return Err(FileDownloadError::IncompatibleImage {
                     target: target_archs,

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -22,7 +22,7 @@ use crate::{
     config::{CoreExt, DebugSequence, RegistryError, Target, TargetSelector, registry::Registry},
     core::{Architecture, CombinedCoreState},
     probe::{
-        AttachMethod, DebugProbeError, Probe, ProbeCreationError, WireProtocol,
+        AttachMethod, DebugProbe, DebugProbeError, Probe, ProbeCreationError, WireProtocol,
         fake_probe::FakeProbe, list::Lister,
     },
 };
@@ -53,6 +53,8 @@ pub struct Session {
     interfaces: ArchitectureInterface,
     cores: Vec<CombinedCoreState>,
     configured_trace_sink: Option<TraceSink>,
+    /// `--chip` RP235x vs RP235x_riscv, kept if YAML is rebound to Arm for flashing.
+    rp235x_requested: Option<crate::vendor::raspberrypi::Rp235xArch>,
 }
 
 /// The `SessionConfig` struct is used to configure a new `Session` during auto-attach.
@@ -186,19 +188,7 @@ impl Session {
     ) -> Result<Self, Error> {
         let (probe, target) = get_target_from_selector(target, attach_method, probe, registry)?;
 
-        let cores = target
-            .cores
-            .iter()
-            .enumerate()
-            .map(|(id, core)| {
-                Core::create_state(
-                    id,
-                    core.core_access_options.clone(),
-                    &target,
-                    core.core_type,
-                )
-            })
-            .collect();
+        let cores = Self::cores_from_target(&target);
 
         // Use ARM DAP path when the target connects via SWD/DAP: either ARM cores or RISC-V cores
         // over mem-AP (e.g. RP235x_riscv).
@@ -211,6 +201,17 @@ impl Session {
         session.clear_all_hw_breakpoints()?;
 
         Ok(session)
+    }
+
+    fn cores_from_target(target: &Target) -> Vec<CombinedCoreState> {
+        target
+            .cores
+            .iter()
+            .enumerate()
+            .map(|(id, core)| {
+                Core::create_state(id, core.core_access_options.clone(), target, core.core_type)
+            })
+            .collect()
     }
 
     fn attach_arm_debug_interface(
@@ -277,6 +278,48 @@ impl Session {
 
         interface.select_debug_port(default_dp)?;
 
+        let rp235x_requested = crate::vendor::raspberrypi::Rp235xArch::from_chip_name(&target.name);
+        let mut target = target;
+        let mut cores = cores;
+        if crate::vendor::raspberrypi::is_rp235x_chip(&target.name) {
+            let live = crate::vendor::raspberrypi::detect_rp235x_arch(interface.as_mut())?;
+            match (live, rp235x_requested) {
+                (Some(crate::vendor::raspberrypi::Rp235xArch::Riscv), Some(desired))
+                    if desired == crate::vendor::raspberrypi::Rp235xArch::Arm =>
+                {
+                    tracing::info!("RP235x live RISC-V, switching to Arm for flash");
+                    crate::vendor::raspberrypi::switch_rp235x_architecture(
+                        interface.as_mut(),
+                        crate::vendor::raspberrypi::Rp235xArch::Arm,
+                    )?;
+                    interface.select_debug_port(default_dp)?;
+                }
+                (
+                    Some(crate::vendor::raspberrypi::Rp235xArch::Arm),
+                    Some(crate::vendor::raspberrypi::Rp235xArch::Riscv),
+                ) => {
+                    tracing::info!(
+                        "RP235x live Arm with --chip RP235x_riscv; stay Arm for flash, IMAGE_DEF bind after"
+                    );
+                    target = Registry::from_builtin_families()
+                        .get_target_by_name("RP235x")
+                        .map_err(Error::from)?;
+                    cores = Self::cores_from_target(&target);
+                }
+                (
+                    Some(crate::vendor::raspberrypi::Rp235xArch::Riscv),
+                    Some(crate::vendor::raspberrypi::Rp235xArch::Riscv),
+                ) => {
+                    tracing::info!("RP235x live RISC-V; flash path will switch to Arm");
+                }
+                _ => {}
+            }
+        }
+
+        let default_memory_ap = target.default_core().memory_ap().ok_or_else(|| {
+            Error::Other("Unable to connect to core, no memory AP configured".into())
+        })?;
+
         let unlock_span = tracing::debug_span!("debug_device_unlock").entered();
 
         // Enable debug mode
@@ -333,6 +376,7 @@ impl Session {
                 interfaces,
                 cores,
                 configured_trace_sink: None,
+                rp235x_requested,
             };
 
             {
@@ -362,10 +406,11 @@ impl Session {
 
             Ok(session)
         } else {
-            // For each core, setup debugging
+            // For each core, setup debugging. After an RP235x architecture switch the
+            // second M33 Mem-AP can briefly FAULT; retry instead of aborting attach.
             for core in &cores {
                 if core.is_arm_core() {
-                    core.enable_arm_debug(&mut *interface)?;
+                    Self::enable_arm_debug_with_retry(&mut *interface, core)?;
                 }
             }
 
@@ -375,6 +420,7 @@ impl Session {
                 interfaces,
                 cores,
                 configured_trace_sink: None,
+                rp235x_requested,
             })
         }
     }
@@ -409,6 +455,9 @@ impl Session {
                 let mut iface =
                     RiscvCommunicationInterface::new(Box::new(dtm), &mut state.interface_state);
                 iface.enter_debug_mode().map_err(Error::Riscv)?;
+                if let DebugSequence::Riscv(sequence) = &target.debug_sequence {
+                    sequence.on_connect(&mut iface)?;
+                }
             }
             Ok(ArchitectureInterface::ArmWithRiscv {
                 arm,
@@ -510,12 +559,14 @@ impl Session {
         }
 
         let interfaces = ArchitectureInterface::Jtag(probe, interfaces);
+        let rp235x_requested = crate::vendor::raspberrypi::Rp235xArch::from_chip_name(&target.name);
 
         let mut session = Session {
             target,
             interfaces,
             cores,
             configured_trace_sink: None,
+            rp235x_requested,
         };
 
         // Connect to the cores
@@ -712,6 +763,155 @@ impl Session {
     pub fn swo_reader(&mut self) -> Result<SwoReader<'_>, Error> {
         let interface = self.get_arm_interface()?;
         Ok(SwoReader::new(interface))
+    }
+
+    fn enable_arm_debug_with_retry(
+        interface: &mut dyn ArmDebugInterface,
+        core: &CombinedCoreState,
+    ) -> Result<(), Error> {
+        let mut last_err = None;
+        for attempt in 0..20 {
+            match core.enable_arm_debug(interface) {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    tracing::debug!(
+                        "enable_arm_debug core {} attempt {}: {e}",
+                        core.id(),
+                        attempt + 1
+                    );
+                    last_err = Some(e);
+                    let _ = interface.reinitialize();
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+            }
+        }
+        Err(last_err.unwrap())
+    }
+
+    fn take_arm_debug_interface(&mut self) -> Result<Box<dyn ArmDebugInterface + 'static>, Error> {
+        let dummy = Box::<FakeProbe>::default()
+            .try_get_arm_debug_interface(DefaultArmSequence::create())
+            .map_err(|(_, err)| err)?;
+        match &mut self.interfaces {
+            ArchitectureInterface::Arm(arm) => Ok(std::mem::replace(arm, dummy)),
+            ArchitectureInterface::ArmWithRiscv { arm, .. } => Ok(std::mem::replace(arm, dummy)),
+            ArchitectureInterface::Jtag(..) => Err(Error::Arm(ArmError::NoArmTarget)),
+        }
+    }
+
+    fn put_arm_debug_interface(&mut self, iface: Box<dyn ArmDebugInterface + 'static>) {
+        match &mut self.interfaces {
+            ArchitectureInterface::Arm(arm) => *arm = iface,
+            ArchitectureInterface::ArmWithRiscv { arm, .. } => *arm = iface,
+            ArchitectureInterface::Jtag(..) => {}
+        }
+    }
+
+    fn rebind_rp235x_yaml(
+        &mut self,
+        desired_arch: crate::vendor::raspberrypi::Rp235xArch,
+    ) -> Result<(), Error> {
+        let mut arm = self.take_arm_debug_interface()?;
+        let new_target = match Registry::from_builtin_families()
+            .get_target_by_name(desired_arch.target_name())
+        {
+            Ok(target) => target,
+            Err(e) => {
+                self.put_arm_debug_interface(arm);
+                return Err(e.into());
+            }
+        };
+
+        let cores = Self::cores_from_target(&new_target);
+
+        for core in &cores {
+            if core.is_arm_core()
+                && let Err(e) = Self::enable_arm_debug_with_retry(&mut *arm, core)
+            {
+                self.put_arm_debug_interface(arm);
+                return Err(e);
+            }
+        }
+
+        let interfaces = match Self::build_arm_interfaces(&new_target, arm) {
+            Ok(interfaces) => interfaces,
+            Err(e) => return Err(e),
+        };
+        self.target = new_target;
+        self.cores = cores;
+        self.interfaces = interfaces;
+        Ok(())
+    }
+
+    /// Switch an RP235x session to `desired` if the live architecture differs.
+    ///
+    /// No-op for other chips, or when the session is already on `desired`.
+    pub fn ensure_architecture(&mut self, desired: Architecture) -> Result<(), Error> {
+        if self.architecture() == desired {
+            return Ok(());
+        }
+        if !crate::vendor::raspberrypi::is_rp235x_chip(&self.target.name) {
+            return Ok(());
+        }
+
+        let desired_arch = match desired {
+            Architecture::Arm => crate::vendor::raspberrypi::Rp235xArch::Arm,
+            Architecture::Riscv => crate::vendor::raspberrypi::Rp235xArch::Riscv,
+            other => {
+                return Err(Error::Other(format!(
+                    "unsupported RP235x architecture {other:?}"
+                )));
+            }
+        };
+
+        tracing::info!(
+            "Switching RP235x from {:?} to {desired:?}",
+            self.architecture()
+        );
+
+        {
+            let arm = self.get_arm_interface()?;
+            crate::vendor::raspberrypi::switch_rp235x_architecture(arm, desired_arch)?;
+        }
+
+        self.rebind_rp235x_yaml(desired_arch)
+    }
+
+    /// `--chip` architecture, even if YAML was rebound to Arm for flashing.
+    pub(crate) fn rp235x_requested_arch(&self) -> Option<crate::vendor::raspberrypi::Rp235xArch> {
+        self.rp235x_requested
+    }
+
+    /// Switch an RP235x session after bootrom auto-selected `desired` from flash.
+    pub fn boot_switch_rebind(&mut self, desired: Architecture) -> Result<(), Error> {
+        if !crate::vendor::raspberrypi::is_rp235x_chip(&self.target.name) {
+            return Ok(());
+        }
+        if self.architecture() == desired {
+            return Ok(());
+        }
+
+        let desired_arch = match desired {
+            Architecture::Arm => crate::vendor::raspberrypi::Rp235xArch::Arm,
+            Architecture::Riscv => crate::vendor::raspberrypi::Rp235xArch::Riscv,
+            other => {
+                return Err(Error::Other(format!(
+                    "unsupported RP235x architecture {other:?}"
+                )));
+            }
+        };
+
+        tracing::info!(
+            "RP235x boot switch rebind: live {:?} → {desired:?} (IMAGE_DEF)",
+            self.architecture()
+        );
+
+        {
+            let arm = self.get_arm_interface()?;
+            crate::vendor::raspberrypi::rebind_after_bootrom_switch(arm, desired_arch)?;
+        }
+
+        self.rebind_rp235x_yaml(desired_arch)
     }
 
     /// Get the Arm probe interface.

--- a/probe-rs/src/vendor/raspberrypi/mod.rs
+++ b/probe-rs/src/vendor/raspberrypi/mod.rs
@@ -2,18 +2,596 @@
 use jep106::JEP106Code;
 use probe_rs_target::Chip;
 use sequences::rp235x::Rp235x;
+use sequences::rp235x_riscv::Rp235xRiscv;
 use sequences::rp2040::Rp2040;
+use std::time::Duration;
 
 use crate::{
+    MemoryMappedRegister,
     architecture::arm::{
-        ApV2Address, ArmChipInfo, ArmDebugInterface, FullyQualifiedApAddress, dp::DpAddress,
+        ApAddress, ApV2Address, ArmChipInfo, ArmDebugInterface, FullyQualifiedApAddress,
+        ap::{ApRegister, CSW, DRW, TAR},
+        armv8m::{Aircr, Dhcsr},
+        dp::DpAddress,
+    },
+    architecture::riscv::{
+        Dmcontrol,
+        communication_interface::{
+            MemoryAccessMethod, RiscvBusAccess, RiscvCommunicationInterface,
+            RiscvCommunicationInterfaceState,
+        },
+        dtm::mem_ap_dtm::MemApDtm,
     },
     config::{DebugSequence, Registry},
     error::Error,
+    memory::MemoryInterface,
     vendor::Vendor,
 };
 
 pub mod sequences;
+
+/// Cortex-M / RISC-V mem-AP bases in the RP235x Class 9 ROM.
+const RP235X_ARM_MEM_AP: u64 = 0x2000;
+const RP235X_ARM_CORE1_MEM_AP: u64 = 0x4000;
+const RP235X_RISCV_MEM_AP: u64 = 0xa000;
+
+const CHIPID_RP2040: u32 = 0x0000_2927;
+const CHIPID_RP235X: u32 = 0x0000_4927;
+
+/// OTP.ARCHSEL — architecture select, sampled on the next processor reset.
+const ARCHSEL_ADDR: u64 = 0x4012_0158;
+const ARCHSEL_STATUS_ADDR: u64 = 0x4012_015c;
+const ARCHSEL_BOTH_ARM: u32 = 0x0;
+const ARCHSEL_BOTH_RISCV: u32 = 0x3;
+
+/// PSM.FRCE_OFF — pulse both processor sockets (RP2350 bits 23/24).
+const PSM_FRCE_OFF: u64 = 0x4001_8004;
+const PSM_FRCE_OFF_BOTH_PROCS: u32 = (1 << 23) | (1 << 24);
+
+/// Live RP235x processor architecture, inferred from present Mem-APs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Rp235xArch {
+    Arm,
+    Riscv,
+}
+
+impl Rp235xArch {
+    pub(crate) fn from_chip_name(name: &str) -> Option<Self> {
+        if !is_rp235x_chip(name) {
+            return None;
+        }
+        if name.contains("riscv") {
+            Some(Self::Riscv)
+        } else {
+            Some(Self::Arm)
+        }
+    }
+
+    pub(crate) fn target_name(self) -> &'static str {
+        match self {
+            Self::Arm => "RP235x",
+            Self::Riscv => "RP235x_riscv",
+        }
+    }
+
+    fn archsel_bits(self) -> u32 {
+        match self {
+            Self::Arm => ARCHSEL_BOTH_ARM,
+            Self::Riscv => ARCHSEL_BOTH_RISCV,
+        }
+    }
+}
+
+pub(crate) fn is_rp235x_chip(name: &str) -> bool {
+    name.starts_with("RP235")
+}
+
+fn ap_v2_base(ap: &FullyQualifiedApAddress) -> Option<u64> {
+    match ap.ap() {
+        ApAddress::V2(ApV2Address(Some(base))) => Some(*base),
+        _ => None,
+    }
+}
+
+/// Detect which RP235x architecture is currently connected, from live APv2 presence.
+pub(crate) fn detect_rp235x_arch(
+    interface: &mut dyn ArmDebugInterface,
+) -> Result<Option<Rp235xArch>, Error> {
+    let aps = match interface.access_ports(DpAddress::Default) {
+        Ok(aps) => aps,
+        Err(e) => {
+            tracing::debug!("RP235x AP enumerate failed: {e}");
+            return Ok(None);
+        }
+    };
+
+    let has_arm = aps
+        .iter()
+        .any(|ap| ap_v2_base(ap) == Some(RP235X_ARM_MEM_AP));
+    let has_riscv = aps
+        .iter()
+        .any(|ap| ap_v2_base(ap) == Some(RP235X_RISCV_MEM_AP));
+
+    if has_riscv && !has_arm {
+        return Ok(Some(Rp235xArch::Riscv));
+    }
+    if has_arm {
+        return Ok(Some(Rp235xArch::Arm));
+    }
+    Ok(None)
+}
+
+fn force_riscv_program_buffer(interface: &mut RiscvCommunicationInterface) {
+    let config = interface.memory_access_config();
+    for width in [RiscvBusAccess::A8, RiscvBusAccess::A16, RiscvBusAccess::A32] {
+        config.set_default_method(width, MemoryAccessMethod::ProgramBuffer);
+    }
+}
+
+fn open_riscv_dm(
+    interface: &mut dyn ArmDebugInterface,
+) -> Result<(MemApDtm<'_>, RiscvCommunicationInterfaceState), Error> {
+    let ap = FullyQualifiedApAddress::v2_with_dp(
+        DpAddress::Default,
+        ApV2Address(Some(RP235X_RISCV_MEM_AP)),
+    );
+    let memory = interface.memory_interface(&ap).map_err(Error::Arm)?;
+    Ok((
+        MemApDtm::new(memory),
+        RiscvCommunicationInterfaceState::new(),
+    ))
+}
+
+fn halt_both_riscv(
+    riscv: &mut RiscvCommunicationInterface,
+    timeout: Duration,
+) -> Result<(), Error> {
+    riscv.set_enabled_harts(0b11);
+    let _ = riscv.select_hart(1).and_then(|_| riscv.halt(timeout));
+    riscv.select_hart(0).map_err(Error::Riscv)?;
+    riscv.halt(timeout).map_err(Error::Riscv)?;
+    Ok(())
+}
+
+fn hartreset_both(riscv: &mut RiscvCommunicationInterface) -> Result<(), Error> {
+    riscv.set_enabled_harts(0b11);
+    riscv.select_hart(0).map_err(Error::Riscv)?;
+    let _ = riscv.reset_hart_and_halt(Duration::from_millis(200));
+    let _ = riscv
+        .select_hart(1)
+        .and_then(|_| riscv.reset_hart_and_halt(Duration::from_millis(200)));
+    riscv.select_hart(0).map_err(Error::Riscv)?;
+    Ok(())
+}
+
+/// Pulse `hartreset` on both harts without `haltreq` so sockets resample ARCHSEL.
+///
+/// OpenOCD: `hasel` + hart window `0b11`, then `dmcontrol = hartreset|dmactive`.
+/// `reset_hart_and_halt` holds `haltreq` and waits for RISC-V `allhalted`.
+fn pulse_hartreset_for_archsel(riscv: &mut RiscvCommunicationInterface) {
+    // OpenOCD: `riscv dm_write 0x10 0x20000001` then `0x00000001` (hartreset|dmactive, no haltreq).
+    let mut dmcontrol = Dmcontrol(0);
+    dmcontrol.set_dmactive(true);
+    dmcontrol.set_haltreq(false);
+    dmcontrol.set_ndmreset(false);
+    dmcontrol.set_hartreset(true);
+    if let Err(e) = riscv.write_dm_register(dmcontrol) {
+        tracing::warn!("RP235x hartreset assert failed: {e}");
+        return;
+    }
+    dmcontrol.set_hartreset(false);
+    let _ = riscv.write_dm_register(dmcontrol);
+}
+
+fn write_archsel_via_arm(interface: &mut dyn ArmDebugInterface, bits: u32) -> Result<u32, Error> {
+    let ap = FullyQualifiedApAddress::v2_with_dp(
+        DpAddress::Default,
+        ApV2Address(Some(RP235X_ARM_MEM_AP)),
+    );
+    let mut memory = interface.memory_interface(&ap).map_err(Error::Arm)?;
+    memory
+        .write_word_32(ARCHSEL_ADDR, bits)
+        .map_err(Error::Arm)?;
+    let readback = memory.read_word_32(ARCHSEL_ADDR).map_err(Error::Arm)?;
+    Ok(readback & 0x3)
+}
+
+fn write_archsel_via_riscv(interface: &mut dyn ArmDebugInterface, bits: u32) -> Result<u32, Error> {
+    let (dtm, mut state) = open_riscv_dm(interface)?;
+    let mut riscv = RiscvCommunicationInterface::new(Box::new(dtm), &mut state);
+    riscv.enter_debug_mode().map_err(Error::Riscv)?;
+    force_riscv_program_buffer(&mut riscv);
+    let _ = halt_both_riscv(&mut riscv, Duration::from_millis(100));
+    riscv.select_hart(0).map_err(Error::Riscv)?;
+
+    riscv.write_word_32(ARCHSEL_ADDR, bits)?;
+    let readback = riscv.read_word_32(ARCHSEL_ADDR)?;
+    let status = riscv.read_word_32(ARCHSEL_STATUS_ADDR).unwrap_or(0);
+    tracing::info!(
+        "RP235x ARCHSEL write {bits:#x}, readback {readback:#x}, ARCHSEL_STATUS {status:#x}"
+    );
+    Ok(readback & 0x3)
+}
+
+fn warm_reset_arm_processors(interface: &mut dyn ArmDebugInterface) -> Result<(), Error> {
+    // SYSRESETREQ on BOTH M33 Mem-APs so both sockets resample ARCHSEL.
+    // Do not hold PSM.FRCE_OFF across a delay.
+    tracing::info!("RP235x Arm warm reset: SYSRESETREQ on core0+core1 Mem-APs");
+    for base in [RP235X_ARM_MEM_AP, RP235X_ARM_CORE1_MEM_AP] {
+        let ap = FullyQualifiedApAddress::v2_with_dp(DpAddress::Default, ApV2Address(Some(base)));
+        if let Ok(mut memory) = interface.memory_interface(&ap) {
+            let mut aircr = Aircr(0);
+            aircr.vectkey();
+            aircr.set_sysresetreq(true);
+            let _ = memory.write_word_32(Aircr::get_mmio_address(), aircr.into());
+        }
+    }
+    Ok(())
+}
+
+fn settle_arm_core1(interface: &mut dyn ArmDebugInterface) {
+    tracing::info!("RP235x Arm settle: re-halt core0 (no PSM pulse)");
+    if try_halt_arm_ap(interface, RP235X_ARM_MEM_AP, true) {
+        tracing::info!("RP235x Arm settle: core0 S_HALT");
+    } else {
+        tracing::warn!("RP235x Arm settle: core0 not S_HALT");
+    }
+}
+
+fn warm_reset_riscv_processors(interface: &mut dyn ArmDebugInterface) -> Result<(), Error> {
+    let (dtm, mut state) = open_riscv_dm(interface)?;
+    let mut riscv = RiscvCommunicationInterface::new(Box::new(dtm), &mut state);
+    riscv.enter_debug_mode().map_err(Error::Riscv)?;
+    force_riscv_program_buffer(&mut riscv);
+    let _ = halt_both_riscv(&mut riscv, Duration::from_millis(100));
+    tracing::info!("RP235x RISC-V warm reset: PSM.FRCE_OFF both PROCs then hartreset (no haltreq)");
+    // Write-0 cannot stick for PROC0 (progbuf hart powers off). Arm catch clears FRCE_OFF.
+    let _ = riscv.write_word_32(PSM_FRCE_OFF, PSM_FRCE_OFF_BOTH_PROCS);
+    pulse_hartreset_for_archsel(&mut riscv);
+    drop(riscv);
+    Ok(())
+}
+
+/// Bootrom auto-switch needs a full processor socket restart (OpenOCD `reset run`).
+fn warm_reset_riscv_processors_with_psm(
+    interface: &mut dyn ArmDebugInterface,
+) -> Result<(), Error> {
+    let (dtm, mut state) = open_riscv_dm(interface)?;
+    let mut riscv = RiscvCommunicationInterface::new(Box::new(dtm), &mut state);
+    riscv.enter_debug_mode().map_err(Error::Riscv)?;
+    force_riscv_program_buffer(&mut riscv);
+    let _ = halt_both_riscv(&mut riscv, Duration::from_millis(100));
+
+    tracing::info!("RP235x RISC-V warm reset: PSM.FRCE_OFF both PROCs + dual hartreset");
+    let _ = riscv.write_word_32(PSM_FRCE_OFF, PSM_FRCE_OFF_BOTH_PROCS);
+    hartreset_both(&mut riscv)?;
+    drop(riscv);
+    Ok(())
+}
+
+/// After programming the other architecture's flash image, align ARCHSEL with
+/// that IMAGE_DEF, reset both sockets, allow bootrom to finish, then halt the
+/// new cores.
+pub(crate) fn rebind_after_bootrom_switch(
+    interface: &mut dyn ArmDebugInterface,
+    desired: Rp235xArch,
+) -> Result<(), Error> {
+    let live = detect_rp235x_arch(interface)?;
+    let bits = desired.archsel_bits();
+    tracing::info!(
+        "RP235x boot switch: live {live:?} → {desired:?} (ARCHSEL={bits:#x} + IMAGE_DEF)"
+    );
+
+    let written = match live {
+        Some(Rp235xArch::Arm) | None => write_archsel_via_arm(interface, bits),
+        Some(Rp235xArch::Riscv) => write_archsel_via_riscv(interface, bits),
+    }?;
+    if written != bits {
+        return Err(Error::Other(format!(
+            "RP235x boot switch: OTP forbids {} (ARCHSEL readback {written:#x})",
+            desired.target_name()
+        )));
+    }
+
+    match live {
+        Some(Rp235xArch::Arm) | None => warm_reset_arm_processors(interface)?,
+        Some(Rp235xArch::Riscv) => warm_reset_riscv_processors_with_psm(interface)?,
+    }
+
+    std::thread::sleep(Duration::from_millis(500));
+    let _ = interface.reinitialize();
+    let _ = interface.select_debug_port(DpAddress::Default);
+
+    if catch_switched_cores(interface, desired) {
+        let _ = interface.reinitialize();
+        if desired == Rp235xArch::Arm {
+            settle_arm_core1(interface);
+        }
+        return Ok(());
+    }
+
+    match detect_rp235x_arch(interface)? {
+        Some(now) if now == desired => Ok(()),
+        Some(now) => Err(Error::Other(format!(
+            "RP235x boot switch to {} failed (still {:?}; IMAGE_DEF / OTP?)",
+            desired.target_name(),
+            now
+        ))),
+        None => Err(Error::Other(format!(
+            "RP235x boot switch to {} failed (no live CPU Mem-AP)",
+            desired.target_name()
+        ))),
+    }
+}
+
+/// Switch both RP2350 cores to `desired` via OTP.ARCHSEL + warm processor reset.
+///
+/// Does **not** use RP-AP rescue (that clears RAM and ARCHSEL).
+pub(crate) fn switch_rp235x_architecture(
+    interface: &mut dyn ArmDebugInterface,
+    desired: Rp235xArch,
+) -> Result<(), Error> {
+    let live = detect_rp235x_arch(interface)?;
+    if live == Some(desired) {
+        return Ok(());
+    }
+
+    let bits = desired.archsel_bits();
+    let written = match live {
+        Some(Rp235xArch::Arm) | None => write_archsel_via_arm(interface, bits),
+        Some(Rp235xArch::Riscv) => write_archsel_via_riscv(interface, bits),
+    }?;
+
+    if written != bits {
+        return Err(Error::Other(format!(
+            "RP235x OTP forbids switching to {} (ARCHSEL readback {written:#x}, wanted {bits:#x})",
+            desired.target_name()
+        )));
+    }
+
+    match live {
+        Some(Rp235xArch::Arm) | None => warm_reset_arm_processors(interface)?,
+        Some(Rp235xArch::Riscv) => {
+            if let Some(entry) = class9_rom_entry(interface, 0) {
+                tracing::info!("RP235x Class9[0] before hartreset {entry:#010x}");
+            }
+            warm_reset_riscv_processors(interface)?;
+        }
+    }
+
+    // Halt the new cores immediately. Do not Class-9-walk (`detect_rp235x_arch`)
+    // during/after the race — that hangs on a sticky FAULT Mem-AP.
+    let _ = interface.select_debug_port(DpAddress::Default);
+    tracing::info!("RP235x switch: catching {desired:?} cores after warm reset");
+    if catch_switched_cores(interface, desired) {
+        let _ = interface.reinitialize();
+        std::thread::sleep(Duration::from_millis(50));
+        if desired == Rp235xArch::Arm {
+            settle_arm_core1(interface);
+        }
+        return Ok(());
+    }
+
+    Err(Error::Other(format!(
+        "RP235x architecture switch to {} failed (new cores not PRESENT/S_HALT; IMAGE_DEF race or OTP)",
+        desired.target_name()
+    )))
+}
+
+fn catch_switched_cores(interface: &mut dyn ArmDebugInterface, arch: Rp235xArch) -> bool {
+    let deadline = std::time::Instant::now() + Duration::from_millis(800);
+    let mut attempts = 0u32;
+    let mut arm_present = false;
+    let mut cleared_psm = false;
+    let mut logged_dfsr = false;
+    while std::time::Instant::now() < deadline {
+        attempts += 1;
+
+        let ok = match arch {
+            Rp235xArch::Arm => {
+                if !arm_present {
+                    if let Some(entry) = class9_rom_entry(interface, 0) {
+                        tracing::info!("RP235x catch: Class9[0]={entry:#010x}");
+                        arm_present = (entry & 1) == 1;
+                    }
+                    if !arm_present {
+                        continue;
+                    }
+                    tracing::info!("RP235x catch: AP 0x2000 PRESENT after {attempts} polls");
+                }
+                // Do not reinitialize() here: DP power-down/up leaves DeviceEn=0.
+                match arm_ap_csw_device_en(interface, RP235X_ARM_MEM_AP) {
+                    None => continue,
+                    Some(false) => {
+                        std::thread::sleep(Duration::from_millis(10));
+                        continue;
+                    }
+                    Some(true) => {}
+                }
+                if !cleared_psm {
+                    cleared_psm = true;
+                    let ap = FullyQualifiedApAddress::v2_with_dp(
+                        DpAddress::Default,
+                        ApV2Address(Some(RP235X_ARM_MEM_AP)),
+                    );
+                    match ap_read_mem32(interface, &ap, PSM_FRCE_OFF as u32) {
+                        Ok(frce) => {
+                            tracing::info!("RP235x catch: PSM.FRCE_OFF {frce:#010x}");
+                            if frce & PSM_FRCE_OFF_BOTH_PROCS != 0 {
+                                let _ = ap_write_mem32(
+                                    interface,
+                                    &ap,
+                                    PSM_FRCE_OFF as u32,
+                                    frce & !PSM_FRCE_OFF_BOTH_PROCS,
+                                );
+                                std::thread::sleep(Duration::from_millis(50));
+                            }
+                        }
+                        Err(e) => tracing::info!("RP235x catch: PSM.FRCE_OFF read failed: {e}"),
+                    }
+                }
+                let core0 = try_halt_arm_ap(interface, RP235X_ARM_MEM_AP, true);
+                if !logged_dfsr {
+                    logged_dfsr = true;
+                    let ap = FullyQualifiedApAddress::v2_with_dp(
+                        DpAddress::Default,
+                        ApV2Address(Some(RP235X_ARM_MEM_AP)),
+                    );
+                    match ap_read_mem32(interface, &ap, 0xe000_ed30) {
+                        Ok(dfsr) => {
+                            tracing::info!("RP235x catch: DFSR {dfsr:#010x} HALTED={}", dfsr & 1)
+                        }
+                        Err(e) => tracing::info!("RP235x catch: DFSR read failed: {e}"),
+                    }
+                }
+                if core0 {
+                    let _ = try_halt_arm_ap(interface, RP235X_ARM_CORE1_MEM_AP, false);
+                }
+                core0
+            }
+            Rp235xArch::Riscv => try_halt_riscv_dm(interface),
+        };
+
+        if ok {
+            tracing::info!("RP235x switch: halted {arch:?} after {attempts} attempts");
+            return true;
+        }
+    }
+    tracing::warn!("RP235x switch: failed to halt {arch:?} after {attempts} attempts");
+    false
+}
+
+/// Read Mem-AP CSW (AP register, not DRW). `None` = CSW access failed.
+fn arm_ap_csw_device_en(interface: &mut dyn ArmDebugInterface, base: u64) -> Option<bool> {
+    let ap = FullyQualifiedApAddress::v2_with_dp(DpAddress::Default, ApV2Address(Some(base)));
+    match interface.read_raw_ap_register(&ap, CSW::ADDRESS) {
+        Ok(raw) => {
+            let csw = CSW::try_from(raw).ok()?;
+            let device_en = csw.DeviceEn();
+            tracing::info!(
+                "RP235x catch: AP {base:#x} CSW {raw:#010x} DeviceEn={} SDeviceEn={} HNONSEC={} TrInProg={}",
+                device_en,
+                csw.SDeviceEn(),
+                (raw >> 30) & 1,
+                csw.TrInProg(),
+            );
+            Some(device_en)
+        }
+        Err(e) => {
+            tracing::info!("RP235x catch: AP {base:#x} CSW read failed: {e}");
+            None
+        }
+    }
+}
+
+fn class9_rom_entry(interface: &mut dyn ArmDebugInterface, entry_off: u64) -> Option<u32> {
+    let root = FullyQualifiedApAddress::v2_with_dp(DpAddress::Default, ApV2Address::root());
+    let mut mem = interface.memory_interface(&root).ok()?;
+    let base = mem.base_address().ok()?;
+    mem.read_word_32(base + entry_off).ok()
+}
+
+fn ap_write_mem32(
+    interface: &mut dyn ArmDebugInterface,
+    ap: &FullyQualifiedApAddress,
+    addr: u32,
+    val: u32,
+) -> Result<(), crate::architecture::arm::ArmError> {
+    interface.write_raw_ap_register(ap, TAR::ADDRESS, addr)?;
+    interface.write_raw_ap_register(ap, DRW::ADDRESS, val)?;
+    Ok(())
+}
+
+fn ap_read_mem32(
+    interface: &mut dyn ArmDebugInterface,
+    ap: &FullyQualifiedApAddress,
+    addr: u32,
+) -> Result<u32, crate::architecture::arm::ArmError> {
+    interface.write_raw_ap_register(ap, TAR::ADDRESS, addr)?;
+    interface.read_raw_ap_register(ap, DRW::ADDRESS)
+}
+
+fn try_halt_arm_ap(interface: &mut dyn ArmDebugInterface, base: u64, log: bool) -> bool {
+    if log {
+        tracing::info!("RP235x catch: try_halt AP {base:#x} (raw TAR/DRW, no CSW rewrite)");
+    }
+    let ap = FullyQualifiedApAddress::v2_with_dp(DpAddress::Default, ApV2Address(Some(base)));
+    let dhcsr_addr = Dhcsr::get_mmio_address() as u32;
+
+    let before = match ap_read_mem32(interface, &ap, dhcsr_addr) {
+        Ok(value) => Dhcsr(value),
+        Err(e) => {
+            if log {
+                tracing::info!("RP235x catch: AP {base:#x} DHCSR before-read failed: {e}");
+            }
+            let _ = arm_ap_csw_device_en(interface, base);
+            return false;
+        }
+    };
+    if log {
+        tracing::info!(
+            "RP235x catch: AP {base:#x} DHCSR before halt {:#010x} S_SLEEP={} S_HALT={}",
+            u32::from(before),
+            before.s_sleep(),
+            before.s_halt()
+        );
+    }
+    if before.s_halt() {
+        return true;
+    }
+    // C_HALT DRW while S_SLEEP stalls AHB and drops DeviceEn.
+    if before.s_sleep() {
+        if log {
+            tracing::info!("RP235x catch: AP {base:#x} S_SLEEP; skip C_HALT");
+        }
+        std::thread::sleep(Duration::from_millis(10));
+        return false;
+    }
+
+    let mut dhcsr = Dhcsr(0);
+    dhcsr.set_c_debugen(true);
+    dhcsr.set_c_halt(true);
+    dhcsr.enable_write();
+    if let Err(e) = ap_write_mem32(interface, &ap, dhcsr_addr, dhcsr.into()) {
+        if log {
+            tracing::info!("RP235x catch: AP {base:#x} C_DEBUGEN|C_HALT write failed: {e}");
+        }
+        let _ = arm_ap_csw_device_en(interface, base);
+        return false;
+    }
+
+    match ap_read_mem32(interface, &ap, dhcsr_addr) {
+        Ok(value) => {
+            let dhcsr = Dhcsr(value);
+            if log {
+                tracing::info!(
+                    "RP235x catch: AP {base:#x} DHCSR after halt {value:#010x} S_HALT={}",
+                    dhcsr.s_halt()
+                );
+            }
+            dhcsr.s_halt()
+        }
+        Err(e) => {
+            if log {
+                tracing::info!("RP235x catch: AP {base:#x} DHCSR read failed: {e}");
+            }
+            let _ = arm_ap_csw_device_en(interface, base);
+            false
+        }
+    }
+}
+
+fn try_halt_riscv_dm(interface: &mut dyn ArmDebugInterface) -> bool {
+    let Ok((dtm, mut state)) = open_riscv_dm(interface) else {
+        return false;
+    };
+    let mut riscv = RiscvCommunicationInterface::new(Box::new(dtm), &mut state);
+    if riscv.enter_debug_mode().is_err() {
+        return false;
+    }
+    force_riscv_program_buffer(&mut riscv);
+    halt_both_riscv(&mut riscv, Duration::from_millis(20)).is_ok()
+}
 
 /// Raspberry Pi
 #[derive(docsplay::Display)]
@@ -23,6 +601,8 @@ impl Vendor for RaspberryPi {
     fn try_create_debug_sequence(&self, chip: &Chip) -> Option<DebugSequence> {
         let sequence = if chip.name.starts_with("RP2040") {
             DebugSequence::Arm(Rp2040::create())
+        } else if chip.name.starts_with("RP235") && chip.name.contains("riscv") {
+            DebugSequence::Riscv(Rp235xRiscv::create())
         } else if chip.name.starts_with("RP235") {
             DebugSequence::Arm(Rp235x::create())
         } else {
@@ -38,8 +618,6 @@ impl Vendor for RaspberryPi {
         chip_info: ArmChipInfo,
     ) -> Result<Option<String>, Error> {
         const JEP_ARM: JEP106Code = JEP106Code { id: 0x3b, cc: 0x4 };
-        const CHIPID_RP2040: u32 = 0x0000_2927;
-        const CHIPID_RP235X: u32 = 0x0000_4927;
 
         // Check for RP2040. We can immediately rule out RP2040 existing if we aren't probing via multidrop.
         if let Some(DpAddress::Multidrop(dp)) = interface.current_debug_port() {
@@ -53,19 +631,35 @@ impl Vendor for RaspberryPi {
             }
         }
 
-        // Check for RP235X.
-        // Before we go poking memory, check that we have a CoreSight Class-1 ROM with a part number of 1225.
-        if chip_info.manufacturer != JEP_ARM || chip_info.part != 1225 {
+        // RP235x identity arrives two ways:
+        // - Arm boot: Cortex-M ROM behind Mem-AP 0x2000 (ARM JEP, PART 1225)
+        // - RISC-V boot: DPv3 root Class 9 ROM (Raspberry Pi designer; unused Arm APs
+        //   are non-PRESENT, so the M33 ROM is not visible)
+        let designer = chip_info.manufacturer.get();
+        let is_arm_m33_rom = chip_info.manufacturer == JEP_ARM && chip_info.part == 1225;
+        let is_rp235x_class9 = designer == Some("Raspberry Pi Trading Ltd");
+        if !is_arm_m33_rom && !is_rp235x_class9 {
             return Ok(None);
         }
 
-        // Read SYSINFO.CHIP_ID and compare against RP235x chip_id
-        let ap = FullyQualifiedApAddress::v2_with_dp(DpAddress::Default, ApV2Address(Some(0x2000)));
-        if let Ok(mut memory) = interface.memory_interface(&ap)
-            && let Ok(chip_id) = memory.read_word_32(0x4000_0000)
-            && (chip_id & 0x0fff_ffff) == CHIPID_RP235X
-        {
-            return Ok(Some("RP235x".to_string()));
+        match detect_rp235x_arch(interface)? {
+            Some(Rp235xArch::Riscv) => return Ok(Some("RP235x_riscv".to_string())),
+            Some(Rp235xArch::Arm) => {
+                let ap = FullyQualifiedApAddress::v2_with_dp(
+                    DpAddress::Default,
+                    ApV2Address(Some(RP235X_ARM_MEM_AP)),
+                );
+                if let Ok(mut memory) = interface.memory_interface(&ap)
+                    && let Ok(chip_id) = memory.read_word_32(0x4000_0000)
+                    && (chip_id & 0x0fff_ffff) != CHIPID_RP235X
+                {
+                    tracing::debug!(
+                        "RP235x Arm AP present but CHIP_ID {chip_id:#010x} != {CHIPID_RP235X:#010x}"
+                    );
+                }
+                return Ok(Some("RP235x".to_string()));
+            }
+            None => {}
         }
 
         Ok(None)

--- a/probe-rs/src/vendor/raspberrypi/mod.rs
+++ b/probe-rs/src/vendor/raspberrypi/mod.rs
@@ -364,10 +364,12 @@ pub(crate) fn switch_rp235x_architecture(
     let _ = interface.select_debug_port(DpAddress::Default);
     tracing::info!("RP235x switch: catching {desired:?} cores after warm reset");
     if catch_switched_cores(interface, desired) {
-        let _ = interface.reinitialize();
-        std::thread::sleep(Duration::from_millis(50));
+        // Do not reinitialize() after an Arm catch: DP power-down/up leaves DeviceEn=0.
         if desired == Rp235xArch::Arm {
+            std::thread::sleep(Duration::from_millis(50));
             settle_arm_core1(interface);
+        } else {
+            let _ = interface.reinitialize();
         }
         return Ok(());
     }
@@ -445,7 +447,15 @@ fn catch_switched_cores(interface: &mut dyn ArmDebugInterface, arch: Rp235xArch)
                     }
                 }
                 if core0 {
-                    let _ = try_halt_arm_ap(interface, RP235X_ARM_CORE1_MEM_AP, false);
+                    match arm_ap_csw_device_en(interface, RP235X_ARM_CORE1_MEM_AP) {
+                        Some(true) => {
+                            let _ = try_halt_arm_ap(interface, RP235X_ARM_CORE1_MEM_AP, false);
+                        }
+                        _ => {
+                            // Core1 often has DeviceEn=0 right after the socket switch.
+                            // Do not probe it: a FAULT here drops core0 DeviceEn too.
+                        }
+                    }
                 }
                 core0
             }

--- a/probe-rs/src/vendor/raspberrypi/sequences/mod.rs
+++ b/probe-rs/src/vendor/raspberrypi/sequences/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod rp2040;
 pub mod rp235x;
+pub mod rp235x_riscv;

--- a/probe-rs/src/vendor/raspberrypi/sequences/rp235x_riscv.rs
+++ b/probe-rs/src/vendor/raspberrypi/sequences/rp235x_riscv.rs
@@ -1,0 +1,79 @@
+//! RISC-V debug sequence for RP235x (Hazard3).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::architecture::riscv::communication_interface::{
+    MemoryAccessMethod, RiscvBusAccess, RiscvCommunicationInterface,
+};
+use crate::architecture::riscv::sequences::RiscvDebugSequence;
+
+/// Debug sequence for RP235x RISC-V (Hazard3) cores.
+///
+/// Hazard3 has no abstract memory commands and a 2-word program buffer.
+/// SBA shares core 1's load/store port, so both harts must be halted and memory
+/// access must go through hart 0's program buffer.
+#[derive(Debug)]
+pub struct Rp235xRiscv {}
+
+impl Rp235xRiscv {
+    /// Create a debug sequencer for RP235x RISC-V.
+    pub fn create() -> Arc<dyn RiscvDebugSequence> {
+        Arc::new(Self {})
+    }
+
+    fn force_program_buffer(interface: &mut RiscvCommunicationInterface) {
+        let config = interface.memory_access_config();
+        for width in [RiscvBusAccess::A8, RiscvBusAccess::A16, RiscvBusAccess::A32] {
+            config.set_default_method(width, MemoryAccessMethod::ProgramBuffer);
+        }
+    }
+
+    fn halt_both(
+        interface: &mut RiscvCommunicationInterface,
+        timeout: Duration,
+    ) -> Result<(), crate::Error> {
+        interface.set_enabled_harts(0b11);
+        let _ = interface
+            .select_hart(1)
+            .and_then(|_| interface.halt(timeout));
+        interface.select_hart(0).map_err(crate::Error::Riscv)?;
+        interface.halt(timeout).map_err(crate::Error::Riscv)?;
+        Ok(())
+    }
+}
+
+impl RiscvDebugSequence for Rp235xRiscv {
+    fn on_connect(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
+        interface.clear_abstractauto();
+        Self::force_program_buffer(interface);
+        // Two Hazard3 harts. `enter_debug_mode` sees hartsellen=1 and skips hart 1.
+        if let Err(e) = Self::halt_both(interface, Duration::from_millis(100)) {
+            tracing::debug!("RP235x RISC-V halt both harts on connect: {e}");
+            let _ = interface.halt(Duration::from_millis(100));
+        }
+        Self::force_program_buffer(interface);
+        Ok(())
+    }
+
+    fn reset_system_and_halt(
+        &self,
+        interface: &mut RiscvCommunicationInterface,
+        timeout: Duration,
+    ) -> Result<(), crate::Error> {
+        Self::force_program_buffer(interface);
+        interface.set_enabled_harts(0b11);
+        interface.select_hart(0).map_err(crate::Error::Riscv)?;
+        if let Err(e) = interface.reset_hart_and_halt(timeout) {
+            tracing::warn!("RP235x RISC-V hart 0 reset failed: {e}");
+        }
+        let _ = interface
+            .select_hart(1)
+            .and_then(|_| interface.reset_hart_and_halt(timeout));
+
+        interface.select_hart(0).map_err(crate::Error::Riscv)?;
+        Self::halt_both(interface, timeout)?;
+        Self::force_program_buffer(interface);
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR was made by an agent without my request.
If you want to read what it wrote, expand the slop below.

<details>
  <summary>Slop warning - do not expand this unless you're into that.</summary>

## Summary

- `--chip RP235x_riscv` programs QSPI with the existing Arm CMSIS-Pack flash algorithm, then IMAGE_DEF-binds Hazard3 and rebinds the `RP235x_riscv` session.
- `--chip RP235x` stays Arm (no RISC-V bind). Live RISC-V is switched to Arm for flashing.
- Chip YAML is the ISA intent. This PR does **not** inspect ELF `e_machine`.

## Acceptance (Picoprobe `2e8a:000c`)

`probe-rs run --chip RP235x_riscv <riscv.elf>`:

- **Live Arm:** stay Arm for flash (do not ARCHSEL to RISC-V at attach), Arm `algo`, IMAGE_DEF rebind Hazard3, RTT, timeout **124**. Lab: Finished **0.70s**.
- **Live RISC-V:** ARCHSEL + `PSM.FRCE_OFF` catch to Arm, Arm `algo`, then IMAGE_DEF bind RISC-V, timeout **124**. Lab: Finished **5.87s**.

`probe-rs run --chip RP235x <arm.elf>`:

- **Live Arm:** stay Arm, `algo`, no bind.
- **Live RISC-V:** switch to Arm at attach, `algo`, stay Arm. Lab: Finished **0.79s**.

Logs contain no `algo_riscv`. `RP235x_riscv` YAML is not given a RISC-V flash algorithm.

## Not in this PR

Working on `rp235x-flash-as-arm` / sibling branches; documenting here so review is scoped:

- **ELF auto-detect** of post-flash ISA (`object::architecture`). User passes `--chip RP235x` vs `RP235x_riscv`.
- **`algo_riscv` / live-core RISC-V flash** (needs varmulet).
- **RV→Arm flash ~0.6s.** Functional catch is several seconds vs Arm-booted ~0.64s. BOOTSEL-after-catch / resume-for-PLL did not land.
- **RISC-V-only `FRCE_OFF` clear** (infeasible; Arm-AP clear stays).
- **RAM-only arch switch** (MSP_NS / HardFault @ 0 / empty IMAGE_DEF).
- **`cmsisdap-recover`**, `DAP_WriteABORT`, Picoprobe USB recover notes.
- **Class-9 `info` RISC-V DM dump** and other info-debug work.
- Lab log, ELFs, datasheet, OpenOCD notes.

## Recover note

A failed RISC-V→Arm catch can leave the DP in a sticky FAULT. This PR does **not** include `jtag-to-swd` + RP-AP rescue. Recover with the existing out-of-tree `cmsisdap-recover` path (`jtag-to-swd` then `rp-ap-rescue`). Rescue clears ARCHSEL; the chip is Arm afterward. Do not use DAPLink `usbreset`, connect-under-reset, or unplug as the recover procedure.

## Test plan

- [x] Arm-booted: `timeout 124 run --chip RP235x_riscv riscv.elf` → stay Arm, Finished ~0.7s, IMAGE_DEF rebind, timeout 124
- [x] RISC-V-booted: same command → RV→Arm catch, Arm `algo`, Finished several seconds, rebind RISC-V, timeout 124
- [x] RISC-V-booted: `run --chip RP235x arm.elf` → switch to Arm, Finished, no bind
- [x] Logs have no `algo_riscv`

</details>