### PR TITLE
Black Magic probe: add get_target_voltage() implementation

### DIFF
--- a/changelog/added-blackmagic-get-target-voltage.md
+++ b/changelog/added-blackmagic-get-target-voltage.md
@@ -1,0 +1,1 @@
+Added `get_target_voltage()` implementation for Black Magic probe

--- a/probe-rs/src/probe/blackmagic/mod.rs
+++ b/probe-rs/src/probe/blackmagic/mod.rs
@@ -97,7 +97,7 @@ enum RemoteCommand<'a> {
     Handshake(&'a mut [u8]),
     GetAccelerators,
     HighLevelCheck,
-    GetVoltage,
+    GetVoltage(&'a mut [u8]),
     GetSpeedKhz,
     SetNrst(bool),
     SetPower(bool),
@@ -297,6 +297,7 @@ impl RemoteCommand<'_> {
     fn response_buffer(&mut self) -> Option<&mut [u8]> {
         match self {
             RemoteCommand::Handshake(data) => Some(data),
+            RemoteCommand::GetVoltage(data) => Some(data),
             RemoteCommand::MemReadV0P { data, .. } => Some(data),
             RemoteCommand::MemReadV1 { data, .. } => Some(data),
             RemoteCommand::MemReadV3 { data, .. } => Some(data),
@@ -326,7 +327,7 @@ impl std::string::ToString for RemoteCommand<'_> {
     fn to_string(&self) -> String {
         match self {
             RemoteCommand::Handshake(_) => "+#!GA#".to_string(),
-            RemoteCommand::GetVoltage => " !GV#".to_string(),
+            RemoteCommand::GetVoltage(_) => " !GV#".to_string(),
             RemoteCommand::GetSpeedKhz => "!Gf#".to_string(),
             RemoteCommand::SetSpeedHz(speed) => {
                 format!("!GF{speed:08x}#")
@@ -791,9 +792,7 @@ impl BlackMagicProbe {
         };
 
         probe.command(RemoteCommand::SetNrst(false)).ok();
-        probe.command(RemoteCommand::GetVoltage).ok();
         probe.command(RemoteCommand::SetSpeedHz(400_0000)).ok();
-        probe.command(RemoteCommand::GetSpeedKhz).ok();
 
         Ok(probe)
     }
@@ -1279,6 +1278,30 @@ impl DebugProbe for BlackMagicProbe {
 
     fn has_xtensa_interface(&self) -> bool {
         true
+    }
+
+    fn get_target_voltage(&mut self) -> Result<Option<f32>, DebugProbeError> {
+        let mut voltage_response = [0u8; 4];
+        let res = self.command(RemoteCommand::GetVoltage(&mut voltage_response));
+        match res {
+            Ok(RemoteResponse(0)) => Err(RemoteError::ParameterError(0).into()),
+            Ok(RemoteResponse(response_size)) => {
+                let response_str = str::from_utf8(&voltage_response[0..response_size as usize])
+                    .map_err(|_| RemoteError::ParameterError(0))?;
+
+                // cut off trailing 'V'
+                let response_str = response_str
+                    .strip_suffix('V')
+                    .ok_or(RemoteError::ParameterError(0))?;
+
+                let voltage: f32 = response_str
+                    .parse()
+                    .map_err(|_| RemoteError::ParameterError(0))?;
+
+                Ok(Some(voltage))
+            }
+            Err(e) => Err(e.into()),
+        }
     }
 }
 


### PR DESCRIPTION
Implementing `get_target_voltage()` for the Black Magic probe.

The current `probe.command(RemoteCommand::GetVoltage)` always returns an error, adding a response buffer fixes that.

Removed line 794: `probe.command(RemoteCommand::GetVoltage).ok();`
Removed line 796: `probe.command(RemoteCommand::GetSpeedKhz).ok();`
I believe these lines do nothing, as the result is never used and the functions seem to have no side effect. They have been there since the initial support for Black Magic probe was added. I didn't notice any difference in functionality after removing these lines. Maybe @xobs (as the original author) has more insight.

Tested with Black Magic Probe V2.3c.