### PR TITLE
Replace u64 SWJ sequences with a bit sequence type

### DIFF
--- a/changelog/changed-swj-sequence-length.md
+++ b/changelog/changed-swj-sequence-length.md
@@ -1,0 +1,1 @@
+A bit sequence now travels in a `BitSequence`, so a debug sequence can send more than 64 bits in one call.

--- a/probe-rs-linux/src/linuxspidevswd/mod.rs
+++ b/probe-rs-linux/src/linuxspidevswd/mod.rs
@@ -44,8 +44,9 @@ use probe_rs::{
         sequences::ArmDebugSequence,
     },
     probe::{
-        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeCreationError,
-        ProbeError, ProbeFactory, SwdSettings, WireProtocol, list::ProbeListItem,
+        BitSequence, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
+        ProbeCreationError, ProbeError, ProbeFactory, SwdSettings, WireProtocol,
+        list::ProbeListItem,
     },
 };
 use spidev::{SpiModeFlags, SpidevOptions, SpidevTransfer};
@@ -61,8 +62,7 @@ const WRITE_PACKET_SIZE: usize = 8; // 7 byte writes work, but only for slower s
 const READ_PACKET_SIZE: usize = 7;
 /// Maximum number of bytes allowed in a single SPI transaction.
 const MAX_QUEUE_BYTES: usize = 4096;
-const SWD_LINE_RESET_BITS: u8 = 51;
-const SWD_LINE_RESET_ONES: u64 = 0x0007_FFFF_FFFF_FFFF;
+const SWD_LINE_RESET_BITS: usize = 51;
 
 /// A factory for creating [`LinuxSpidevSwdProbe`] instances.
 #[derive(Debug)]
@@ -491,14 +491,14 @@ impl RawDapAccess for LinuxSpidevSwdProbe {
         self.flush_writes()
     }
 
-    fn jtag_sequence(&mut self, _cycles: u8, _tms: bool, _tdi: u64) -> Result<(), DebugProbeError> {
+    fn jtag_sequence(&mut self, _tms: bool, _tdi: &BitSequence) -> Result<(), DebugProbeError> {
         Err(DebugProbeError::NotImplemented {
             function_name: "jtag_sequence",
         })
     }
 
-    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError> {
-        let tx = encode_swj_sequence(bit_len, bits);
+    fn swj_sequence(&mut self, bits: &BitSequence) -> Result<(), DebugProbeError> {
+        let tx = encode_swj_sequence(bits);
         self.transfer_raw_bytes(&tx)
     }
 
@@ -622,43 +622,58 @@ impl core::fmt::Display for LinuxSpidevSwdError {
 
 impl ProbeError for LinuxSpidevSwdError {}
 
-fn encode_swj_sequence(bit_len: u8, bits: u64) -> Vec<u8> {
-    assert!(bit_len <= 64);
-
+fn encode_swj_sequence(bits: &BitSequence) -> Vec<u8> {
+    let bit_len = bits.len();
     if bit_len == 0 {
         return Vec::new();
     }
 
-    if is_line_reset_pattern(bit_len, bits) {
+    if is_line_reset_pattern(bits) {
+        // The high phase extends to the byte boundary. Only the requested idle cycles
+        // stay low.
         let send_bits = bit_len.div_ceil(8) * 8;
-        let remaining_low_cycles = bit_len.saturating_sub(SWD_LINE_RESET_BITS);
-        let reset_sequence = 0xFFFF_FFFF_FFFF_FFFF_u64 >> (64 - send_bits + remaining_low_cycles);
+        let high_bits = send_bits - (bit_len - SWD_LINE_RESET_BITS);
 
-        let mut tx: Vec<u8> =
-            reset_sequence.to_le_bytes()[0..bit_len.div_ceil(8) as usize].to_vec();
-        tx = tx.into_iter().map(|b: u8| b.reverse_bits()).collect();
-        return tx;
+        let mut tx = vec![0u8; send_bits / 8];
+        for i in 0..high_bits {
+            tx[i / 8] |= 1 << (i % 8);
+        }
+        return tx.into_iter().map(|byte| byte.reverse_bits()).collect();
     }
 
-    let mut tx: Vec<u8> = bits.to_le_bytes()[0..bit_len.div_ceil(8) as usize].to_vec();
-    tx = tx.into_iter().map(|b: u8| b.reverse_bits()).collect();
-    tx
+    let mut tx = vec![0u8; bit_len.div_ceil(8)];
+    for i in 0..bit_len {
+        if bits[i] {
+            tx[i / 8] |= 1 << (i % 8);
+        }
+    }
+    tx.into_iter().map(|byte| byte.reverse_bits()).collect()
 }
 
-fn is_line_reset_pattern(bit_len: u8, bits: u64) -> bool {
+fn is_line_reset_pattern(bits: &BitSequence) -> bool {
+    let bit_len = bits.len();
     if bit_len < SWD_LINE_RESET_BITS {
         return false;
     }
 
-    let lower_bits_are_ones = (bits & SWD_LINE_RESET_ONES) == SWD_LINE_RESET_ONES;
-    let upper_bits_are_zero = (bits >> SWD_LINE_RESET_BITS) == 0;
-
-    lower_bits_are_ones && upper_bits_are_zero
+    for i in 0..SWD_LINE_RESET_BITS {
+        if !bits[i] {
+            return false;
+        }
+    }
+    for i in SWD_LINE_RESET_BITS..bit_len {
+        if bits[i] {
+            return false;
+        }
+    }
+    true
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const SWD_LINE_RESET_ONES: u64 = 0x0007_FFFF_FFFF_FFFF;
 
     #[test]
     fn probe_info_uses_spidev_path_as_serial() {
@@ -707,18 +722,24 @@ mod tests {
 
     #[test]
     fn encode_swj_sequence_matches_switch_bytes() {
-        assert_eq!(encode_swj_sequence(16, 0xE79E), vec![0x79, 0xE7]);
+        assert_eq!(
+            encode_swj_sequence(&BitSequence::from_u64(16, 0xE79E)),
+            vec![0x79, 0xE7]
+        );
     }
 
     #[test]
     fn encode_swj_sequence_rounds_line_reset_up_with_high_padding() {
-        assert_eq!(encode_swj_sequence(51, SWD_LINE_RESET_ONES), vec![0xFF; 7]);
+        assert_eq!(
+            encode_swj_sequence(&BitSequence::from_u64(51, SWD_LINE_RESET_ONES)),
+            vec![0xFF; 7]
+        );
     }
 
     #[test]
     fn encode_swj_sequence_rounds_line_reset_low_suffix_to_zero_bytes() {
         assert_eq!(
-            encode_swj_sequence(53, SWD_LINE_RESET_ONES),
+            encode_swj_sequence(&BitSequence::from_u64(53, SWD_LINE_RESET_ONES)),
             vec![0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFC]
         );
     }

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -10,7 +10,7 @@ use crate::{
         memory::{ADIMemoryInterface, ArmMemoryInterface, Component},
         sequences::ArmDebugSequence,
     },
-    probe::{DebugProbe, DebugProbeError, Probe, WireProtocol},
+    probe::{BitSequence, DebugProbe, DebugProbeError, Probe, WireProtocol},
 };
 use jep106::JEP106Code;
 
@@ -116,7 +116,7 @@ pub fn read_chip_info_from_rom_table(
 /// Support for sending raw sequences via the probe.
 pub trait SwdSequence {
     /// Corresponds to the DAP_SWJ_Sequence function from the ARM Debug sequences
-    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError>;
+    fn swj_sequence(&mut self, bits: &BitSequence) -> Result<(), DebugProbeError>;
 
     /// Corresponds to the DAP_SWJ_Pins function from the ARM Debug sequences
     fn swj_pins(
@@ -297,8 +297,8 @@ impl ArmDebugInterface for ArmCommunicationInterface {
 }
 
 impl SwdSequence for ArmCommunicationInterface {
-    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError> {
-        self.probe_mut().swj_sequence(bit_len, bits)?;
+    fn swj_sequence(&mut self, bits: &BitSequence) -> Result<(), DebugProbeError> {
+        self.probe_mut().swj_sequence(bits)?;
 
         Ok(())
     }

--- a/probe-rs/src/architecture/arm/core/armv7ar.rs
+++ b/probe-rs/src/architecture/arm/core/armv7ar.rs
@@ -1791,7 +1791,7 @@ mod test {
             FullyQualifiedApAddress, communication_interface::SwdSequence,
             sequences::DefaultArmSequence,
         },
-        probe::DebugProbeError,
+        probe::{BitSequence, DebugProbeError},
     };
 
     use super::*;
@@ -1973,7 +1973,7 @@ mod test {
     }
 
     impl SwdSequence for MockProbe {
-        fn swj_sequence(&mut self, _bit_len: u8, _bits: u64) -> Result<(), DebugProbeError> {
+        fn swj_sequence(&mut self, _bits: &BitSequence) -> Result<(), DebugProbeError> {
             todo!()
         }
 

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -1703,7 +1703,7 @@ mod test {
             FullyQualifiedApAddress, communication_interface::SwdSequence,
             sequences::DefaultArmSequence,
         },
-        probe::DebugProbeError,
+        probe::{BitSequence, DebugProbeError},
     };
 
     use super::*;
@@ -1874,7 +1874,7 @@ mod test {
     }
 
     impl SwdSequence for MockProbe {
-        fn swj_sequence(&mut self, _bit_len: u8, _bits: u64) -> Result<(), DebugProbeError> {
+        fn swj_sequence(&mut self, _bits: &BitSequence) -> Result<(), DebugProbeError> {
             todo!()
         }
 

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -19,7 +19,7 @@ use crate::{
         core::registers::cortex_m::{PC, SP},
         dp::{Ctrl, DLPIDR, DebugPortError, DpRegister, TARGETID},
     },
-    probe::WireProtocol,
+    probe::{BitSequence, WireProtocol},
 };
 
 use super::{
@@ -529,13 +529,11 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
             tracing::trace!("Sending Selection Alert sequence");
 
             // Ensure target is not in the middle of detecting a selection alert
-            interface.swj_sequence(8, 0xFF)?;
+            interface.swj_sequence(&BitSequence::from_u64(8, 0xFF))?;
 
-            // Alert Sequence Bits  0.. 63
-            interface.swj_sequence(64, 0x86852D956209F392)?;
-
-            // Alert Sequence Bits 64..127
-            interface.swj_sequence(64, 0x19BC0EA2E3DDAFE9)?;
+            let mut alert = BitSequence::from_u64(64, 0x86852D956209F392);
+            alert.extend(&BitSequence::from_u64(64, 0x19BC0EA2E3DDAFE9));
+            interface.swj_sequence(&alert)?;
 
             Ok(())
         }
@@ -554,23 +552,23 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
                 Some(WireProtocol::Jtag) => {
                     if has_dormant {
                         tracing::debug!("Select Dormant State (from SWD)");
-                        interface.swj_sequence(16, 0xE3BC)?;
+                        interface.swj_sequence(&BitSequence::from_u64(16, 0xE3BC))?;
 
                         // Send alert sequence
                         alert_sequence(interface)?;
 
                         // 4 cycles SWDIO/TMS LOW + 8-Bit JTAG Activation Code (0x0A)
-                        interface.swj_sequence(12, 0x0A0)?;
+                        interface.swj_sequence(&BitSequence::from_u64(12, 0x0A0))?;
                     } else {
                         // Execute SWJ-DP Switch Sequence SWD to JTAG (0xE73C).
-                        interface.swj_sequence(16, 0xE73C)?;
+                        interface.swj_sequence(&BitSequence::from_u64(16, 0xE73C))?;
                     }
 
                     // Execute at least >5 TCK cycles with TMS high to enter the Test-Logic-Reset state
-                    interface.swj_sequence(6, 0x3F)?;
+                    interface.swj_sequence(&BitSequence::from_u64(6, 0x3F))?;
 
                     // Enter Run-Test-Idle state, as required by the DAP_Transfer command when using JTAG
-                    interface.jtag_sequence(1, false, 0x01)?;
+                    interface.jtag_sequence(false, &BitSequence::from_u64(1, 0x01))?;
 
                     // Configure JTAG IR lengths in probe
                     interface.configure_jtag(false)?;
@@ -579,17 +577,17 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
                     if has_dormant {
                         // Select Dormant State (from JTAG)
                         tracing::debug!("SelectV1 Dormant State (from JTAG)");
-                        interface.swj_sequence(31, 0x33BBBBBA)?;
+                        interface.swj_sequence(&BitSequence::from_u64(31, 0x33BBBBBA))?;
 
                         // Leave dormant state
                         alert_sequence(interface)?;
 
                         // 4 cycles SWDIO/TMS LOW + 8-Bit SWD Activation Code (0x1A)
-                        interface.swj_sequence(12, 0x1A0)?;
+                        interface.swj_sequence(&BitSequence::from_u64(12, 0x1A0))?;
                     } else {
                         // Execute SWJ-DP Switch Sequence JTAG to SWD (0xE79E).
                         // Change if SWJ-DP uses deprecated switch code (0xEDB6).
-                        interface.swj_sequence(16, 0xE79E)?;
+                        interface.swj_sequence(&BitSequence::from_u64(16, 0xE79E))?;
 
                         // > 50 cycles SWDIO/TMS High, at least 2 idle cycles (SWDIO/TMS Low).
                         // -> done in debug_port_connect
@@ -1026,7 +1024,7 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
 
                 // Should this be a swd_sequence?
                 // Technically we shouldn't drive SWDIO all the time when sending a request.
-                interface.swj_sequence(6 * 8, data)?;
+                interface.swj_sequence(&BitSequence::from_bytes(&data.to_le_bytes(), 6 * 8))?;
             }
 
             tracing::debug!("Reading DPIDR to enable SWD interface");
@@ -1208,10 +1206,10 @@ pub trait DebugEraseSequence: Send + Sync {
 ///
 /// After the line reset, SWDIO will be kept low for `swdio_low_cycles` cycles.
 fn swd_line_reset(interface: &mut dyn DapProbe, swdio_low_cycles: u8) -> Result<(), ArmError> {
-    assert!(swdio_low_cycles + 51 <= 64);
-
     tracing::debug!("Performing SWD line reset");
-    interface.swj_sequence(51 + swdio_low_cycles, 0x0007_FFFF_FFFF_FFFF)?;
+    let mut sequence = BitSequence::repeat(true, 51);
+    sequence.extend(&BitSequence::repeat(false, swdio_low_cycles as usize));
+    interface.swj_sequence(&sequence)?;
 
     Ok(())
 }

--- a/probe-rs/src/architecture/arm/traits.rs
+++ b/probe-rs/src/architecture/arm/traits.rs
@@ -1,6 +1,6 @@
 use crate::{
     CoreStatus,
-    probe::{DebugProbe, DebugProbeError},
+    probe::{BitSequence, DebugProbe, DebugProbeError},
 };
 
 use super::{
@@ -276,13 +276,13 @@ pub trait RawDapAccess {
     ///
     /// This can only be used for output, and should be used to generate
     /// the initial reset sequence, for example.
-    fn jtag_sequence(&mut self, cycles: u8, tms: bool, tdi: u64) -> Result<(), DebugProbeError>;
+    fn jtag_sequence(&mut self, tms: bool, tdi: &BitSequence) -> Result<(), DebugProbeError>;
 
     /// Send a specific output sequence over JTAG or SWD.
     ///
     /// This can only be used for output, and should be used to generate
     /// the initial reset sequence, for example.
-    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError>;
+    fn swj_sequence(&mut self, bits: &BitSequence) -> Result<(), DebugProbeError>;
 
     /// Set the state of debugger output pins directly.
     ///

--- a/probe-rs/src/architecture/arm/traits/polyfill.rs
+++ b/probe-rs/src/architecture/arm/traits/polyfill.rs
@@ -4,7 +4,7 @@
 //!
 //! See <https://developer.arm.com/documentation/ihi0031/f/?lang=en> for the ADIv5 specification.
 
-use bitvec::{bitvec, field::BitField, slice::BitSlice, vec::BitVec};
+use bitvec::{bitvec, field::BitField, slice::BitSlice};
 
 use crate::{
     architecture::arm::{
@@ -12,8 +12,8 @@ use crate::{
         dp::{Abort, Ctrl, DPIDR, DpRegister, RdBuff},
     },
     probe::{
-        CommandResult, DebugProbe, DebugProbeError, IoSequenceItem, JtagAccess, JtagSequence,
-        JtagWriteCommand, JtagWriteData, RawSwdIo, WireProtocol,
+        BitSequence, CommandResult, DebugProbe, DebugProbeError, IoSequenceItem, JtagAccess,
+        JtagSequence, JtagWriteCommand, JtagWriteData, RawSwdIo, WireProtocol,
         common::bits_to_byte,
         queue::{BatchError, Queue},
     },
@@ -721,22 +721,6 @@ impl OutSequence {
         OutSequence { bits: vec![] }
     }
 
-    fn from_bytes(data: &[u8], mut bits: usize) -> Self {
-        let mut this = Self::new();
-
-        'outer: for byte in data {
-            for i in 0..8 {
-                this.add_output(byte & (1 << i) != 0);
-                bits -= 1;
-                if bits == 0 {
-                    break 'outer;
-                }
-            }
-        }
-
-        this
-    }
-
     fn add_output(&mut self, bit: bool) {
         self.bits.push(bit);
     }
@@ -1133,26 +1117,23 @@ impl<Probe: DebugProbe + RawSwdIo + JtagAccess + 'static> RawDapAccess for Probe
         self
     }
 
-    fn jtag_sequence(&mut self, bit_len: u8, tms: bool, bits: u64) -> Result<(), DebugProbeError> {
-        let mut data = BitVec::with_capacity(bit_len as usize);
-
-        for i in 0..bit_len {
-            data.push((bits >> i) & 1 == 1);
-        }
-
+    fn jtag_sequence(&mut self, tms: bool, tdi: &BitSequence) -> Result<(), DebugProbeError> {
         self.shift_raw_sequence(JtagSequence {
             tms,
-            data,
+            data: tdi.iter().collect(),
             tdo_capture: false,
         })?;
 
         Ok(())
     }
 
-    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError> {
+    fn swj_sequence(&mut self, bits: &BitSequence) -> Result<(), DebugProbeError> {
         let protocol = self.active_protocol().unwrap();
 
-        let io_sequence = OutSequence::from_bytes(&bits.to_le_bytes(), bit_len as usize);
+        let mut io_sequence = OutSequence::new();
+        for bit in bits.iter() {
+            io_sequence.add_output(bit);
+        }
         send_sequence(self, protocol, &io_sequence)
     }
 

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -1,4 +1,5 @@
 //! Probe drivers
+mod bits;
 pub(crate) mod common;
 pub mod usb_util;
 
@@ -39,6 +40,7 @@ use std::any::Any;
 use std::fmt;
 use std::sync::{Arc, LazyLock};
 
+pub use bits::BitSequence;
 pub use selector::DebugProbeSelector;
 
 /// Used to log warnings when the measured target voltage is

--- a/probe-rs/src/probe/bits.rs
+++ b/probe-rs/src/probe/bits.rs
@@ -1,0 +1,146 @@
+//! Bit sequences for probe output.
+
+use bitvec::order::Lsb0;
+use bitvec::slice::BitSlice;
+use bitvec::vec::BitVec;
+use std::fmt;
+use std::ops::Index;
+
+/// A bit sequence for SWJ and JTAG output.
+///
+/// The probe sends the bit at index 0 first.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct BitSequence(BitVec<u8, Lsb0>);
+
+impl BitSequence {
+    /// Create an empty sequence.
+    pub fn new() -> Self {
+        Self(BitVec::new())
+    }
+
+    /// Create an empty sequence with space for `bits` bits.
+    pub fn with_capacity(bits: usize) -> Self {
+        Self(BitVec::with_capacity(bits))
+    }
+
+    /// Return the number of bits in the sequence.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Return whether the sequence has no bits.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Build a sequence from the low `len` bits of `bits`.
+    pub fn from_u64(len: usize, bits: u64) -> Self {
+        assert!(len <= 64, "from_u64 supports at most 64 bits");
+        let bytes = bits.to_le_bytes();
+        Self::from_bytes(&bytes, len)
+    }
+
+    /// Build a sequence from `bytes`, using `len` bits in LSB-first byte order.
+    pub fn from_bytes(bytes: &[u8], len: usize) -> Self {
+        let mut sequence = Self::with_capacity(len);
+        for byte in bytes {
+            for i in 0..8 {
+                if sequence.len() == len {
+                    return sequence;
+                }
+                sequence.0.push(byte & (1 << i) != 0);
+            }
+        }
+        sequence
+    }
+
+    /// Build a sequence that repeats one bit value.
+    pub fn repeat(bit: bool, len: usize) -> Self {
+        Self(BitVec::repeat(bit, len))
+    }
+
+    /// Append one bit to the sequence.
+    pub fn push(&mut self, bit: bool) {
+        self.0.push(bit);
+    }
+
+    /// Append another sequence to this one.
+    pub fn extend(&mut self, other: &BitSequence) {
+        self.0.extend_from_bitslice(other.as_bits());
+    }
+
+    /// Iterate over the bits in send order.
+    pub fn iter(&self) -> impl Iterator<Item = bool> + '_ {
+        self.0.iter().map(|bit| *bit)
+    }
+
+    /// Return the underlying bit slice.
+    pub fn as_bits(&self) -> &BitSlice<u8, Lsb0> {
+        self.0.as_bitslice()
+    }
+}
+
+impl Index<usize> for BitSequence {
+    type Output = bool;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl fmt::Debug for BitSequence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("BitSequence(")?;
+        for bit in self.iter() {
+            f.write_str(if bit { "1" } else { "0" })?;
+        }
+        write!(f, ", len={})", self.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_u64_sends_low_bit_first() {
+        let sequence = BitSequence::from_u64(4, 0b1011);
+        assert_eq!(sequence.len(), 4);
+        assert_eq!(
+            sequence.iter().collect::<Vec<_>>(),
+            [true, true, false, true]
+        );
+    }
+
+    #[test]
+    fn from_bytes_sends_lsb_of_each_byte_first() {
+        let sequence = BitSequence::from_bytes(&[0b1011_0100, 0b0000_0011], 10);
+        assert_eq!(sequence.len(), 10);
+        assert_eq!(
+            sequence.iter().collect::<Vec<_>>(),
+            [
+                false, false, true, false, true, true, false, true, true, true,
+            ]
+        );
+    }
+
+    #[test]
+    fn repeat_builds_a_sequence_of_one_bit() {
+        let sequence = BitSequence::repeat(true, 51);
+        assert_eq!(sequence.len(), 51);
+        assert!(sequence.iter().all(|bit| bit));
+    }
+
+    #[test]
+    fn sequence_longer_than_64_bits() {
+        let mut sequence = BitSequence::from_u64(64, 0x8685_2D95_6209_F392);
+        sequence.extend(&BitSequence::from_u64(64, 0x19BC_0EA2_E3DD_AFE9));
+        assert_eq!(sequence.len(), 128);
+    }
+
+    #[test]
+    #[should_panic(expected = "from_u64 supports at most 64 bits")]
+    fn from_u64_panics_above_64_bits() {
+        BitSequence::from_u64(65, 0);
+    }
+}

--- a/probe-rs/src/probe/blackmagic/arm.rs
+++ b/probe-rs/src/probe/blackmagic/arm.rs
@@ -18,7 +18,7 @@ use crate::architecture::arm::{
 use crate::probe::blackmagic::{
     Accelerators, Align, BlackMagicProbe, ProtocolVersion, RemoteCommand,
 };
-use crate::probe::{ArmError, DebugProbeError, Probe};
+use crate::probe::{ArmError, BitSequence, DebugProbeError, Probe};
 use std::collections::BTreeSet;
 use std::collections::hash_map;
 use std::{collections::HashMap, sync::Arc};
@@ -424,8 +424,8 @@ impl SwoAccess for BlackMagicProbeArmDebug {
 }
 
 impl SwdSequence for BlackMagicProbeArmDebug {
-    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError> {
-        self.probe.swj_sequence(bit_len, bits)
+    fn swj_sequence(&mut self, bits: &BitSequence) -> Result<(), DebugProbeError> {
+        self.probe.swj_sequence(bits)
     }
 
     fn swj_pins(
@@ -679,8 +679,8 @@ impl ArmMemoryInterface for BlackMagicProbeMemoryInterface<'_> {
 }
 
 impl SwdSequence for BlackMagicProbeMemoryInterface<'_> {
-    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError> {
-        self.probe.swj_sequence(bit_len, bits)
+    fn swj_sequence(&mut self, bits: &BitSequence) -> Result<(), DebugProbeError> {
+        self.probe.swj_sequence(bits)
     }
 
     fn swj_pins(

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -22,8 +22,8 @@ use crate::{
         },
     },
     probe::{
-        AutoImplementJtagAccess, BatchCommand, DebugProbe, DebugProbeError, DebugProbeSelector,
-        JtagAccess, JtagDriverState, ProbeFactory, WireProtocol,
+        AutoImplementJtagAccess, BatchCommand, BitSequence, DebugProbe, DebugProbeError,
+        DebugProbeSelector, JtagAccess, JtagDriverState, ProbeFactory, WireProtocol,
         cmsisdap::commands::{
             CmsisDapError, RequestError,
             general::info::{CapabilitiesCommand, PacketCountCommand, SWOTraceBufferSizeCommand},
@@ -1232,11 +1232,11 @@ impl RawDapAccess for CmsisDap {
         Ok(())
     }
 
-    fn jtag_sequence(&mut self, cycles: u8, tms: bool, tdi: u64) -> Result<(), DebugProbeError> {
+    fn jtag_sequence(&mut self, tms: bool, tdi: &BitSequence) -> Result<(), DebugProbeError> {
         self.connect_if_needed()?;
 
-        let tdi_bytes = tdi.to_le_bytes();
-        let sequence = JtagSequence::new(cycles, false, tms, tdi_bytes)?;
+        let tdi_bits = tdi.iter().collect::<bitvec::vec::BitVec>();
+        let sequence = JtagSequence::no_capture(tms, tdi_bits.as_bitslice())?;
         let sequences = vec![sequence];
 
         self.send_jtag_sequences(JtagSequenceRequest::new(sequences)?)?;
@@ -1244,20 +1244,16 @@ impl RawDapAccess for CmsisDap {
         Ok(())
     }
 
-    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError> {
+    fn swj_sequence(&mut self, bits: &BitSequence) -> Result<(), DebugProbeError> {
         self.connect_if_needed()?;
-
-        let data = bits.to_le_bytes();
 
         if tracing::enabled!(tracing::Level::TRACE) {
             let mut seq = String::new();
 
             let _ = write!(&mut seq, "swj sequence:");
 
-            for i in 0..bit_len {
-                let bit = (bits >> i) & 1;
-
-                if bit == 1 {
+            for bit in bits.iter() {
+                if bit {
                     let _ = write!(&mut seq, "1");
                 } else {
                     let _ = write!(&mut seq, "0");
@@ -1266,7 +1262,25 @@ impl RawDapAccess for CmsisDap {
             tracing::trace!("{}", seq);
         }
 
-        self.send_swj_sequences(SequenceRequest::new(&data, bit_len)?)?;
+        // CMSIS-DAP caps one SWJ_SEQUENCE command at 256 bits.
+        const MAX_BITS: usize = 256;
+        let mut offset = 0;
+        while offset < bits.len() {
+            let chunk_len = (bits.len() - offset).min(MAX_BITS);
+            let mut data = vec![0u8; chunk_len.div_ceil(8)];
+            for i in 0..chunk_len {
+                if bits[offset + i] {
+                    data[i / 8] |= 1 << (i % 8);
+                }
+            }
+            let bit_count = if chunk_len == MAX_BITS {
+                0
+            } else {
+                chunk_len as u8
+            };
+            self.send_swj_sequences(SequenceRequest::new(&data, bit_count)?)?;
+            offset += chunk_len;
+        }
 
         Ok(())
     }

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -11,7 +11,7 @@ use crate::{
         memory::{ADIMemoryInterface, ArmMemoryInterface},
         sequences::ArmDebugSequence,
     },
-    probe::{DebugProbe, DebugProbeError, Probe, WireProtocol},
+    probe::{BitSequence, DebugProbe, DebugProbeError, Probe, WireProtocol},
 };
 
 #[cfg(any(test, feature = "test"))]
@@ -110,7 +110,7 @@ impl MockCore {
 }
 
 impl SwdSequence for &mut MockCore {
-    fn swj_sequence(&mut self, _bit_len: u8, _bits: u64) -> Result<(), DebugProbeError> {
+    fn swj_sequence(&mut self, _bits: &BitSequence) -> Result<(), DebugProbeError> {
         todo!()
     }
 
@@ -574,11 +574,11 @@ impl RawDapAccess for FakeProbe {
         handler(address, value)
     }
 
-    fn jtag_sequence(&mut self, _cycles: u8, _tms: bool, _tdi: u64) -> Result<(), DebugProbeError> {
+    fn jtag_sequence(&mut self, _tms: bool, _tdi: &BitSequence) -> Result<(), DebugProbeError> {
         todo!()
     }
 
-    fn swj_sequence(&mut self, _bit_len: u8, _bits: u64) -> Result<(), DebugProbeError> {
+    fn swj_sequence(&mut self, _bits: &BitSequence) -> Result<(), DebugProbeError> {
         todo!()
     }
 
@@ -616,8 +616,8 @@ impl FakeArmInterface {
 }
 
 impl SwdSequence for FakeArmInterface {
-    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError> {
-        self.probe.swj_sequence(bit_len, bits)?;
+    fn swj_sequence(&mut self, bits: &BitSequence) -> Result<(), DebugProbeError> {
+        self.probe.swj_sequence(bits)?;
 
         Ok(())
     }

--- a/probe-rs/src/probe/glasgow/mod.rs
+++ b/probe-rs/src/probe/glasgow/mod.rs
@@ -14,8 +14,8 @@ use crate::architecture::arm::{
 };
 
 use super::{
-    DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeFactory, WireProtocol,
-    list::ProbeListItem,
+    BitSequence, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeFactory,
+    WireProtocol, list::ProbeListItem,
 };
 
 mod mux;
@@ -345,20 +345,26 @@ impl RawDapAccess for Glasgow {
         Ok(())
     }
 
-    fn jtag_sequence(&mut self, cycles: u8, tms: bool, tdi: u64) -> Result<(), DebugProbeError> {
-        tracing::debug!("jtag_sequence({cycles}, {tms}, {tdi})");
+    fn jtag_sequence(&mut self, tms: bool, tdi: &BitSequence) -> Result<(), DebugProbeError> {
+        tracing::debug!("jtag_sequence({tms}, {tdi:?})");
         Err(DebugProbeError::CommandNotSupportedByProbe {
             command_name: "jtag_sequence",
         })
     }
 
-    fn swj_sequence(&mut self, len: u8, bits: u64) -> Result<(), DebugProbeError> {
-        tracing::debug!("swj_sequence({len}, {bits:#x})");
-        if len > 0 {
-            self.device.swd_sequence(len.min(32), bits as u32)?;
-        }
-        if len > 32 {
-            self.device.swd_sequence(len - 32, (bits >> 32) as u32)?;
+    fn swj_sequence(&mut self, bits: &BitSequence) -> Result<(), DebugProbeError> {
+        tracing::debug!("swj_sequence({bits:?})");
+        let mut offset = 0;
+        while offset < bits.len() {
+            let chunk_len = (bits.len() - offset).min(32);
+            let mut value = 0u32;
+            for i in 0..chunk_len {
+                if bits[offset + i] {
+                    value |= 1 << i;
+                }
+            }
+            self.device.swd_sequence(chunk_len as u8, value)?;
+            offset += chunk_len;
         }
         Ok(())
     }

--- a/probe-rs/src/probe/sifliuart/arm.rs
+++ b/probe-rs/src/probe/sifliuart/arm.rs
@@ -11,7 +11,7 @@ use crate::architecture::arm::{
     ArmDebugInterface, ArmError, DapAccess, FullyQualifiedApAddress, SwoAccess, SwoConfig,
 };
 use crate::probe::sifliuart::{SifliUart, SifliUartCommand, SifliUartResponse};
-use crate::probe::{DebugProbeError, Probe};
+use crate::probe::{BitSequence, DebugProbeError, Probe};
 use std::cmp::{max, min};
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -99,7 +99,7 @@ impl DapAccess for SifliUartArmDebug {
 }
 
 impl SwdSequence for SifliUartArmDebug {
-    fn swj_sequence(&mut self, _bit_len: u8, _bits: u64) -> Result<(), DebugProbeError> {
+    fn swj_sequence(&mut self, _bits: &BitSequence) -> Result<(), DebugProbeError> {
         Err(DebugProbeError::NotImplemented {
             function_name: "swj_sequence",
         })

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -20,8 +20,8 @@ use crate::{
         valid_32bit_arm_address,
     },
     probe::{
-        DebugProbe, DebugProbeError, DebugProbeSelector, Probe, ProbeError, ProbeFactory,
-        WireProtocol,
+        BitSequence, DebugProbe, DebugProbeError, DebugProbeSelector, Probe, ProbeError,
+        ProbeFactory, WireProtocol,
     },
 };
 
@@ -1456,7 +1456,7 @@ impl ArmDebugInterface for StlinkArmDebug {
 }
 
 impl SwdSequence for StlinkArmDebug {
-    fn swj_sequence(&mut self, _bit_len: u8, _bits: u64) -> Result<(), DebugProbeError> {
+    fn swj_sequence(&mut self, _bits: &BitSequence) -> Result<(), DebugProbeError> {
         // This is not supported for ST-Links, unfortunately.
         Err(DebugProbeError::CommandNotSupportedByProbe {
             command_name: "swj_sequence",
@@ -1494,8 +1494,8 @@ struct StLinkMemoryInterface<'probe> {
 }
 
 impl SwdSequence for StLinkMemoryInterface<'_> {
-    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError> {
-        self.probe.swj_sequence(bit_len, bits)
+    fn swj_sequence(&mut self, bits: &BitSequence) -> Result<(), DebugProbeError> {
+        self.probe.swj_sequence(bits)
     }
 
     fn swj_pins(

--- a/probe-rs/src/vendor/infineon/sequences/psoc_c3_x7x8.rs
+++ b/probe-rs/src/vendor/infineon/sequences/psoc_c3_x7x8.rs
@@ -45,6 +45,7 @@ use crate::{
         sequences::{ArmDebugSequence, DefaultArmSequence, cortex_m_wait_for_reset},
     },
     config::CoreExt,
+    probe::BitSequence,
 };
 
 /// RAM address where the debug certificate is loaded (mandatory for x7/x8 series).
@@ -324,14 +325,30 @@ impl PsocC3X7X8 {
             // DORMANT-to-SWD sequence (ARM ADI §B4.3.4):
             // line reset → JTAG-to-Dormant → 8-cycle preamble → 128-bit alert → SWD activation →
             // line reset → idle
-            let ok = interface.swj_sequence(51, 0x0007_FFFF_FFFF_FFFF).is_ok()
-                && interface.swj_sequence(31, 0x33BB_BBBA).is_ok()
-                && interface.swj_sequence(8, 0xFF).is_ok()
-                && interface.swj_sequence(64, 0x8685_2D95_6209_F392).is_ok()
-                && interface.swj_sequence(64, 0x19BC_0EA2_E3DD_AFE9).is_ok()
-                && interface.swj_sequence(12, 0x1A0).is_ok()
-                && interface.swj_sequence(51, 0x0007_FFFF_FFFF_FFFF).is_ok()
-                && interface.swj_sequence(3, 0x00).is_ok();
+            let ok = interface
+                .swj_sequence(&BitSequence::from_u64(51, 0x0007_FFFF_FFFF_FFFF))
+                .is_ok()
+                && interface
+                    .swj_sequence(&BitSequence::from_u64(31, 0x33BB_BBBA))
+                    .is_ok()
+                && interface
+                    .swj_sequence(&BitSequence::from_u64(8, 0xFF))
+                    .is_ok()
+                && interface
+                    .swj_sequence(&BitSequence::from_u64(64, 0x8685_2D95_6209_F392))
+                    .is_ok()
+                && interface
+                    .swj_sequence(&BitSequence::from_u64(64, 0x19BC_0EA2_E3DD_AFE9))
+                    .is_ok()
+                && interface
+                    .swj_sequence(&BitSequence::from_u64(12, 0x1A0))
+                    .is_ok()
+                && interface
+                    .swj_sequence(&BitSequence::from_u64(51, 0x0007_FFFF_FFFF_FFFF))
+                    .is_ok()
+                && interface
+                    .swj_sequence(&BitSequence::from_u64(3, 0x00))
+                    .is_ok();
             if ok {
                 match interface.raw_read_register(RegisterAddress::DpRegister(DPIDR::ADDRESS)) {
                     Ok(v) => {

--- a/probe-rs/src/vendor/microchip/sequences/atsam.rs
+++ b/probe-rs/src/vendor/microchip/sequences/atsam.rs
@@ -9,7 +9,7 @@ use crate::{
         memory::ArmMemoryInterface,
         sequences::{ArmDebugSequence, ArmDebugSequenceError, DebugEraseSequence},
     },
-    probe::DebugProbeError,
+    probe::{BitSequence, DebugProbeError},
     session::MissingPermissions,
 };
 use bitfield::bitfield;
@@ -242,8 +242,8 @@ impl<'a> From<&'a mut dyn DapProbe> for SwdSequenceShim<'a> {
 }
 
 impl SwdSequence for SwdSequenceShim<'_> {
-    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError> {
-        self.0.swj_sequence(bit_len, bits)
+    fn swj_sequence(&mut self, bits: &BitSequence) -> Result<(), DebugProbeError> {
+        self.0.swj_sequence(bits)
     }
 
     fn swj_pins(

--- a/probe-rs/src/vendor/ti/sequences/cc13xx_cc26xx.rs
+++ b/probe-rs/src/vendor/ti/sequences/cc13xx_cc26xx.rs
@@ -8,7 +8,7 @@ use crate::architecture::arm::communication_interface::DapProbe;
 use crate::architecture::arm::memory::ArmMemoryInterface;
 use crate::architecture::arm::sequences::{ArmDebugSequence, ArmDebugSequenceError};
 use crate::architecture::arm::{ArmError, dp::DpAddress};
-use crate::probe::WireProtocol;
+use crate::probe::{BitSequence, WireProtocol};
 
 use super::icepick::{DefaultProtocol, Icepick};
 
@@ -104,7 +104,7 @@ impl ArmDebugSequence for CC13xxCC26xx {
         _dp: DpAddress,
     ) -> Result<(), ArmError> {
         // Ensure current debug interface is in reset state.
-        interface.swj_sequence(51, 0x0007_FFFF_FFFF_FFFF)?;
+        interface.swj_sequence(&BitSequence::from_u64(51, 0x0007_FFFF_FFFF_FFFF))?;
 
         match interface.active_protocol() {
             Some(WireProtocol::Jtag) => {


### PR DESCRIPTION
Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>