### PR TITLE
Pass SWJ pin requests on to an SWD probe

### DIFF
--- a/changelog/fixed-connect-under-reset-swj-pins.md
+++ b/changelog/fixed-connect-under-reset-swj-pins.md
@@ -1,0 +1,1 @@
+`--connect-under-reset` works again with SWD probes: the reset release is passed to the probe as a pins operation instead of being refused for every probe.

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -696,16 +696,25 @@ impl SwdSequence for ArmCommunicationInterface {
 
     fn swj_pins(
         &mut self,
-        _pin_out: u32,
-        _pin_select: u32,
-        _pin_wait: u32,
+        pin_out: u32,
+        pin_select: u32,
+        pin_wait: u32,
     ) -> Result<u32, DebugProbeError> {
         match self.probe.as_mut().unwrap() {
-            ArmProbe::Swd(_, _) | ArmProbe::Jtag(_, _) => {
-                Err(DebugProbeError::CommandNotSupportedByProbe {
-                    command_name: "swj_pins",
-                })
+            ArmProbe::Swd(probe, _) => {
+                let mut batch = SwdBatch::new();
+                let _ = batch.schedule(SwdOp::Pins {
+                    out: Pins(pin_out as u8),
+                    select: Pins(pin_select as u8),
+                    wait: Duration::from_micros(pin_wait.into()),
+                });
+                probe.run_batch(&batch).map_err(batch_probe_error)?;
+                // The batch reports no levels; every pin high is what a released line reads.
+                Ok(0xFF)
             }
+            ArmProbe::Jtag(_, _) => Err(DebugProbeError::CommandNotSupportedByProbe {
+                command_name: "swj_pins",
+            }),
         }
     }
 }
@@ -1158,7 +1167,7 @@ mod tests {
     use super::*;
     use crate::architecture::arm::sequences::DefaultArmSequence;
     use crate::probe::BitSequence;
-    use crate::probe::swd::mock::{MockSwdProbe, RecordedOp, RecordedSequence};
+    use crate::probe::swd::mock::{MockSwdProbe, RecordedOp, RecordedPins, RecordedSequence};
     use crate::probe::swd::{Direction, Port};
 
     const DP_RDBUFF_ADDR: u8 = 0b1100;
@@ -1218,6 +1227,24 @@ mod tests {
     fn prepare_swd_probe(probe: &mut MockSwdProbe) {
         push_attach_responses(probe);
         attach_ctrl_reads(probe, 0);
+    }
+
+    #[test]
+    fn swj_pins_is_passed_to_the_swd_probe() {
+        // The reset release of connect-under-reset drives nRESET through swj_pins.
+        let probe = MockSwdProbe::new();
+        let pins = probe.shared_pins();
+        let (mut interface, _) = swd_interface(probe);
+        let nreset = 1 << 7;
+        assert_eq!(interface.swj_pins(nreset, nreset, 10).unwrap(), 0xFF);
+        assert_eq!(
+            *pins.lock().unwrap(),
+            [RecordedPins {
+                out: nreset as u8,
+                select: nreset as u8,
+                wait: Duration::from_micros(10),
+            }]
+        );
     }
 
     #[test]

--- a/probe-rs/src/probe/swd/mock.rs
+++ b/probe-rs/src/probe/swd/mock.rs
@@ -42,6 +42,17 @@ pub(crate) struct RecordedSequence {
     pub bits: BitSequence,
 }
 
+/// One recorded pins operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RecordedPins {
+    /// The output levels.
+    pub out: u8,
+    /// The pin select mask.
+    pub select: u8,
+    /// The maximum wait time.
+    pub wait: std::time::Duration,
+}
+
 /// Mock probe that records SWD operations.
 #[derive(Debug)]
 pub(crate) struct MockSwdProbe {
@@ -55,6 +66,7 @@ pub(crate) struct MockSwdProbe {
     handles_ap_pipeline: bool,
     capture_flags: Arc<Mutex<Vec<bool>>>,
     idles: Arc<Mutex<Vec<u32>>>,
+    pins: Arc<Mutex<Vec<RecordedPins>>>,
 }
 
 impl MockSwdProbe {
@@ -71,12 +83,18 @@ impl MockSwdProbe {
             handles_ap_pipeline: false,
             capture_flags: Arc::new(Mutex::new(Vec::new())),
             idles: Arc::new(Mutex::new(Vec::new())),
+            pins: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
     /// Return a handle to the recorded operations.
     pub(crate) fn shared_operations(&self) -> Arc<Mutex<Vec<RecordedOp>>> {
         self.operations.clone()
+    }
+
+    /// Return a handle to the recorded pins operations.
+    pub(crate) fn shared_pins(&self) -> Arc<Mutex<Vec<RecordedPins>>> {
+        self.pins.clone()
     }
 
     /// Return a handle to the recorded sequences.
@@ -275,7 +293,13 @@ impl SwdProbe for MockSwdProbe {
                         .unwrap()
                         .push(RecordedSequence { bits: bits.clone() });
                 }
-                SwdOp::Pins { .. } => {}
+                SwdOp::Pins { out, select, wait } => {
+                    self.pins.lock().unwrap().push(RecordedPins {
+                        out: out.0,
+                        select: select.0,
+                        wait: *wait,
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
reset_hardware_deassert releases the target through ArmDebugInterface::swj_pins, which ArmCommunicationInterface has refused for every probe since the SWD/JTAG refactor, so --connect-under-reset failed on all of them. Schedule the request as a pins operation for the SWD probe, as the debug port wire already does, and answer with every pin high since the batch reports no levels. A JTAG probe still has no pin interface.

Verified with --connect-under-reset on an STM32F407VETx over a CH347.