### PR TITLE
Compress target db

### DIFF
--- a/changelog/changed-compress-builtin-targets.md
+++ b/changelog/changed-compress-builtin-targets.md
@@ -1,0 +1,1 @@
+Built-in target descriptions are stored zlib-compressed, which reduces the size of the `probe-rs` binary.

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -25,7 +25,7 @@ default = ["builtin-targets", "cmsisdap_v1", "builtin-formats", "coredump"]
 flate2 = ["dep:flate2"]
 
 # Enable all built in targets.
-builtin-targets = ["dep:bincode", "dep:probe-rs-target"]
+builtin-targets = ["dep:bincode", "dep:probe-rs-target", "flate2"]
 cmsisdap_v1 = ["dep:hidapi"]
 
 # Enables the bin, hex, elf image formats
@@ -86,6 +86,7 @@ nix = { version = "0.31", features = ["fs"] }
 
 [build-dependencies]
 probe-rs-target = { workspace = true, optional = true, features = ["bincode"] }
+flate2 = { version = "1.0", optional = true }
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/probe-rs/build.rs
+++ b/probe-rs/build.rs
@@ -41,4 +41,23 @@ fn handle_builtin_targets() {
     }
 
     probe_rs_target::process_targets(&source_paths, &dest_path);
+
+    let raw = std::fs::read(&dest_path).expect("Failed to read serialized targets");
+    let compressed = {
+        use std::io::Write as _;
+
+        let mut encoder =
+            flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder
+            .write_all(&raw)
+            .expect("Failed to compress serialized targets");
+        encoder
+            .finish()
+            .expect("Failed to compress serialized targets")
+    };
+    std::fs::write(
+        Path::new(&out_dir).join("targets.bincode.zlib"),
+        &compressed,
+    )
+    .expect("Failed to write compressed targets");
 }

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -165,9 +165,18 @@ pub fn add_builtin_target(family: ChipFamily) {
 
 #[cfg(feature = "builtin-targets")]
 fn builtin_targets() -> Vec<ChipFamily> {
-    const BUILTIN_TARGETS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/targets.bincode"));
+    use std::io::Read as _;
 
-    bincode::serde::decode_from_slice(BUILTIN_TARGETS, bincode::config::standard())
+    const BUILTIN_TARGETS: &[u8] =
+        include_bytes!(concat!(env!("OUT_DIR"), "/targets.bincode.zlib"));
+
+    let mut decoder = flate2::read::ZlibDecoder::new(BUILTIN_TARGETS);
+    let mut bytes = Vec::new();
+    decoder
+        .read_to_end(&mut bytes)
+        .expect("Failed to decompress builtin targets. This is a bug");
+
+    bincode::serde::decode_from_slice(&bytes, bincode::config::standard())
         .expect("Failed to deserialize builtin targets. This is a bug")
         .0
 }


### PR DESCRIPTION
A small experiment to shrink the binary just a bit. May not be worth it. Removes about 2.5MB for the cost of ~10ms startup time. The CI-built binary contains debuginfo so it's unreasonably large, but debuginfo can easily be `strip`ped after the fact.