### PR TITLE
Flash before DAP

### DIFF
--- a/changelog/changed-debug-launch-cli-flash.md
+++ b/changelog/changed-debug-launch-cli-flash.md
@@ -1,0 +1,1 @@
+`probe-rs debug --launch` flashes with the same `cli::flash` path as `probe-rs run`, including the shared download options and progress UI.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -120,6 +120,11 @@ pub struct Debugger {
     /// end of that session (in [`Self::debug_session_impl`]); `None` in local mode and between
     /// sessions in TCP multi-session mode.
     uploaded_files: Option<UploadedFiles>,
+
+    /// Optional RPC session already attached by the CLI (for example after
+    /// `cli::flash`). When set, [`SessionData::new_rpc_backed`] reuses it
+    /// instead of calling `probe/attach` again.
+    pub(crate) preattached_session: Option<probe_rs_rpc_client::SessionInterface>,
 }
 
 impl Debugger {
@@ -135,6 +140,7 @@ impl Debugger {
             svd_timestamp: None,
             debug_logger: DebugLogger::new(log_file)?,
             uploaded_files: None,
+            preattached_session: None,
         };
 
         debugger
@@ -657,8 +663,13 @@ impl Debugger {
 
         self.config.validate_config_files()?;
 
-        let mut session_data =
-            SessionData::new_rpc_backed(client, &mut self.config, timestamp_offset).await?;
+        let mut session_data = SessionData::new_rpc_backed(
+            client,
+            &mut self.config,
+            timestamp_offset,
+            self.preattached_session.take(),
+        )
+        .await?;
 
         debug_adapter.halt_after_reset = self.config.flashing_config.halt_after_reset;
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -757,7 +757,11 @@ impl SessionData {
             // the RPC server owns the live core and semihosting state. The
             // backend returns UI events (RTT window open, console/RTT output)
             // that we replay on the DAP adapter here.
-            if let Some(_command) = semihosting_command {
+            //
+            // An unhandled command (for example `GetCommandLine` from
+            // embedded-test) leaves the core halted. Call the handler only
+            // on a new halt, otherwise the poll loop warns forever.
+            if semihosting_command.is_some() && previous_core_status != current_core_status {
                 let result = self.backend.handle_semihosting(core_index).await?;
                 for event in result.events {
                     match event {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -26,7 +26,7 @@ use probe_rs_debug::SourceLocation;
 use probe_rs_rpc::breakpoints::SourceBreakpointLocation;
 use probe_rs_rpc::format::FormatKind;
 use probe_rs_rpc::rtt_client::ScanRegion as WireScanRegion;
-use probe_rs_rpc_client::{ResolvedUpload, RpcClient};
+use probe_rs_rpc_client::{ResolvedUpload, RpcClient, SessionInterface};
 use std::{any::Any, env::set_current_dir, path::Path};
 use time::UtcOffset;
 
@@ -91,15 +91,24 @@ impl SessionData {
     /// (name, default image format, core list) are fetched from the server
     /// after attach so the DAP client does not mirror the full target
     /// description locally.
+    ///
+    /// When `preattached` is `Some`, that session is reused and `probe/attach`
+    /// is not called again.
     pub(crate) async fn new_rpc_backed(
         client: &RpcClient,
         config: &mut configuration::SessionConfig,
         timestamp_offset: UtcOffset,
+        preattached: Option<SessionInterface>,
     ) -> Result<Self, DebuggerError> {
-        // Reuse the shared CLI helper: it uploads any user-supplied chip
-        // description, selects a probe, and performs the `probe/attach` RPC.
-        let probe_options = config.probe_options();
-        let session = attach_probe_rpc(client, probe_options, None, false).await?;
+        let session = match preattached {
+            Some(session) => session,
+            None => {
+                // Reuse the shared CLI helper: it uploads any user-supplied chip
+                // description, selects a probe, and performs the `probe/attach` RPC.
+                let probe_options = config.probe_options();
+                attach_probe_rpc(client, probe_options, None, false).await?
+            }
+        };
         let sessid = session.session_key();
 
         let wire_metadata = session.target_metadata().await.map_err(|e| {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
@@ -422,6 +422,7 @@ impl Cmd {
         let (mut rl, writer) =
             Readline::new(Prompt::new(format!("{}> ", debug_client.current_prompt())).to_string())
                 .unwrap();
+        let _prompt_logs = crate::util::logging::install_prompt_writer(writer.clone());
         debug_client.writer = Some(writer);
 
         let readline_result = if server_result.is_some() {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/debug.rs
@@ -30,9 +30,11 @@ use crate::cmd::dap_server::server::configuration::CoreConfig;
 use crate::cmd::dap_server::server::configuration::FlashingConfig;
 use crate::cmd::dap_server::server::configuration::SessionConfig;
 use crate::cmd::dap_server::server::debugger::Debugger;
-use crate::util::cli::{Prompt, probe_rs_color_enabled};
+use crate::util::cli::{self, Prompt, parse_metadata, probe_rs_color_enabled};
+use crate::util::common_options::BinaryDownloadOptions;
 use crate::util::rtt::RttConfig;
 use crate::{CoreOptions, util::common_options::ProbeOptions};
+use probe_rs_rpc::format::FormatOptions;
 use probe_rs_rpc_client::RpcClient;
 
 use super::dap_server::debug_adapter::dap::dap_types::Request;
@@ -199,18 +201,34 @@ pub struct Cmd {
     #[clap(long, help_heading = "LOG CONFIGURATION / RTT")]
     pub no_rtt: bool,
 
-    // TODO: support all options in BinaryDownloadOptions
-    /// Before flashing, read back all the flashed data to skip flashing if the device is up to date.
-    #[arg(long, help_heading = "DOWNLOAD CONFIGURATION")]
-    pub preverify: bool,
-
-    /// After flashing, read back all the flashed data to verify it has been written correctly.
-    #[arg(long, help_heading = "DOWNLOAD CONFIGURATION")]
-    pub verify: bool,
+    #[clap(flatten)]
+    pub download_options: BinaryDownloadOptions,
 }
 
 impl Cmd {
     pub async fn run(self, client: RpcClient, utc_offset: UtcOffset) -> anyhow::Result<()> {
+        let preattached_session = if self.launch {
+            if let Some(path) = &self.binary {
+                let (_file_meta, elf_meta) = parse_metadata(path).await?;
+                let session =
+                    cli::attach_probe(&client, self.common.clone(), elf_meta, false).await?;
+                cli::flash(
+                    &session,
+                    path,
+                    FormatOptions::default(),
+                    self.download_options,
+                    None,
+                    None,
+                )
+                .await?;
+                Some(session)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         let (req_sender, req_receiver) = mpsc::channel(100);
         let (msg_sender, mut msg_receiver) = mpsc::unbounded_channel();
 
@@ -285,9 +303,7 @@ impl Cmd {
                     attach_timeout: self.common.attach_timeout.map(|t| t.as_secs_f64()),
                     allow_erase_all: false,
                     flashing_config: FlashingConfig {
-                        flashing_enabled: self.launch && self.binary.is_some(),
-                        verify_before_flashing: self.preverify,
-                        verify_after_flashing: self.verify,
+                        flashing_enabled: false,
                         ..FlashingConfig::default()
                     },
                     core_configs: vec![CoreConfig {
@@ -331,6 +347,7 @@ impl Cmd {
         // instead of `tokio::spawn`.
         let server = async move {
             let mut debugger = Debugger::new(utc_offset, None)?;
+            debugger.preattached_session = preattached_session;
             debugger
                 .debug_session_rpc(&client, debug_adapter)
                 .await

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/core_ops.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/core_ops.rs
@@ -443,7 +443,7 @@ fn handle_semihosting_impl(
         }
 
         unhandled => {
-            tracing::warn!("Unhandled semihosting command: {:?}", unhandled);
+            tracing::warn!("Unhandled semihosting command: {unhandled}");
             return Ok(CoreStatus::Halted(HaltReason::Breakpoint(
                 BreakpointCause::Semihosting(unhandled),
             )));

--- a/probe-rs-tools/src/bin/probe-rs/util/cli.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/cli.rs
@@ -754,6 +754,8 @@ pub async fn monitor(
             return;
         };
 
+        let _prompt_logs = logging::install_prompt_writer(sw.clone());
+
         context
             .update(|data| data.shared_writer = Some(sw.clone()))
             .await;

--- a/probe-rs-tools/src/bin/probe-rs/util/logging.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/logging.rs
@@ -1,7 +1,8 @@
 use indicatif::MultiProgress;
 use parking_lot::Mutex;
+use rustyline_async::SharedWriter;
 use serde::{Deserialize, Serialize};
-use std::{fs::File, path::Path, sync::LazyLock};
+use std::{fs::File, io::Write, path::Path, sync::LazyLock};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{
     EnvFilter, Layer, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
@@ -9,6 +10,25 @@ use tracing_subscriber::{
 
 /// Stores the progress bar for the logging facility.
 static PROGRESS_BAR: LazyLock<Mutex<Option<MultiProgress>>> = LazyLock::new(|| Mutex::new(None));
+
+/// When a CLI prompt is active, tracing and `eprintln` write through this
+/// rustyline writer so log lines do not overwrite the prompt.
+static PROMPT_WRITER: LazyLock<Mutex<Option<SharedWriter>>> = LazyLock::new(|| Mutex::new(None));
+
+/// Clears [`PROMPT_WRITER`] when the prompt session ends.
+pub struct PromptWriterGuard;
+
+impl Drop for PromptWriterGuard {
+    fn drop(&mut self) {
+        *PROMPT_WRITER.lock() = None;
+    }
+}
+
+/// Route [`eprintln`] / tracing output through `writer` until the guard is dropped.
+pub fn install_prompt_writer(writer: SharedWriter) -> PromptWriterGuard {
+    *PROMPT_WRITER.lock() = Some(writer);
+    PromptWriterGuard
+}
 
 pub struct FileLoggerGuard<'a> {
     _append_guard: WorkerGuard,
@@ -163,7 +183,14 @@ pub fn eprintln(message: impl AsRef<str>) {
             Some(pb) => {
                 let _ = pb.println(message);
             }
-            None => eprintln!("{message}"),
+            None => {
+                let prompt_writer = PROMPT_WRITER.lock().clone();
+                if let Some(mut writer) = prompt_writer {
+                    let _ = writeln!(writer, "{message}");
+                } else {
+                    eprintln!("{message}");
+                }
+            }
         }
     }
     inner(message.as_ref())
@@ -178,7 +205,14 @@ pub fn println(message: impl AsRef<str>) {
             Some(pb) => {
                 let _ = pb.println(message);
             }
-            None => println!("{message}"),
+            None => {
+                let prompt_writer = PROMPT_WRITER.lock().clone();
+                if let Some(mut writer) = prompt_writer {
+                    let _ = writeln!(writer, "{message}");
+                } else {
+                    println!("{message}");
+                }
+            }
         }
     }
     inner(message.as_ref())

--- a/probe-rs/src/semihosting.rs
+++ b/probe-rs/src/semihosting.rs
@@ -103,6 +103,32 @@ impl std::fmt::Display for ExitErrorDetails {
     }
 }
 
+impl std::fmt::Display for SemihostingCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ExitSuccess => write!(f, "SYS_EXIT (success)"),
+            Self::ExitError(details) => write!(f, "SYS_EXIT ({details})"),
+            Self::GetCommandLine(_) => write!(f, "SYS_GET_CMDLINE"),
+            Self::Open(_) => write!(f, "SYS_OPEN"),
+            Self::Close(_) => write!(f, "SYS_CLOSE"),
+            Self::WriteConsole(_) => write!(f, "SYS_WRITEC/SYS_WRITE0"),
+            Self::Write(_) => write!(f, "SYS_WRITE"),
+            Self::Read(_) => write!(f, "SYS_READ"),
+            Self::Seek(_) => write!(f, "SYS_SEEK"),
+            Self::FileLength(_) => write!(f, "SYS_FLEN"),
+            Self::Remove(_) => write!(f, "SYS_REMOVE"),
+            Self::Rename(_) => write!(f, "SYS_RENAME"),
+            Self::Time(_) => write!(f, "SYS_TIME"),
+            Self::Errno(_) => write!(f, "SYS_ERRNO"),
+            Self::Unknown(details) => write!(
+                f,
+                "operation {:#x} with parameter {:#x}",
+                details.operation, details.parameter
+            ),
+        }
+    }
+}
+
 /// Details of a semihosting operation that we don't support yet
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct UnknownCommandDetails {


### PR DESCRIPTION
<img width="1195" height="242" alt="image" src="https://github.com/user-attachments/assets/41be965a-aec4-49b5-8f10-c01799aef7ae" />

debug is now a bit more friendly - we display the usual progress bar (flashing doesn't need to go through the DAP server), and warnings no longer mess up the prompts