### PR TITLE
fix(chip erase): running once per flash algorithm instead of once per chip

### DIFF
--- a/changelog/fixed-chip-erase-repeated-per-algorithm.md
+++ b/changelog/fixed-chip-erase-repeated-per-algorithm.md
@@ -1,0 +1,1 @@
+Fixed `probe-rs erase` running a target's chip-erase debug sequence once per flash algorithm instead of once for the whole chip.

--- a/probe-rs/src/flashing/erase.rs
+++ b/probe-rs/src/flashing/erase.rs
@@ -119,13 +119,25 @@ pub fn erase_all(
     }
     progress.initialized(phases);
 
+    // A debug sequence erases the whole chip in one go, unlike a flash algorithm's `erase_all`
+    // which only covers the memory that algorithm serves. Running it once per algorithm would
+    // erase the chip repeatedly, so it is only run for the first one.
+    let sequence_erases_whole_chip = session.has_sequence_erase_all();
+    let mut chip_erased = false;
+
     for el in algos {
         let mut flasher = el.flasher;
         tracing::debug!("Erasing with algorithm: {}", flasher.flash_algorithm.name);
 
         if flasher.is_chip_erase_supported(session) {
+            if sequence_erases_whole_chip && chip_erased {
+                tracing::debug!("     -- chip already erased by the debug sequence.");
+                continue;
+            }
+
             tracing::debug!("     -- chip erase supported, doing it.");
             flasher.run_erase_all(session, progress)?;
+            chip_erased = true;
         } else {
             tracing::debug!("     -- chip erase not supported, erasing by sector.");
 


### PR DESCRIPTION
This PR contains a fix for erase_all invoking a target's chip-erase debug sequence repeatedly.
It groups NVM regions by flash algorithm and calls run_erase_all for each, but a chip-erase debug sequence erases the whole chip, not just the memory one algorithm serves, so on a target with more than one NVM region it runs multiple times. This runs it only once.

Currently latent: the targets that provide a chip-erase sequence all have a single NVM region today, and the targets with several don't provide one. Found while working on dual-bank PSOC C3 support ([#4332](https://github.com/probe-rs/probe-rs/pull/4332)).