### PR TITLE
CMSIS-DAP: Resynchronise the probe whenever a command fails, handle stale replies when opening the probe.

### DIFF
--- a/changelog/fixed-cmsisdap-desync-after-failed-command.md
+++ b/changelog/fixed-cmsisdap-desync-after-failed-command.md
@@ -1,3 +1,1 @@
-Fixed a CMSIS-DAP probe becoming unusable after a command failed. The probe still held a reply,
-and every later command read that reply instead of its own and rejected it as the wrong command,
-until the probe was physically reconnected.
+Fixed a CMSIS-DAP probe becoming unusable after a command failed.

--- a/changelog/fixed-cmsisdap-desync-after-failed-command.md
+++ b/changelog/fixed-cmsisdap-desync-after-failed-command.md
@@ -1,0 +1,3 @@
+Fixed a CMSIS-DAP probe becoming unusable after a command failed. The probe still held a reply,
+and every later command read that reply instead of its own and rejected it as the wrong command,
+until the probe was physically reconnected.

--- a/changelog/fixed-cmsisdap-recover-desynchronised-probe.md
+++ b/changelog/fixed-cmsisdap-recover-desynchronised-probe.md
@@ -1,1 +1,1 @@
-A CMSIS-DAP probe interrupted mid-transfer no longer has to be physically reconnected. A stale reply used to desynchronize the channel until it was reconnected.
+A CMSIS-DAP probe interrupted mid-transfer no longer has to be physically reconnected.

--- a/changelog/fixed-cmsisdap-recover-desynchronised-probe.md
+++ b/changelog/fixed-cmsisdap-recover-desynchronised-probe.md
@@ -1,0 +1,1 @@
+A CMSIS-DAP probe interrupted mid-transfer no longer has to be physically reconnected. A stale reply used to desynchronize the channel until it was reconnected.

--- a/changelog/fixed-cmsisdap-stale-info-reply-misparsed.md
+++ b/changelog/fixed-cmsisdap-stale-info-reply-misparsed.md
@@ -1,0 +1,3 @@
+Fixed a CMSIS-DAP probe being reported as not supporting SWD after an earlier session left it with
+replies outstanding. Every `DAP_Info` sub-command shares one command ID and the reply does not say
+which it answers, so a stale packet count was read as the capability mask.

--- a/changelog/fixed-cmsisdap-stale-info-reply-misparsed.md
+++ b/changelog/fixed-cmsisdap-stale-info-reply-misparsed.md
@@ -1,3 +1,1 @@
-Fixed a CMSIS-DAP probe being reported as not supporting SWD after an earlier session left it with
-replies outstanding. Every `DAP_Info` sub-command shares one command ID and the reply does not say
-which it answers, so a stale packet count was read as the capability mask.
+Fixed a CMSIS-DAP probe being reported as not supporting SWD after an earlier session left it with replies outstanding.

--- a/probe-rs/src/probe/cmsisdap/commands/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/mod.rs
@@ -248,6 +248,16 @@ impl CmsisDapDevice {
     /// synchronised to requests. Swallows any errors, which are expected if
     /// there is no pending data to read.
     pub(super) fn drain(&mut self) {
+        self.drain_idle_for(Duration::from_millis(1));
+    }
+
+    /// Drain as [`CmsisDapDevice::drain`], treating the queue as empty only once the probe has
+    /// produced nothing for `idle`.
+    ///
+    /// A probe working through a backlog hands its replies over one at a time and not always
+    /// promptly, so the short window that suffices for an ordinary open sees an empty pipe and
+    /// leaves the rest of the backlog in place.
+    pub(super) fn drain_idle_for(&mut self, idle: Duration) {
         tracing::debug!("Draining probe of any pending data.");
 
         match self {
@@ -258,7 +268,7 @@ impl CmsisDapDevice {
                 ..
             } => loop {
                 let mut discard = vec![0u8; *report_size + 1];
-                match handle.read_timeout(&mut discard, 1) {
+                match handle.read_timeout(&mut discard, idle.as_millis().max(1) as i32) {
                     Ok(n) if n != 0 => continue,
                     _ => break,
                 }
@@ -269,7 +279,7 @@ impl CmsisDapDevice {
                 max_packet_size,
                 ..
             } => {
-                let timeout = Duration::from_millis(1);
+                let timeout = idle;
                 let mut discard = vec![0u8; *max_packet_size];
                 loop {
                     match in_ep.read_bulk(&mut discard, timeout) {

--- a/probe-rs/src/probe/cmsisdap/commands/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/mod.rs
@@ -329,6 +329,13 @@ impl CmsisDapDevice {
                     ..
                 }) => (),
 
+                // A reply to a command from before this device was opened. It has now been read
+                // and the rest of the queue discarded with it, so the next attempt gets its own.
+                Err(CmsisDapError::Send {
+                    source: SendError::CommandIdMismatch(..),
+                    ..
+                }) => (),
+
                 // Raise other errors.
                 Err(e) => return Err(e),
             }
@@ -554,7 +561,17 @@ fn send_command_inner<Req: Request>(
     let mut buffer = vec![0; packet_buffer_len(device)];
 
     send_request_inner(device, request, &mut buffer)?;
-    receive_response_inner(device, request, &mut buffer)
+
+    // Once the request is out the probe owes a reply, so a failure here has to take it off the
+    // device before returning. Left there, the next command reads this reply instead of its own
+    // and rejects it as the wrong command, and so does every command after that for as long as
+    // the device stays open.
+    let response = receive_response_inner(device, request, &mut buffer);
+    if response.is_err() {
+        device.drain();
+    }
+
+    response
 }
 
 /// Trace log a buffer, including only the first trailing zero.

--- a/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
@@ -422,3 +422,24 @@ pub struct TransferBlockResponse {
     pub transfer_response: LastTransferResponse,
     pub transfer_data: Vec<u32>,
 }
+
+/// `DAP_TransferAbort`, which ends a transfer the probe is still working through.
+///
+/// The probe sends no reply to this, so it is the one command that can be issued while the device
+/// still owes a response to something else.
+#[derive(Clone, Copy, Debug)]
+pub struct TransferAbortRequest;
+
+impl Request for TransferAbortRequest {
+    const COMMAND_ID: CommandId = CommandId::TransferAbort;
+
+    type Response = ();
+
+    fn to_bytes(&self, _buffer: &mut [u8]) -> Result<usize, SendError> {
+        Ok(0)
+    }
+
+    fn parse_response(&self, _buffer: &[u8]) -> Result<Self::Response, SendError> {
+        Ok(())
+    }
+}

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 
 use commands::{
-    CmsisDapDevice, Status,
+    CmsisDapDevice, SendError, Status,
     general::{
         connect::{ConnectRequest, ConnectResponse},
         disconnect::{DisconnectRequest, DisconnectResponse},
@@ -127,26 +127,64 @@ impl std::fmt::Debug for CmsisDap {
     }
 }
 
+/// Times the opening sequence is restarted while the probe is still answering with replies it owes
+/// from an earlier session.
+const MAX_OPEN_ATTEMPTS: usize = 8;
+
+/// How long the probe has to stay silent before its backlog counts as drained, once one has been
+/// seen. Only paid on the recovery path.
+const BACKLOG_IDLE: Duration = Duration::from_millis(100);
+
+/// Whether an error says the probe answered with something that was not a reply to what was asked.
+///
+/// A timeout or a USB failure says the probe is gone or silent, which asking again does not fix.
+/// These say a reply arrived and made no sense as an answer to the question, which is what a
+/// backlog from an earlier session looks like.
+fn reply_is_not_ours(error: &CmsisDapError) -> bool {
+    matches!(
+        error,
+        CmsisDapError::Send {
+            source: SendError::CommandIdMismatch(..)
+                | SendError::UnexpectedAnswer
+                | SendError::NotEnoughData,
+            ..
+        }
+    )
+}
+
+/// What `new_from_device` asks the probe about itself.
+struct ProbeInfo {
+    packet_size: u16,
+    packet_count: u8,
+    capabilities: Capabilities,
+    swo_buffer_size: Option<usize>,
+}
+
 impl CmsisDap {
     fn new_from_device(mut device: CmsisDapDevice) -> Result<Self, DebugProbeError> {
         // Discard anything left in buffer, as otherwise
         // we'll get out of sync between requests and responses.
         device.drain();
 
-        // Determine and set the packet size. We do this as soon as possible after
-        // opening the probe to ensure all future communication uses the correct size.
-        let packet_size = device.find_packet_size()? as u16;
+        // A probe that still owes replies from an earlier session answers the start of this one
+        // with the previous one's data. Drain properly and ask again for as long as the answers
+        // look like they belong to someone else.
+        let mut info = Self::read_probe_info(&mut device);
+        for _ in 1..MAX_OPEN_ATTEMPTS {
+            if !matches!(&info, Err(e) if reply_is_not_ours(e)) {
+                break;
+            }
 
-        // Read remaining probe information.
-        let packet_count = commands::send_command(&mut device, &PacketCountCommand {})?;
-        let caps: Capabilities = commands::send_command(&mut device, &CapabilitiesCommand {})?;
-        tracing::debug!("Detected probe capabilities: {:?}", caps);
-        let mut swo_buffer_size = None;
-        if caps.swo_uart_implemented || caps.swo_manchester_implemented {
-            let swo_size = commands::send_command(&mut device, &SWOTraceBufferSizeCommand {})?;
-            swo_buffer_size = Some(swo_size as usize);
-            tracing::debug!("Probe SWO buffer size: {}", swo_size);
+            device.drain_idle_for(BACKLOG_IDLE);
+            info = Self::read_probe_info(&mut device);
         }
+
+        let ProbeInfo {
+            packet_size,
+            packet_count,
+            capabilities: caps,
+            swo_buffer_size,
+        } = info?;
 
         Ok(Self {
             device,
@@ -164,6 +202,38 @@ impl CmsisDap {
             transfer_wait_retry: 0,
             jtag_state: JtagChainState::default(),
             jtag_buffer: JtagBuffer::new(packet_size - 1),
+        })
+    }
+
+    fn read_probe_info(device: &mut CmsisDapDevice) -> Result<ProbeInfo, CmsisDapError> {
+        // Determine and set the packet size. We do this as soon as possible after
+        // opening the probe to ensure all future communication uses the correct size.
+        let packet_size = device.find_packet_size()? as u16;
+
+        // Read remaining probe information.
+        let packet_count = commands::send_command(device, &PacketCountCommand {})?;
+        let capabilities: Capabilities = commands::send_command(device, &CapabilitiesCommand {})?;
+        tracing::debug!("Detected probe capabilities: {:?}", capabilities);
+
+        let mut swo_buffer_size = None;
+        if capabilities.swo_uart_implemented || capabilities.swo_manchester_implemented {
+            let swo_size = commands::send_command(device, &SWOTraceBufferSizeCommand {})?;
+            swo_buffer_size = Some(swo_size as usize);
+            tracing::debug!("Probe SWO buffer size: {}", swo_size);
+        }
+
+        // Nothing above can tell its own answer from one the probe still owed. Every `DAP_Info`
+        // sub-command shares command ID 0x00 and the reply does not say which one it answers, so
+        // a stale packet count reads as a capability mask and the probe comes out not supporting
+        // SWD. A command with a different ID does say: if anything was queued ahead of it, its
+        // reply arrives under the wrong ID, and everything read above came from the backlog.
+        commands::send_command(device, &HostStatusRequest::connected(false))?;
+
+        Ok(ProbeInfo {
+            packet_size,
+            packet_count,
+            capabilities,
+            swo_buffer_size,
         })
     }
 

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -212,6 +212,8 @@ impl CmsisDap {
 
         // Read remaining probe information.
         let packet_count = commands::send_command(device, &PacketCountCommand {})?;
+        tracing::debug!("Probe buffers {} packets", packet_count);
+
         let capabilities: Capabilities = commands::send_command(device, &CapabilitiesCommand {})?;
         tracing::debug!("Detected probe capabilities: {:?}", capabilities);
 

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -26,7 +26,10 @@ use crate::{
         JtagChainState, ProbeFactory, WireProtocol,
         cmsisdap::commands::{
             CmsisDapError, RequestError,
-            general::info::{CapabilitiesCommand, PacketCountCommand, SWOTraceBufferSizeCommand},
+            general::info::{
+                CapabilitiesCommand, PacketCountCommand, PacketSizeCommand,
+                SWOTraceBufferSizeCommand,
+            },
         },
         swd::SwdProbe,
     },
@@ -56,7 +59,7 @@ use commands::{
         sequence::{SequenceRequest, SequenceResponse},
     },
     swo,
-    transfer::{Ack, TransferRequest, configure::ConfigureRequest},
+    transfer::{Ack, TransferAbortRequest, TransferRequest, configure::ConfigureRequest},
 };
 use probe_rs_target::ScanChainElement;
 
@@ -135,6 +138,49 @@ const MAX_OPEN_ATTEMPTS: usize = 8;
 /// seen. Only paid on the recovery path.
 const BACKLOG_IDLE: Duration = Duration::from_millis(100);
 
+/// Rounds spent bringing replies back into step before giving up on the probe.
+const MAX_RESYNC_ROUNDS: usize = 32;
+
+/// How long to wait for a reply the probe was prompted to give up.
+const RESYNC_IDLE: Duration = Duration::from_millis(5);
+
+/// Bring requests and replies back into step.
+///
+/// A probe interrupted mid-transfer answers the next command with the previous one's reply, and
+/// goes on doing so across a close and reopen. Draining does not clear it: nothing is waiting on
+/// the endpoint, so a drain reads nothing and the next command is answered late all the same.
+/// Ordinary commands do not clear it either, however many are sent.
+///
+/// What does clear it, measured a reply at a time, is `DAP_TransferAbort`, which the probe answers
+/// with nothing at all.
+///
+/// Whether the stream is level has to be asked with two different commands. A repeated one cannot
+/// tell its own reply from the previous copy's, which is the same blindness that hides a slipped
+/// `DAP_Info`: all its sub-commands share one command ID. So level means a `DAP_HostStatus` sent
+/// after a `DAP_Info` comes back under its own ID.
+fn resynchronise(device: &mut CmsisDapDevice) {
+    for round in 0..MAX_RESYNC_ROUNDS {
+        // Unconditionally, and before asking anything: a probe that owes a reply does not give it
+        // up for a command that queues another one behind it, so the question cannot be asked
+        // until this has been done at least once.
+        let _ = commands::send_request(device, &TransferAbortRequest);
+        device.drain_idle_for(RESYNC_IDLE);
+
+        let _ = commands::send_command(device, &PacketSizeCommand {});
+        if commands::send_command(device, &HostStatusRequest::connected(false)).is_ok() {
+            if round > 0 {
+                tracing::debug!("Probe back in step after {round} rounds");
+            }
+            return;
+        }
+    }
+
+    tracing::warn!(
+        "Probe is still answering with replies to an earlier session's commands after \
+         {MAX_RESYNC_ROUNDS} attempts to bring it back into step."
+    );
+}
+
 /// Whether an error says the probe answered with something that was not a reply to what was asked.
 ///
 /// A timeout or a USB failure says the probe is gone or silent, which asking again does not fix.
@@ -154,7 +200,6 @@ fn reply_is_not_ours(error: &CmsisDapError) -> bool {
 
 /// What `new_from_device` asks the probe about itself.
 struct ProbeInfo {
-    packet_size: u16,
     packet_count: u8,
     capabilities: Capabilities,
     swo_buffer_size: Option<usize>,
@@ -166,9 +211,15 @@ impl CmsisDap {
         // we'll get out of sync between requests and responses.
         device.drain();
 
+        // Before anything else is asked of the probe. Until this returns, the size a report has to
+        // be to reach the device is a guess -- and some answer nothing at all until they receive a
+        // full one, which is what the retrying inside here is for. Anything sent before it can go
+        // unanswered on those probes for reasons that have nothing to do with the probe's state.
+        let packet_size = device.find_packet_size()? as u16;
+
         // A probe that still owes replies from an earlier session answers the start of this one
-        // with the previous one's data. Drain properly and ask again for as long as the answers
-        // look like they belong to someone else.
+        // with the previous one's data. Drain properly, prompt out what it is holding, and ask
+        // again for as long as the answers look like they belong to someone else.
         let mut info = Self::read_probe_info(&mut device);
         for _ in 1..MAX_OPEN_ATTEMPTS {
             if !matches!(&info, Err(e) if reply_is_not_ours(e)) {
@@ -176,11 +227,11 @@ impl CmsisDap {
             }
 
             device.drain_idle_for(BACKLOG_IDLE);
+            resynchronise(&mut device);
             info = Self::read_probe_info(&mut device);
         }
 
         let ProbeInfo {
-            packet_size,
             packet_count,
             capabilities: caps,
             swo_buffer_size,
@@ -206,10 +257,6 @@ impl CmsisDap {
     }
 
     fn read_probe_info(device: &mut CmsisDapDevice) -> Result<ProbeInfo, CmsisDapError> {
-        // Determine and set the packet size. We do this as soon as possible after
-        // opening the probe to ensure all future communication uses the correct size.
-        let packet_size = device.find_packet_size()? as u16;
-
         // Read remaining probe information.
         let packet_count = commands::send_command(device, &PacketCountCommand {})?;
         tracing::debug!("Probe buffers {} packets", packet_count);
@@ -232,7 +279,6 @@ impl CmsisDap {
         commands::send_command(device, &HostStatusRequest::connected(false))?;
 
         Ok(ProbeInfo {
-            packet_size,
             packet_count,
             capabilities,
             swo_buffer_size,


### PR DESCRIPTION
A failed command could leave a reply queued in the probe, desynchronising it until a reconnection.

Now stale commands are drained when opening and if a command fails.