### PR TITLE
Fix the semihosting file open modes for update and append

### DIFF
--- a/changelog/fixed-semihosting-file-modes.md
+++ b/changelog/fixed-semihosting-file-modes.md
@@ -1,0 +1,1 @@
+Semihosting file access: opening a file with mode `r+` no longer empties it, modes `a` and `a+` now append instead of overwriting the file from the start, and mode `a+` no longer fails to open the file.

--- a/probe-rs-tools/src/bin/probe-rs/rpc/utils/semihosting.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/utils/semihosting.rs
@@ -193,11 +193,15 @@ impl SemihostingFileManager {
                 .write(false)
                 .truncate(false)
                 .create(false),
-            "r+" | "r+b" => options.read(true).write(true).truncate(true).create(false),
+            "r+" | "r+b" => options.read(true).write(true).truncate(false).create(false),
             "w" | "wb" => options.read(false).write(true).truncate(true).create(true),
             "w+" | "w+b" => options.read(true).write(true).truncate(true).create(true),
-            "a" | "ab" => options.read(false).write(true).truncate(false).create(true),
-            "a+" | "a+b" => options.read(true).write(false).truncate(false).create(true),
+            "a" | "ab" => options
+                .read(false)
+                .append(true)
+                .truncate(false)
+                .create(true),
+            "a+" | "a+b" => options.read(true).append(true).truncate(false).create(true),
             mode => {
                 tracing::error!(
                     "Target wanted to open file {path} with invalid mode {mode}. Continuing..."
@@ -448,5 +452,91 @@ impl FileHandleLog {
             handle = self.handle,
             variant = self.variant,
         );
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::path::PathBuf;
+
+    const CONTENTS: &[u8] = b"0123456789";
+    const APPENDED: &[u8] = b"0123456789ab";
+
+    struct TestFile {
+        _dir: tempfile::TempDir,
+        path: PathBuf,
+    }
+
+    impl TestFile {
+        fn new() -> Self {
+            let dir = tempfile::TempDir::new().unwrap();
+            let path = dir.path().join("semihosting.txt");
+            std::fs::write(&path, CONTENTS).unwrap();
+
+            TestFile { _dir: dir, path }
+        }
+
+        fn open(&self, mode: &str) -> Option<File> {
+            let manager = SemihostingFileManager::new(SemihostingOptions::new());
+            match manager.open_file(self.path.to_str().unwrap(), mode)? {
+                FileHandle::File(file) => Some(file),
+                _ => panic!("open_file did not return a file"),
+            }
+        }
+
+        fn contents(&self) -> Vec<u8> {
+            std::fs::read(&self.path).unwrap()
+        }
+    }
+
+    #[test]
+    fn read_does_not_truncate() {
+        let file = TestFile::new();
+        let handle = file.open("r").expect("mode r failed to open the file");
+        drop(handle);
+
+        assert_eq!(file.contents(), CONTENTS);
+    }
+
+    #[test]
+    fn read_update_does_not_truncate() {
+        let file = TestFile::new();
+        let mut handle = file.open("r+").expect("mode r+ failed to open the file");
+
+        let mut read_back = Vec::new();
+        handle.read_to_end(&mut read_back).unwrap();
+
+        assert_eq!(read_back, CONTENTS);
+        assert_eq!(file.contents(), CONTENTS);
+    }
+
+    #[test]
+    fn write_truncates() {
+        let file = TestFile::new();
+        let handle = file.open("w").expect("mode w failed to open the file");
+        drop(handle);
+
+        assert_eq!(file.contents(), b"".as_slice());
+    }
+
+    #[test]
+    fn append_writes_to_the_end() {
+        let file = TestFile::new();
+        let mut handle = file.open("a").expect("mode a failed to open the file");
+        handle.write_all(b"ab").unwrap();
+        drop(handle);
+
+        assert_eq!(file.contents(), APPENDED);
+    }
+
+    #[test]
+    fn append_update_writes_to_the_end() {
+        let file = TestFile::new();
+        let mut handle = file.open("a+").expect("mode a+ failed to open the file");
+        handle.write_all(b"ab").unwrap();
+        drop(handle);
+
+        assert_eq!(file.contents(), APPENDED);
     }
 }


### PR DESCRIPTION
`open_file` in `probe-rs-tools/src/bin/probe-rs/rpc/utils/semihosting.rs` maps the ARM semihosting `SYS_OPEN` mode strings onto `File::options()`. Three of the six rows do not do what C `fopen` does, so a target that opens a file for update or for appending gets the wrong file.

Line 196, `"r+" | "r+b"`, sets `truncate(true)`. `fopen` opens `r+` for update and leaves the contents alone, so a target that reopened a file to patch part of it found the file empty.

Line 199, `"a" | "ab"`, sets `write(true)` and never `append(true)`, so the writes land at offset 0 and overwrite the start of the file. Writing `ab` to a file holding `0123456789` produced `ab23456789` instead of `0123456789ab`.

Line 200, `"a+" | "a+b"`, sets `read(true).write(false).create(true)`. `create` needs write or append access, so `File::options().open()` returns `InvalidInput` with "creating or truncating a file requires write or append access" and `a+` never opens a file at all. That is the same std rule #3960 ran into for `r`, which fixed `r` only.

The fix is `truncate(false)` for `r+`, and `append(true)` for `a` and `a+`. `w` and `w+` were already right.

The tests call `open_file` directly, so they need no probe and no target. They cover the five distinct behaviours of the mode table. Against the mode table on master, `r` and `w` pass and the other three fail:

```
test rpc::utils::semihosting::test::read_does_not_truncate ... ok
test rpc::utils::semihosting::test::write_truncates ... ok
test rpc::utils::semihosting::test::read_update_does_not_truncate ... FAILED
test rpc::utils::semihosting::test::append_writes_to_the_end ... FAILED
test rpc::utils::semihosting::test::append_update_writes_to_the_end ... FAILED

---- read_update_does_not_truncate ----
  left: []
 right: [48, 49, 50, 51, 52, 53, 54, 55, 56, 57]

---- append_writes_to_the_end ----
  left: [97, 98, 50, 51, 52, 53, 54, 55, 56, 57]
 right: [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 97, 98]

---- append_update_writes_to_the_end ----
mode a+ failed to open the file
```

With the change, on macOS 26.2 arm64 with rustc 1.95.0:

`cargo test -p probe-rs-tools --bin probe-rs semihosting::` gives `test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 150 filtered out`.

`cargo fmt --all -- --check` reports no diff.

`cargo clippy -p probe-rs-tools --all-features --all-targets --locked -- -D warnings -A clippy::collapsible_match` finishes clean. The allow covers `util/cargo.rs:86`, which the clippy in my toolchain also rejects on master, before this change.

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo fmt` was run.
- [x] Add a changelog fragment describing your changes in `changelogs/`. See https://github.com/probe-rs/probe-rs/blob/master/CONTRIBUTING.md#changelog-entries.

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs (in code, rustdoc and README.md) for your newly added features and code.
