### PR TITLE
Serve the RISC-V debug module directly on WCH-Link

### DIFF
--- a/changelog/fixed-wlink-jtag-emulation.md
+++ b/changelog/fixed-wlink-jtag-emulation.md
@@ -1,0 +1,1 @@
+The WCH-Link probe now serves the RISC-V debug module directly, so it no longer emulates a JTAG TAP that the hardware does not have.

--- a/probe-rs/src/architecture/riscv/dtm/mod.rs
+++ b/probe-rs/src/architecture/riscv/dtm/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod jtag_dtm;
 pub(crate) mod mem_ap_dtm;
+pub(crate) mod wlink_dtm;
 
 use crate::architecture::riscv::communication_interface::RiscvError;
 use crate::probe::queue::Handle;

--- a/probe-rs/src/architecture/riscv/dtm/wlink_dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm/wlink_dtm.rs
@@ -1,0 +1,273 @@
+use std::time::{Duration, Instant};
+
+use crate::architecture::riscv::communication_interface::{
+    RiscvCommunicationInterface, RiscvDebugInterfaceState, RiscvError, RiscvInterfaceBuilder,
+};
+use crate::architecture::riscv::dtm::DtmAccess;
+use crate::architecture::riscv::dtm::jtag_dtm::{
+    DmiOperation, DmiOperationError, DmiOperationStatus,
+};
+use crate::probe::queue::{Handle, HandleId, Results};
+use crate::probe::wlink::WchLink;
+use crate::probe::{CommandResult, DebugProbe, DebugProbeError};
+
+/// Hardcoded IDCODE, the same as WCH's OpenOCD fork.
+const WCH_LINK_IDCODE: u32 = 0x00000001;
+
+/// Number of address bits in the DMI register.
+const WCH_LINK_DTMCS_ABITS: u32 = 7;
+
+/// RISC-V debug specification version implemented by the probe (1 = 0.13).
+const WCH_LINK_DTMCS_VERSION: u32 = 1;
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Default)]
+struct WchLinkDtmState {
+    pending: Vec<(Option<HandleId>, DmiOperation)>,
+    results: Results,
+    abits: u32,
+}
+
+/// Object that can be used to build a RISC-V DTM interface from a WCH-Link probe.
+pub struct WchLinkDtmBuilder<'f>(&'f mut WchLink);
+
+impl<'f> WchLinkDtmBuilder<'f> {
+    /// Create a new DTM builder via a WCH-Link probe.
+    pub fn new(probe: &'f mut WchLink) -> Self {
+        Self(probe)
+    }
+}
+
+impl<'probe> RiscvInterfaceBuilder<'probe> for WchLinkDtmBuilder<'probe> {
+    fn create_state(&self) -> RiscvDebugInterfaceState {
+        RiscvDebugInterfaceState::new(Box::<WchLinkDtmState>::default())
+    }
+
+    fn attach<'state>(
+        self: Box<Self>,
+        state: &'state mut RiscvDebugInterfaceState,
+    ) -> Result<RiscvCommunicationInterface<'state>, DebugProbeError>
+    where
+        'probe: 'state,
+    {
+        let dtm_state = state.dtm_state.downcast_mut::<WchLinkDtmState>().unwrap();
+
+        Ok(RiscvCommunicationInterface::new(
+            Box::new(WchLinkDtm::new(self.0, dtm_state)),
+            &mut state.interface_state,
+        ))
+    }
+}
+
+#[derive(Debug)]
+struct WchLinkDtm<'probe> {
+    probe: &'probe mut WchLink,
+    state: &'probe mut WchLinkDtmState,
+}
+
+impl<'probe> WchLinkDtm<'probe> {
+    fn new(probe: &'probe mut WchLink, state: &'probe mut WchLinkDtmState) -> Self {
+        Self { probe, state }
+    }
+
+    fn transform_dmi_response(data: u32, op: u8) -> Result<u32, DmiOperationError> {
+        let status = DmiOperationStatus::parse(op).expect("INVALID DMI OP status");
+
+        match status {
+            DmiOperationStatus::Ok => Ok(data),
+            DmiOperationStatus::Reserved => Err(DmiOperationError::Reserved),
+            DmiOperationStatus::RequestInProgress => Err(DmiOperationError::RequestInProgress),
+            DmiOperationStatus::OperationFailed => Err(DmiOperationError::OperationFailed),
+        }
+    }
+
+    fn perform_dmi_operation(
+        &mut self,
+        op: DmiOperation,
+    ) -> Result<Result<u32, DmiOperationError>, DebugProbeError> {
+        let (_addr, data, status) = match op {
+            DmiOperation::Read { address } => {
+                let response = self.probe.dmi_op_read(address as u8)?;
+                tracing::trace!(
+                    "dmi read 0x{:02x} 0x{:08x} op={}",
+                    response.0,
+                    response.1,
+                    response.2
+                );
+                self.probe.set_last_dmi_read(response);
+                response
+            }
+            DmiOperation::NoOp => {
+                // No idea why NOP with zero addr should return the last read value.
+                // see-also: RiscvCommunicationInterface::read_dm_register_untyped
+                let response = match self.probe.last_dmi_read() {
+                    Some(cached) => cached,
+                    None => self.probe.dmi_op_nop()?,
+                };
+                tracing::trace!(
+                    "dmi nop 0x{:02x} 0x{:08x} op={}",
+                    response.0,
+                    response.1,
+                    response.2
+                );
+                response
+            }
+            DmiOperation::Write { address, value } => {
+                let response = self.probe.dmi_op_write(address as u8, value)?;
+                tracing::trace!(
+                    "dmi write 0x{:02x} 0x{:08x} op={}",
+                    response.0,
+                    response.1,
+                    response.2
+                );
+                if address == 0x10 && value == 0x40000001 {
+                    // needs additional sleep for a resume operation
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                response
+            }
+        };
+
+        Ok(Self::transform_dmi_response(data, status))
+    }
+
+    fn dmi_operation_with_retry(
+        &mut self,
+        op: DmiOperation,
+        timeout: Duration,
+    ) -> Result<u32, RiscvError> {
+        let start_time = Instant::now();
+
+        loop {
+            match self.perform_dmi_operation(op)? {
+                Ok(result) => return Ok(result),
+                Err(DmiOperationError::RequestInProgress) => {
+                    self.clear_error_state()?;
+                }
+                Err(DmiOperationError::Reserved | DmiOperationError::OperationFailed) => {
+                    self.clear_error_state()?;
+                    return Err(RiscvError::DtmOperationFailed);
+                }
+            }
+
+            if start_time.elapsed() > timeout {
+                return Err(RiscvError::Timeout);
+            }
+        }
+    }
+
+    fn dmi_operation_with_timeout(
+        &mut self,
+        op: DmiOperation,
+        timeout: Duration,
+    ) -> Result<u32, RiscvError> {
+        self.execute()?;
+        self.dmi_operation_with_retry(op, timeout)
+    }
+}
+
+impl DtmAccess for WchLinkDtm<'_> {
+    fn init(&mut self) -> Result<(), RiscvError> {
+        if WCH_LINK_DTMCS_VERSION != 1 {
+            return Err(RiscvError::UnsupportedDebugTransportModuleVersion(
+                WCH_LINK_DTMCS_VERSION as u8,
+            ));
+        }
+
+        self.state.abits = WCH_LINK_DTMCS_ABITS;
+
+        Ok(())
+    }
+
+    fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
+        self.probe.target_reset_assert()
+    }
+
+    fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {
+        self.probe.target_reset_deassert()
+    }
+
+    fn clear_error_state(&mut self) -> Result<(), RiscvError> {
+        tracing::debug!("DMI reset");
+        self.probe.dmi_op_write(0x10, 0x00000000)?;
+        self.probe.dmi_op_write(0x10, 0x00000001)?;
+        Ok(())
+    }
+
+    fn read_deferred_result(
+        &mut self,
+        index: Handle<CommandResult>,
+    ) -> Result<CommandResult, RiscvError> {
+        match self.state.results.take(index) {
+            Ok(result) => Ok(result),
+            Err(handle) => {
+                self.execute()?;
+                self.state
+                    .results
+                    .take(handle)
+                    .map_err(|_| RiscvError::BatchedResultNotAvailable)
+            }
+        }
+    }
+
+    fn execute(&mut self) -> Result<(), RiscvError> {
+        for (id, op) in std::mem::take(&mut self.state.pending) {
+            let result = self.dmi_operation_with_retry(op, COMMAND_TIMEOUT)?;
+            if let Some(handle_id) = id {
+                self.state
+                    .results
+                    .push(&handle_id, CommandResult::U32(result));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn schedule_write(
+        &mut self,
+        address: u64,
+        value: u32,
+    ) -> Result<Option<Handle<CommandResult>>, RiscvError> {
+        let id = HandleId::new();
+        self.state
+            .pending
+            .push((Some(id.clone()), DmiOperation::Write { address, value }));
+        Ok(Some(Handle::from_id(id)))
+    }
+
+    fn schedule_read(&mut self, address: u64) -> Result<Handle<CommandResult>, RiscvError> {
+        self.state
+            .pending
+            .push((None, DmiOperation::Read { address }));
+
+        let id = HandleId::new();
+        self.state
+            .pending
+            .push((Some(id.clone()), DmiOperation::NoOp));
+        Ok(Handle::from_id(id))
+    }
+
+    fn read_with_timeout(&mut self, address: u64, timeout: Duration) -> Result<u32, RiscvError> {
+        self.state
+            .pending
+            .push((None, DmiOperation::Read { address }));
+
+        self.dmi_operation_with_timeout(DmiOperation::NoOp, timeout)
+    }
+
+    fn write_with_timeout(
+        &mut self,
+        address: u64,
+        value: u32,
+        timeout: Duration,
+    ) -> Result<Option<u32>, RiscvError> {
+        self.dmi_operation_with_timeout(DmiOperation::Write { address, value }, timeout)
+            .map(Some)
+    }
+
+    fn read_idcode(&mut self) -> Result<Option<u32>, DebugProbeError> {
+        tracing::debug!("using hard coded idcode 0x00000001");
+        Ok(Some(WCH_LINK_IDCODE))
+    }
+}

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -4,22 +4,18 @@
 //! For more details see: <https://github.com/ch32-rs/wlink>
 
 use std::fmt;
-use std::time::Duration;
 
-use bitvec::{bitvec, field::BitField, order::Lsb0, vec::BitVec, view::BitView};
 use nusb::{DeviceInfo, MaybeFuture};
-use probe_rs_target::ScanChainElement;
 
 use self::{commands::Speed, usb_interface::WchLinkUsbDevice};
-use super::JtagAccess;
 use crate::{
     architecture::riscv::{
         communication_interface::{RiscvError, RiscvInterfaceBuilder},
-        dtm::jtag_dtm::JtagDtmBuilder,
+        dtm::wlink_dtm::WchLinkDtmBuilder,
     },
     probe::{
-        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JtagSequence, ProbeError,
-        ProbeFactory, WireProtocol,
+        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeError, ProbeFactory,
+        WireProtocol,
         list::{ProbeListItem, usb_probe_accessibility},
     },
 };
@@ -31,21 +27,9 @@ const VENDOR_ID: u16 = 0x1a86;
 const PRODUCT_ID: u16 = 0x8010;
 
 // See: RISC-V Debug Specification, 6.1 JTAG DTM Registers
-const DMI_VALUE_BIT_OFFSET: u32 = 2;
-const DMI_ADDRESS_BIT_OFFSET: u32 = 34;
-const DMI_OP_MASK: u128 = 0b11; // 2 bits
-
-const DMI_OP_NOP: u8 = 0;
-const DMI_OP_READ: u8 = 1;
-const DMI_OP_WRITE: u8 = 2;
-
-const REG_BYPASS_ADDRESS: u8 = 0x1f;
-const REG_IDCODE_ADDRESS: u8 = 0x01;
-const REG_DTMCS_ADDRESS: u8 = 0x10;
-const REG_DMI_ADDRESS: u8 = 0x11;
-
-const DTMCS_DMIRESET_MASK: u32 = 1 << 16;
-const DTMCS_DMIHARDRESET_MASK: u32 = 1 << 17;
+pub(crate) const DMI_OP_NOP: u8 = 0;
+pub(crate) const DMI_OP_READ: u8 = 1;
+pub(crate) const DMI_OP_WRITE: u8 = 2;
 
 /// All WCH-Link probe variants, see-also: <http://www.wch-ic.com/products/WCH-Link.html>
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -286,13 +270,17 @@ impl WchLink {
         self.chip_family
     }
 
-    fn dmi_op_read(&mut self, addr: u8) -> Result<(u8, u32, u8), DebugProbeError> {
+    pub(crate) fn dmi_op_read(&mut self, addr: u8) -> Result<(u8, u32, u8), DebugProbeError> {
         let resp = self.device.send_command(commands::DmiOp::read(addr))?;
 
         Ok((resp.addr, resp.data, resp.op))
     }
 
-    fn dmi_op_write(&mut self, addr: u8, data: u32) -> Result<(u8, u32, u8), DebugProbeError> {
+    pub(crate) fn dmi_op_write(
+        &mut self,
+        addr: u8,
+        data: u32,
+    ) -> Result<(u8, u32, u8), DebugProbeError> {
         let resp = self
             .device
             .send_command(commands::DmiOp::write(addr, data))?;
@@ -300,10 +288,18 @@ impl WchLink {
         Ok((resp.addr, resp.data, resp.op))
     }
 
-    fn dmi_op_nop(&mut self) -> Result<(u8, u32, u8), DebugProbeError> {
+    pub(crate) fn dmi_op_nop(&mut self) -> Result<(u8, u32, u8), DebugProbeError> {
         let resp = self.device.send_command(commands::DmiOp::nop())?;
 
         Ok((resp.addr, resp.data, resp.op))
+    }
+
+    pub(crate) fn last_dmi_read(&self) -> Option<(u8, u32, u8)> {
+        self.last_dmi_read
+    }
+
+    pub(crate) fn set_last_dmi_read(&mut self, value: (u8, u32, u8)) {
+        self.last_dmi_read = Some(value);
     }
 }
 
@@ -399,164 +395,14 @@ impl DebugProbe for WchLink {
         true
     }
 
+    fn try_as_jtag_probe(&mut self) -> Option<&mut dyn crate::probe::JtagAccess> {
+        None
+    }
+
     fn try_get_riscv_interface_builder<'probe>(
         &'probe mut self,
     ) -> Result<Box<dyn RiscvInterfaceBuilder<'probe> + 'probe>, RiscvError> {
-        Ok(Box::new(JtagDtmBuilder::new(self)))
-    }
-}
-
-/// Wrap WCH-Link's USB based DMI access as a fake JtagAccess
-impl JtagAccess for WchLink {
-    fn set_expected_scan_chain(
-        &mut self,
-        _scan_chain: &[ScanChainElement],
-    ) -> Result<(), DebugProbeError> {
-        Ok(())
-    }
-
-    fn set_scan_chain(&mut self, _scan_chain: &[ScanChainElement]) -> Result<(), DebugProbeError> {
-        Ok(())
-    }
-
-    fn scan_chain(&mut self) -> Result<&[ScanChainElement], DebugProbeError> {
-        Ok(&[])
-    }
-
-    fn tap_reset(&mut self) -> Result<(), DebugProbeError> {
-        Ok(())
-    }
-
-    fn read_register(
-        &mut self,
-        address: u32,
-        len: u32,
-        _idle_cycles: u32,
-    ) -> Result<BitVec, DebugProbeError> {
-        tracing::debug!("read register 0x{:08x}", address);
-        assert_eq!(len, 32);
-
-        let mut ret = bitvec![0; len as usize];
-        match address as u8 {
-            REG_IDCODE_ADDRESS => {
-                // using hard coded idcode 0x00000001, the same as WCH's openocd fork
-                tracing::debug!("using hard coded idcode 0x00000001");
-                ret[0..8].store_le::<u8>(0x1);
-                Ok(ret)
-            }
-            REG_DTMCS_ADDRESS => {
-                // See: RISC-V Debug Specification, 6.1.4
-                // 0x71: abits=7, version=1(1.0)
-                ret[0..8].store_le::<u8>(0x71);
-                Ok(ret)
-            }
-            REG_BYPASS_ADDRESS => Ok(bitvec![0; 4]),
-            _ => panic!("unknown read register address {address:08x}"),
-        }
-    }
-
-    fn write_register(
-        &mut self,
-        address: u32,
-        data: &[u8],
-        len: u32,
-        _idle_cycles: u32,
-    ) -> Result<BitVec, DebugProbeError> {
-        match address as u8 {
-            REG_DTMCS_ADDRESS => {
-                let val = u32::from_le_bytes(data.try_into().unwrap());
-                if val & DTMCS_DMIRESET_MASK != 0 {
-                    tracing::debug!("DMI reset");
-                    self.dmi_op_write(0x10, 0x00000000)?;
-                    self.dmi_op_write(0x10, 0x00000001)?;
-                    // dmcontrol.dmactive is checked later
-                } else if val & DTMCS_DMIHARDRESET_MASK != 0 {
-                    return Err(WchLinkError::UnsupportedOperation.into());
-                }
-
-                let mut ret = bitvec![0; len as usize];
-                ret[0..8].store_le::<u8>(0x71);
-                Ok(ret)
-            }
-            REG_DMI_ADDRESS => {
-                assert_eq!(
-                    len, 41,
-                    "should be 41 bits: 8 bits abits + 32 bits data + 2 bits op"
-                );
-                let register_value: u128 = u128::from_le_bytes(data.try_into().unwrap());
-
-                let dmi_addr = ((register_value >> DMI_ADDRESS_BIT_OFFSET) & 0x3f) as u8;
-                let dmi_value = ((register_value >> DMI_VALUE_BIT_OFFSET) & 0xffffffff) as u32;
-                let dmi_op = (register_value & DMI_OP_MASK) as u8;
-
-                tracing::trace!(
-                    "dmi op={} addr 0x{:02x} data 0x{:08x}",
-                    dmi_op,
-                    dmi_addr,
-                    dmi_value,
-                );
-
-                let (addr, data, op) = match dmi_op {
-                    DMI_OP_READ => {
-                        let (addr, data, op) = self.dmi_op_read(dmi_addr)?;
-                        tracing::trace!("dmi read 0x{:02x} 0x{:08x} op={}", addr, data, op);
-                        self.last_dmi_read = Some((addr, data, op));
-                        (addr, data, op)
-                    }
-                    DMI_OP_NOP => {
-                        // No idea why NOP with zero addr should return the last read value.
-                        // see-also: RiscvCommunicationInterface::read_dm_register_untyped
-                        let (addr, data, op) = if dmi_addr == 0 && dmi_value == 0 {
-                            self.last_dmi_read.unwrap()
-                        } else {
-                            self.dmi_op_nop()?
-                        };
-                        tracing::trace!("dmi nop 0x{:02x} 0x{:08x} op={}", addr, data, op);
-                        (addr, data, op)
-                    }
-                    DMI_OP_WRITE => {
-                        let (addr, data, op) = self.dmi_op_write(dmi_addr, dmi_value)?;
-                        tracing::trace!("dmi write 0x{:02x} 0x{:08x} op={}", addr, data, op);
-                        if dmi_addr == 0x10 && dmi_value == 0x40000001 {
-                            // needs additional sleep for a resume operation
-                            std::thread::sleep(Duration::from_millis(10));
-                        }
-                        (addr, data, op)
-                    }
-                    _ => unreachable!("unknown dmi_op {dmi_op}"),
-                };
-
-                let ret = ((addr as u128) << DMI_ADDRESS_BIT_OFFSET)
-                    | ((data as u128) << DMI_VALUE_BIT_OFFSET)
-                    | (op as u128);
-
-                let ret_bytes = ret.to_le_bytes();
-                Ok(ret_bytes
-                    .iter()
-                    .fold(BitVec::with_capacity(128), |mut acc, s| {
-                        acc.extend_from_bitslice(s.view_bits::<Lsb0>());
-                        acc
-                    }))
-            }
-            _ => unreachable!("unknown register address 0x{:08x}", address),
-        }
-    }
-
-    fn write_dr(
-        &mut self,
-        _data: &[u8],
-        _len: u32,
-        _idle_cycles: u32,
-    ) -> Result<BitVec, DebugProbeError> {
-        Err(DebugProbeError::NotImplemented {
-            function_name: "write_dr",
-        })
-    }
-
-    fn shift_raw_sequence(&mut self, _sequence: JtagSequence) -> Result<BitVec, DebugProbeError> {
-        Err(DebugProbeError::NotImplemented {
-            function_name: "shift_raw_sequence ",
-        })
+        Ok(Box::new(WchLinkDtmBuilder::new(self)))
     }
 }
 
@@ -617,8 +463,6 @@ pub(crate) enum WchLinkError {
     Protocol(u8, Vec<u8>),
     /// Unknown chip {0:#04x}.
     UnknownChip(u8),
-    /// Unsupported operation.
-    UnsupportedOperation,
 }
 
 impl ProbeError for WchLinkError {}


### PR DESCRIPTION
Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>