### PR TITLE
ASR: Don't fail `reset_system` when vector table is invalid

### DIFF
--- a/probe-rs/src/vendor/asrmicro/sequences.rs
+++ b/probe-rs/src/vendor/asrmicro/sequences.rs
@@ -116,9 +116,10 @@ impl ArmDebugSequence for Asr6601 {
         let sp = interface.read_word_32(VECTOR_TABLE)?;
         let pc = interface.read_word_32(VECTOR_TABLE + 4)?;
         if !RAM_RANGE.contains(&sp) || !FLASH_RANGE.contains(&(pc & !1)) || pc & 1 == 0 {
-            return Err(ArmError::Other(format!(
-                "vector table at {VECTOR_TABLE:#010x} is invalid (SP={sp:#010x}, PC={pc:#010x})"
-            )));
+            tracing::warn!(
+                "vector table at {VECTOR_TABLE:#010x} is invalid (SP={sp:#010x}, PC={pc:#010x}), \
+                 continuing with reset anyway"
+            );
         }
 
         interface.write_word_32(SYST_CSR, 0)?;


### PR DESCRIPTION
The ASR6601 reset_system sequence validated the vector table at `0x08000000` and returned an error if SP/PC looked invalid. This broke flash programming because `reset_system` is called from `core.reset_and_halt()` during flash algorithm loading (flasher.rs:201), before any firmware has been written. With empty flash, `SP=0xFFFFFFFF` and `PC=0xFFFFFFFF`, so the check always failed and aborted the entire flash procedure.

Change the validation from a fatal error to a warning. None of the other 17 vendor `reset_system` implementations perform this check — they all just halt the core and proceed. The ASR6601 sequence is unique in needing to emulate a reset (`SYSRESETREQ` drops the debug connection), but the vector table validation is not necessary for the reset to work.

@Kezii 

_Side note_: the vector table check was added to catch corrupted/invalid
flash content after programming, but it fires during flash algorithm loading
when flash is guaranteed to be empty. The proper fix would be to not
invoke the vendor `reset_sequence` during flash algorithm loading — the
flasher only needs the core halted, not a full emulated boot. This
requires either adding a halt-only path to the `ArmDebugSequence` trait
or having the flasher skip the vendor sequence in its `reset_and_halt`
call. Both options need broader architectural changes in probe-rs which
are outside the scope of this fix.