### PR TITLE
Various debugger tweaks

### DIFF
--- a/changelog/changed-debugger-stack-frame-info.md
+++ b/changelog/changed-debugger-stack-frame-info.md
@@ -1,0 +1,1 @@
+`probe-rs-debug`: `StackFrameInfo` is now passed by reference to public functions.

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -2126,7 +2126,7 @@ mod test {
             &debug_info,
             &mut adapter,
             10,
-            StackFrameInfo {
+            &StackFrameInfo {
                 registers: &initial_registers,
                 frame_base: None,
                 canonical_frame_address: None,

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -47,7 +47,7 @@ pub struct DebugInfo {
     ///
     /// Wrapped in a [`Mutex`] because `addr2line::Loader` is `Send` but not
     /// `Sync`, while [`DebugInfo`] must be both so an RPC server can share it.
-    pub(crate) addr2line: Option<Mutex<addr2line::Loader>>,
+    pub(crate) addr2line: Option<Mutex<Box<addr2line::Loader>>>,
 }
 
 impl DebugInfo {
@@ -56,7 +56,10 @@ impl DebugInfo {
         let data = std::fs::read(path.as_ref())?;
 
         let mut this = DebugInfo::from_raw(&data)?;
-        this.addr2line = addr2line::Loader::new(path).ok().map(Mutex::new);
+        this.addr2line = addr2line::Loader::new(path)
+            .ok()
+            .map(Box::new)
+            .map(Mutex::new);
         Ok(this)
     }
 

--- a/probe-rs-debug/src/debug_info.rs
+++ b/probe-rs-debug/src/debug_info.rs
@@ -292,7 +292,7 @@ impl DebugInfo {
         cache: &mut VariableCache,
         memory: &mut dyn MemoryInterface,
         parent_variable: &mut Variable,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         if !parent_variable.is_valid() {
             // Do nothing. The parent_variable.get_value() will already report back the debug_error value.
@@ -453,7 +453,7 @@ impl DebugInfo {
         let frame_base = functions[0].frame_base(
             self,
             memory,
-            StackFrameInfo {
+            &StackFrameInfo {
                 registers: unwind_registers,
                 frame_base: None,
                 canonical_frame_address: cfa,
@@ -2088,7 +2088,7 @@ mod test {
                     &debug_info,
                     &mut adapter,
                     10,
-                    StackFrameInfo {
+                    &StackFrameInfo {
                         registers: &frame.registers,
                         frame_base: frame.frame_base,
                         canonical_frame_address: frame.canonical_frame_address,

--- a/probe-rs-debug/src/function_die.rs
+++ b/probe-rs-debug/src/function_die.rs
@@ -272,7 +272,7 @@ impl<'a> FunctionDie<'a> {
         &self,
         debug_info: &super::DebugInfo,
         memory: &mut dyn MemoryInterface,
-        frame_info: StackFrameInfo,
+        frame_info: &StackFrameInfo,
     ) -> Result<Option<u64>, DebugError> {
         match self.unit_info.extract_location(
             debug_info,

--- a/probe-rs-debug/src/language.rs
+++ b/probe-rs-debug/src/language.rs
@@ -135,7 +135,7 @@ pub trait ProgrammingLanguage {
         _variable: &mut Variable,
         _memory: &mut dyn MemoryInterface,
         _cache: &mut VariableCache,
-        _frame_info: StackFrameInfo<'_>,
+        _frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         Ok(())
     }

--- a/probe-rs-debug/src/language/rust/mod.rs
+++ b/probe-rs-debug/src/language/rust/mod.rs
@@ -1031,7 +1031,7 @@ impl RustPath {
     }
 
     fn from_named(named: &crate::NamedType) -> Option<Self> {
-        let mut namespaces = named.namespace.clone();
+        let mut namespaces = named.namespace.to_vec();
         if namespaces.is_empty() {
             return None;
         }

--- a/probe-rs-debug/src/language/rust/mod.rs
+++ b/probe-rs-debug/src/language/rust/mod.rs
@@ -116,7 +116,7 @@ impl Rust {
         variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         let Some(path) = RustPath::from_die(unit_info, debug_info, node) else {
             return Ok(());
@@ -179,7 +179,7 @@ impl Rust {
         variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         let Some(path) = RustPath::from_die(unit_info, debug_info, node) else {
             return Ok(());
@@ -273,7 +273,7 @@ impl Rust {
         scope: &Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         let params: Vec<_> = cache.get_children(scope.variable_key).cloned().collect();
         let Some(env_param) = params
@@ -406,7 +406,7 @@ impl Rust {
         debug_info: &DebugInfo,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         mut current: Variable,
     ) -> Result<Option<Variable>, DebugError> {
         for _ in 0..8 {
@@ -451,7 +451,7 @@ impl Rust {
         debug_info: &DebugInfo,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         mut env: Variable,
     ) -> Result<Option<Variable>, DebugError> {
         debug_info.cache_deferred_variables(cache, memory, &mut env, frame_info)?;
@@ -480,7 +480,7 @@ impl Rust {
         debug_info: &DebugInfo,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         mut buffer: Variable,
     ) -> Result<Option<Variable>, DebugError> {
         // Walk down a few levels to cover both old and new heapless::Vec layouts
@@ -513,7 +513,7 @@ impl Rust {
         debug_info: &DebugInfo,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         element: &mut Variable,
     ) -> Result<(), DebugError> {
         self.unwrap_maybe_uninit_slot(debug_info, memory, cache, frame_info, element)?;
@@ -551,7 +551,7 @@ impl Rust {
         debug_info: &DebugInfo,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         element: &mut Variable,
     ) -> Result<(), DebugError> {
         debug_info.cache_deferred_variables(cache, memory, element, frame_info)?;
@@ -610,7 +610,7 @@ impl Rust {
         variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         let Some(slice) = Self::try_get_slice(variable, cache) else {
             return Ok(());
@@ -843,7 +843,7 @@ impl ProgrammingLanguage for Rust {
         variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         if variable
             .type_name

--- a/probe-rs-debug/src/language/rust/type_name.rs
+++ b/probe-rs-debug/src/language/rust/type_name.rs
@@ -138,9 +138,9 @@ impl<'a> Parser<'a> {
             }
         } else {
             Some(VariableType::Struct(NamedType {
-                ident: String::new(),
-                namespace: Vec::new(),
-                args,
+                ident: String::new().into_boxed_str(),
+                namespace: Box::new([]),
+                args: args.into_boxed_slice(),
             }))
         }
     }
@@ -180,9 +180,9 @@ impl<'a> Parser<'a> {
             }
         }
         Some(VariableType::Struct(NamedType {
-            ident: "dyn".to_string(),
-            namespace: Vec::new(),
-            args,
+            ident: "dyn".to_string().into_boxed_str(),
+            namespace: Box::new([]),
+            args: args.into_boxed_slice(),
         }))
     }
 
@@ -226,9 +226,9 @@ impl<'a> Parser<'a> {
             args.push(GenericArg::Type(self.parse_type()?));
         }
         Some(VariableType::Struct(NamedType {
-            ident,
-            namespace: Vec::new(),
-            args,
+            ident: ident.into_boxed_str(),
+            namespace: Box::new([]),
+            args: args.into_boxed_slice(),
         }))
     }
 
@@ -281,9 +281,9 @@ impl<'a> Parser<'a> {
         }
 
         Some(VariableType::Struct(NamedType {
-            ident,
-            namespace: segments,
-            args,
+            ident: ident.into_boxed_str(),
+            namespace: segments.into_boxed_slice(),
+            args: args.into_boxed_slice(),
         }))
     }
 
@@ -401,9 +401,9 @@ impl AsPrefix for char {
 
 fn prefix_type(ident: &str, inner: VariableType) -> VariableType {
     VariableType::Struct(NamedType {
-        ident: ident.to_string(),
-        namespace: Vec::new(),
-        args: vec![GenericArg::Type(inner)],
+        ident: ident.to_string().into_boxed_str(),
+        namespace: Box::new([]),
+        args: Box::new([GenericArg::Type(inner)]),
     })
 }
 
@@ -723,8 +723,8 @@ pub(crate) fn synthesise_async_name(segments: &[impl AsRef<str>]) -> Option<Stri
 fn synthesise_async_type(ty: &VariableType) -> Option<String> {
     match ty {
         VariableType::Struct(named) | VariableType::Enum(named) => {
-            let mut segments = named.namespace.clone();
-            segments.push(named.ident.clone());
+            let mut segments = named.namespace.to_vec();
+            segments.push(named.ident.to_string());
             synthesise_async_name(&segments)
         }
         VariableType::Pointer(Some(inner)) => synthesise_async_type(inner),
@@ -760,8 +760,8 @@ pub(crate) fn synthesise_closure_name(segments: &[impl AsRef<str>]) -> Option<St
 fn synthesise_closure_type(ty: &VariableType) -> Option<String> {
     match ty {
         VariableType::Struct(named) | VariableType::Enum(named) => {
-            let mut segments = named.namespace.clone();
-            segments.push(named.ident.clone());
+            let mut segments = named.namespace.to_vec();
+            segments.push(named.ident.to_string());
             synthesise_closure_name(&segments)
         }
         VariableType::Pointer(Some(inner)) => synthesise_closure_type(inner),

--- a/probe-rs-debug/src/language/rust/type_name.rs
+++ b/probe-rs-debug/src/language/rust/type_name.rs
@@ -996,8 +996,8 @@ mod tests {
     fn option_with_a_qualified_argument_splits_into_ident_and_args() {
         let named = parse_named_type("Option<esp_hal::soc::implementation::clocks::XtalClkConfig>")
             .unwrap();
-        assert_eq!(named.ident, "Option");
-        assert_eq!(named.namespace, [] as [String; 0]);
+        assert_eq!(named.ident.as_ref(), "Option");
+        assert_eq!(named.namespace.as_ref(), [] as [String; 0]);
         assert_eq!(
             named.display(&rust(), TypeNameStyle::Compact),
             "Option<XtalClkConfig>"
@@ -1036,7 +1036,7 @@ mod tests {
     #[test]
     fn a_mut_slice_pointer_keeps_the_pointer_syntax() {
         let named = parse_named_type("*mut [core::mem::maybe_uninit::MaybeUninit<u32>]").unwrap();
-        assert_eq!(named.ident, "*mut");
+        assert_eq!(named.ident.as_ref(), "*mut");
         assert_eq!(
             named.display(&rust(), TypeNameStyle::Compact),
             "*mut [MaybeUninit<u32>]"

--- a/probe-rs-debug/src/unit_info.rs
+++ b/probe-rs-debug/src/unit_info.rs
@@ -253,7 +253,7 @@ impl UnitInfo {
         child_variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         // Identify the parent.
         child_variable.parent_key = parent_variable.variable_key;
@@ -524,7 +524,7 @@ impl UnitInfo {
         tree_node: &gimli::DebuggingInformationEntry<GimliReader>,
         attributes_entry: Option<&gimli::DebuggingInformationEntry<GimliReader>>,
         child_variable: &mut Variable,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         let die = if tree_node.attr(gimli::DW_AT_start_scope).is_some() {
             tree_node
@@ -549,7 +549,7 @@ impl UnitInfo {
         &self,
         debug_info: &DebugInfo,
         die: &gimli::DebuggingInformationEntry<GimliReader>,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<bool, DebugError> {
         let Some(attr) = die.attr(gimli::DW_AT_start_scope) else {
             return Ok(true);
@@ -605,7 +605,7 @@ impl UnitInfo {
         parent_variable: &Variable,
         child_variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         cache: &mut VariableCache,
     ) -> Result<(), DebugError> {
         // Reference to a type, or an entry to another type or a type modifier which will point to another type.
@@ -651,7 +651,7 @@ impl UnitInfo {
         parent_key: crate::ObjectRef,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         enum Job {
             /// The compilation unit or a namespace whose children should be walked.
@@ -766,7 +766,7 @@ impl UnitInfo {
         parent_key: crate::ObjectRef,
         die_offset: UnitOffset,
         memory: &mut dyn MemoryInterface,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         let Some(mut parent_variable) = cache.get_variable_by_key(parent_key) else {
             return Err(DebugError::Other(
@@ -824,7 +824,7 @@ impl UnitInfo {
         parent_variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         if !parent_variable.is_valid() {
             cache.update_variable(parent_variable)?;
@@ -958,7 +958,7 @@ impl UnitInfo {
         parent_variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         child_node: gimli::EntriesTreeNode<GimliReader>,
     ) -> Result<(), DebugError> {
         let mut child_variable = cache.create_variable(parent_variable.variable_key, Some(self))?;
@@ -1004,7 +1004,7 @@ impl UnitInfo {
         parent_variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         child_node: gimli::EntriesTreeNode<GimliReader>,
     ) -> Result<(), DebugError> {
         let mut child_variable = cache.create_variable(parent_variable.variable_key, Some(self))?;
@@ -1036,7 +1036,7 @@ impl UnitInfo {
         parent_variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         default_variant: &mut Option<UnitOffset>,
         child_node: gimli::EntriesTreeNode<GimliReader>,
     ) -> Result<(), DebugError> {
@@ -1074,7 +1074,7 @@ impl UnitInfo {
         parent_variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         child_node: gimli::EntriesTreeNode<GimliReader>,
     ) -> Result<(), DebugError> {
         let Some(program_counter) = frame_info
@@ -1116,7 +1116,7 @@ impl UnitInfo {
         parent_variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         child_node: gimli::EntriesTreeNode<GimliReader>,
     ) -> Result<(), DebugError> {
         let variable_name =
@@ -1163,7 +1163,7 @@ impl UnitInfo {
         child_variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         self.process_tree_node_attributes(
             debug_info,
@@ -1352,7 +1352,7 @@ impl UnitInfo {
         child_variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         let type_name = match self.extract_type_name(debug_info, node) {
             Ok(name) => name,
@@ -1645,7 +1645,7 @@ impl UnitInfo {
         child_variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         let type_name = type_name.unwrap_or_else(|| "<unnamed struct>".to_string());
         let mut visiting = HashSet::new();
@@ -1717,7 +1717,7 @@ impl UnitInfo {
         variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         cache: &mut VariableCache,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         self.language
             .process_struct(self, debug_info, node, variable, memory, cache, frame_info)
@@ -1731,7 +1731,7 @@ impl UnitInfo {
         parent_variable: &Variable,
         child_variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
-        frame_info: StackFrameInfo,
+        frame_info: &StackFrameInfo,
         cache: &mut VariableCache,
     ) -> Result<(), DebugError> {
         let subranges = match self.extract_array_range(node.offset()) {
@@ -1799,7 +1799,7 @@ impl UnitInfo {
         node: &DebuggingInformationEntry<GimliReader>,
         parent_variable: &Variable,
         memory: &mut dyn MemoryInterface,
-        frame_info: StackFrameInfo,
+        frame_info: &StackFrameInfo,
     ) -> Result<(), DebugError> {
         let mut visiting = HashSet::new();
         if let Some(offset) = node.offset().to_debug_info_offset(&self.unit.header) {
@@ -1948,7 +1948,7 @@ impl UnitInfo {
         array_variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
         subranges: &[Range<u64>],
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         let Some((current_range, remaining_ranges)) = subranges.split_first() else {
             array_variable.set_value(VariableValue::Error(
@@ -2044,7 +2044,7 @@ impl UnitInfo {
         parent_variable: &Variable,
         child_variable: &mut Variable,
         memory: &mut dyn MemoryInterface,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
         // The `byte_size` is used for arrays, etc. to offset the memory location of the next element.
         // For nested arrays, the `byte_size` may need to be calculated as the product of the `byte_size` and array upper bound.
@@ -2126,7 +2126,7 @@ impl UnitInfo {
         parent_location: &VariableLocation,
         byte_size: Option<u64>,
         memory: &mut dyn MemoryInterface,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<ExpressionResult, DebugError> {
         trait ResultExt {
             /// Turns UnwindIncompleteResults into Unavailable locations
@@ -2224,7 +2224,7 @@ impl UnitInfo {
         &self,
         debug_info: &DebugInfo,
         location_list_offset: gimli::LocationListsOffset,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         memory: &mut dyn MemoryInterface,
     ) -> Result<ExpressionResult, DebugError> {
         let mut locations = match debug_info.dwarf.locations(&self.unit, location_list_offset) {
@@ -2281,7 +2281,7 @@ impl UnitInfo {
         debug_info: &DebugInfo,
         memory: &mut dyn MemoryInterface,
         expression: gimli::Expression<GimliReader>,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<ExpressionResult, DebugError> {
         fn evaluate_address(address: u64, memory: &mut dyn MemoryInterface) -> ExpressionResult {
             let location = if address >= u32::MAX as u64 && !memory.supports_native_64bit_access() {
@@ -2347,7 +2347,7 @@ impl UnitInfo {
     fn assemble_pieces(
         &self,
         pieces: &[gimli::Piece<GimliReader, usize>],
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) -> Result<ExpressionResult, DebugError> {
         let mut location_pieces = Vec::with_capacity(pieces.len());
 
@@ -2400,7 +2400,7 @@ impl UnitInfo {
         debug_info: &DebugInfo,
         memory: &mut dyn MemoryInterface,
         expression: gimli::Expression<GimliReader>,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         entry_value_depth: u8,
     ) -> Result<Vec<gimli::Piece<GimliReader, usize>>, DebugError> {
         let mut evaluation = expression.evaluation(self.unit.encoding());
@@ -2450,7 +2450,7 @@ impl UnitInfo {
         debug_info: &DebugInfo,
         memory: &mut dyn MemoryInterface,
         inner: gimli::Expression<GimliReader>,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         entry_value_depth: u8,
     ) -> Result<gimli::Value, DebugError> {
         if entry_value_depth >= 4 {
@@ -2474,11 +2474,11 @@ impl UnitInfo {
                 debug_info,
                 memory,
                 expression,
-                *caller,
+                caller,
                 entry_value_depth + 1,
             )
         } else {
-            self.expression_to_value(debug_info, memory, inner, *caller, entry_value_depth + 1)
+            self.expression_to_value(debug_info, memory, inner, caller, entry_value_depth + 1)
         }
     }
 
@@ -2487,7 +2487,7 @@ impl UnitInfo {
         debug_info: &DebugInfo,
         memory: &mut dyn MemoryInterface,
         expression: gimli::Expression<GimliReader>,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
         entry_value_depth: u8,
     ) -> Result<gimli::Value, DebugError> {
         let mut evaluation = expression.evaluation(self.unit.encoding());
@@ -3282,7 +3282,7 @@ fn expression_bytes(expression: &gimli::Expression<GimliReader>) -> Option<Vec<u
 
 fn pieces_to_value(
     pieces: &[gimli::Piece<GimliReader, usize>],
-    frame_info: StackFrameInfo<'_>,
+    frame_info: &StackFrameInfo<'_>,
 ) -> Result<gimli::Value, DebugError> {
     let [piece] = pieces else {
         return Err(DebugError::WarnAndContinue {

--- a/probe-rs-debug/src/unit_info.rs
+++ b/probe-rs-debug/src/unit_info.rs
@@ -2787,9 +2787,9 @@ impl UnitInfo {
         match node.tag() {
             gimli::DW_TAG_structure_type => VariableType::Struct(named),
             gimli::DW_TAG_enumeration_type => VariableType::Enum(named),
-            gimli::DW_TAG_base_type => VariableType::Base(named.ident),
-            gimli::DW_TAG_pointer_type => self.pointer_from_name(Some(named.ident)),
-            _ => VariableType::Other(named.ident),
+            gimli::DW_TAG_base_type => VariableType::Base(named.ident.to_string()),
+            gimli::DW_TAG_pointer_type => self.pointer_from_name(Some(named.ident.to_string())),
+            _ => VariableType::Other(named.ident.to_string()),
         }
     }
 

--- a/probe-rs-debug/src/unit_info.rs
+++ b/probe-rs-debug/src/unit_info.rs
@@ -838,212 +838,59 @@ impl UnitInfo {
         while let Some(child_node) = child_nodes.next()? {
             match child_node.entry().tag() {
                 gimli::DW_TAG_namespace => {
-                    let variable_name = if let Ok(Some(name)) =
-                        extract_name(debug_info, &self.unit, child_node.entry())
-                    {
-                        VariableName::Namespace(name)
-                    } else {
-                        VariableName::AnonymousNamespace
-                    };
-
-                    // See if this namespace already exists in the cache.
-                    let mut namespace_variable = if let Some(existing_var) = cache
-                        .get_variable_by_name_and_parent(
-                            &variable_name,
-                            parent_variable.variable_key,
-                        ) {
-                        existing_var
-                    } else {
-                        let mut namespace_variable = Variable::new(Some(self));
-
-                        namespace_variable.name = variable_name;
-                        namespace_variable.type_name = VariableType::Namespace;
-                        namespace_variable.memory_location = VariableLocation::Unavailable;
-                        cache
-                            .add_variable(parent_variable.variable_key, &mut namespace_variable)?;
-
-                        namespace_variable
-                    };
-
-                    // Recurse for additional namespace variables.
-                    self.process_tree(
+                    self.process_namespace(
                         debug_info,
-                        child_node,
-                        &mut namespace_variable,
+                        parent_variable,
                         memory,
                         cache,
                         frame_info,
+                        child_node,
                     )?;
-
-                    // Do not keep empty namespaces around
-                    if !cache.has_children(&namespace_variable) {
-                        cache.remove_cache_entry(namespace_variable.variable_key)?;
-                    }
                 }
 
                 gimli::DW_TAG_formal_parameter | gimli::DW_TAG_variable | gimli::DW_TAG_member => {
-                    // This branch handles:
-                    //  - Parameters to functions.
-                    //  - Typical top-level variables.
-                    //  - Members of structured types.
-                    //  - Possible values for enumerators, used by extract_type() when processing DW_TAG_enumeration_type.
-                    let mut child_variable =
-                        cache.create_variable(parent_variable.variable_key, Some(self))?;
-                    self.process_tree_node_attributes(
+                    self.process_variable(
                         debug_info,
-                        child_node.entry(),
                         parent_variable,
-                        &mut child_variable,
                         memory,
                         cache,
                         frame_info,
+                        child_node,
                     )?;
-
-                    // In the case of C code, we can have entries for both the declaration and the definition of a variable.
-                    // We don't do anything with the declaration right now, so we remove it from the cache.
-                    let is_declaration = if let Some(AttributeValue::Flag(value)) =
-                        child_node.entry().attr_value(gimli::DW_AT_declaration)
-                    {
-                        value
-                    } else {
-                        false
-                    };
-
-                    // Do not keep or process PhantomData nodes, or variant parts that we have already used.
-                    if is_declaration
-                        || child_variable.type_name.is_phantom_data()
-                        || child_variable.name == VariableName::Artificial
-                    {
-                        cache.remove_cache_entry(child_variable.variable_key)?;
-                    } else if child_variable.is_valid() {
-                        // Recursively process each child.
-                        self.process_tree(
-                            debug_info,
-                            child_node,
-                            &mut child_variable,
-                            memory,
-                            cache,
-                            frame_info,
-                        )?;
-                    }
                 }
                 gimli::DW_TAG_variant_part => {
-                    // We need to recurse through the children, to find the DW_TAG_variant with discriminant matching
-                    // the DW_TAG_variant, and ONLY add it's children to the parent variable.
-                    // The structure looks like this (there are other nodes in the structure that we use and discard
-                    // before we get here):
-                    // Level 1: --> An actual variable that has a variant value
-                    //      Level 2: --> this DW_TAG_variant_part node (some child nodes are used to calc the active
-                    //                   Variant discriminant)
-                    //          Level 3: --> Some DW_TAG_variant's that have discriminant values to be matched against
-                    //                       the discriminant
-                    //              Level 4: --> The actual variables, with matching discriminant, which will be added
-                    //                           to `parent_variable`
-                    // TODO: Handle Level 3 nodes that belong to a DW_AT_discr_list, instead of having a discreet
-                    // DW_AT_discr_value
-                    let mut child_variable =
-                        cache.create_variable(parent_variable.variable_key, Some(self))?;
-                    // To determine the discriminant, we use the following rules:
-                    // - If there is no DW_AT_discr, then there will be a single DW_TAG_variant, and this will be the
-                    //   matching value. In the code here, we assign a default value of u64::MAX to both, so that they
-                    //   will be matched as belonging together (https://dwarfstd.org/ShowIssue.php?issue=180517.2)
-                    // - TODO: The [DWARF] standard, 5.7.10, allows for a case where there is no DW_AT_discr attribute,
-                    //   but a DW_AT_type to represent the tag. I have not seen that generated from RUST yet.
-                    // - If there is a DW_AT_discr that has a value, then this is a reference to the member entry for
-                    //   the discriminant. This value will be resolved to match against the appropriate DW_TAG_variant.
-                    // - TODO: The [DWARF] standard, 5.7.10, allows for a DW_AT_discr_list, but I have not seen that
-                    //   generated from RUST yet.
-                    parent_variable.role = VariantRole::VariantPart(u64::MAX);
-                    self.process_tree_node_attributes(
+                    self.process_variant_part(
                         debug_info,
-                        child_node.entry(),
                         parent_variable,
-                        &mut child_variable,
                         memory,
                         cache,
                         frame_info,
-                    )?;
-                    // At this point we have everything we need (It has updated the parent's `role`) from the
-                    // child_variable, so eliminate it before we continue ...
-                    cache.remove_cache_entry(child_variable.variable_key)?;
-                    self.process_tree(
-                        debug_info,
                         child_node,
-                        parent_variable,
-                        memory,
-                        cache,
-                        frame_info,
                     )?;
                 }
 
                 // Variant is a child of a structure, and one of them should have a discriminant value to match the
                 // DW_TAG_variant_part
                 gimli::DW_TAG_variant => {
-                    // We only need to do this if we have not already found our variant.
-                    // The default variant (no DW_AT_discr_value) matches every discriminant that has
-                    // no exact variant. Process it after the other variants, so that a niche of 0 on a
-                    // reference type is None, not Some with a null pointer.
-                    if !cache.has_children(parent_variable) {
-                        let mut child_variable =
-                            cache.create_variable(parent_variable.variable_key, Some(self))?;
-                        self.extract_variant_discriminant(&child_node, &mut child_variable)?;
-                        if let VariantRole::Variant(discriminant) = child_variable.role {
-                            if parent_variable.role == VariantRole::VariantPart(discriminant) {
-                                self.process_variant(
-                                    debug_info,
-                                    child_node,
-                                    parent_variable,
-                                    &mut child_variable,
-                                    memory,
-                                    cache,
-                                    frame_info,
-                                )?;
-                            } else {
-                                if discriminant == u64::MAX {
-                                    default_variant = Some(child_node.entry().offset());
-                                }
-                                cache.remove_cache_entry(child_variable.variable_key)?;
-                            }
-                        } else {
-                            cache.remove_cache_entry(child_variable.variable_key)?;
-                        }
-                    }
+                    self.process_variant_node(
+                        debug_info,
+                        parent_variable,
+                        memory,
+                        cache,
+                        frame_info,
+                        &mut default_variant,
+                        child_node,
+                    )?;
                 }
                 gimli::DW_TAG_lexical_block => {
-                    let Some(program_counter) = frame_info
-                        .registers
-                        .get_program_counter()
-                        .and_then(|reg| reg.value)
-                    else {
-                        return Err(DebugError::WarnAndContinue {
-                            message:
-                                "Cannot unwind `Variable` without a valid PC (program_counter)"
-                                    .to_string(),
-                        });
-                    };
-                    let program_counter = program_counter.try_into()?;
-                    let in_scope = die_contains_pc(
+                    self.process_lexical_block(
                         debug_info,
-                        &self.unit,
-                        child_node.entry(),
-                        program_counter,
+                        parent_variable,
+                        memory,
+                        cache,
+                        frame_info,
+                        child_node,
                     )?;
-                    if in_scope {
-                        // This is IN scope.
-                        // Recursively process each child, but pass the parent_variable, so that we don't create
-                        // intermediate nodes for scope identifiers.
-                        self.process_tree(
-                            debug_info,
-                            child_node,
-                            parent_variable,
-                            memory,
-                            cache,
-                            frame_info,
-                        )?;
-                    } else {
-                        // This lexical block is NOT in scope, but other children of this parent may well be in scope,
-                        // so do NOT invalidate the parent_variable.
-                    }
                 }
                 gimli::DW_TAG_template_type_parameter => {
                     // The parent node for Rust generic type parameter
@@ -1102,6 +949,207 @@ impl UnitInfo {
         parent_variable.extract_value(memory, cache);
         cache.update_variable(parent_variable)?;
 
+        Ok(())
+    }
+
+    fn process_variable(
+        &self,
+        debug_info: &DebugInfo,
+        parent_variable: &mut Variable,
+        memory: &mut dyn MemoryInterface,
+        cache: &mut VariableCache,
+        frame_info: StackFrameInfo<'_>,
+        child_node: gimli::EntriesTreeNode<GimliReader>,
+    ) -> Result<(), DebugError> {
+        let mut child_variable = cache.create_variable(parent_variable.variable_key, Some(self))?;
+        self.process_tree_node_attributes(
+            debug_info,
+            child_node.entry(),
+            parent_variable,
+            &mut child_variable,
+            memory,
+            cache,
+            frame_info,
+        )?;
+        let is_declaration = if let Some(AttributeValue::Flag(value)) =
+            child_node.entry().attr_value(gimli::DW_AT_declaration)
+        {
+            value
+        } else {
+            false
+        };
+        if is_declaration
+            || child_variable.type_name.is_phantom_data()
+            || child_variable.name == VariableName::Artificial
+        {
+            cache.remove_cache_entry(child_variable.variable_key)?;
+        } else if child_variable.is_valid() {
+            // Recursively process each child.
+            self.process_tree(
+                debug_info,
+                child_node,
+                &mut child_variable,
+                memory,
+                cache,
+                frame_info,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn process_variant_part(
+        &self,
+        debug_info: &DebugInfo,
+        parent_variable: &mut Variable,
+        memory: &mut dyn MemoryInterface,
+        cache: &mut VariableCache,
+        frame_info: StackFrameInfo<'_>,
+        child_node: gimli::EntriesTreeNode<GimliReader>,
+    ) -> Result<(), DebugError> {
+        let mut child_variable = cache.create_variable(parent_variable.variable_key, Some(self))?;
+        parent_variable.role = VariantRole::VariantPart(u64::MAX);
+        self.process_tree_node_attributes(
+            debug_info,
+            child_node.entry(),
+            parent_variable,
+            &mut child_variable,
+            memory,
+            cache,
+            frame_info,
+        )?;
+        cache.remove_cache_entry(child_variable.variable_key)?;
+        self.process_tree(
+            debug_info,
+            child_node,
+            parent_variable,
+            memory,
+            cache,
+            frame_info,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn process_variant_node(
+        &self,
+        debug_info: &DebugInfo,
+        parent_variable: &mut Variable,
+        memory: &mut dyn MemoryInterface,
+        cache: &mut VariableCache,
+        frame_info: StackFrameInfo<'_>,
+        default_variant: &mut Option<UnitOffset>,
+        child_node: gimli::EntriesTreeNode<GimliReader>,
+    ) -> Result<(), DebugError> {
+        if cache.has_children(parent_variable) {
+            return Ok(());
+        }
+
+        let mut child_variable = cache.create_variable(parent_variable.variable_key, Some(self))?;
+        self.extract_variant_discriminant(&child_node, &mut child_variable)?;
+        if let VariantRole::Variant(discriminant) = child_variable.role {
+            if parent_variable.role == VariantRole::VariantPart(discriminant) {
+                return self.process_variant(
+                    debug_info,
+                    child_node,
+                    parent_variable,
+                    &mut child_variable,
+                    memory,
+                    cache,
+                    frame_info,
+                );
+            }
+
+            if discriminant == u64::MAX {
+                *default_variant = Some(child_node.entry().offset());
+            }
+        }
+
+        cache.remove_cache_entry(child_variable.variable_key)?;
+        Ok(())
+    }
+
+    fn process_lexical_block(
+        &self,
+        debug_info: &DebugInfo,
+        parent_variable: &mut Variable,
+        memory: &mut dyn MemoryInterface,
+        cache: &mut VariableCache,
+        frame_info: StackFrameInfo<'_>,
+        child_node: gimli::EntriesTreeNode<GimliReader>,
+    ) -> Result<(), DebugError> {
+        let Some(program_counter) = frame_info
+            .registers
+            .get_program_counter()
+            .and_then(|reg| reg.value)
+        else {
+            return Err(DebugError::WarnAndContinue {
+                message: "Cannot unwind `Variable` without a valid PC (program_counter)"
+                    .to_string(),
+            });
+        };
+        let program_counter = program_counter.try_into()?;
+        let in_scope =
+            die_contains_pc(debug_info, &self.unit, child_node.entry(), program_counter)?;
+
+        if in_scope {
+            // This is IN scope.
+            // Recursively process each child, but pass the parent_variable, so that we don't create
+            // intermediate nodes for scope identifiers.
+            self.process_tree(
+                debug_info,
+                child_node,
+                parent_variable,
+                memory,
+                cache,
+                frame_info,
+            )
+        } else {
+            // This lexical block is NOT in scope, but other children of this parent may well be in scope,
+            // so do NOT invalidate the parent_variable.
+            Ok(())
+        }
+    }
+
+    fn process_namespace(
+        &self,
+        debug_info: &DebugInfo,
+        parent_variable: &mut Variable,
+        memory: &mut dyn MemoryInterface,
+        cache: &mut VariableCache,
+        frame_info: StackFrameInfo<'_>,
+        child_node: gimli::EntriesTreeNode<GimliReader>,
+    ) -> Result<(), DebugError> {
+        let variable_name =
+            if let Ok(Some(name)) = extract_name(debug_info, &self.unit, child_node.entry()) {
+                VariableName::Namespace(name)
+            } else {
+                VariableName::AnonymousNamespace
+            };
+        let mut namespace_variable = if let Some(existing_var) =
+            cache.get_variable_by_name_and_parent(&variable_name, parent_variable.variable_key)
+        {
+            existing_var
+        } else {
+            let mut namespace_variable = Variable::new(Some(self));
+
+            namespace_variable.name = variable_name;
+            namespace_variable.type_name = VariableType::Namespace;
+            namespace_variable.memory_location = VariableLocation::Unavailable;
+            cache.add_variable(parent_variable.variable_key, &mut namespace_variable)?;
+
+            namespace_variable
+        };
+        self.process_tree(
+            debug_info,
+            child_node,
+            &mut namespace_variable,
+            memory,
+            cache,
+            frame_info,
+        )?;
+        if !cache.has_children(&namespace_variable) {
+            cache.remove_cache_entry(namespace_variable.variable_key)?;
+        }
         Ok(())
     }
 

--- a/probe-rs-debug/src/unit_info.rs
+++ b/probe-rs-debug/src/unit_info.rs
@@ -10,7 +10,7 @@ use super::{
 };
 use crate::{language, stack_frame::StackFrameInfo};
 use gimli::{
-    AttributeValue, DebugInfoOffset, DebuggingInformationEntry, EvaluationResult, Location,
+    AttributeValue, DebugInfoOffset, DebuggingInformationEntry, DwAt, EvaluationResult, Location,
     UnitOffset,
 };
 use probe_rs::MemoryInterface;
@@ -19,6 +19,12 @@ use probe_rs::MemoryInterface;
 #[derive(Debug)]
 pub(crate) enum ExpressionResult {
     Location(VariableLocation),
+}
+
+enum AttributesEntry {
+    Found(DebuggingInformationEntry<GimliReader, usize>),
+    Unsupported,
+    NotFound,
 }
 
 /// A struct containing information about a single compilation unit.
@@ -258,73 +264,35 @@ impl UnitInfo {
         // Identify the parent.
         child_variable.parent_key = parent_variable.variable_key;
 
-        let abstract_entry;
-
         // We need to determine if we are working with a 'abstract` location, and use that node for the attributes we need
-        let attributes_entry = if let Some(abstract_origin) =
-            tree_node.attr(gimli::DW_AT_abstract_origin)
-        {
-            match abstract_origin.value() {
-                gimli::AttributeValue::UnitRef(unit_ref) => {
-                    // The abstract origin is a reference to another DIE, so we need to resolve that,
-                    // but first we need to process the (optional) memory location using the current DIE.
-                    self.process_memory_location(
-                        debug_info,
-                        tree_node,
-                        parent_variable,
-                        child_variable,
-                        memory,
-                        frame_info,
-                    )?;
-
-                    abstract_entry = self.unit.entry(unit_ref)?;
-
-                    Some(&abstract_entry)
-                }
-                other_attribute_value => {
-                    child_variable.set_value(VariableValue::Error(format!(
-                        "Unimplemented: Attribute Value for DW_AT_abstract_origin {other_attribute_value:?}"
-                    )));
-                    None
-                }
-            }
-        } else {
-            Some(tree_node)
+        let abstract_origin = match self.attributes_entry(
+            gimli::DW_AT_abstract_origin,
+            debug_info,
+            tree_node,
+            parent_variable,
+            child_variable,
+            memory,
+            frame_info,
+        )? {
+            AttributesEntry::Found(entry) => Some(entry),
+            AttributesEntry::Unsupported => None,
+            AttributesEntry::NotFound => Some(tree_node.clone()),
         };
-
-        let specification_entry;
 
         // We need to determine if we are working with a variable definition which refers to a declaration,
         // and use that node for the attributes we need
-        let attributes_entry = if let Some(specification) =
-            tree_node.attr(gimli::DW_AT_specification)
-        {
-            match specification.value() {
-                gimli::AttributeValue::UnitRef(unit_ref) => {
-                    // The abstract origin is a reference to another DIE, so we need to resolve that,
-                    // but first we need to process the (optional) memory location using the current DIE.
-                    self.process_memory_location(
-                        debug_info,
-                        tree_node,
-                        parent_variable,
-                        child_variable,
-                        memory,
-                        frame_info,
-                    )?;
-
-                    specification_entry = self.unit.entry(unit_ref)?;
-
-                    Some(&specification_entry)
-                }
-                other_attribute_value => {
-                    child_variable.set_value(VariableValue::Error(format!(
-                        "Unimplemented: Attribute Value for DW_AT_specification {other_attribute_value:?}"
-                    )));
-                    None
-                }
-            }
-        } else {
-            attributes_entry
+        let attributes_entry = match self.attributes_entry(
+            gimli::DW_AT_specification,
+            debug_info,
+            tree_node,
+            parent_variable,
+            child_variable,
+            memory,
+            frame_info,
+        )? {
+            AttributesEntry::Found(entry) => Some(entry),
+            AttributesEntry::Unsupported => None,
+            AttributesEntry::NotFound => abstract_origin,
         };
 
         // For variable attribute resolution, we need to resolve a few attributes in advance of looping through all the other ones.
@@ -378,23 +346,21 @@ impl UnitInfo {
                             cache,
                         )?;
                     }
-                    gimli::DW_AT_enum_class => match attr.value() {
-                        gimli::AttributeValue::Flag(true) => {
-                            child_variable.set_value(VariableValue::Valid(
-                                child_variable.compact_type_name(),
-                            ));
-                        }
-                        gimli::AttributeValue::Flag(false) => {
-                            child_variable.set_value(VariableValue::Error(
+                    gimli::DW_AT_enum_class => {
+                        let value = match attr.value() {
+                            AttributeValue::Flag(true) => {
+                                VariableValue::Valid(child_variable.compact_type_name())
+                            }
+                            AttributeValue::Flag(false) => VariableValue::Error(
                                 "Unimplemented: DW_AT_enum_class(false)".to_string(),
-                            ));
-                        }
-                        other_attribute_value => {
-                            child_variable.set_value(VariableValue::Error(format!(
+                            ),
+                            other_attribute_value => VariableValue::Error(format!(
                                 "Unimplemented: Attribute Value for DW_AT_enum_class: {other_attribute_value:?}"
-                            )));
-                        }
-                    },
+                            )),
+                        };
+
+                        child_variable.set_value(value);
+                    }
                     gimli::DW_AT_const_value => {
                         let attr_value = attr.value();
                         let variable_value = if let Some(const_value) = attr_value.udata_value() {
@@ -417,35 +383,15 @@ impl UnitInfo {
                         // These are references for entries like discriminant values of `VariantParts`.
                         child_variable.name = VariableName::Artificial;
                     }
-                    gimli::DW_AT_discr => match attr.value() {
-                        // This calculates the active discriminant value for the `VariantPart`.
-                        gimli::AttributeValue::UnitRef(unit_ref) => {
-                            let discriminant_node = self.unit.entry(unit_ref)?;
-                            let mut discriminant_variable =
-                                cache.create_variable(parent_variable.variable_key, Some(self))?;
-                            self.process_tree_node_attributes(
-                                debug_info,
-                                &discriminant_node,
-                                parent_variable,
-                                &mut discriminant_variable,
-                                memory,
-                                cache,
-                                frame_info,
-                            )?;
-
-                            parent_variable.role = VariantRole::VariantPart(
-                                discriminant_variable
-                                    .integer_value(memory)
-                                    .unwrap_or(u64::MAX),
-                            );
-                            cache.remove_cache_entry(discriminant_variable.variable_key)?;
-                        }
-                        other_attribute_value => {
-                            child_variable.set_value(VariableValue::Error(format!(
-                                "Unimplemented: Attribute Value for DW_AT_discr {other_attribute_value:?}"
-                            )));
-                        }
-                    },
+                    gimli::DW_AT_discr => self.process_discriminant(
+                        debug_info,
+                        parent_variable,
+                        child_variable,
+                        memory,
+                        cache,
+                        frame_info,
+                        attr,
+                    )?,
                     gimli::DW_AT_linkage_name => {
                         let value = attr.value();
                         let raw_str = debug_info.dwarf.attr_string(&self.unit, value).ok();
@@ -505,7 +451,7 @@ impl UnitInfo {
         self.apply_start_scope(
             debug_info,
             tree_node,
-            attributes_entry,
+            attributes_entry.as_ref(),
             child_variable,
             frame_info,
         )?;
@@ -513,6 +459,88 @@ impl UnitInfo {
         child_variable.extract_value(memory, cache);
         cache.update_variable(child_variable)?;
 
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn attributes_entry(
+        &self,
+        attr: DwAt,
+        debug_info: &DebugInfo,
+        tree_node: &DebuggingInformationEntry<GimliReader, usize>,
+        parent_variable: &mut Variable,
+        child_variable: &mut Variable,
+        memory: &mut dyn MemoryInterface,
+        frame_info: &StackFrameInfo<'_>,
+    ) -> Result<AttributesEntry, DebugError> {
+        let Some(abstract_origin) = tree_node.attr(attr) else {
+            return Ok(AttributesEntry::NotFound);
+        };
+
+        match abstract_origin.value() {
+            AttributeValue::UnitRef(unit_ref) => {
+                // The abstract origin is a reference to another DIE, so we need to resolve that,
+                // but first we need to process the (optional) memory location using the current DIE.
+                self.process_memory_location(
+                    debug_info,
+                    tree_node,
+                    parent_variable,
+                    child_variable,
+                    memory,
+                    frame_info,
+                )?;
+
+                Ok(AttributesEntry::Found(self.unit.entry(unit_ref)?))
+            }
+            other_attribute_value => {
+                child_variable.set_value(VariableValue::Error(format!(
+                    "Unimplemented: Attribute Value for {attr} {other_attribute_value:?}"
+                )));
+                Ok(AttributesEntry::Unsupported)
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn process_discriminant(
+        &self,
+        debug_info: &DebugInfo,
+        parent_variable: &mut Variable,
+        child_variable: &mut Variable,
+        memory: &mut dyn MemoryInterface,
+        cache: &mut VariableCache,
+        frame_info: &StackFrameInfo<'_>,
+        attr: &gimli::Attribute<GimliReader>,
+    ) -> Result<(), DebugError> {
+        match attr.value() {
+            // This calculates the active discriminant value for the `VariantPart`.
+            AttributeValue::UnitRef(unit_ref) => {
+                let discriminant_node = self.unit.entry(unit_ref)?;
+                let mut discriminant_variable =
+                    cache.create_variable(parent_variable.variable_key, Some(self))?;
+                self.process_tree_node_attributes(
+                    debug_info,
+                    &discriminant_node,
+                    parent_variable,
+                    &mut discriminant_variable,
+                    memory,
+                    cache,
+                    frame_info,
+                )?;
+
+                parent_variable.role = VariantRole::VariantPart(
+                    discriminant_variable
+                        .integer_value(memory)
+                        .unwrap_or(u64::MAX),
+                );
+                cache.remove_cache_entry(discriminant_variable.variable_key)?;
+            }
+            other_attribute_value => {
+                child_variable.set_value(VariableValue::Error(format!(
+                    "Unimplemented: Attribute Value for DW_AT_discr {other_attribute_value:?}"
+                )));
+            }
+        }
         Ok(())
     }
 
@@ -2151,15 +2179,13 @@ impl UnitInfo {
                 gimli::DW_AT_location
                 | gimli::DW_AT_frame_base
                 | gimli::DW_AT_data_member_location => match attr.value() {
-                    gimli::AttributeValue::Exprloc(expression) => self
+                    AttributeValue::Exprloc(expression) => self
                         .evaluate_expression(debug_info, memory, expression, frame_info)
                         .convert_incomplete()?,
 
-                    gimli::AttributeValue::Udata(offset_from_location) => {
-                        ExpressionResult::Location(
-                            parent_location.offset_by(offset_from_location, byte_size),
-                        )
-                    }
+                    AttributeValue::Udata(offset_from_location) => ExpressionResult::Location(
+                        parent_location.offset_by(offset_from_location, byte_size),
+                    ),
 
                     other_attribute_value => {
                         match debug_info
@@ -2189,11 +2215,11 @@ impl UnitInfo {
 
                 gimli::DW_AT_address_class => {
                     let location = match attr.value() {
-                        gimli::AttributeValue::AddressClass(gimli::DwAddr(0)) => {
+                        AttributeValue::AddressClass(gimli::DwAddr(0)) => {
                             // We pass on the location of the parent, which will later to be used along with DW_AT_data_member_location to calculate the location of this variable.
                             parent_location.clone()
                         }
-                        gimli::AttributeValue::AddressClass(address_class) => {
+                        AttributeValue::AddressClass(address_class) => {
                             VariableLocation::Unsupported(format!(
                                 "Unimplemented: extract_location() found unsupported DW_AT_address_class(gimli::DwAddr({address_class:?}))"
                             ))
@@ -3179,7 +3205,7 @@ fn extract_name(
 fn attribute_string(
     debug_info: &DebugInfo,
     unit: &gimli::Unit<GimliReader>,
-    attr: gimli::AttributeValue<GimliReader>,
+    attr: AttributeValue<GimliReader>,
 ) -> String {
     match debug_info.dwarf.attr_string(unit, attr) {
         Ok(raw) => String::from_utf8_lossy(&raw).to_string(),

--- a/probe-rs-debug/src/variable.rs
+++ b/probe-rs-debug/src/variable.rs
@@ -279,11 +279,11 @@ impl GenericArg {
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 pub struct NamedType {
     /// The type ident, without a crate or module path.
-    pub ident: String,
+    pub ident: Box<str>,
     /// Enclosing namespace segments, crate first.
-    pub namespace: Vec<String>,
+    pub namespace: Box<[String]>,
     /// Generic arguments from DWARF template parameter DIEs.
-    pub args: Vec<GenericArg>,
+    pub args: Box<[GenericArg]>,
 }
 
 impl NamedType {
@@ -291,7 +291,7 @@ impl NamedType {
     pub fn ident_stem(&self) -> &str {
         self.ident
             .split_once('<')
-            .map_or(self.ident.as_str(), |(head, _)| head)
+            .map_or(self.ident.as_ref(), |(head, _)| head)
     }
 
     /// Build a named type from a DWARF `DW_AT_name` and namespace DIEs.
@@ -318,9 +318,9 @@ impl NamedType {
                 .map(|(head, _)| head.to_string())
                 .unwrap_or(remainder);
             return Self {
-                ident,
-                namespace,
-                args,
+                ident: ident.into_boxed_str(),
+                namespace: namespace.into_boxed_slice(),
+                args: args.into_boxed_slice(),
             };
         }
 
@@ -332,16 +332,16 @@ impl NamedType {
                 namespace: if namespace.is_empty() {
                     parsed.namespace
                 } else {
-                    namespace
+                    namespace.into_boxed_slice()
                 },
                 args: parsed.args,
             };
         }
 
         Self {
-            ident: remainder,
-            namespace,
-            args,
+            ident: remainder.into_boxed_str(),
+            namespace: namespace.into_boxed_slice(),
+            args: args.into_boxed_slice(),
         }
     }
 
@@ -375,20 +375,16 @@ impl NamedType {
 
 impl From<&str> for NamedType {
     fn from(ident: &str) -> Self {
-        Self {
-            ident: ident.to_string(),
-            namespace: Vec::new(),
-            args: Vec::new(),
-        }
+        Self::from(ident.to_string())
     }
 }
 
 impl From<String> for NamedType {
     fn from(ident: String) -> Self {
         Self {
-            ident,
-            namespace: Vec::new(),
-            args: Vec::new(),
+            ident: ident.into_boxed_str(),
+            namespace: Vec::new().into_boxed_slice(),
+            args: Vec::new().into_boxed_slice(),
         }
     }
 }

--- a/probe-rs-debug/src/variable.rs
+++ b/probe-rs-debug/src/variable.rs
@@ -1732,7 +1732,7 @@ mod test {
             &language,
         );
 
-        assert_eq!(option.ident, "Option");
+        assert_eq!(option.ident.as_ref(), "Option");
         assert_eq!(option.ident_stem(), "Option");
         assert_eq!(
             option.display(&language, TypeNameStyle::Compact),

--- a/probe-rs-debug/src/variable_cache.rs
+++ b/probe-rs-debug/src/variable_cache.rs
@@ -421,7 +421,7 @@ impl VariableCache {
         debug_info: &DebugInfo,
         memory: &mut dyn MemoryInterface,
         max_recursion_depth: usize,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) {
         let mut parent_variable = self.root_variable().clone();
 
@@ -442,7 +442,7 @@ impl VariableCache {
         parent_variable: &mut Variable,
         max_recursion_depth: usize,
         current_recursion_depth: usize,
-        frame_info: StackFrameInfo<'_>,
+        frame_info: &StackFrameInfo<'_>,
     ) {
         if current_recursion_depth >= max_recursion_depth {
             return;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/rpc_lifetime.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/rpc_lifetime.rs
@@ -41,9 +41,7 @@ impl DapRpcConnection {
 
         let probe_broker = Arc::new(crate::rpc::probe_broker::ProbeBroker::new());
         let (local_server, tx, rx) = RpcApp::create_server(16, ProbeAccess::All, probe_broker);
-        let handle = tokio::spawn(async move {
-            local_server.run().await;
-        });
+        let handle = tokio::spawn(local_server.run());
         let client = RpcClient::new_local_from_wire(tx, rx);
         Ok(Self {
             client: Some(client),

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions.rs
@@ -1,7 +1,7 @@
 use std::{any::Any, ops::DerefMut, panic::AssertUnwindSafe, sync::Arc};
 use std::{collections::HashMap, convert::Infallible, future::Future};
 
-use crate::rpc::debug_state::{CoreDebugState, ServerDebugState};
+use crate::rpc::debug_state::ServerDebugState;
 use crate::rpc::functions::file::{append_temp_file, create_temp_file};
 use crate::rpc::probe_broker::ProbeBroker;
 use crate::rpc::{
@@ -398,22 +398,6 @@ impl RpcContext {
         let states = self.debug_states();
         let mut guard = states.lock().await;
         f(guard.entry(sessid).or_default())
-    }
-
-    pub async fn with_core_debug_state_mut<R>(
-        &self,
-        sessid: Key<Session>,
-        core: u32,
-        f: impl FnOnce(&mut CoreDebugState) -> R,
-    ) -> Result<R, &'static str> {
-        let states = self.debug_states();
-        let mut guard = states.lock().await;
-        let state = guard.get_mut(&sessid).ok_or("No debug state for session")?;
-        let core_state = state
-            .per_core
-            .get_mut(&(core as usize))
-            .ok_or("No debug state for core")?;
-        Ok(f(core_state))
     }
 
     pub fn lister(&self) -> Lister {

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/debug_vars.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/debug_vars.rs
@@ -48,69 +48,74 @@ pub async fn scopes(
     _header: VarHeader,
     request: ScopesRequest,
 ) -> ScopesResponse {
-    Ok(ctx
-        .with_core_debug_state_mut(request.sessid, request.core, |core_state| {
-            let frame_ref = ObjectRef::from(request.frame_id as i64);
-            let mut scopes: Vec<WireScope> = Vec::new();
+    let states = ctx.debug_states();
+    let mut guard = states.lock().await;
+    let state = guard
+        .get_mut(&request.sessid)
+        .ok_or("No debug state for session")?;
+    let core_state = state
+        .per_core
+        .get_mut(&(request.core as usize))
+        .ok_or("No debug state for core")?;
+    let frame_ref = ObjectRef::from(request.frame_id as i64);
+    let mut scopes: Vec<WireScope> = Vec::new();
 
-            if let Some(static_cache) = &core_state.static_variables {
-                scopes.push(WireScope {
-                    name: "Static".to_string(),
-                    presentation_hint: Some("statics".to_string()),
-                    variables_reference: i64::from(static_cache.root_variable().variable_key()),
-                    expensive: true,
-                    line: None,
-                    column: None,
-                });
-            }
+    if let Some(static_cache) = &core_state.static_variables {
+        scopes.push(WireScope {
+            name: "Static".to_string(),
+            presentation_hint: Some("statics".to_string()),
+            variables_reference: i64::from(static_cache.root_variable().variable_key()),
+            expensive: true,
+            line: None,
+            column: None,
+        });
+    }
 
-            if let Some(svd_cache) = &core_state.svd_variables {
-                scopes.push(WireScope {
-                    name: "Peripherals".to_string(),
-                    presentation_hint: None,
-                    variables_reference: i64::from(svd_cache.root_variable_key()),
-                    expensive: true,
-                    line: None,
-                    column: None,
-                });
-            }
+    if let Some(svd_cache) = &core_state.svd_variables {
+        scopes.push(WireScope {
+            name: "Peripherals".to_string(),
+            presentation_hint: None,
+            variables_reference: i64::from(svd_cache.root_variable_key()),
+            expensive: true,
+            line: None,
+            column: None,
+        });
+    }
 
-            if let Some(frame) = core_state.stack_frames.iter().find(|f| f.id == frame_ref) {
-                // Registers scope: reuse the frame id as its variables_reference.
-                scopes.push(WireScope {
-                    name: "Registers".to_string(),
-                    presentation_hint: Some("registers".to_string()),
-                    variables_reference: i64::from(frame.id),
-                    expensive: true,
-                    line: None,
-                    column: None,
-                });
+    if let Some(frame) = core_state.stack_frames.iter().find(|f| f.id == frame_ref) {
+        // Registers scope: reuse the frame id as its variables_reference.
+        scopes.push(WireScope {
+            name: "Registers".to_string(),
+            presentation_hint: Some("registers".to_string()),
+            variables_reference: i64::from(frame.id),
+            expensive: true,
+            line: None,
+            column: None,
+        });
 
-                if let Some(locals) = &frame.local_variables {
-                    let line = frame
-                        .source_location
-                        .as_ref()
-                        .and_then(|l| l.line.map(|l| l as i64));
-                    let column = frame.source_location.as_ref().and_then(|l| {
-                        l.column.map(|c| match c {
-                            probe_rs_debug::ColumnType::LeftEdge => 0,
-                            probe_rs_debug::ColumnType::Column(c) => c as i64,
-                        })
-                    });
-                    scopes.push(WireScope {
-                        name: "Variables".to_string(),
-                        presentation_hint: Some("locals".to_string()),
-                        variables_reference: i64::from(locals.root_variable().variable_key()),
-                        expensive: false,
-                        line,
-                        column,
-                    });
-                }
-            }
+        if let Some(locals) = &frame.local_variables {
+            let line = frame
+                .source_location
+                .as_ref()
+                .and_then(|l| l.line.map(|l| l as i64));
+            let column = frame.source_location.as_ref().and_then(|l| {
+                l.column.map(|c| match c {
+                    probe_rs_debug::ColumnType::LeftEdge => 0,
+                    probe_rs_debug::ColumnType::Column(c) => c as i64,
+                })
+            });
+            scopes.push(WireScope {
+                name: "Variables".to_string(),
+                presentation_hint: Some("locals".to_string()),
+                variables_reference: i64::from(locals.root_variable().variable_key()),
+                expensive: false,
+                line,
+                column,
+            });
+        }
+    }
 
-            scopes
-        })
-        .await?)
+    Ok(scopes)
 }
 
 pub async fn variables(

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/debug_vars.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/debug_vars.rs
@@ -18,7 +18,9 @@ fn memory_reference(location: &VariableLocation) -> Option<String> {
     location.address().map(|address| format!("{address:#010x}"))
 }
 
-/// Mirrors `request_helpers::get_variable_reference` for the server-side path.
+/// The DAP protocol uses three related values to determine how to invoke the `Variables` request.
+/// This function retrieves that information from the `DebugInfo::VariableCache` and returns it as
+/// (`variable_reference`, `named_child_variables_cnt`, `indexed_child_variables_cnt`)
 fn variable_reference(parent: &Variable, cache: &VariableCache) -> (ObjectRef, i64, i64) {
     if !parent.is_valid() {
         return (ObjectRef::Invalid, 0, 0);

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/debug_vars.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/debug_vars.rs
@@ -271,7 +271,7 @@ pub async fn variables(
         && !variable_cache.has_children(parent)
         && let Some(frame_info) = frame_info
     {
-        lift(debug_info.cache_deferred_variables(variable_cache, &mut core, parent, frame_info))?;
+        lift(debug_info.cache_deferred_variables(variable_cache, &mut core, parent, &frame_info))?;
     }
 
     Ok(variable_cache
@@ -415,7 +415,7 @@ fn resolve_expression(
     core: &mut probe_rs::Core,
     cache: &mut VariableCache,
     expression: &str,
-    frame_info: StackFrameInfo<'_>,
+    frame_info: &StackFrameInfo<'_>,
 ) -> Option<WireEvaluateResponse> {
     if cache.len() == 1 {
         let mut root = cache.root_variable().clone();
@@ -540,7 +540,7 @@ pub async fn evaluate(
             &mut core,
             cache,
             &request.expression,
-            StackFrameInfo {
+            &StackFrameInfo {
                 registers: &frame_regs,
                 frame_base,
                 canonical_frame_address: cfa,
@@ -563,7 +563,7 @@ pub async fn evaluate(
                 &mut core,
                 cache,
                 &request.expression,
-                StackFrameInfo {
+                &StackFrameInfo {
                     registers: &top_regs,
                     frame_base: top_base,
                     canonical_frame_address: top_cfa,

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/debug_vars.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/debug_vars.rs
@@ -140,10 +140,6 @@ pub async fn variables(
 
     let variable_ref = ObjectRef::from(request.variables_reference as i64);
 
-    let mut parent_variable: Option<Variable> = None;
-    let mut variable_cache: Option<&mut VariableCache> = None;
-    let mut frame_info: Option<StackFrameInfo<'_>> = None;
-    let cloned_registers = core_state.stack_frames.first().map(|f| f.registers.clone());
     if let Some(frame) = core_state
         .stack_frames
         .iter()
@@ -190,6 +186,10 @@ pub async fn variables(
         return Ok(dap_variables);
     }
 
+    let mut parent_variable: Option<Variable> = None;
+    let mut variable_cache: Option<&mut VariableCache> = None;
+    let mut frame_info: Option<StackFrameInfo<'_>> = None;
+    let cloned_registers = core_state.stack_frames.first().map(|f| f.registers.clone());
     if let Some(search_cache) = core_state.static_variables.as_mut()
         && let Some(search_variable) = search_cache.get_variable_by_key(variable_ref)
     {


### PR DESCRIPTION
Splits apart `process_tree` and the likes a bit, clippy reports much lower frame sizes for these now (whether or not that survives LLVM is another question).