### PR TITLE
Cherry-picked bugfixes

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/info.rs
@@ -226,7 +226,7 @@ fn format_info_event(event: &InfoEvent) -> String {
             architecture,
             idcode: None,
         } => {
-            writeln!(output, "No IDCODE info for this {architecture} chip.").unwrap();
+            writeln!(output, "The chip is presumably not {architecture}.").unwrap();
         }
         InfoEvent::ArmDp(dp_info) => {
             writeln!(output, "{}", format_debug_port_info(dp_info)).unwrap();

--- a/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
+++ b/probe-rs-tools/src/bin/probe-rs/rpc/functions/info.rs
@@ -759,7 +759,7 @@ async fn show_xtensa_info(
         VarSeq::Seq2(0),
         &InfoEvent::Idcode {
             architecture: "Xtensa".to_string(),
-            idcode: Some(idcode),
+            idcode,
         },
     )
     .await

--- a/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm/jtag_dtm.rs
@@ -21,6 +21,17 @@ use crate::probe::{
     ShiftDrData,
 };
 
+/// Interpret a raw 32-bit JTAG IDCODE-instruction capture, returning `None` if it isn't actually a
+/// valid IDCODE.
+///
+/// Per IEEE 1149.1, a TAP's IDCODE register always has bit 0 hardwired to 1, distinguishing a real
+/// capture from the 1-bit BYPASS register (always 0) or a floating/no-response bus. Without this
+/// check, probing a JTAG target with no RISC-V TAP at all reads back all-zero bits, which would be
+/// reported as a bogus "IDCODE 0000000000, Unknown Manufacturer" instead of "no RISC-V DTM found".
+fn valid_idcode(value: u32) -> Option<u32> {
+    if value & 1 == 1 { Some(value) } else { None }
+}
+
 #[derive(Debug, Default)]
 struct DtmState {
     queued_commands: JtagQueue<DmiOperationError>,
@@ -403,7 +414,7 @@ impl DtmAccess for JtagDtm<'_> {
         self.tap_reset()?;
         let value = self.exchange_register(0x1, BitSequence::repeat(false, 32), 0)?;
 
-        Ok(Some(value.as_bits().load_le::<u32>()))
+        Ok(valid_idcode(value.as_bits().load_le::<u32>()))
     }
 }
 
@@ -762,7 +773,7 @@ impl DtmAccess for TunneledJtagDtm<'_> {
         // from `probe-rs info`), because the TAP state may be indeterminate after attach.
         self.tap_reset()?;
         let value = self.exchange_register_at(0x1, BitSequence::repeat(false, 32), 0)?;
-        Ok(Some(value.as_bits().load_le::<u32>()))
+        Ok(valid_idcode(value.as_bits().load_le::<u32>()))
     }
 }
 
@@ -990,5 +1001,27 @@ mod tests {
         let width_offset = 1 + dmi_bits + 3;
         let msb_offset = 7 + width_offset;
         assert_eq!(bit_size, msb_offset + 1);
+    }
+
+    #[test]
+    fn all_zero_capture_is_not_a_valid_idcode() {
+        // The all-zero pattern this fix was found from: an unrelated/unrecognized JTAG target
+        // (no RISC-V DTM at all) capturing a floating or BYPASS-register bit as the "IDCODE".
+        assert_eq!(valid_idcode(0), None);
+    }
+
+    #[test]
+    fn lsb_clear_is_never_a_valid_idcode() {
+        // Per IEEE 1149.1, a real IDCODE register's bit 0 is always hardwired to 1 - any other
+        // even-valued capture (not just all-zero) is equally not a real IDCODE.
+        assert_eq!(valid_idcode(0xffff_fffe), None);
+        assert_eq!(valid_idcode(0x1234_5678), None);
+    }
+
+    #[test]
+    fn lsb_set_is_accepted_as_a_valid_idcode() {
+        // A real-looking IDCODE (bit 0 set) is returned unchanged.
+        assert_eq!(valid_idcode(0x1234_5679), Some(0x1234_5679));
+        assert_eq!(valid_idcode(1), Some(1));
     }
 }

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -292,7 +292,7 @@ impl<'probe> XtensaCommunicationInterface<'probe> {
     }
 
     /// Read the targets IDCODE.
-    pub fn read_idcode(&mut self) -> Result<u32, XtensaError> {
+    pub fn read_idcode(&mut self) -> Result<Option<u32>, XtensaError> {
         self.xdm.read_idcode()
     }
 

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -139,6 +139,17 @@ fn print_narsel(narsel: &u8) -> String {
     format!("{name} ({narsel:#04X})")
 }
 
+/// Interpret a raw 32-bit JTAG IDCODE-instruction capture, returning `None` if it isn't actually a
+/// valid IDCODE.
+///
+/// Per IEEE 1149.1, a TAP's IDCODE register always has bit 0 hardwired to 1, distinguishing a real
+/// capture from the 1-bit BYPASS register (always 0) or a floating/no-response bus. Without this
+/// check, probing a JTAG target with no Xtensa TAP at all reads back all-zero bits, which would be
+/// reported as a bogus "IDCODE 0000000000, Unknown Manufacturer" instead of "No Xtensa ID code returned.".
+fn valid_idcode(value: u32) -> Option<u32> {
+    if value & 1 == 1 { Some(value) } else { None }
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct XdmState {
     /// The last instruction to be executed.
@@ -526,7 +537,7 @@ impl<'probe> Xdm<'probe> {
         Ok(res)
     }
 
-    pub(super) fn read_idcode(&mut self) -> Result<u32, XtensaError> {
+    pub(super) fn read_idcode(&mut self) -> Result<Option<u32>, XtensaError> {
         self.tap_reset()?;
         let instr = TapInstruction::Idcode;
 
@@ -540,7 +551,7 @@ impl<'probe> Xdm<'probe> {
 
         tracing::debug!("idcode response: {:x?}", res);
 
-        Ok(res)
+        Ok(valid_idcode(res))
     }
 
     pub(super) fn schedule_read_nexus_register<R: NexusRegister>(

--- a/probe-rs/src/probe/ftdi/command_compacter.rs
+++ b/probe-rs/src/probe/ftdi/command_compacter.rs
@@ -76,7 +76,7 @@ impl Command {
                 bit_count: 1,
                 tms_bits: 1,
                 tdi: last_tdi,
-                capture: false,
+                capture,
             });
         }
 

--- a/probe-rs/src/vendor/mod.rs
+++ b/probe-rs/src/vendor/mod.rs
@@ -281,7 +281,7 @@ fn try_detect_xtensa_chip(registry: &Registry, probe: &mut Probe) -> Result<Opti
             }
 
             match interface.read_idcode() {
-                Ok(idcode) => {
+                Ok(Some(idcode)) => {
                     tracing::debug!("ID code read over JTAG: {idcode:#x}");
                     let vendors = vendors();
                     for vendor in vendors.iter() {
@@ -294,6 +294,7 @@ fn try_detect_xtensa_chip(registry: &Registry, probe: &mut Probe) -> Result<Opti
                         }
                     }
                 }
+                Ok(_) => tracing::debug!("No Xtensa ID code returned."),
                 Err(error) => tracing::debug!("Error during Xtensa chip detection: {error}"),
             }
 


### PR DESCRIPTION
encode_tdi_exchange hardcoded capture: false for the TMS-merged last bit of an Exchange, silently dropping it regardless of the caller's capture flag. Any capturing DR/IR shift that ends in a state transition landed one bit short - confirmed on real ARM7TDMI/MC1322x hardware as "the probe captured N bits, but the batch needs N+1".

Picked off of #4344