### PR TITLE
fix: xvc parsing

### DIFF
--- a/changelog/fixed-xvc-address-filtering.md
+++ b/changelog/fixed-xvc-address-filtering.md
@@ -1,0 +1,1 @@
+Fixed XVC probe address filtering causing it to erroneously show up sometimes.

--- a/probe-rs/src/probe/xvc/mod.rs
+++ b/probe-rs/src/probe/xvc/mod.rs
@@ -81,7 +81,7 @@ impl ProbeFactory for XvcFactory {
             && selector.vendor_id == XVC_VID
             && selector.product_id == XVC_PID
             && let Some(address) = selector.serial_number.clone()
-            && !address.is_empty()
+            && is_xvc_address(&address)
         {
             return vec![ProbeListItem::accessible(DebugProbeInfo {
                 identifier: "XVC".to_string(),
@@ -96,6 +96,24 @@ impl ProbeFactory for XvcFactory {
 
         Vec::new()
     }
+}
+
+fn is_xvc_address(serial: &str) -> bool {
+    // Drop a trailing numeric port, except for bracketed IPv6 literals.
+    let host = if serial.contains('[') {
+        serial
+    } else if let Some((host, port)) = serial.rsplit_once(':') {
+        if !port.bytes().all(|b| b.is_ascii_digit()) {
+            return false;
+        }
+        host
+    } else {
+        serial
+    };
+    !host.is_empty()
+        && host.bytes().all(|b| {
+            b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_' | b'[' | b']' | b':')
+        })
 }
 
 /// An XVC (Xilinx Virtual Cable) debug probe.

--- a/probe-rs/src/probe/xvc/protocol.rs
+++ b/probe-rs/src/probe/xvc/protocol.rs
@@ -98,6 +98,10 @@ impl XvcDevice {
             return Err(ProbeCreationError::NotFound);
         };
 
+        if !super::is_xvc_address(serial) {
+            return Err(ProbeCreationError::NotFound);
+        }
+
         let address = normalize_address(serial)?;
 
         let mut stream = TcpStream::connect(&address).map_err(XvcError::from)?;


### PR DESCRIPTION
XVC addresses are now filtered to not collide with other configurations, e.g. linuxgpio implementations. This was an issue on the Uno Q where tryign to flash a program resulted in a "multiple probes" error, even after selecting a probe. A better solution would be to have the filtering system properly respect selected probe index, but XVC should be better about its filtering regardless.

```
~/dev/probe-rs> target/debug/probe-rs erase --host ws://127.0.0.1:3000 --token arduino --chip STM32U585AI --probe 0:0:gpiochip1,swclk=26,swdio=25,srst=38
Available Probes:
0: XVC -- 0000:0000:gpiochip1,swclk=26,swdio=25,srst=38 (XVC)
1: Linux GPIO bit-bang SWD (gpiochip1,swclk=26,swdio=25,srst=38) -- 0000:0000:gpiochip1,swclk=26,swdio=25,srst=38 (Linux GPIO bit-bang SWD)
Selection: 1
DebugProbeEntry {
    identifier: "Linux GPIO bit-bang SWD (gpiochip1,swclk=26,swdio=25,srst=38)",
    vendor_id: 0,
    product_id: 0,
    interface: None,
    serial_number: "gpiochip1,swclk=26,swdio=25,srst=38",
    probe_type: "Linux GPIO bit-bang SWD",
    inaccessible: false,
}
 WARN probe_rs::util::setup_hints::linux: If your probe is plugged in but not listed, or shown as inaccessible, it is most likely a permissions problem.
 WARN probe_rs::util::setup_hints::linux: Your user needs read and write access to the probe's device node: a USB node under /dev/bus/usb, or a serial port such as /dev/ttyACM0.
 WARN probe_rs::util::setup_hints::linux: See https://probe.rs/docs/getting-started/probe-setup/ for how to set up the required udev rules and group membership.
Error: Did not expect multiple probes
```