### PR TITLE
Check if remote server is compatible with client

### DIFF
--- a/changelog/added-rpc-schema-check.md
+++ b/changelog/added-rpc-schema-check.md
@@ -1,0 +1,1 @@
+The RPC client now fetches the server schema on connect and exits when it does not match the client schema.

--- a/probe-rs-rpc-client/README.md
+++ b/probe-rs-rpc-client/README.md
@@ -13,4 +13,6 @@ probe-rs-rpc-client = { version = "0.1", features = ["remote"] }
 ```
 
 Use `connect` to open a remote session, then call methods on
-`SessionInterface` and `CoreInterface`.
+`SessionInterface` and `CoreInterface`. `connect` fetches the schema of the
+server and returns `ClientError::IncompatibleServer` when it does not match
+the schema of this client.

--- a/probe-rs-rpc-client/src/lib.rs
+++ b/probe-rs-rpc-client/src/lib.rs
@@ -22,6 +22,7 @@ use std::{
     time::Duration,
 };
 
+mod schema;
 mod upload_cache;
 
 use upload_cache::UploadCache;
@@ -127,6 +128,10 @@ pub enum ClientError {
     /// The server does not know this endpoint. The client and the server
     /// versions may differ.
     UnknownEndpoint,
+    /// The RPC schema of the server does not match this client.
+    ///
+    /// Use the same probe-rs version for the client and the server.
+    IncompatibleServer,
     /// The server refused the request.
     #[display("{0}")]
     Remote(RpcError),
@@ -138,7 +143,7 @@ pub enum ClientError {
     FileRead(PathBuf, #[source] std::io::Error),
 }
 
-fn from_host_err(e: HostErr<WireError>) -> ClientError {
+pub(crate) fn from_host_err(e: HostErr<WireError>) -> ClientError {
     match e {
         HostErr::Wire(WireError::UnknownKey) => ClientError::UnknownEndpoint,
         HostErr::Wire(w) => ClientError::Transport(TransportError::Wire(w)),
@@ -160,7 +165,7 @@ async fn rpc_client_from_websocket<S>(
     ws_stream: tokio_tungstenite::WebSocketStream<S>,
     challenge: &str,
     token: Option<&str>,
-) -> Result<RpcClient, TransportError>
+) -> Result<RpcClient, ClientError>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
@@ -182,7 +187,7 @@ where
         TransportError::Message(format!("Failed to send challenge response: {err:?}"))
     })?;
 
-    Ok(RpcClient::new_from_wire(
+    RpcClient::new_from_wire(
         tx,
         WebsocketRx::new(rx.map(|message| {
             message.map(|message| match message {
@@ -190,7 +195,9 @@ where
                 _ => Bytes::new(),
             })
         })),
-    ))
+    )
+    .ensure_compatible()
+    .await
 }
 
 /// Connect to a `probe-rs serve` server.
@@ -262,9 +269,7 @@ pub async fn connect(
         .to_str()
         .map_err(|_| TransportError::Message("Failed to parse challenge header".into()))?;
 
-    rpc_client_from_websocket(ws_stream, challenge, token)
-        .await
-        .map_err(ClientError::Transport)
+    rpc_client_from_websocket(ws_stream, challenge, token).await
 }
 
 #[cfg(all(feature = "remote", unix))]
@@ -281,7 +286,7 @@ pub async fn connect_unix(path: &str) -> Result<RpcClient, ClientError> {
     let tx = UnixStreamTx::new(writer);
     let rx = UnixStreamRx::new(reader);
 
-    Ok(RpcClient::new_from_wire(tx, rx))
+    RpcClient::new_from_wire(tx, rx).ensure_compatible().await
 }
 
 #[cfg(feature = "remote")]
@@ -396,6 +401,37 @@ impl RpcClient {
         let mut this = Self::new_from_wire(tx, rx);
         this.is_localhost = true;
         this
+    }
+
+    /// Fetch the schema of the server and refuse to continue when it does
+    /// not match the schema of this client.
+    pub async fn ensure_compatible(self) -> Result<Self, ClientError> {
+        self.check_compatibility().await?;
+        Ok(self)
+    }
+
+    /// Fetch the schema of the server and compare it with the schema of this
+    /// client.
+    pub async fn check_compatibility(&self) -> Result<(), ClientError> {
+        let expected = schema::expected_schema_report()?;
+        let actual = self
+            .client
+            .get_schema_report()
+            .await
+            .map_err(schema::from_schema_err)?;
+
+        if schema::schema_reports_match(&expected, &actual) {
+            Ok(())
+        } else {
+            tracing::error!(
+                expected_endpoints = expected.endpoints.len(),
+                actual_endpoints = actual.endpoints.len(),
+                expected_types = expected.types.len(),
+                actual_types = actual.types.len(),
+                "RPC schema of the server does not match this client"
+            );
+            Err(ClientError::IncompatibleServer)
+        }
     }
 
     async fn send<E, T>(&self, req: &E::Request) -> Result<T, ClientError>

--- a/probe-rs-rpc-client/src/schema.rs
+++ b/probe-rs-rpc-client/src/schema.rs
@@ -1,0 +1,100 @@
+use postcard_rpc::Key;
+use postcard_rpc::host_client::{HostErr, SchemaError, SchemaReport, TopicReport};
+use postcard_rpc::standard_icd::WireError;
+use postcard_schema::schema::owned::OwnedNamedType;
+use probe_rs_rpc::{ENDPOINT_LIST, TOPICS_IN_LIST, TOPICS_OUT_LIST};
+
+use crate::{ClientError, TransportError, from_host_err};
+
+/// Schema the client implements, including postcard-rpc standard endpoints
+/// and topics that the `endpoints!` / `topics!` macros merge in.
+pub fn expected_schema_report() -> Result<SchemaReport, ClientError> {
+    let mut report = SchemaReport::default();
+
+    for ty in ENDPOINT_LIST
+        .types
+        .iter()
+        .chain(TOPICS_IN_LIST.types)
+        .chain(TOPICS_OUT_LIST.types)
+    {
+        report.add_type(OwnedNamedType::from(*ty));
+    }
+
+    for (path, req_key, resp_key) in ENDPOINT_LIST.endpoints {
+        report
+            .add_endpoint((*path).into(), *req_key, *resp_key)
+            .map_err(|_| schema_build_error())?;
+    }
+
+    for (path, key) in TOPICS_IN_LIST.topics {
+        report
+            .add_topic_in((*path).into(), *key)
+            .map_err(|_| schema_build_error())?;
+    }
+
+    for (path, key) in TOPICS_OUT_LIST.topics {
+        report
+            .add_topic_out((*path).into(), *key)
+            .map_err(|_| schema_build_error())?;
+    }
+
+    Ok(report)
+}
+
+/// Compare the schema of the client with the schema of the server.
+///
+/// [`SchemaReport`] stores a named type on each endpoint and topic by
+/// searching the type set for a matching key. Two types can hash to the same
+/// key, so that lookup is not unique. The type set together with the path and
+/// key of each endpoint and topic is the schema on the wire.
+pub fn schema_reports_match(expected: &SchemaReport, actual: &SchemaReport) -> bool {
+    expected.types == actual.types
+        && endpoint_keys(expected) == endpoint_keys(actual)
+        && topic_keys(&expected.topics_in) == topic_keys(&actual.topics_in)
+        && topic_keys(&expected.topics_out) == topic_keys(&actual.topics_out)
+}
+
+pub fn from_schema_err(error: SchemaError<WireError>) -> ClientError {
+    match error {
+        SchemaError::Comms(HostErr::Wire(WireError::UnknownKey)) => ClientError::IncompatibleServer,
+        SchemaError::Comms(error) => from_host_err(error),
+        SchemaError::TaskError | SchemaError::InvalidReportData | SchemaError::LostData => {
+            ClientError::IncompatibleServer
+        }
+    }
+}
+
+fn endpoint_keys(report: &SchemaReport) -> Vec<(&str, Key, Key)> {
+    let mut keys: Vec<_> = report
+        .endpoints
+        .iter()
+        .map(|endpoint| (endpoint.path.as_str(), endpoint.req_key, endpoint.resp_key))
+        .collect();
+    keys.sort_unstable();
+    keys
+}
+
+fn topic_keys(topics: &[TopicReport]) -> Vec<(&str, Key)> {
+    let mut keys: Vec<_> = topics
+        .iter()
+        .map(|topic| (topic.path.as_str(), topic.key))
+        .collect();
+    keys.sort_unstable();
+    keys
+}
+
+fn schema_build_error() -> ClientError {
+    ClientError::Transport(TransportError::Message(
+        "Failed to build the client RPC schema".into(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expected_schema_report;
+
+    #[test]
+    fn client_schema_report_resolves() {
+        expected_schema_report().expect("client ICD maps must resolve to named types");
+    }
+}

--- a/probe-rs-rpc/README.md
+++ b/probe-rs-rpc/README.md
@@ -6,10 +6,11 @@ probe-rs RPC protocol. The `probe-rs-rpc-client` crate and the
 
 ## Version compatibility
 
-The protocol is not stable between releases. postcard-rpc keys each endpoint
-by a hash of its path and its schemas. A client that talks to a server of
-a different version gets an unknown endpoint error, not corrupt data. See
-`ClientError::UnknownEndpoint` in the `probe-rs-rpc-client` crate.
+The protocol is not stable between releases. On connect, the client fetches
+the schema of the server and compares it with the schema of the client. A
+mismatch ends the session with `ClientError::IncompatibleServer`. postcard-rpc
+also keys each endpoint by a hash of its path and its schemas, so a later
+unknown endpoint cannot corrupt data.
 
 ## Usage
 

--- a/probe-rs-tools/src/bin/probe-rs/rpc/client_tests.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/client_tests.rs
@@ -27,3 +27,22 @@ async fn local_resolve_upload_tracks_content_changes() {
     assert_ne!(first.content_hash, second.content_hash);
     assert_eq!(first.remote_path, second.remote_path);
 }
+
+#[tokio::test]
+async fn local_server_schema_matches_the_client() {
+    let (server, tx, rx) = RpcApp::create_server(
+        16,
+        ProbeAccess::All,
+        Arc::new(crate::rpc::probe_broker::ProbeBroker::new()),
+    );
+    let handle = tokio::spawn(async move { server.run().await });
+    let client = RpcClient::new_local_from_wire(tx, rx);
+
+    client
+        .check_compatibility()
+        .await
+        .expect("the in-process server must match the client schema");
+
+    drop(client);
+    let _ = handle.await;
+}


### PR DESCRIPTION
Resolves #3326 by checking for compatibility. If the schemas mismatch, probe-rs refuses to work with the server, and the user will need to update. Not ideal, but the reality is that current postcard-rpc is limited in what it can do for us. We have techniques to mitigate the breakages, but at least it will be obvious now.