### PR TITLE
Fix info command not working correctly in XVC

### DIFF
--- a/probe-rs/src/probe/xvc/mod.rs
+++ b/probe-rs/src/probe/xvc/mod.rs
@@ -121,9 +121,8 @@ impl DebugProbe for XvcProbe {
     }
 
     fn attach(&mut self) -> Result<(), DebugProbeError> {
-        // The TCP connection is established when the probe is opened, so there
-        // is nothing to initialize here.
-        Ok(())
+        // Performs initial scan_chain, and sets non zero IR length.
+        self.select_target(0)
     }
 
     fn detach(&mut self) -> Result<(), crate::Error> {


### PR DESCRIPTION
Some commands such as "info --verbose" rely on IR length to be set by the probe attach(). Other commands override it later so we only need to set something once. The same approach is done by other probes too.

CC @bugadani 