### PR TITLE
CMSIS-DAP: keep several block requests in flight

### DIFF
--- a/changelog/changed-cmsisdap-pipelined-block-transfers.md
+++ b/changelog/changed-cmsisdap-pipelined-block-transfers.md
@@ -1,0 +1,1 @@
+CMSIS-DAP: several `DAP_TransferBlock` packets are now kept in flight at once, up to the packet count the probe reports.

--- a/probe-rs/src/probe/cmsisdap/cmsis_swd.rs
+++ b/probe-rs/src/probe/cmsisdap/cmsis_swd.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::time::Duration;
 
 use crate::{
@@ -29,6 +30,12 @@ pub(crate) fn cmsis_handles_wait(wait_retry: u16) -> bool {
 /// `DAP_TransferBlock` sends the access once for every repeat, so it needs
 /// fewer packets than `DAP_Transfer`.
 const MIN_BLOCK_TRANSFERS: usize = 2;
+
+/// How many `DAP_TransferBlock` requests may be outstanding at once.
+///
+/// Overlapping a request with the previous reply hides one round trip each time. Past a handful
+/// the wait is already covered and a deeper queue only holds more requests in memory.
+const MAX_PIPELINED_BLOCKS: usize = 8;
 
 /// Return how many words one `DAP_TransferBlock` packet holds.
 pub(crate) fn block_words_per_packet(packet_size: u16) -> usize {
@@ -228,7 +235,85 @@ impl CmsisDap {
         block_words_per_packet(self.packet_size)
     }
 
-    /// Send a repeated access as `DAP_TransferBlock` packets.
+    /// Classify one `DAP_TransferBlock` reply.
+    ///
+    /// Takes no `self`, so it cannot issue a command. Whatever the reply says, recovery has to
+    /// wait until every outstanding reply has been taken.
+    fn classify_block_response(
+        response: &TransferBlockResponse,
+        chunk_len: usize,
+        chunk_start: usize,
+    ) -> Result<(), (BatchError<DebugProbeError>, usize)> {
+        let count = usize::from(response.transfer_count);
+        let fault_operation = chunk_start + count.min(chunk_len).saturating_sub(1);
+
+        if response.transfer_response.protocol_error {
+            return Err((
+                BatchError::Specific(DebugProbeError::SwdTransfer(SwdTransferError::Protocol)),
+                fault_operation,
+            ));
+        }
+
+        match response.transfer_response.ack {
+            Ack::Ok => {}
+            ack => {
+                return Err((
+                    BatchError::Specific(DebugProbeError::SwdTransfer(
+                        Self::ack_to_transfer_error(ack),
+                    )),
+                    fault_operation,
+                ));
+            }
+        }
+
+        if count < chunk_len {
+            return Err((
+                BatchError::Probe(DebugProbeError::Other(format!(
+                    "Possible error in CMSIS-DAP probe: Only {}/{} transfers were executed, but no error was reported.",
+                    count, chunk_len
+                ))),
+                fault_operation,
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Put the port back in order after a block transfer failed.
+    ///
+    /// Each arm is a command in its own right, which is why this is separate from classifying the
+    /// reply: issuing one while the probe still owes replies leaves the two out of step.
+    fn recover_from_block_error(&mut self, error: &BatchError<DebugProbeError>) {
+        match error {
+            BatchError::Specific(DebugProbeError::SwdTransfer(SwdTransferError::FaultResponse)) => {
+                if let Err(error) = self.handle_sticky_err() {
+                    tracing::warn!("Failed to clear the sticky error: {error}");
+                }
+            }
+            BatchError::Specific(DebugProbeError::SwdTransfer(SwdTransferError::WaitResponse)) => {
+                let abort = {
+                    let mut abort = Abort(0);
+                    abort.set_dapabort(true);
+                    abort
+                };
+                if let Err(error) = self.write_abort(abort) {
+                    tracing::warn!("Failed to abort the transfer: {error}");
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Send a repeated access as `DAP_TransferBlock` packets, several at a time.
+    ///
+    /// Sending the next request before reading the previous reply hides one round trip per
+    /// overlap. ADIv5 §B4.2.4 describes this as the intended use: "A debugger might stream a block
+    /// of data and then check the CTRL/STAT register at the end of the block."
+    ///
+    /// A request already on the wire when an earlier one faults cannot reach the target. Once a
+    /// sticky flag is set the DP answers FAULT to every access except reads of DPIDR and
+    /// CTRL/STAT and writes to ABORT, so the tail is refused rather than performed, and the first
+    /// failure in batch order is the one reported.
     fn run_transfer_block(
         &mut self,
         run: &[(HandleId, SwdOp)],
@@ -246,107 +331,87 @@ impl CmsisDap {
         };
         let address = Self::swd_register(port, addr);
         let words_per_packet = self.max_words_per_block_packet();
+        let depth = (self.packet_count as usize).clamp(1, MAX_PIPELINED_BLOCKS);
 
-        for (chunk_index, chunk) in run.chunks(words_per_packet).enumerate() {
-            let chunk_start = run_start + chunk_index * words_per_packet;
-            let mut request = match direction {
-                Direction::Read => TransferBlockRequest::read_request(address, chunk.len() as u16),
-                Direction::Write => TransferBlockRequest::write_request(
-                    address,
-                    chunk.iter().map(|(_, op)| transfer_data(op)).collect(),
-                ),
-            };
-            request.dap_index = self.jtag_state.chain_params.index as u8;
+        let mut chunks = run.chunks(words_per_packet).enumerate();
+        let mut in_flight = VecDeque::with_capacity(depth);
+        let mut failure: Option<(BatchError<DebugProbeError>, usize)> = None;
+        // A chunk that failed ends the run, so nothing after it is the caller's to see. A chunk
+        // that was never sent does not: whatever is already in flight ran before the failure and
+        // would have run without the pipeline too.
+        let mut capture = true;
 
-            let response: TransferBlockResponse =
-                match commands::send_command(&mut self.device, &request) {
-                    Ok(response) => response,
-                    Err(error) => {
-                        return Err(BatchExecutionError::new_from_debug_probe_at(
-                            DebugProbeError::from(error),
-                            results,
-                            chunk_start,
-                        ));
-                    }
+        loop {
+            while failure.is_none() && in_flight.len() < depth {
+                let Some((chunk_index, chunk)) = chunks.next() else {
+                    break;
                 };
+                let chunk_start = run_start + chunk_index * words_per_packet;
 
-            let count = usize::from(response.transfer_count);
-            let fault_operation = chunk_start + count.saturating_sub(1).min(chunk.len() - 1);
-
-            if response.transfer_response.protocol_error {
-                return Err(BatchExecutionError {
-                    error: BatchError::Specific(DebugProbeError::SwdTransfer(
-                        SwdTransferError::Protocol,
-                    )),
-                    results,
-                    fault_operation,
-                });
-            }
-
-            match response.transfer_response.ack {
-                Ack::Ok => {}
-                Ack::Fault => {
-                    if let Err(error) = self.handle_sticky_err() {
-                        tracing::warn!("Failed to clear the sticky error: {error}");
+                let mut request = match direction {
+                    Direction::Read => {
+                        TransferBlockRequest::read_request(address, chunk.len() as u16)
                     }
-                    return Err(BatchExecutionError {
-                        error: BatchError::Specific(DebugProbeError::SwdTransfer(
-                            SwdTransferError::FaultResponse,
-                        )),
-                        results,
-                        fault_operation,
-                    });
+                    Direction::Write => TransferBlockRequest::write_request(
+                        address,
+                        chunk.iter().map(|(_, op)| transfer_data(op)).collect(),
+                    ),
+                };
+                request.dap_index = self.jtag_state.chain_params.index as u8;
+
+                if let Err(error) = commands::send_request(&mut self.device, &request) {
+                    failure = Some((BatchError::Probe(DebugProbeError::from(error)), chunk_start));
+                    break;
                 }
-                Ack::Wait => {
-                    let abort = {
-                        let mut abort = Abort(0);
-                        abort.set_dapabort(true);
-                        abort
-                    };
-                    if let Err(error) = self.write_abort(abort) {
-                        tracing::warn!("Failed to abort the transfer: {error}");
-                    }
-                    return Err(BatchExecutionError {
-                        error: BatchError::Specific(DebugProbeError::SwdTransfer(
-                            SwdTransferError::WaitResponse,
-                        )),
-                        results,
-                        fault_operation,
-                    });
-                }
-                ack => {
-                    return Err(BatchExecutionError {
-                        error: BatchError::Specific(DebugProbeError::SwdTransfer(
-                            Self::ack_to_transfer_error(ack),
-                        )),
-                        results,
-                        fault_operation,
-                    });
-                }
+
+                in_flight.push_back((chunk_start, chunk, request));
             }
 
-            if count < chunk.len() {
-                return Err(BatchExecutionError::new_from_debug_probe_at(
-                    DebugProbeError::Other(format!(
-                        "Possible error in CMSIS-DAP probe: Only {}/{} transfers were executed, but no error was reported.",
-                        count,
-                        chunk.len()
-                    )),
-                    results,
-                    fault_operation,
-                ));
-            }
+            let Some((chunk_start, chunk, request)) = in_flight.pop_front() else {
+                break;
+            };
 
-            if direction == Direction::Read {
-                for ((id, _), value) in chunk.iter().zip(response.transfer_data.iter()) {
-                    if id.should_capture() {
-                        results.push(id, CommandResult::U32(*value));
+            let response = match commands::receive_response(&mut self.device, &request) {
+                Ok(response) => response,
+                Err(error) => {
+                    failure.get_or_insert((
+                        BatchError::Probe(DebugProbeError::from(error)),
+                        chunk_start,
+                    ));
+                    capture = false;
+                    continue;
+                }
+            };
+
+            match Self::classify_block_response(&response, chunk.len(), chunk_start) {
+                Err(problem) => {
+                    failure.get_or_insert(problem);
+                    capture = false;
+                }
+                Ok(()) if !capture => {}
+                Ok(()) => {
+                    if direction == Direction::Read {
+                        for ((id, _), value) in chunk.iter().zip(response.transfer_data.iter()) {
+                            if id.should_capture() {
+                                results.push(id, CommandResult::U32(*value));
+                            }
+                        }
                     }
                 }
             }
         }
 
-        Ok(results)
+        match failure {
+            Some((error, fault_operation)) => {
+                self.recover_from_block_error(&error);
+                Err(BatchExecutionError {
+                    error,
+                    results,
+                    fault_operation,
+                })
+            }
+            None => Ok(results),
+        }
     }
 
     fn run_swj_sequence_op(&mut self, bits: &BitSequence) -> Result<(), DebugProbeError> {
@@ -510,9 +575,66 @@ impl SwdProbe for CmsisDap {
 mod tests {
     use super::*;
     use crate::probe::{
-        cmsisdap::commands::Request,
+        cmsisdap::commands::{Request, transfer::LastTransferResponse},
         swd::{Direction, Port, SwdOp},
     };
+
+    fn block_response(count: u16, ack: Ack) -> TransferBlockResponse {
+        TransferBlockResponse {
+            transfer_count: count,
+            transfer_response: LastTransferResponse {
+                ack,
+                protocol_error: false,
+                _value_mismatch: false,
+            },
+            transfer_data: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_complete_block_reply_is_a_success() {
+        let response = block_response(4, Ack::Ok);
+        assert!(CmsisDap::classify_block_response(&response, 4, 100).is_ok());
+    }
+
+    #[test]
+    fn a_fault_names_the_transfer_that_failed() {
+        // Two of the four ran, so the second is the one that faulted.
+        let response = block_response(2, Ack::Fault);
+        let (error, fault_operation) =
+            CmsisDap::classify_block_response(&response, 4, 100).unwrap_err();
+
+        assert!(matches!(
+            error,
+            BatchError::Specific(DebugProbeError::SwdTransfer(
+                SwdTransferError::FaultResponse
+            ))
+        ));
+        assert_eq!(fault_operation, 101);
+    }
+
+    #[test]
+    fn a_short_count_with_no_error_is_reported_against_the_probe() {
+        let response = block_response(3, Ack::Ok);
+        let (error, fault_operation) =
+            CmsisDap::classify_block_response(&response, 4, 100).unwrap_err();
+
+        assert!(matches!(
+            error,
+            BatchError::Probe(DebugProbeError::Other(_))
+        ));
+        assert_eq!(fault_operation, 102);
+    }
+
+    #[test]
+    fn a_count_past_the_chunk_stays_inside_it() {
+        // A probe claiming more transfers than it was given must not point outside the chunk.
+        let response = block_response(9, Ack::Fault);
+        let (_, fault_operation) =
+            CmsisDap::classify_block_response(&response, 4, 100).unwrap_err();
+
+        assert_eq!(fault_operation, 103);
+    }
 
     #[derive(Clone)]
     struct RecordedTransfer {

--- a/probe-rs/src/probe/cmsisdap/commands/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/mod.rs
@@ -458,23 +458,52 @@ pub(crate) fn send_command<Req: Request>(
     })
 }
 
-fn send_command_inner<Req: Request>(
+/// Send a request without waiting for its reply.
+///
+/// The probe owes a reply for every request it accepts, and they come back in order. A caller
+/// that sends more than one before reading must take the same number of replies, in the same
+/// order, or the next command reads someone else's answer.
+pub(crate) fn send_request<Req: Request>(
     device: &mut CmsisDapDevice,
     request: &Req,
-) -> Result<Req::Response, SendError> {
-    // Size the buffer for the maximum packet size.
-    // On v1, we always send this full-sized report, while
-    // on v2 we can truncate to just the required data.
-    // Add one byte for HID report ID.
-    let buffer_len: usize = match device {
+) -> Result<(), CmsisDapError> {
+    let mut buffer = vec![0; packet_buffer_len(device)];
+    send_request_inner(device, request, &mut buffer).map_err(|e| CmsisDapError::Send {
+        command_id: Req::COMMAND_ID,
+        source: e,
+    })
+}
+
+/// Take the reply to a request already sent by [`send_request`].
+pub(crate) fn receive_response<Req: Request>(
+    device: &mut CmsisDapDevice,
+    request: &Req,
+) -> Result<Req::Response, CmsisDapError> {
+    let mut buffer = vec![0; packet_buffer_len(device)];
+    receive_response_inner(device, request, &mut buffer).map_err(|e| CmsisDapError::Send {
+        command_id: Req::COMMAND_ID,
+        source: e,
+    })
+}
+
+/// Size a buffer for the largest packet the device can carry, plus the HID report id.
+fn packet_buffer_len(device: &CmsisDapDevice) -> usize {
+    match device {
         #[cfg(feature = "cmsisdap_v1")]
         CmsisDapDevice::V1 { report_size, .. } => *report_size + 1,
         CmsisDapDevice::V2 {
             max_packet_size, ..
         } => *max_packet_size + 1,
-    };
-    let mut buffer = vec![0; buffer_len];
+    }
+}
 
+/// `buffer` must be zeroed past the request. A v1 device is sent a whole report, so whatever is
+/// left in the tail goes on the wire.
+fn send_request_inner<Req: Request>(
+    device: &mut CmsisDapDevice,
+    request: &Req,
+    buffer: &mut [u8],
+) -> Result<(), SendError> {
     // Leave byte 0 as the HID report, and write the command and request to the buffer.
     buffer[1] = Req::COMMAND_ID as u8;
     #[cfg_attr(not(feature = "cmsisdap_v1"), allow(unused_mut))]
@@ -489,12 +518,18 @@ fn send_command_inner<Req: Request>(
         size = *report_size + 1;
     }
 
-    // Send buffer to the device.
     let _ = device.write(&buffer[..size])?;
     trace_buffer("Transmit buffer", &buffer[..size]);
 
-    // Read back response.
-    let bytes_read = device.read(&mut buffer)?;
+    Ok(())
+}
+
+fn receive_response_inner<Req: Request>(
+    device: &mut CmsisDapDevice,
+    request: &Req,
+    buffer: &mut [u8],
+) -> Result<Req::Response, SendError> {
+    let bytes_read = device.read(buffer)?;
     let response_data = &buffer[..bytes_read];
     trace_buffer("Receive buffer", response_data);
 
@@ -510,6 +545,16 @@ fn send_command_inner<Req: Request>(
             Req::COMMAND_ID,
         ))
     }
+}
+
+fn send_command_inner<Req: Request>(
+    device: &mut CmsisDapDevice,
+    request: &Req,
+) -> Result<Req::Response, SendError> {
+    let mut buffer = vec![0; packet_buffer_len(device)];
+
+    send_request_inner(device, request, &mut buffer)?;
+    receive_response_inner(device, request, &mut buffer)
 }
 
 /// Trace log a buffer, including only the first trailing zero.


### PR DESCRIPTION
`run_transfer_block` sends one `DAP_TransferBlock` packet, waits for the reply, then sends the next.
On a frame-quantised transport that wait is a whole USB frame carrying nothing. Depth now comes from the packet count the probe already reports through `DAP_Info`, clamped to 8. 
This was requested in #1757.

**What does not change.** A probe reporting a packet count of 1 sends and receives in the same order as before.
Where a block fits one packet there is nothing to overlap: over an MCU-Link Pro all 444 `DAP_TransferBlock` packets are byte-identical to master, run to run. That transport gains about 1% once blocks span packets.

**Where it helps.** XDS110, CMSIS-DAP v1, 64-byte reports, MSPM0L1306, 34,266 loadable bytes, SWD at 4 MHz:
| phase | master | this branch |
| --- | --- | --- |
| erase | 5.740 s | 5.716 s |
| program | 25.864 s | 25.328 s |
| verify | 1.624 s | 1.088 s |
| total | 33.321 s | 32.225 s |

The saving is one USB frame per overlap. In this example a 64-word page over a 14-word report is 5 packets, 4 overlaps, across 134 blocks in each of program and verify, plus 24 in erase.
That is 1096 overlaps against 1.096 s measured. Every run was identical to the millisecond.

**Outstanding requests when one faults.** Once a sticky flag is set the DP answers FAULT to everything but DPIDR and CTRL/STAT reads and ABORT writes (ADIv5 §B4.2.4), so a request already on the wire is refused rather than performed.
The first failure in batch order is the one reported, as the serial path did.
Clearing a FAULT or a WAIT is itself a command, so it waits until every outstanding reply has been taken.

Tests cover classifying a reply. The loop has no tests: `CmsisDapDevice` has no interface to substitute.

An LLM was used to review the changes, adapt them for the refactor and for first drafts of some of the prose.