### PR TITLE
P4: Use sysbus access for uncached RAM

### DIFF
--- a/probe-rs-espressif/src/sequences/esp32p4.rs
+++ b/probe-rs-espressif/src/sequences/esp32p4.rs
@@ -180,7 +180,7 @@ impl ESP32P4 {
                 memory_access_config.set_region_override(
                     access,
                     0x8ff0_0000..0x8ffc_0000,
-                    MemoryAccessMethod::ProgramBuffer,
+                    MemoryAccessMethod::SystemBus,
                 );
                 // CPU peripherals
                 memory_access_config.set_region_override(


### PR DESCRIPTION
For some reason, trying to access cached memory via sysbus freezes tests, but flashing (which uses the uncached address range) works just fine - so maybe we can just keep it for the flashing speed gains. Needs a bit of testing