### PR TITLE
breakpoint/status/step improvements

### DIFF
--- a/changelog/added-repl-step-commands.md
+++ b/changelog/added-repl-step-commands.md
@@ -1,0 +1,1 @@
+The REPL now has `step over`, `step into`, and `step out` commands, so you can step at statement granularity from the debug console.

--- a/changelog/changed-repl-breakpoint-output.md
+++ b/changelog/changed-repl-breakpoint-output.md
@@ -1,0 +1,1 @@
+The REPL `break` and `clear` commands now accept an address without the `*` prefix, and `break` reports the address and the source location of every breakpoint in one colorized message.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/backend/rpc.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/backend/rpc.rs
@@ -702,6 +702,16 @@ impl RpcBackend {
         }
     }
 
+    /// The source location of a single address. `None` when the address has no
+    /// debug information, or when the server cannot be reached.
+    pub(crate) async fn source_location(&self, address: u64) -> Option<DebugSourceLocation> {
+        self.resolve_source_locations(vec![address])
+            .await
+            .ok()?
+            .pop()
+            .flatten()
+    }
+
     pub(crate) async fn scopes(
         &mut self,
         core_index: usize,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -734,8 +734,9 @@ impl DebugAdapter {
                 )
             {
                 let program_counter = session_data.backend.program_counter(core_index).await;
-                let (reason, description) =
-                    current_core_status.short_long_status(program_counter, false);
+                let (reason, description) = current_core_status
+                    .short_long_status(&session_data.backend, program_counter, false)
+                    .await;
                 let event_body = Some(StoppedEventBody {
                     reason: reason.to_owned(),
                     description: Some(description),
@@ -1467,13 +1468,13 @@ impl DebugAdapter {
                 self.send_event("continued", event_body)?;
             } else {
                 self.send_response::<()>(request, Ok(None))?;
+                let description = CoreStatus::Halted(HaltReason::External)
+                    .short_long_status(&session_data.backend, None, false)
+                    .await
+                    .1;
                 let event_body = Some(StoppedEventBody {
                     reason: "restart".to_owned(),
-                    description: Some(
-                        CoreStatus::Halted(HaltReason::External)
-                            .short_long_status(None, false)
-                            .1,
-                    ),
+                    description: Some(description),
                     thread_id: Some(core_index as i64),
                     preserve_focus_hint: None,
                     text: None,
@@ -1483,13 +1484,13 @@ impl DebugAdapter {
                 self.send_event("stopped", event_body)?;
             }
         } else if self.configuration_is_done() {
+            let description = CoreStatus::Halted(HaltReason::External)
+                .short_long_status(&session_data.backend, Some(core_info.pc), false)
+                .await
+                .1;
             let event_body = Some(StoppedEventBody {
                 reason: "restart".to_owned(),
-                description: Some(
-                    CoreStatus::Halted(HaltReason::External)
-                        .short_long_status(Some(core_info.pc), false)
-                        .1,
-                ),
+                description: Some(description),
                 thread_id: Some(core_index as i64),
                 preserve_focus_hint: None,
                 text: None,
@@ -1722,9 +1723,13 @@ impl DebugAdapter {
         core_data.invalidate_stack_frame_cache();
         let cpu_info = backend.halt(core_index, Duration::from_millis(500)).await?;
         let new_status = CoreStatus::Halted(HaltReason::Request);
+        let description = new_status
+            .short_long_status(backend, Some(cpu_info.pc), false)
+            .await
+            .1;
         let event_body = Some(StoppedEventBody {
             reason: "pause".to_owned(),
-            description: Some(new_status.short_long_status(Some(cpu_info.pc), false).1),
+            description: Some(description),
             thread_id: Some(core_index as i64),
             preserve_focus_hint: Some(false),
             text: None,
@@ -1821,17 +1826,19 @@ impl DebugAdapter {
         // otherwise surface as a "BreakPoint" halt reason.
         core_data.last_known_status = CoreStatus::Halted(HaltReason::Step);
         if matches!(new_status, CoreStatus::Halted(_)) {
+            let reason = core_data
+                .last_known_status
+                .short_long_status(backend, None, false)
+                .await
+                .0
+                .to_string();
+            let description = CoreStatus::Halted(HaltReason::Step)
+                .short_long_status(backend, Some(program_counter), false)
+                .await
+                .1;
             let event_body = StoppedEventBody {
-                reason: core_data
-                    .last_known_status
-                    .short_long_status(None, false)
-                    .0
-                    .to_string(),
-                description: Some(
-                    CoreStatus::Halted(HaltReason::Step)
-                        .short_long_status(Some(program_counter), false)
-                        .1,
-                ),
+                reason,
+                description: Some(description),
                 thread_id: Some(core_index as i64),
                 preserve_focus_hint: None,
                 text: None,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -734,7 +734,8 @@ impl DebugAdapter {
                 )
             {
                 let program_counter = session_data.backend.program_counter(core_index).await;
-                let (reason, description) = current_core_status.short_long_status(program_counter);
+                let (reason, description) =
+                    current_core_status.short_long_status(program_counter, false);
                 let event_body = Some(StoppedEventBody {
                     reason: reason.to_owned(),
                     description: Some(description),
@@ -1470,7 +1471,7 @@ impl DebugAdapter {
                     reason: "restart".to_owned(),
                     description: Some(
                         CoreStatus::Halted(HaltReason::External)
-                            .short_long_status(None)
+                            .short_long_status(None, false)
                             .1,
                     ),
                     thread_id: Some(core_index as i64),
@@ -1486,7 +1487,7 @@ impl DebugAdapter {
                 reason: "restart".to_owned(),
                 description: Some(
                     CoreStatus::Halted(HaltReason::External)
-                        .short_long_status(Some(core_info.pc))
+                        .short_long_status(Some(core_info.pc), false)
                         .1,
                 ),
                 thread_id: Some(core_index as i64),
@@ -1723,7 +1724,7 @@ impl DebugAdapter {
         let new_status = CoreStatus::Halted(HaltReason::Request);
         let event_body = Some(StoppedEventBody {
             reason: "pause".to_owned(),
-            description: Some(new_status.short_long_status(Some(cpu_info.pc)).1),
+            description: Some(new_status.short_long_status(Some(cpu_info.pc), false).1),
             thread_id: Some(core_index as i64),
             preserve_focus_hint: Some(false),
             text: None,
@@ -1823,12 +1824,12 @@ impl DebugAdapter {
             let event_body = StoppedEventBody {
                 reason: core_data
                     .last_known_status
-                    .short_long_status(None)
+                    .short_long_status(None, false)
                     .0
                     .to_string(),
                 description: Some(
                     CoreStatus::Halted(HaltReason::Step)
-                        .short_long_status(Some(program_counter))
+                        .short_long_status(Some(program_counter), false)
                         .1,
                 ),
                 thread_id: Some(core_index as i64),

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/core_status.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/core_status.rs
@@ -1,10 +1,12 @@
 use probe_rs::{BreakpointCause, CoreStatus, HaltReason};
 
-use crate::util::style::ReplAddress;
+use crate::cmd::dap_server::backend::rpc::RpcBackend;
+use crate::util::style::format_location;
 
 pub(crate) trait DapStatus {
-    fn short_long_status(
+    async fn short_long_status(
         &self,
+        backend: &RpcBackend,
         program_counter: Option<u64>,
         colorize: bool,
     ) -> (&'static str, String);
@@ -15,61 +17,66 @@ impl DapStatus for CoreStatus {
     /// The short status matches with the strings implemented by the Microsoft DAP protocol,
     /// e.g. `let (short_status, long status) = CoreStatus::short_long_status(core_status)`
     ///
+    /// The source location of `program_counter` is resolved through `backend`, and is left out
+    /// of the description when the address has no debug information.
+    ///
     /// `colorize` may only be set for text that the client shows in its console.
-    fn short_long_status(
+    async fn short_long_status(
         &self,
+        backend: &RpcBackend,
         program_counter: Option<u64>,
         colorize: bool,
     ) -> (&'static str, String) {
-        let at = program_counter
-            .map(|pc| {
-                format!(
-                    " at {}",
-                    ReplAddress::new(format!("{pc:#010x}")).colorize(colorize)
-                )
-            })
-            .unwrap_or_default();
-
-        match self {
-            CoreStatus::Running => ("continued", "The core is running.".to_string()),
-            CoreStatus::Sleeping => ("sleeping", "The core is asleep.".to_string()),
-            CoreStatus::LockedUp => (
-                "lockedup",
-                "The core locked up after an unrecoverable exception.".to_string(),
-            ),
-            CoreStatus::Halted(halt_reason) => match halt_reason {
-                HaltReason::Breakpoint(cause) => {
-                    let breakpoint = match cause {
-                        BreakpointCause::Hardware => "a hardware breakpoint",
-                        BreakpointCause::Software => "a software breakpoint",
-                        BreakpointCause::Semihosting(_) => "a semihosting request",
-                        BreakpointCause::Unknown => "a breakpoint",
-                    };
-                    ("breakpoint", format!("Stopped at {breakpoint}{at}."))
-                }
-                HaltReason::Exception => (
-                    "exception",
-                    format!("Stopped by an exception, for example an interrupt{at}."),
-                ),
-                HaltReason::Watchpoint => {
-                    ("data breakpoint", format!("Stopped by a watchpoint{at}."))
-                }
-                HaltReason::Step => ("step", format!("Stopped after one step{at}.")),
-                HaltReason::Request => ("pause", format!("Stopped on your request{at}.")),
-                HaltReason::External => {
-                    ("external", format!("Stopped by an external request{at}."))
-                }
-                HaltReason::Multiple => (
-                    "breakpoint",
-                    format!("Stopped for more than one reason{at}."),
-                ),
-                _other => (
-                    "unrecognized",
-                    format!("Stopped for an unknown reason{at}."),
-                ),
-            },
-            CoreStatus::Unknown => ("unknown", "The state of the core is unknown.".to_string()),
+        let mut at = String::new();
+        if let Some(pc) = program_counter {
+            let source_location = backend.source_location(pc).await;
+            at = format!(
+                " at {}",
+                format_location(pc, source_location.as_ref(), colorize)
+            );
         }
+
+        describe(self, &at)
+    }
+}
+
+/// `at` names where the core stopped, and is empty when the location is unknown.
+fn describe(status: &CoreStatus, at: &str) -> (&'static str, String) {
+    match status {
+        CoreStatus::Running => ("continued", "The core is running.".to_string()),
+        CoreStatus::Sleeping => ("sleeping", "The core is asleep.".to_string()),
+        CoreStatus::LockedUp => (
+            "lockedup",
+            "The core locked up after an unrecoverable exception.".to_string(),
+        ),
+        CoreStatus::Halted(halt_reason) => match halt_reason {
+            HaltReason::Breakpoint(cause) => {
+                let breakpoint = match cause {
+                    BreakpointCause::Hardware => "a hardware breakpoint",
+                    BreakpointCause::Software => "a software breakpoint",
+                    BreakpointCause::Semihosting(_) => "a semihosting request",
+                    BreakpointCause::Unknown => "a breakpoint",
+                };
+                ("breakpoint", format!("Stopped at {breakpoint}{at}."))
+            }
+            HaltReason::Exception => (
+                "exception",
+                format!("Stopped by an exception, for example an interrupt{at}."),
+            ),
+            HaltReason::Watchpoint => ("data breakpoint", format!("Stopped by a watchpoint{at}.")),
+            HaltReason::Step => ("step", format!("Stopped after one step{at}.")),
+            HaltReason::Request => ("pause", format!("Stopped on your request{at}.")),
+            HaltReason::External => ("external", format!("Stopped by an external request{at}.")),
+            HaltReason::Multiple => (
+                "breakpoint",
+                format!("Stopped for more than one reason{at}."),
+            ),
+            _other => (
+                "unrecognized",
+                format!("Stopped for an unknown reason{at}."),
+            ),
+        },
+        CoreStatus::Unknown => ("unknown", "The state of the core is unknown.".to_string()),
     }
 }
 
@@ -78,28 +85,20 @@ mod test {
     use super::*;
 
     #[test]
-    fn describes_a_halt_with_and_without_a_program_counter() {
+    fn describes_a_halt_with_and_without_a_location() {
         pretty_assertions::assert_eq!(
-            CoreStatus::Halted(HaltReason::Breakpoint(BreakpointCause::Hardware))
-                .short_long_status(Some(0x2000), false),
+            describe(
+                &CoreStatus::Halted(HaltReason::Breakpoint(BreakpointCause::Hardware)),
+                " at 0x00002000 (/src/main.rs:42:7)"
+            ),
             (
                 "breakpoint",
-                "Stopped at a hardware breakpoint at 0x00002000.".to_string()
+                "Stopped at a hardware breakpoint at 0x00002000 (/src/main.rs:42:7).".to_string()
             )
         );
         pretty_assertions::assert_eq!(
-            CoreStatus::Halted(HaltReason::Request).short_long_status(None, true),
+            describe(&CoreStatus::Halted(HaltReason::Request), ""),
             ("pause", "Stopped on your request.".to_string())
-        );
-    }
-
-    #[test]
-    fn styles_the_program_counter_for_ansi_clients() {
-        pretty_assertions::assert_eq!(
-            CoreStatus::Halted(HaltReason::Step)
-                .short_long_status(Some(0x2000), true)
-                .1,
-            "Stopped after one step at \u{1b}[33m0x00002000\u{1b}[0m."
         );
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/core_status.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/core_status.rs
@@ -1,71 +1,105 @@
-use probe_rs::{CoreStatus, HaltReason};
+use probe_rs::{BreakpointCause, CoreStatus, HaltReason};
+
+use crate::util::style::ReplAddress;
 
 pub(crate) trait DapStatus {
-    fn short_long_status(&self, program_counter: Option<u64>) -> (&'static str, String);
+    fn short_long_status(
+        &self,
+        program_counter: Option<u64>,
+        colorize: bool,
+    ) -> (&'static str, String);
 }
 impl DapStatus for CoreStatus {
-    /// Return a tuple with short and long descriptions of the core status for human machine interface / hmi. The short status matches with the strings implemented by the Microsoft DAP protocol, e.g. `let (short_status, long status) = CoreStatus::short_long_status(core_status)`
-    fn short_long_status(&self, program_counter: Option<u64>) -> (&'static str, String) {
+    /// Return a tuple with short and long descriptions of the core status for human machine interface.
+    ///
+    /// The short status matches with the strings implemented by the Microsoft DAP protocol,
+    /// e.g. `let (short_status, long status) = CoreStatus::short_long_status(core_status)`
+    ///
+    /// `colorize` may only be set for text that the client shows in its console.
+    fn short_long_status(
+        &self,
+        program_counter: Option<u64>,
+        colorize: bool,
+    ) -> (&'static str, String) {
+        let at = program_counter
+            .map(|pc| {
+                format!(
+                    " at {}",
+                    ReplAddress::new(format!("{pc:#010x}")).colorize(colorize)
+                )
+            })
+            .unwrap_or_default();
+
         match self {
-            CoreStatus::Running => ("continued", "Core is running".to_string()),
-            CoreStatus::Sleeping => ("sleeping", "Core is in SLEEP mode".to_string()),
+            CoreStatus::Running => ("continued", "The core is running.".to_string()),
+            CoreStatus::Sleeping => ("sleeping", "The core is asleep.".to_string()),
             CoreStatus::LockedUp => (
                 "lockedup",
-                "Core is in LOCKUP status - encountered an unrecoverable exception".to_string(),
+                "The core locked up after an unrecoverable exception.".to_string(),
             ),
             CoreStatus::Halted(halt_reason) => match halt_reason {
-                HaltReason::Breakpoint(cause) => (
-                    "breakpoint",
-                    format!(
-                        "Halted on breakpoint ({:?}) @{}.",
-                        cause,
-                        if let Some(program_counter) = program_counter {
-                            format!("{program_counter:#010x}")
-                        } else {
-                            "(unspecified location)".to_string()
-                        }
-                    ),
-                ),
+                HaltReason::Breakpoint(cause) => {
+                    let breakpoint = match cause {
+                        BreakpointCause::Hardware => "a hardware breakpoint",
+                        BreakpointCause::Software => "a software breakpoint",
+                        BreakpointCause::Semihosting(_) => "a semihosting request",
+                        BreakpointCause::Unknown => "a breakpoint",
+                    };
+                    ("breakpoint", format!("Stopped at {breakpoint}{at}."))
+                }
                 HaltReason::Exception => (
                     "exception",
-                    "Core halted due to an exception, e.g. interrupt handler".to_string(),
+                    format!("Stopped by an exception, for example an interrupt{at}."),
                 ),
-                HaltReason::Watchpoint => (
-                    "data breakpoint",
-                    "Core halted due to a watchpoint or data breakpoint".to_string(),
-                ),
-                HaltReason::Step => (
-                    "step",
-                    format!(
-                        "Halted after a 'step' instruction @{}.",
-                        if let Some(program_counter) = program_counter {
-                            format!("{program_counter:#010x}")
-                        } else {
-                            "(unspecified location)".to_string()
-                        }
-                    ),
-                ),
-                HaltReason::Request => (
-                    "pause",
-                    format!(
-                        "Core halted due to a user (debugger client) request @{}.",
-                        if let Some(program_counter) = program_counter {
-                            format!("{program_counter:#010x}")
-                        } else {
-                            "(unspecified location)".to_string()
-                        }
-                    ),
-                ),
-                HaltReason::External => (
-                    "external",
-                    "Core halted due to an external request".to_string(),
+                HaltReason::Watchpoint => {
+                    ("data breakpoint", format!("Stopped by a watchpoint{at}."))
+                }
+                HaltReason::Step => ("step", format!("Stopped after one step{at}.")),
+                HaltReason::Request => ("pause", format!("Stopped on your request{at}.")),
+                HaltReason::External => {
+                    ("external", format!("Stopped by an external request{at}."))
+                }
+                HaltReason::Multiple => (
+                    "breakpoint",
+                    format!("Stopped for more than one reason{at}."),
                 ),
                 _other => (
                     "unrecognized",
-                    "Core halted: unrecognized cause".to_string(),
+                    format!("Stopped for an unknown reason{at}."),
                 ),
             },
-            CoreStatus::Unknown => ("unknown", "Core status cannot be determined".to_string()),
+            CoreStatus::Unknown => ("unknown", "The state of the core is unknown.".to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn describes_a_halt_with_and_without_a_program_counter() {
+        pretty_assertions::assert_eq!(
+            CoreStatus::Halted(HaltReason::Breakpoint(BreakpointCause::Hardware))
+                .short_long_status(Some(0x2000), false),
+            (
+                "breakpoint",
+                "Stopped at a hardware breakpoint at 0x00002000.".to_string()
+            )
+        );
+        pretty_assertions::assert_eq!(
+            CoreStatus::Halted(HaltReason::Request).short_long_status(None, true),
+            ("pause", "Stopped on your request.".to_string())
+        );
+    }
+
+    #[test]
+    fn styles_the_program_counter_for_ansi_clients() {
+        pretty_assertions::assert_eq!(
+            CoreStatus::Halted(HaltReason::Step)
+                .short_long_status(Some(0x2000), true)
+                .1,
+            "Stopped after one step at \u{1b}[33m0x00002000\u{1b}[0m."
+        );
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/breakpoint.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/breakpoint.rs
@@ -140,7 +140,7 @@ async fn create_breakpoint<'a>(
         let core_info = adapter.pause_impl_async(backend, core_data).await?;
         return Ok(EvalResponse::Message(
             CoreStatus::Halted(HaltReason::Request)
-                .short_long_status(Some(core_info.pc))
+                .short_long_status(Some(core_info.pc), adapter.supports_ansi_styling)
                 .1,
         ));
     }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/breakpoint.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/breakpoint.rs
@@ -1,6 +1,8 @@
+use std::fmt::Write;
+
 use linkme::distributed_slice;
 use probe_rs::{CoreStatus, HaltReason};
-use probe_rs_debug::{ColumnType, VerifiedBreakpoint};
+use probe_rs_debug::{ColumnType, SourceLocation, VerifiedBreakpoint};
 use typed_path::TypedPath;
 
 use crate::cmd::dap_server::{
@@ -11,13 +13,14 @@ use crate::cmd::dap_server::{
         core_status::DapStatus,
         dap_types::{Breakpoint, BreakpointEventBody, EvaluateArguments, MemoryAddress, Source},
         repl_commands::{EvalResponse, EvalResult, REPL_COMMANDS, ReplCommand, async_fn},
+        repl_commands_helpers::format_source_location,
         repl_types::ReplCommandArgs,
-        request_helpers::instruction_breakpoint_response,
+        request_helpers::get_dap_source,
     },
     server::core_data::CoreData,
     server::session_data::{ActiveBreakpoint, BreakpointType, SourceLocationScope},
 };
-use crate::util::style::ReplAddress;
+use crate::util::style::{ReplAddress, ReplDim};
 use probe_rs_rpc::breakpoints::SourceBreakpointLocation;
 
 #[distributed_slice(REPL_COMMANDS)]
@@ -26,7 +29,7 @@ static BREAK: ReplCommand = ReplCommand {
     help_text: "Set a breakpoint at a location, or halt the target if unspecified.",
     requires_target_halted: false,
     sub_commands: &[],
-    args: &[ReplCommandArgs::Optional("*address | file:line[:column]")],
+    args: &[ReplCommandArgs::Optional("address | file:line[:column]")],
     handler: async_fn!(create_breakpoint),
 };
 
@@ -36,7 +39,7 @@ static CLEAR: ReplCommand = ReplCommand {
     help_text: "Clear a breakpoint.",
     requires_target_halted: false,
     sub_commands: &[],
-    args: &[ReplCommandArgs::Required("*address | file:line[:column]")],
+    args: &[ReplCommandArgs::Required("address | file:line[:column]")],
     handler: async_fn!(clear_breakpoint),
 };
 
@@ -49,7 +52,7 @@ enum BreakpointLocation<'a> {
     },
 }
 
-/// Parse `*<address>`, `<file>:<line>`, or `<file>:<line>:<column>` from a single REPL token.
+/// Parse `[*]<address>`, `<file>:<line>`, or `<file>:<line>:<column>` from a single REPL token.
 ///
 /// Splitting is done from the right so that Windows drive letters
 /// (e.g. `C:\foo.rs:42` or `C:\foo.rs:42:5`) are handled correctly.
@@ -79,8 +82,12 @@ fn parse_breakpoint_location(input: &str) -> Result<BreakpointLocation<'_>, Debu
         });
     }
 
+    if let Ok(MemoryAddress(address)) = input.try_into() {
+        return Ok(BreakpointLocation::Address(address));
+    }
+
     Err(DebuggerError::UserMessage(format!(
-        "Invalid argument {input:?}. Expected `*<address>` or `<file>:<line>[:<column>]`. See `help`."
+        "Invalid argument {input:?}. Expected `[*]<address>` or `<file>:<line>[:<column>]`. See `help`."
     )))
 }
 
@@ -144,39 +151,19 @@ async fn create_breakpoint<'a>(
         ));
     };
 
-    match parse_breakpoint_location(token)? {
+    let (address, source_location, breakpoint_type) = match parse_breakpoint_location(token)? {
         BreakpointLocation::Address(address) => {
-            let set_result = backend.set_hw_breakpoint(core_index, address).await;
-            let source_location = if set_result.is_ok() {
-                backend
-                    .resolve_source_locations(vec![address])
-                    .await
-                    .ok()
-                    .and_then(|mut locations| locations.pop().flatten())
-            } else {
-                None
-            };
-            let breakpoint_response = instruction_breakpoint_response(
-                address,
-                set_result.is_ok(),
-                set_result.as_ref().err().map(|e| e.to_string()).as_deref(),
-                source_location.as_ref(),
-            );
-            let body = if breakpoint_response.verified {
-                serde_json::to_value(BreakpointEventBody {
-                    breakpoint: breakpoint_response.clone(),
-                    reason: "new".to_string(),
-                })
+            let source_location = backend
+                .resolve_source_locations(vec![address])
+                .await
                 .ok()
-            } else {
-                None
-            };
-            adapter.dyn_send_event("breakpoint", body)?;
-            Ok(EvalResponse::Message(
-                breakpoint_response.message.unwrap_or_else(|| {
-                    format!("Unexpected error creating breakpoint at {address:#x}.")
-                }),
-            ))
+                .and_then(|mut locations| locations.pop().flatten());
+
+            (
+                address,
+                source_location,
+                BreakpointType::InstructionBreakpoint,
+            )
         }
 
         BreakpointLocation::FileLine { path, line, column } => {
@@ -184,43 +171,79 @@ async fn create_breakpoint<'a>(
                 address,
                 source_location,
             } = resolve_one_source_breakpoint(backend, path, line, column).await?;
-            backend.set_hw_breakpoint(core_index, address).await?;
-            let source = source_from_path(path);
-            core_data.breakpoints.push(ActiveBreakpoint {
-                breakpoint_type: BreakpointType::SourceBreakpoint {
-                    source: Box::new(source.clone()),
-                    location: SourceLocationScope::Specific(source_location.clone()),
-                },
-                address,
-            });
-            let body = serde_json::to_value(BreakpointEventBody {
-                breakpoint: Breakpoint {
-                    id: Some(address as i64),
-                    verified: true,
-                    line: source_location.line.map(|l| l as i64),
-                    source: Some(source),
-                    message: Some(format!("Source breakpoint at {:#010X}", address)),
-                    column: source_location.column.map(|col| match col {
-                        ColumnType::LeftEdge => 0_i64,
-                        ColumnType::Column(c) => c as i64,
-                    }),
-                    end_column: None,
-                    end_line: None,
-                    instruction_reference: None,
-                    offset: None,
-                    reason: None,
-                },
-                reason: "new".to_string(),
-            })
-            .ok();
-            adapter.dyn_send_event("breakpoint", body)?;
-            Ok(EvalResponse::Message(format!(
-                "Breakpoint set at {}",
-                ReplAddress::new(format!("{address:#010X}"))
-                    .colorize(adapter.supports_ansi_styling)
-            )))
+            let breakpoint_type = BreakpointType::SourceBreakpoint {
+                source: Box::new(source_from_path(path)),
+                location: SourceLocationScope::Specific(source_location.clone()),
+            };
+
+            (address, Some(source_location), breakpoint_type)
         }
+    };
+
+    backend.set_hw_breakpoint(core_index, address).await?;
+    core_data.breakpoints.push(ActiveBreakpoint {
+        breakpoint_type,
+        address,
+    });
+
+    let body = serde_json::to_value(BreakpointEventBody {
+        breakpoint: Breakpoint {
+            id: Some(address as i64),
+            verified: true,
+            line: source_location
+                .as_ref()
+                .and_then(|loc| loc.line)
+                .map(|l| l as i64),
+            column: source_location
+                .as_ref()
+                .and_then(|loc| loc.column)
+                .map(|col| match col {
+                    ColumnType::LeftEdge => 0_i64,
+                    ColumnType::Column(c) => c as i64,
+                }),
+            source: source_location.as_ref().and_then(get_dap_source),
+            message: Some(breakpoint_set_message(
+                address,
+                source_location.as_ref(),
+                false,
+            )),
+            instruction_reference: Some(format!("{address:#010x}")),
+            end_column: None,
+            end_line: None,
+            offset: None,
+            reason: None,
+        },
+        reason: "new".to_string(),
+    })
+    .ok();
+    adapter.dyn_send_event("breakpoint", body)?;
+
+    Ok(EvalResponse::Message(breakpoint_set_message(
+        address,
+        source_location.as_ref(),
+        adapter.supports_ansi_styling,
+    )))
+}
+
+fn breakpoint_set_message(
+    address: u64,
+    source_location: Option<&SourceLocation>,
+    colorize: bool,
+) -> String {
+    let mut message = format!(
+        "Breakpoint set at {}",
+        ReplAddress::new(format!("{address:#010x}")).colorize(colorize)
+    );
+    if let Some(location) = source_location {
+        #[expect(clippy::unwrap_used, reason = "Writing to a string is infallible")]
+        write!(
+            &mut message,
+            " {}",
+            ReplDim::new(format!("({})", format_source_location(location))).colorize(colorize)
+        )
+        .unwrap();
     }
+    message
 }
 
 async fn clear_breakpoint<'a>(
@@ -323,5 +346,36 @@ mod tests {
         assert_eq!(path, "/src/main.rs");
         assert_eq!(line, 42);
         assert_eq!(column, None);
+    }
+
+    #[test]
+    fn reports_the_source_location_of_a_breakpoint() {
+        let location = SourceLocation {
+            path: TypedPath::derive("/src/main.rs").to_path_buf(),
+            line: Some(42),
+            column: Some(ColumnType::Column(7)),
+            address: Some(0x2000),
+        };
+
+        pretty_assertions::assert_eq!(
+            breakpoint_set_message(0x2000, Some(&location), false),
+            "Breakpoint set at 0x00002000 (/src/main.rs:42:7)"
+        );
+        pretty_assertions::assert_eq!(
+            breakpoint_set_message(0x2000, None, true),
+            "Breakpoint set at \u{1b}[33m0x00002000\u{1b}[0m"
+        );
+    }
+
+    #[test]
+    fn parses_addresses_with_and_without_the_star_prefix() {
+        for input in ["*0x2000", "0x2000", "8192"] {
+            let BreakpointLocation::Address(address) = parse_breakpoint_location(input).unwrap()
+            else {
+                panic!("expected address breakpoint for {input:?}");
+            };
+
+            assert_eq!(address, 0x2000);
+        }
     }
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/breakpoint.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/breakpoint.rs
@@ -1,5 +1,3 @@
-use std::fmt::Write;
-
 use linkme::distributed_slice;
 use probe_rs::{CoreStatus, HaltReason};
 use probe_rs_debug::{ColumnType, SourceLocation, VerifiedBreakpoint};
@@ -13,14 +11,13 @@ use crate::cmd::dap_server::{
         core_status::DapStatus,
         dap_types::{Breakpoint, BreakpointEventBody, EvaluateArguments, MemoryAddress, Source},
         repl_commands::{EvalResponse, EvalResult, REPL_COMMANDS, ReplCommand, async_fn},
-        repl_commands_helpers::format_source_location,
         repl_types::ReplCommandArgs,
         request_helpers::get_dap_source,
     },
     server::core_data::CoreData,
     server::session_data::{ActiveBreakpoint, BreakpointType, SourceLocationScope},
 };
-use crate::util::style::{ReplAddress, ReplDim};
+use crate::util::style::format_location;
 use probe_rs_rpc::breakpoints::SourceBreakpointLocation;
 
 #[distributed_slice(REPL_COMMANDS)]
@@ -140,7 +137,8 @@ async fn create_breakpoint<'a>(
         let core_info = adapter.pause_impl_async(backend, core_data).await?;
         return Ok(EvalResponse::Message(
             CoreStatus::Halted(HaltReason::Request)
-                .short_long_status(Some(core_info.pc), adapter.supports_ansi_styling)
+                .short_long_status(backend, Some(core_info.pc), adapter.supports_ansi_styling)
+                .await
                 .1,
         ));
     }
@@ -153,11 +151,7 @@ async fn create_breakpoint<'a>(
 
     let (address, source_location, breakpoint_type) = match parse_breakpoint_location(token)? {
         BreakpointLocation::Address(address) => {
-            let source_location = backend
-                .resolve_source_locations(vec![address])
-                .await
-                .ok()
-                .and_then(|mut locations| locations.pop().flatten());
+            let source_location = backend.source_location(address).await;
 
             (
                 address,
@@ -230,20 +224,10 @@ fn breakpoint_set_message(
     source_location: Option<&SourceLocation>,
     colorize: bool,
 ) -> String {
-    let mut message = format!(
+    format!(
         "Breakpoint set at {}",
-        ReplAddress::new(format!("{address:#010x}")).colorize(colorize)
-    );
-    if let Some(location) = source_location {
-        #[expect(clippy::unwrap_used, reason = "Writing to a string is infallible")]
-        write!(
-            &mut message,
-            " {}",
-            ReplDim::new(format!("({})", format_source_location(location))).colorize(colorize)
-        )
-        .unwrap();
-    }
-    message
+        format_location(address, source_location, colorize)
+    )
 }
 
 async fn clear_breakpoint<'a>(

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/cpu.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/cpu.rs
@@ -35,9 +35,34 @@ static RESET: ReplCommand = ReplCommand {
 #[distributed_slice(REPL_COMMANDS)]
 static STEP: ReplCommand = ReplCommand {
     command: "step",
-    help_text: "Step one instruction",
+    help_text: "Step one instruction.",
     requires_target_halted: true,
-    sub_commands: &[],
+    sub_commands: &[
+        ReplCommand {
+            command: "over",
+            help_text: "Step over the current statement.",
+            requires_target_halted: true,
+            sub_commands: &[],
+            args: &[],
+            handler: async_fn!(step_over_repl),
+        },
+        ReplCommand {
+            command: "into",
+            help_text: "Step into the current statement.",
+            requires_target_halted: true,
+            sub_commands: &[],
+            args: &[],
+            handler: async_fn!(step_into_repl),
+        },
+        ReplCommand {
+            command: "out",
+            help_text: "Step out of the current function.",
+            requires_target_halted: true,
+            sub_commands: &[],
+            args: &[],
+            handler: async_fn!(step_out_repl),
+        },
+    ],
     args: &[],
     handler: async_fn!(step_repl),
 };
@@ -73,9 +98,46 @@ async fn step_repl<'a>(
     _evaluate_arguments: &'a EvaluateArguments,
     adapter: &'a mut DebugAdapter,
 ) -> EvalResult {
-    let pc = adapter
-        .step_impl_async(SteppingMode::StepInstruction, backend, core_data)
-        .await?;
+    step_with_mode(backend, core_data, adapter, SteppingMode::StepInstruction).await
+}
+
+async fn step_over_repl<'a>(
+    backend: &'a mut RpcBackend,
+    core_data: &'a mut CoreData,
+    _command_arguments: &'a str,
+    _evaluate_arguments: &'a EvaluateArguments,
+    adapter: &'a mut DebugAdapter,
+) -> EvalResult {
+    step_with_mode(backend, core_data, adapter, SteppingMode::OverStatement).await
+}
+
+async fn step_into_repl<'a>(
+    backend: &'a mut RpcBackend,
+    core_data: &'a mut CoreData,
+    _command_arguments: &'a str,
+    _evaluate_arguments: &'a EvaluateArguments,
+    adapter: &'a mut DebugAdapter,
+) -> EvalResult {
+    step_with_mode(backend, core_data, adapter, SteppingMode::IntoStatement).await
+}
+
+async fn step_out_repl<'a>(
+    backend: &'a mut RpcBackend,
+    core_data: &'a mut CoreData,
+    _command_arguments: &'a str,
+    _evaluate_arguments: &'a EvaluateArguments,
+    adapter: &'a mut DebugAdapter,
+) -> EvalResult {
+    step_with_mode(backend, core_data, adapter, SteppingMode::OutOfStatement).await
+}
+
+async fn step_with_mode(
+    backend: &mut RpcBackend,
+    core_data: &mut CoreData,
+    adapter: &mut DebugAdapter,
+    mode: SteppingMode,
+) -> EvalResult {
+    let pc = adapter.step_impl_async(mode, backend, core_data).await?;
     Ok(EvalResponse::Message(
         CoreStatus::Halted(HaltReason::Step)
             .short_long_status(backend, Some(pc), adapter.supports_ansi_styling)

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/cpu.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/cpu.rs
@@ -77,8 +77,8 @@ async fn step_repl<'a>(
         .step_impl_async(SteppingMode::StepInstruction, backend, core_data)
         .await?;
     Ok(EvalResponse::Message(
-        CoreStatus::Halted(HaltReason::Request)
-            .short_long_status(Some(pc))
+        CoreStatus::Halted(HaltReason::Step)
+            .short_long_status(Some(pc), adapter.supports_ansi_styling)
             .1,
     ))
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/cpu.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/cpu.rs
@@ -78,7 +78,8 @@ async fn step_repl<'a>(
         .await?;
     Ok(EvalResponse::Message(
         CoreStatus::Halted(HaltReason::Step)
-            .short_long_status(Some(pc), adapter.supports_ansi_styling)
+            .short_long_status(backend, Some(pc), adapter.supports_ansi_styling)
+            .await
             .1,
     ))
 }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/info.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 
 use linkme::distributed_slice;
 use probe_rs::{CoreRegister, RegisterId};
-use probe_rs_debug::{ColumnType, StackFrame, VariableName};
+use probe_rs_debug::{StackFrame, VariableName};
 
 use crate::cmd::dap_server::{
     DebuggerError,
@@ -14,8 +14,8 @@ use crate::cmd::dap_server::{
             EvalResponse, EvalResult, REPL_COMMANDS, ReplCommand, async_fn, need_subcommand,
         },
         repl_commands_helpers::{
-            PrintTree, format_repl_variables, get_local_variable, scope_variables, select_frame,
-            stack_frame_id,
+            PrintTree, format_repl_variables, format_source_location, get_local_variable,
+            scope_variables, select_frame, stack_frame_id,
         },
         repl_types::{GdbFormat, GdbNuf, ReplCommandArgs},
     },
@@ -140,20 +140,11 @@ fn format_frame(index: usize, frame: &StackFrame, colorize: bool) -> String {
         .unwrap();
     }
     if let Some(location) = &frame.source_location {
-        let mut source = format!("{}", location.path.to_path().display());
-        if let Some(line) = location.line {
-            #[expect(clippy::unwrap_used, reason = "Writing to a string is infallible")]
-            write!(&mut source, ":{line}").unwrap();
-            if let Some(ColumnType::Column(column)) = location.column {
-                #[expect(clippy::unwrap_used, reason = "Writing to a string is infallible")]
-                write!(&mut source, ":{column}").unwrap();
-            }
-        }
         #[expect(clippy::unwrap_used, reason = "Writing to a string is infallible")]
         write!(
             &mut response,
             "\nSource: {}",
-            ReplDim::new(source).colorize(colorize)
+            ReplDim::new(format_source_location(location)).colorize(colorize)
         )
         .unwrap();
     }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands/info.rs
@@ -14,14 +14,14 @@ use crate::cmd::dap_server::{
             EvalResponse, EvalResult, REPL_COMMANDS, ReplCommand, async_fn, need_subcommand,
         },
         repl_commands_helpers::{
-            PrintTree, format_repl_variables, format_source_location, get_local_variable,
-            scope_variables, select_frame, stack_frame_id,
+            PrintTree, format_repl_variables, get_local_variable, scope_variables, select_frame,
+            stack_frame_id,
         },
         repl_types::{GdbFormat, GdbNuf, ReplCommandArgs},
     },
     server::core_data::CoreData,
 };
-use crate::util::style::{ReplAddress, ReplDim, ReplSymbol};
+use crate::util::style::{ReplAddress, ReplDim, ReplSymbol, format_source_location};
 
 #[distributed_slice(REPL_COMMANDS)]
 static INFO: ReplCommand = ReplCommand {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use probe_rs_debug::{ObjectRef, StackFrame, VariableName};
+use probe_rs_debug::{ColumnType, ObjectRef, SourceLocation, StackFrame, VariableName};
 
 use crate::cmd::dap_server::{
     DebuggerError,
@@ -42,6 +42,18 @@ pub(crate) async fn scope_variables(
             .variables(core_index, variables_reference, None)
             .await?,
     ))
+}
+
+/// Format a source location as `path[:line[:column]]`.
+pub(crate) fn format_source_location(location: &SourceLocation) -> String {
+    let mut source = format!("{}", location.path.to_path().display());
+    if let Some(line) = location.line {
+        source.push_str(&format!(":{line}"));
+        if let Some(ColumnType::Column(column)) = location.column {
+            source.push_str(&format!(":{column}"));
+        }
+    }
+    source
 }
 
 pub(crate) fn stack_frame_id(stack_frame: &StackFrame) -> Result<u32, DebuggerError> {
@@ -675,7 +687,7 @@ mod test {
             &[
                 (
                     "break ",
-                    "break [*address | file:line[:column]]: Set a breakpoint at a location, or halt the target if unspecified.",
+                    "break [address | file:line[:column]]: Set a breakpoint at a location, or halt the target if unspecified.",
                 ),
                 (
                     "bt ",
@@ -689,14 +701,14 @@ mod test {
             "br",
             &[(
                 "break ",
-                "break [*address | file:line[:column]]: Set a breakpoint at a location, or halt the target if unspecified.",
+                "break [address | file:line[:column]]: Set a breakpoint at a location, or halt the target if unspecified.",
             )],
         );
         assert_completion_result(
             "break",
             &[(
                 "break ",
-                "break [*address | file:line[:column]]: Set a breakpoint at a location, or halt the target if unspecified.",
+                "break [address | file:line[:column]]: Set a breakpoint at a location, or halt the target if unspecified.",
             )],
         );
         assert_completion_result(

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
@@ -653,6 +653,17 @@ mod test {
         assert_eq!(last_piece, "b");
         assert_eq!(commands[0].command, "break");
         assert_eq!(root, ""); // yaml is not a subcommand so we don't include "b" in the command root.
+
+        let (_root, last_piece, commands) = build_expanded_commands(&REPL_COMMANDS, "step");
+        assert_eq!(commands.len(), 1);
+        assert_eq!(last_piece, "step");
+        assert_eq!(commands[0].command, "step");
+
+        let (root, last_piece, commands) = build_expanded_commands(&REPL_COMMANDS, "step over");
+        assert_eq!(commands.len(), 1);
+        assert_eq!(last_piece, "over");
+        assert_eq!(commands[0].command, "over");
+        assert_eq!(root, "step ");
     }
 
     #[test]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use probe_rs_debug::{ColumnType, ObjectRef, SourceLocation, StackFrame, VariableName};
+use probe_rs_debug::{ObjectRef, StackFrame, VariableName};
 
 use crate::cmd::dap_server::{
     DebuggerError,
@@ -42,18 +42,6 @@ pub(crate) async fn scope_variables(
             .variables(core_index, variables_reference, None)
             .await?,
     ))
-}
-
-/// Format a source location as `path[:line[:column]]`.
-pub(crate) fn format_source_location(location: &SourceLocation) -> String {
-    let mut source = format!("{}", location.path.to_path().display());
-    if let Some(line) = location.line {
-        source.push_str(&format!(":{line}"));
-        if let Some(ColumnType::Column(column)) = location.column {
-            source.push_str(&format!(":{column}"));
-        }
-    }
-    source
 }
 
 pub(crate) fn stack_frame_id(stack_frame: &StackFrame) -> Result<u32, DebuggerError> {

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -1713,7 +1713,7 @@ mod test {
         protocol_adapter.expect_event(
             "output",
             Some(OutputEventBody {
-                output: String::from("Core is running\n"),
+                output: String::from("The core is running.\n"),
                 category: Some("console".to_owned()),
                 variables_reference: None,
                 source: None,
@@ -1757,7 +1757,7 @@ mod test {
                 thread_id: 0,
             }),
         );
-        protocol_adapter.expect_output_event("Core is running\n");
+        protocol_adapter.expect_output_event("The core is running.\n");
 
         let unknown_variables_reference = 0xDEAD_BEEF_i64;
         let expected_error =
@@ -1874,7 +1874,7 @@ mod test {
         protocol_adapter.expect_event(
             "output",
             Some(OutputEventBody {
-                output: String::from("Core is running\n"),
+                output: String::from("The core is running.\n"),
                 category: Some("console".to_owned()),
                 variables_reference: None,
                 source: None,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -508,7 +508,7 @@ impl SessionData {
     ) -> Result<(), DebuggerError> {
         let core_index = self.core_data[cd_idx].core_index;
         let program_counter = self.backend.program_counter(core_index).await;
-        let (reason, description) = status.short_long_status(program_counter);
+        let (reason, description) = status.short_long_status(program_counter, false);
         let event_body = Some(StoppedEventBody {
             reason: reason.to_string(),
             description: Some(description),
@@ -864,7 +864,11 @@ impl SessionData {
                 } else {
                     None
                 };
-                debug_adapter.log_to_console(current_core_status.short_long_status(pc).1);
+                debug_adapter.log_to_console(
+                    current_core_status
+                        .short_long_status(pc, debug_adapter.supports_ansi_styling)
+                        .1,
+                );
             }
 
             // If the core is running, we set the flag to indicate that at least one core is not halted.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -508,7 +508,9 @@ impl SessionData {
     ) -> Result<(), DebuggerError> {
         let core_index = self.core_data[cd_idx].core_index;
         let program_counter = self.backend.program_counter(core_index).await;
-        let (reason, description) = status.short_long_status(program_counter, false);
+        let (reason, description) = status
+            .short_long_status(&self.backend, program_counter, false)
+            .await;
         let event_body = Some(StoppedEventBody {
             reason: reason.to_string(),
             description: Some(description),
@@ -864,11 +866,11 @@ impl SessionData {
                 } else {
                     None
                 };
-                debug_adapter.log_to_console(
-                    current_core_status
-                        .short_long_status(pc, debug_adapter.supports_ansi_styling)
-                        .1,
-                );
+                let description = current_core_status
+                    .short_long_status(&self.backend, pc, debug_adapter.supports_ansi_styling)
+                    .await
+                    .1;
+                debug_adapter.log_to_console(description);
             }
 
             // If the core is running, we set the flag to indicate that at least one core is not halted.

--- a/probe-rs-tools/src/bin/probe-rs/util/style.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/style.rs
@@ -1,5 +1,6 @@
 //! Named text styles for the CLI and for the DAP REPL.
 
+use probe_rs_debug::{ColumnType, SourceLocation};
 use ratatui::crossterm::style::Stylize;
 use std::env::VarError;
 use std::fmt::Display;
@@ -66,3 +67,68 @@ styled!(ReplCommandName(name) => format_args!("\x1b[1m{name}\x1b[0m"));
 styled!(ReplSymbol(name) => format_args!("\x1b[36m{name}\x1b[0m"));
 styled!(ReplAddress(addr) => format_args!("\x1b[33m{addr}\x1b[0m"));
 styled!(ReplDim(text) => format_args!("\x1b[2m{text}\x1b[0m"));
+
+/// Format a source location as `path[:line[:column]]`.
+pub fn format_source_location(location: &SourceLocation) -> String {
+    let mut source = format!("{}", location.path.to_path().display());
+    if let Some(line) = location.line {
+        source.push_str(&format!(":{line}"));
+        if let Some(ColumnType::Column(column)) = location.column {
+            source.push_str(&format!(":{column}"));
+        }
+    }
+    source
+}
+
+/// Format a target address, and the source location that belongs to it, for the
+/// client console.
+pub fn format_location(
+    address: u64,
+    source_location: Option<&SourceLocation>,
+    colorize: bool,
+) -> String {
+    let mut location = format!(
+        "{}",
+        ReplAddress::new(format!("{address:#010x}")).colorize(colorize)
+    );
+    if let Some(source) = source_location {
+        location.push_str(&format!(
+            " {}",
+            ReplDim::new(format!("({})", format_source_location(source))).colorize(colorize)
+        ));
+    }
+    location
+}
+
+#[cfg(test)]
+mod test {
+    use typed_path::TypedPath;
+
+    use super::*;
+
+    fn source_location() -> SourceLocation {
+        SourceLocation {
+            path: TypedPath::derive("/src/main.rs").to_path_buf(),
+            line: Some(42),
+            column: Some(ColumnType::Column(7)),
+            address: Some(0x2000),
+        }
+    }
+
+    #[test]
+    fn formats_an_address_with_its_source_location() {
+        pretty_assertions::assert_eq!(
+            format_location(0x2000, Some(&source_location()), false),
+            "0x00002000 (/src/main.rs:42:7)"
+        );
+        pretty_assertions::assert_eq!(format_location(0x2000, None, false), "0x00002000");
+    }
+
+    #[test]
+    fn styles_the_address_and_the_source_location_for_ansi_clients() {
+        pretty_assertions::assert_eq!(
+            format_location(0x2000, Some(&source_location()), true),
+            "\u{1b}[33m0x00002000\u{1b}[0m \u{1b}[2m(/src/main.rs:42:7)\u{1b}[0m"
+        );
+    }
+}


### PR DESCRIPTION
Accept bare address, colorize output, add location info to core status. Also added `step into`, `step over` and `step out` commands.

<img width="869" height="278" alt="image" src="https://github.com/user-attachments/assets/006a38fd-3e8f-44f2-be20-d149605b661d" />
